### PR TITLE
Exclude fluxC when importing login library

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -186,6 +186,7 @@ dependencies {
 
     implementation ("$gradle.ext.loginFlowBinaryPath:$wordPressLoginVersion") {
         exclude group: "org.wordpress", module: "utils"
+        exclude group: "org.wordpress", module: "fluxc"
     }
 
     implementation("com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:$aztecVersion") {


### PR DESCRIPTION
### Description
As we are using versions that don't follow sem versioning for FluxC, and start with letters instead of digits (for example `develop-{hash}`), this causes importing older versions of FluxC when importing the login library, for more details: p91TBi-61j-p2

This PR makes sure `FluxC` is not imported from the login library.