### PR TITLE
Nick/order editing viewmodel p2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
@@ -48,6 +49,7 @@ import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentDialogFragm
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.OnShippingLabelClickListener
 import com.woocommerce.android.ui.orders.details.editing.BaseOrderEditFragment
+import com.woocommerce.android.ui.orders.details.editing.OrderEditingViewModel
 import com.woocommerce.android.ui.orders.fulfill.OrderFulfillViewModel
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
 import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelFragment
@@ -72,6 +74,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
     }
 
     private val viewModel: OrderDetailViewModel by viewModels()
+    private val orderEditingViewModel by hiltNavGraphViewModels<OrderEditingViewModel>(R.id.nav_graph_orders)
 
     @Inject lateinit var navigator: OrderNavigator
     @Inject lateinit var currencyFormatter: CurrencyFormatter
@@ -113,6 +116,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
 
         setHasOptionsMenu(true)
         setupObservers(viewModel)
+        setupOrderEditingObservers(orderEditingViewModel)
         setupResultHandlers(viewModel)
 
         binding.orderRefreshLayout.apply {
@@ -219,6 +223,14 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             }
         )
         viewModel.start()
+    }
+
+    private fun setupOrderEditingObservers(orderEditingViewModel: OrderEditingViewModel) {
+        orderEditingViewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
+            if (new.orderEditingFailed == true) {
+                viewModel.onOrderEditFailed()
+            }
+        }
     }
 
     private fun setupResultHandlers(viewModel: OrderDetailViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -249,6 +249,10 @@ class OrderDetailViewModel @Inject constructor(
         reloadOrderDetails()
     }
 
+    fun onOrderEditFailed() {
+        triggerEvent(ShowSnackbar(string.order_error_update_general))
+    }
+
     private fun loadReceiptUrl(): String? {
         return selectedSite.getIfExists()?.let {
             appPrefs.getReceiptUrl(it.id, it.siteId, it.selfHostedSiteId, order.remoteId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -245,11 +245,20 @@ class OrderDetailViewModel @Inject constructor(
         triggerEvent(ViewPrintingInstructions)
     }
 
+    /**
+     * This is triggered when the user taps "Done" on any of the order editing fragments - assumes that FluxC
+     * immediately updated the order in the database before the network request was sent
+     */
     fun onOrderEdited() {
         reloadOrderDetails()
     }
 
+    /**
+     * This is triggered when the above network request to edit an order fails - assumes that FluxC restored the
+     * original order in the database upon failure
+     */
     fun onOrderEditFailed() {
+        reloadOrderDetails()
         triggerEvent(ShowSnackbar(string.order_error_update_general))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
@@ -19,7 +19,8 @@ class OrderEditingRepository @Inject constructor(
     suspend fun updateCustomerOrderNote(
         order: Order,
         customerOrderNote: String
-    ) {
+    ): Boolean {
         // TODO push changes once FluxC work is ready
+        return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.delay
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
@@ -20,7 +21,8 @@ class OrderEditingRepository @Inject constructor(
         order: Order,
         customerOrderNote: String
     ): Boolean {
-        // TODO push changes once FluxC work is ready
+        // TODO remove delay and push changes once FluxC work is ready
+        delay(2500)
         return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
@@ -17,6 +17,7 @@ class OrderEditingRepository @Inject constructor(
 ) {
     fun getOrder(orderIdentifier: OrderIdentifier) = orderStore.getOrderByIdentifier(orderIdentifier)!!.toAppModel()
 
+    @Suppress("MagicNumber")
     suspend fun updateCustomerOrderNote(
         order: Order,
         customerOrderNote: String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -1,13 +1,18 @@
 package com.woocommerce.android.ui.orders.details.editing
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentArgs
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,6 +23,9 @@ class OrderEditingViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs by savedState.navArgs<OrderDetailFragmentArgs>()
     private val order: Order
+
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
+    private var viewState by viewStateData
 
     private val orderIdentifier: String
         get() = navArgs.orderId
@@ -31,7 +39,16 @@ class OrderEditingViewModel @Inject constructor(
 
     fun updateCustomerOrderNote(updatedCustomerOrderNote: String) {
         launch(dispatchers.io) {
-            orderEditingRepository.updateCustomerOrderNote(order, updatedCustomerOrderNote)
+            if (!orderEditingRepository.updateCustomerOrderNote(order, updatedCustomerOrderNote)) {
+                withContext(Dispatchers.Main) {
+                    viewState = viewState.copy(orderEditingFailed = true)
+                }
+            }
         }
     }
+
+    @Parcelize
+    data class ViewState(
+        val orderEditingFailed: Boolean? = null
+    ) : Parcelable
 }


### PR DESCRIPTION
This is the second PR related to the shared order editing ViewModel.

The purpose of this PR is to detect when the request to update an order failed, and communicate that failure back to `OrderDetailViewModel`. This required observing `OrderEditingViewModel` in the order detail fragment, which feels a bit odd since that fragment now has two ViewModels.

Another way to achieve this would be to have `OrderDetailViewModel` send the request to update the order, but I'd rather not further complicate that ViewModel. Any other ideas welcome!

