### PR TITLE
Update Product description hint text

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -61,6 +61,12 @@ class AztecEditorFragment :
         aztec = Aztec.with(binding.visualEditor, binding.sourceEditor, binding.aztecToolbar, this)
             .setImageGetter(GlideImageLoader(requireContext()))
 
+        if (navArgs.productTitle.isNullOrBlank()) {
+            aztec.visualEditor.setHint(R.string.product_description_hint_no_title)
+        } else {
+            aztec.visualEditor.hint = getString(R.string.product_description_hint_with_title, navArgs.productTitle)
+        }
+
         aztec.initSourceEditorHistory()
 
         aztec.visualEditor.fromHtml(navArgs.aztecText)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -496,6 +496,7 @@ class ProductDetailCardBuilder(
 
     private fun Product.description(): ProductProperty {
         val productDescription = this.description
+        val productTitle = this.name
         val showTitle = productDescription.isNotEmpty()
         val description = if (productDescription.isEmpty()) {
             resources.getString(string.product_description_empty)
@@ -510,7 +511,8 @@ class ProductDetailCardBuilder(
         ) {
             viewModel.onEditProductCardClicked(
                 ViewProductDescriptionEditor(
-                    productDescription, resources.getString(string.product_description)
+                    productDescription, resources.getString(string.product_description),
+                    productTitle
                 ),
                 PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -20,16 +20,20 @@ sealed class ProductNavigationTarget : Event() {
     data class ViewProductVariations(
         val remoteId: Long
     ) : ProductNavigationTarget()
+
     data class ViewProductInventory(
         val inventoryData: InventoryData,
         val sku: String,
         val productType: ProductType
     ) : ProductNavigationTarget()
+
     object ViewProductAttributes : ProductNavigationTarget()
     data class ViewProductPricing(val pricingData: PricingData) : ProductNavigationTarget()
     data class ViewProductShipping(val shippingData: ShippingData) : ProductNavigationTarget()
     data class ViewProductExternalLink(val remoteId: Long) : ProductNavigationTarget()
-    data class ViewProductDescriptionEditor(val description: String, val title: String) : ProductNavigationTarget()
+    data class ViewProductDescriptionEditor(val description: String, val title: String, val productTitle: String) :
+        ProductNavigationTarget()
+
     data class ViewProductPurchaseNoteEditor(
         val purchaseNote: String,
         val title: String,
@@ -38,21 +42,25 @@ sealed class ProductNavigationTarget : Event() {
 
     data class ViewProductShortDescriptionEditor(val shortDescription: String, val title: String) :
         ProductNavigationTarget()
+
     data class ViewProductImageGallery(
         val remoteId: Long,
         val images: List<Image>,
         val showChooser: Boolean = false,
         val selectedImage: Image? = null
     ) : ProductNavigationTarget()
+
     data class ViewMediaUploadErrors(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductSettings(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductStatus(val status: ProductStatus?) : ProductNavigationTarget()
     data class ViewProductCatalogVisibility(val catalogVisibility: ProductCatalogVisibility?, val isFeatured: Boolean) :
         ProductNavigationTarget()
+
     data class ViewProductVisibility(
         val visibility: ProductVisibility?,
         val password: String?
     ) : ProductNavigationTarget()
+
     data class ViewProductSlug(val slug: String) : ProductNavigationTarget()
     data class ViewProductMenuOrder(val menuOrder: Int) : ProductNavigationTarget()
     object ExitProduct : ProductNavigationTarget()
@@ -70,23 +78,27 @@ sealed class ProductNavigationTarget : Event() {
         val groupedProductType: GroupedProductListType,
         val excludedProductIds: List<Long>
     ) : ProductNavigationTarget()
+
     object ViewProductDownloads : ProductNavigationTarget()
     object ViewProductDownloadsSettings : ProductNavigationTarget()
     data class ViewProductDownloadDetails(
         val isEditing: Boolean,
         val file: ProductFile
     ) : ProductNavigationTarget()
+
     object ViewProductAddonsDetails : ProductNavigationTarget()
     object AddProductDownloadableFile : ProductNavigationTarget()
     data class AddProductAttribute(
         val isVariationCreation: Boolean = false
     ) : ProductNavigationTarget()
+
     data class AddProductAttributeTerms(
         val attributeId: Long,
         val attributeName: String,
         val isNewAttribute: Boolean,
         val isVariationCreation: Boolean
     ) : ProductNavigationTarget()
+
     data class RenameProductAttribute(
         val attributeName: String
     ) : ProductNavigationTarget()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -97,7 +97,8 @@ class ProductNavigator @Inject constructor() {
                         target.description,
                         target.title,
                         null,
-                        RequestCodes.AZTEC_EDITOR_PRODUCT_DESCRIPTION
+                        RequestCodes.AZTEC_EDITOR_PRODUCT_DESCRIPTION,
+                        target.productTitle
                     )
                 fragment.findNavController().navigateSafely(action)
             }

--- a/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
+++ b/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
@@ -46,7 +46,6 @@
                 style="@style/Woo.AztecText.VisualEditor"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:hint="@string/product_description_hint"
                 android:scrollbars="vertical" />
 
             <org.wordpress.aztec.source.SourceViewEditText
@@ -54,7 +53,6 @@
                 style="@style/Woo.AztecText.SourceEditor"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:hint="@string/product_description_hint"
                 android:scrollbars="vertical"
                 android:visibility="gone" />
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -26,7 +26,7 @@
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"/>
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
         <action
             android:id="@+id/action_productDetailFragment_to_productInventoryFragment"
             app:destination="@id/productInventoryFragment"
@@ -61,7 +61,7 @@
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"/>
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
         <action
             android:id="@+id/action_productDetailFragment_to_productTypesBottomSheetFragment"
             app:destination="@id/productTypesBottomSheetFragment"
@@ -122,7 +122,7 @@
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"/>
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <fragment
         android:id="@+id/variationListFragment"
@@ -171,7 +171,7 @@
             app:launchSingleTop="true"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right"
-            app:popUpTo="@id/productDetailFragment" >
+            app:popUpTo="@id/productDetailFragment">
             <argument
                 android:name="isVariationCreation"
                 android:defaultValue="false"
@@ -286,10 +286,10 @@
             app:destination="@id/productDetailFragment"
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
+            app:launchSingleTop="true"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right"
-            app:launchSingleTop="true"
-            app:popUpTo="@id/nav_graph_products"/>
+            app:popUpTo="@id/nav_graph_products" />
     </fragment>
     <fragment
         android:id="@+id/aztecEditorFragment"
@@ -312,6 +312,11 @@
             android:name="requestCode"
             android:defaultValue="0"
             app:argType="integer" />
+        <argument
+            android:name="productTitle"
+            android:defaultValue='""'
+            app:argType="string" />
+
     </fragment>
     <fragment
         android:id="@+id/productInventoryFragment"
@@ -328,8 +333,8 @@
             app:argType="string" />
         <argument
             android:name="productType"
-            app:argType="com.woocommerce.android.ui.products.ProductType"
-            android:defaultValue="SIMPLE" />
+            android:defaultValue="SIMPLE"
+            app:argType="com.woocommerce.android.ui.products.ProductType" />
     </fragment>
     <fragment
         android:id="@+id/editVariationAttributesFragment"
@@ -481,7 +486,7 @@
             app:argType="long[]" />
         <argument
             android:name="groupedProductListType"
-            app:argType="com.woocommerce.android.ui.products.GroupedProductListType"/>
+            app:argType="com.woocommerce.android.ui.products.GroupedProductListType" />
     </fragment>
     <fragment
         android:id="@+id/productSelectionListFragment"
@@ -493,7 +498,7 @@
             app:argType="long" />
         <argument
             android:name="groupedProductListType"
-            app:argType="com.woocommerce.android.ui.products.GroupedProductListType"/>
+            app:argType="com.woocommerce.android.ui.products.GroupedProductListType" />
         <argument
             android:name="excludedProductIds"
             app:argType="long[]" />
@@ -621,7 +626,7 @@
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"/>
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
         <action
             android:id="@+id/action_variationDetailFragment_to_productInventoryFragment"
             app:destination="@id/productInventoryFragment" />
@@ -658,7 +663,7 @@
     <fragment
         android:id="@+id/productAddonsFragment"
         android:name="com.woocommerce.android.ui.products.addons.product.ProductAddonsFragment"
-        android:label="ProductAddonsFragment"/>
+        android:label="ProductAddonsFragment" />
     <fragment
         android:id="@+id/productDownloadDetailsFragment"
         android:name="com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsFragment"
@@ -685,8 +690,8 @@
         <argument
             android:name="errorList"
             android:defaultValue="@null"
-            app:nullable="true"
-            app:argType="com.woocommerce.android.ui.media.MediaFileUploadHandler$ProductImageUploadData[]" />
+            app:argType="com.woocommerce.android.ui.media.MediaFileUploadHandler$ProductImageUploadData[]"
+            app:nullable="true" />
     </fragment>
     <dialog
         android:id="@+id/addProductDownloadBottomSheetFragment"
@@ -699,7 +704,7 @@
         app:enterAnim="@anim/activity_slide_in_from_right"
         app:exitAnim="@anim/activity_slide_out_to_left"
         app:popEnterAnim="@anim/activity_slide_in_from_left"
-        app:popExitAnim="@anim/activity_slide_out_to_right"/>
+        app:popExitAnim="@anim/activity_slide_out_to_right" />
     <action
         android:id="@+id/action_global_productDownloadDetailsFragment"
         app:destination="@id/productDownloadDetailsFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1053,7 +1053,8 @@
     <string name="product_variant_list_empty">Adding options like size and color is currently available only on the web. These will show up as options on the product page of your site.</string>
     <string name="product_variant_list_add_first_variation">Add your first variation</string>
     <string name="product_variant_list_empty_action">Add Variation</string>
-    <string name="product_description_hint">Start writing…</string>
+    <string name="product_description_hint_no_title">Describe your product to your future customers…</string>
+    <string name="product_description_hint_with_title">Tell us more about %s…</string>
     <string name="product_edit_description">Edit description</string>
     <string name="product_description">Description</string>
     <string name="product_description_empty">Describe your product</string>


### PR DESCRIPTION
Fixes #3580 

## Changes

The product description hint to give the user more context about the product they are editing. If the product has a title the hint will pull the product title and display it to let the customer know the description of which product they are editing. If it's a new product or the product does not have a title/name the hint is set to be more generic:

No title: “Describe your product to your future customers…”
With title: “Tell us more about [product title]…”

## Images/gif

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/136204203-90fe89f9-2c11-492a-ac50-15894a6720d1.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/136204171-b334629a-f2f6-46a8-a5aa-4cbbe5315bd0.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/136204203-90fe89f9-2c11-492a-ac50-15894a6720d1.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/136204282-8cfab5c4-7be8-41df-bb82-6ca066509b69.png" width="350"/> |


| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/136204397-103ec057-3ad0-4a88-9911-eb7b37eb9655.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/136204439-afc1c8cd-dfcc-4c27-8e5e-e6918b5376a4.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/136204397-103ec057-3ad0-4a88-9911-eb7b37eb9655.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/136204465-da7d7432-e410-4ad3-b749-4bd73d4dfbab.png" width="350"/> |


## Testing instructions

- Go to the products tab
- Open a product that has a title/name
- click on the Description field
- Note the description hint change

Also 

- Go to the products tab
- Create a new product or open a product that has not name/title 
- click on the Description field
- Note the description hint change

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
