### PR TITLE
Issue/4944 events related to software updates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -258,9 +258,9 @@ class AnalyticsTracker private constructor(private val context: Context) {
         CARD_READER_CONNECTION_SUCCESS,
         CARD_READER_DISCONNECT_TAPPED,
         CARD_READER_AUTO_CONNECTION_STARTED,
-        CARD_READER_SOFTWARE_UPDATE_STARTED,
 
         // -- Card Reader - software update
+        CARD_READER_SOFTWARE_UPDATE_STARTED,
         CARD_READER_SOFTWARE_UPDATE_SUCCESS,
         CARD_READER_SOFTWARE_UPDATE_FAILED,
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -258,6 +258,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         CARD_READER_CONNECTION_SUCCESS,
         CARD_READER_DISCONNECT_TAPPED,
         CARD_READER_AUTO_CONNECTION_STARTED,
+        CARD_READER_SOFTWARE_UPDATE_STARTED,
 
         // -- Card Reader - software update
         CARD_READER_SOFTWARE_UPDATE_SUCCESS,
@@ -690,6 +691,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_FULFILL_ORDER = "fulfill_order"
         const val KEY_STEP = "step"
         const val KEY_ADDONS = "addons"
+        const val KEY_SOFTWARE_UPDATE_TYPE = "software_update_type"
 
         const val KEY_SORT_ORDER = "order"
         const val VALUE_SORT_NAME_ASC = "name,ascending"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
@@ -66,8 +66,7 @@ class CardReaderUpdateViewModel @Inject constructor(
         tracker.track(
             CARD_READER_SOFTWARE_UPDATE_STARTED,
             hashMapOf(
-                KEY_SOFTWARE_UPDATE_TYPE to if (navArgs.requiredUpdate) REQUIRED_UPDATE else OPTIONAL_UPDATE,
-                KEY_ERROR_CONTEXT to this@CardReaderUpdateViewModel.javaClass.simpleName
+                KEY_SOFTWARE_UPDATE_TYPE to if (navArgs.requiredUpdate) REQUIRED_UPDATE else OPTIONAL_UPDATE
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -261,8 +261,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
             verify(tracker).track(
                 CARD_READER_SOFTWARE_UPDATE_STARTED,
                 hashMapOf(
-                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to REQUIRED_UPDATE,
-                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel"
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to REQUIRED_UPDATE
                 )
             )
         }
@@ -281,8 +280,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
             verify(tracker).track(
                 CARD_READER_SOFTWARE_UPDATE_STARTED,
                 hashMapOf(
-                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to OPTIONAL_UPDATE,
-                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel"
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to OPTIONAL_UPDATE
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -309,6 +309,50 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given user presses cancel, when optional update is shown, then failed event is tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            softwareStatus.value = Installing(0.5f)
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.onBackPressed()
+            (viewModel.viewStateData.value as UpdatingCancelingState).button.onActionClicked.invoke()
+
+            // THEN
+            verify(tracker).track(
+                CARD_READER_SOFTWARE_UPDATE_FAILED,
+                hashMapOf(
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to OPTIONAL_UPDATE,
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel",
+                    AnalyticsTracker.KEY_ERROR_DESC to "User manually cancelled the flow"
+                )
+            )
+        }
+
+    @Test
+    fun `given user presses cancel, when required update is shown, then failed event is tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            softwareStatus.value = Installing(0.5f)
+            val viewModel = createViewModel(requiredUpdate = true)
+
+            // WHEN
+            viewModel.onBackPressed()
+            (viewModel.viewStateData.value as UpdatingCancelingState).button.onActionClicked.invoke()
+
+            // THEN
+            verify(tracker).track(
+                CARD_READER_SOFTWARE_UPDATE_FAILED,
+                hashMapOf(
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to REQUIRED_UPDATE,
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel",
+                    AnalyticsTracker.KEY_ERROR_DESC to "User manually cancelled the flow"
+                )
+            )
+        }
+
+    @Test
     fun `given user presses back, when progress state shown, then dialog not dismissed`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.prefs.cardreader.update
 
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTWARE_UPDATE_STARTED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTWARE_UPDATE_FAILED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTWARE_UPDATE_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -29,11 +31,8 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
@@ -45,6 +44,10 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
         on { softwareUpdateStatus }.thenReturn(softwareStatus)
     }
     private val tracker: AnalyticsTrackerWrapper = mock()
+    companion object {
+        private const val REQUIRED_UPDATE = "Required"
+        private const val OPTIONAL_UPDATE = "Optional"
+    }
 
     @Test
     fun `given required update, when view model created, then installation not started`() =
@@ -184,7 +187,27 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given success status, when view model created, then success tracked`() =
+    fun `given success status for required update, when view model created, then success tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val status = Success
+
+            // WHEN
+            createViewModel(requiredUpdate = true)
+            softwareStatus.value = status
+
+            // THEN
+            verify(tracker).track(
+                CARD_READER_SOFTWARE_UPDATE_SUCCESS,
+                hashMapOf(
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to REQUIRED_UPDATE,
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel"
+                )
+            )
+        }
+
+    @Test
+    fun `given success status for optional update, when view model created, then success tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val status = Success
@@ -194,25 +217,94 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
             softwareStatus.value = status
 
             // THEN
-            verify(tracker).track(CARD_READER_SOFTWARE_UPDATE_SUCCESS)
+            verify(tracker).track(
+                CARD_READER_SOFTWARE_UPDATE_SUCCESS,
+                hashMapOf(
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to OPTIONAL_UPDATE,
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel"
+                )
+            )
         }
 
     @Test
-    fun `given failed status, when view model created, then failed tracked`() =
+    fun `given failed status for optional update, when view model created, then failed tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            val status = Failed(SoftwareUpdateStatusErrorType.Failed, "")
+            val status = Failed(SoftwareUpdateStatusErrorType.Failed, "Failed")
 
             // WHEN
             createViewModel()
             softwareStatus.value = status
 
             // THEN
-            verify(tracker, times(2)).track(
-                eq(CARD_READER_SOFTWARE_UPDATE_FAILED),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull()
+            verify(tracker).track(
+                CARD_READER_SOFTWARE_UPDATE_FAILED,
+                hashMapOf(
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to OPTIONAL_UPDATE,
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel",
+                    AnalyticsTracker.KEY_ERROR_DESC to status.message
+                )
+            )
+        }
+
+    @Test
+    fun `given required update started, when view model created, then started tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val status = InstallationStarted
+
+            // WHEN
+            createViewModel(requiredUpdate = true)
+            softwareStatus.value = status
+
+            // THEN
+            verify(tracker).track(
+                CARD_READER_SOFTWARE_UPDATE_STARTED,
+                hashMapOf(
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to REQUIRED_UPDATE,
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel"
+                )
+            )
+        }
+
+    @Test
+    fun `given optional update started, when view model created, then started tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val status = InstallationStarted
+
+            // WHEN
+            createViewModel()
+            softwareStatus.value = status
+
+            // THEN
+            verify(tracker).track(
+                CARD_READER_SOFTWARE_UPDATE_STARTED,
+                hashMapOf(
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to OPTIONAL_UPDATE,
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel"
+                )
+            )
+        }
+
+    @Test
+    fun `given failed status for required update, when view model created, then failed tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val status = Failed(SoftwareUpdateStatusErrorType.Failed, "")
+
+            // WHEN
+            createViewModel(requiredUpdate = true)
+            softwareStatus.value = status
+
+            // THEN
+            verify(tracker).track(
+                CARD_READER_SOFTWARE_UPDATE_FAILED,
+                hashMapOf(
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to REQUIRED_UPDATE,
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel",
+                    AnalyticsTracker.KEY_ERROR_DESC to status.message
+                )
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -200,8 +200,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
             verify(tracker).track(
                 CARD_READER_SOFTWARE_UPDATE_SUCCESS,
                 hashMapOf(
-                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to REQUIRED_UPDATE,
-                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel"
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to REQUIRED_UPDATE
                 )
             )
         }
@@ -220,8 +219,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
             verify(tracker).track(
                 CARD_READER_SOFTWARE_UPDATE_SUCCESS,
                 hashMapOf(
-                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to OPTIONAL_UPDATE,
-                    AnalyticsTracker.KEY_ERROR_CONTEXT to "CardReaderUpdateViewModel"
+                    AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to OPTIONAL_UPDATE
                 )
             )
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Track events related to a software update for Stripe's SDK v2

Closes: #4944 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds events related to a software update for Stripe's SDK v2. It contains 3 events which are as below.
1. `card_reader_software_update_started`
2. `card_reader_software_update_success`
3. `card_reader_software_update_failed`

All the above 3 events must contain a property called `software_update_type` which can be either `required` or `optional`
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Try to connect to the card reader from the settings -> In-person payments -> Manage Card Reader
    #### In case of Required update TC1
    1. If the required update starts while connecting. Monitor the logcat and make sure you see the `card_reader_software_update_started` event with a property type `software_update_type` set to `required`.
    2. After the required update completes successfully, make sure `card_reader_software_update_success` event is fired and contains a property type `software_update_type` set to `required`
    #### In case of Required update TC2
    1. If the required update starts while connecting. Monitor the logcat and make sure you see `card_reader_software_update_started` event with a property type `software_update_type` set to `required`.
    2. While the update is in progress. Press back and cancel the update. Make sure make sure `card_reader_software_update_failed` event is fired and contains a property type `software_update_type` set to `required`

    #### In case of Optional update TC1
    1. When clicked on the update button for an optional update. Monitor the logcat and make sure you see the `card_reader_software_update_started` event with a property type `software_update_type` set to `optional`.
    2. After the optional update completes successfully, make sure `card_reader_software_update_success` event is fired and contains a property type `software_update_type` set to `optional`.
    #### In case of Optional update TC2
    1. When clicked on the update button for an optional update. Monitor the logcat and make sure you see `card_reader_software_update_started` event with a property type `software_update_type` set to `optional`.
    2. While the update is in progress. Press back and cancel the update. Make sure make sure `card_reader_software_update_failed` event is fired and contains a property type `software_update_type` set to `optional`
   


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
