### PR TITLE
Jetpack CP: show empty visitor stats

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
@@ -11,7 +11,6 @@ interface MyStoreContract {
         fun loadStats(granularity: StatsGranularity, forced: Boolean = false)
         fun getStatsCurrency(): String?
         fun getSelectedSiteName(): String?
-        suspend fun fetchTopPerformersStats(granularity: StatsGranularity, forced: Boolean)
         suspend fun loadTopPerformersStats(granularity: StatsGranularity, forced: Boolean = false)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
@@ -10,8 +10,6 @@ interface MyStoreContract {
     interface Presenter : BasePresenter<View> {
         fun loadStats(granularity: StatsGranularity, forced: Boolean = false)
         fun getStatsCurrency(): String?
-        fun fetchHasOrders()
-        fun fetchVisitorStats(granularity: StatsGranularity, forced: Boolean)
         fun getSelectedSiteName(): String?
         suspend fun fetchTopPerformersStats(granularity: StatsGranularity, forced: Boolean)
         suspend fun loadTopPerformersStats(granularity: StatsGranularity, forced: Boolean = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
@@ -29,6 +29,7 @@ interface MyStoreContract {
         fun showTopPerformersError(granularity: StatsGranularity)
         fun showVisitorStats(visitorStats: Map<String, Int>, granularity: StatsGranularity)
         fun showVisitorStatsError(granularity: StatsGranularity)
+        fun showEmptyVisitorStatsForJetpackCP()
         fun showErrorSnack()
         fun showEmptyView(show: Boolean)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
@@ -11,7 +11,6 @@ interface MyStoreContract {
         fun loadStats(granularity: StatsGranularity, forced: Boolean = false)
         fun getStatsCurrency(): String?
         fun fetchHasOrders()
-        fun fetchRevenueStats(granularity: StatsGranularity, forced: Boolean)
         fun fetchVisitorStats(granularity: StatsGranularity, forced: Boolean)
         fun getSelectedSiteName(): String?
         suspend fun fetchTopPerformersStats(granularity: StatsGranularity, forced: Boolean)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -282,6 +282,10 @@ class MyStoreFragment :
         }
     }
 
+    override fun showEmptyVisitorStatsForJetpackCP() {
+        binding.myStoreStats.showEmptyVisitorStatsForJetpackCP()
+    }
+
     override fun showErrorSnack() {
         if (errorSnackbar?.isShownOrQueued == false || NetworkUtils.isNetworkAvailable(context)) {
             errorSnackbar = uiMessageResolver.getSnack(R.string.dashboard_stats_error)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -311,6 +311,9 @@ class MyStoreFragment :
         }
         presenter.run {
             loadStats(activeGranularity, forced)
+            coroutineScope.launch {
+                presenter.loadTopPerformersStats(activeGranularity, forced)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -312,7 +312,6 @@ class MyStoreFragment :
         presenter.run {
             loadStats(activeGranularity, forced)
             coroutineScope.launch { loadTopPerformersStats(activeGranularity, forced) }
-            fetchHasOrders()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -311,7 +311,6 @@ class MyStoreFragment :
         }
         presenter.run {
             loadStats(activeGranularity, forced)
-            coroutineScope.launch { loadTopPerformersStats(activeGranularity, forced) }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -32,7 +32,6 @@ class MyStorePresenter @Inject constructor(
     private val networkStatus: NetworkStatus
 ) : Presenter {
     companion object {
-        private val TAG = MyStorePresenter::class.java
         private const val NUM_TOP_PERFORMERS = 3
         private val statsForceRefresh = BooleanArray(StatsGranularity.values().size)
         private val topPerformersForceRefresh = BooleanArray(StatsGranularity.values().size)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -120,7 +120,6 @@ class MyStorePresenter @Inject constructor(
                         myStoreView?.showEmptyVisitorStatsForJetpackCP()
                     }
                 }
-
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -9,18 +9,21 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.MyStoreContract.Presenter
 import com.woocommerce.android.ui.mystore.MyStoreContract.View
+import com.woocommerce.android.ui.mystore.StatsRepository.StatsException
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.DASHBOARD
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_NEW_VISITOR_STATS
-import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.leaderboards.WCTopPerformerProductModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCLeaderboardsStore
@@ -28,12 +31,8 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCStatsStore
-import org.wordpress.android.fluxc.store.WCStatsStore.FetchNewVisitorStatsPayload
-import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
-import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
-import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.*
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.PLUGIN_NOT_ACTIVE
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
@@ -42,6 +41,7 @@ class MyStorePresenter @Inject constructor(
     private val wooCommerceStore: WooCommerceStore, // Required to ensure the WooCommerceStore is initialized!
     private val wcLeaderboardsStore: WCLeaderboardsStore,
     private val wcStatsStore: WCStatsStore,
+    private val statsRepository: StatsRepository,
     @Suppress("UnusedPrivateMember", "Required to ensure the WCOrderStore is initialized!")
     private val wcOrderStore: WCOrderStore,
     private val selectedSite: SelectedSite,
@@ -75,12 +75,14 @@ class MyStorePresenter @Inject constructor(
 
     override fun takeView(view: View) {
         myStoreView = view
+        statsRepository.init()
         dispatcher.register(this)
         ConnectionChangeReceiver.getEventBus().register(this)
     }
 
     override fun dropView() {
         myStoreView = null
+        statsRepository.onCleanup()
         dispatcher.unregister(this)
         ConnectionChangeReceiver.getEventBus().unregister(this)
     }
@@ -97,11 +99,17 @@ class MyStorePresenter @Inject constructor(
             myStoreView?.showChartSkeleton(true)
         }
 
-        // fetch revenue stats
-        fetchRevenueStats(granularity, forceRefresh)
+        coroutineScope.launch {
+            // fetch revenue stats
+            val revenueStatsTask = async {
+                statsRepository.fetchRevenueStats(granularity, forced)
+            }
 
-        // fetch visitor stats
-        fetchVisitorStats(granularity, forceRefresh)
+            // fetch visitor stats
+            fetchVisitorStats(granularity, forceRefresh)
+
+            handleRevenueStatsResult(granularity, revenueStatsTask.await())
+        }
     }
 
     override suspend fun loadTopPerformersStats(
@@ -123,9 +131,30 @@ class MyStorePresenter @Inject constructor(
         fetchTopPerformersStats(granularity, forceRefresh)
     }
 
-    override fun fetchRevenueStats(granularity: StatsGranularity, forced: Boolean) {
-        val statsPayload = FetchRevenueStatsPayload(selectedSite.get(), granularity, forced = forced)
-        dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(statsPayload))
+    private fun handleRevenueStatsResult(granularity: StatsGranularity, result: Result<WCRevenueStatsModel?>) {
+        myStoreView?.showChartSkeleton(false)
+        result.fold(
+            onSuccess = { stats ->
+                // Track fresh data load
+                AnalyticsTracker.track(
+                    Stat.DASHBOARD_MAIN_STATS_LOADED,
+                    mapOf(AnalyticsTracker.KEY_RANGE to granularity.name.toLowerCase())
+                )
+
+                AppPrefs.setV4StatsSupported(true)
+                myStoreView?.showStats(stats, granularity)
+            },
+            onFailure = {
+                // display a different error snackbar if the error type is not "plugin not active", since
+                // this error is already being handled by the activity class
+                if ((it as? StatsException)?.error?.type == PLUGIN_NOT_ACTIVE) {
+                    AppPrefs.setV4StatsSupported(false)
+                    myStoreView?.updateStatsAvailabilityError()
+                } else {
+                    myStoreView?.showStatsError(granularity)
+                }
+            }
+        )
     }
 
     override fun fetchVisitorStats(granularity: StatsGranularity, forced: Boolean) {
@@ -191,40 +220,6 @@ class MyStorePresenter @Inject constructor(
     override fun fetchHasOrders() {
         val payload = FetchHasOrdersPayload(selectedSite.get())
         dispatcher.dispatch(WCOrderActionBuilder.newFetchHasOrdersAction(payload))
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onWCRevenueStatsChanged(event: OnWCRevenueStatsChanged) {
-        when (event.causeOfChange) {
-            FETCH_REVENUE_STATS -> {
-                myStoreView?.showChartSkeleton(false)
-                if (event.isError) {
-                    WooLog.e(DASHBOARD, "$TAG - Error fetching stats: ${event.error.message}")
-                    // display a different error snackbar if the error type is not "plugin not active", since
-                    // this error is already being handled by the activity class
-                    if (event.error.type == PLUGIN_NOT_ACTIVE) {
-                        AppPrefs.setV4StatsSupported(false)
-                        myStoreView?.updateStatsAvailabilityError()
-                    } else {
-                        myStoreView?.showStatsError(event.granularity)
-                    }
-                    return
-                }
-
-                // Track fresh data load
-                AnalyticsTracker.track(
-                    Stat.DASHBOARD_MAIN_STATS_LOADED,
-                    mapOf(AnalyticsTracker.KEY_RANGE to event.granularity.name.toLowerCase())
-                )
-
-                AppPrefs.setV4StatsSupported(true)
-                val revenueStatsModel = wcStatsStore.getRawRevenueStats(
-                    selectedSite.get(), event.granularity, event.startDate!!, event.endDate!!
-                )
-                myStoreView?.showStats(revenueStatsModel, event.granularity)
-            }
-        }
     }
 
     @Suppress("unused")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -32,7 +32,7 @@ class MyStorePresenter @Inject constructor(
     private val networkStatus: NetworkStatus
 ) : Presenter {
     companion object {
-        private const val NUM_TOP_PERFORMERS = 3
+        const val NUM_TOP_PERFORMERS = 3
         private val statsForceRefresh = BooleanArray(StatsGranularity.values().size)
         private val topPerformersForceRefresh = BooleanArray(StatsGranularity.values().size)
 
@@ -98,11 +98,6 @@ class MyStorePresenter @Inject constructor(
                 statsRepository.fetchVisitorStats(granularity, forced)
             }
 
-            // fetch top performers
-            val topPerformersTask = async {
-                loadTopPerformersStats(granularity, forced)
-            }
-
             val storeHasNoOrders = hasNoOrdersTask.await().getOrNull()
             if (storeHasNoOrders == true) {
                 myStoreView?.showEmptyView(true)
@@ -112,7 +107,6 @@ class MyStorePresenter @Inject constructor(
                 val visitorStatsResult = visitorStatsTask.await()
                 handleRevenueStatsResult(granularity, revenueStatsResult)
                 handleVisitorStatsResults(granularity, visitorStatsResult)
-                topPerformersTask.await()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -333,6 +333,11 @@ class MyStoreStatsView @JvmOverloads constructor(
         if (visitorsLayout.visibility == View.GONE) {
             WooAnimUtils.fadeIn(visitorsLayout)
         }
+
+        // Make sure the empty view is hidden
+        binding.statsViewRow.emptyVisitorStatsGroup.isVisible = false
+        binding.statsViewRow.visitorsValue.isVisible = true
+
         fadeInLabelValue(visitorsValue, visitorStats.values.sum().toString())
     }
 
@@ -340,6 +345,12 @@ class MyStoreStatsView @JvmOverloads constructor(
         if (visitorsLayout.visibility == View.VISIBLE) {
             WooAnimUtils.fadeOut(visitorsLayout)
         }
+    }
+
+    fun showEmptyVisitorStatsForJetpackCP() {
+        visitorsLayout.isVisible = true
+        binding.statsViewRow.emptyVisitorStatsGroup.isVisible = true
+        binding.statsViewRow.visitorsValue.isVisible = false
     }
 
     fun clearLabelValues() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/StatsRepository.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.mystore
 
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.mystore.MyStorePresenter.Companion
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Success
@@ -17,7 +16,6 @@ import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.leaderboards.WCTopPerformerProductModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCLeaderboardsStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
@@ -74,7 +72,7 @@ class StatsRepository @Inject constructor(
         }
     }
 
-    suspend fun fetchProductLeaderboards(granularity: StatsGranularity, quantity: Int, forced: Boolean): WooResult<List<WCTopPerformerProductModel>> {
+    suspend fun fetchProductLeaderboards(granularity: StatsGranularity, quantity: Int, forced: Boolean): Result<List<WCTopPerformerProductModel>> {
         return when (forced) {
             true -> wcLeaderboardsStore.fetchProductLeaderboards(
                 site = selectedSite.get(),
@@ -85,6 +83,13 @@ class StatsRepository @Inject constructor(
                 site = selectedSite.get(),
                 unit = granularity
             )
+        }.let { result ->
+            val model = result.model
+            if (result.isError || model == null) {
+                Result.failure(Exception(result.error?.message.orEmpty()))
+            } else {
+                Result.success(model)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/StatsRepository.kt
@@ -72,7 +72,8 @@ class StatsRepository @Inject constructor(
         }
     }
 
-    suspend fun fetchProductLeaderboards(granularity: StatsGranularity, quantity: Int, forced: Boolean): Result<List<WCTopPerformerProductModel>> {
+    suspend fun fetchProductLeaderboards(granularity: StatsGranularity, quantity: Int, forced: Boolean):
+        Result<List<WCTopPerformerProductModel>> {
         return when (forced) {
             true -> wcLeaderboardsStore.fetchProductLeaderboards(
                 site = selectedSite.get(),
@@ -152,7 +153,7 @@ class StatsRepository @Inject constructor(
                     DASHBOARD,
                     "$TAG - Error fetching whether orders exist: ${event.error.message}"
                 )
-                continuationHasOrders.continueWith(Result.failure(Exception()))
+                continuationHasOrders.continueWith(Result.failure(Exception(event.error.message)))
             } else {
                 val hasNoOrders = event.rowsAffected == 0
                 continuationHasOrders.continueWith(Result.success(hasNoOrders))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/StatsRepository.kt
@@ -16,6 +16,10 @@ import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.model.leaderboards.WCTopPerformerProductModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WCLeaderboardsStore
+import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCStatsStore
@@ -25,7 +29,10 @@ import javax.inject.Inject
 class StatsRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val dispatcher: Dispatcher,
-    private val wcStatsStore: WCStatsStore
+    private val wcStatsStore: WCStatsStore,
+    @Suppress("UnusedPrivateMember", "Required to ensure the WCOrderStore is initialized!")
+    private val wcOrderStore: WCOrderStore,
+    private val wcLeaderboardsStore: WCLeaderboardsStore
 ) {
     companion object {
         private val TAG = MyStorePresenter::class.java
@@ -64,6 +71,20 @@ class StatsRepository @Inject constructor(
         return when (result) {
             is Cancellation -> Result.failure(result.exception)
             is Success -> result.value
+        }
+    }
+
+    suspend fun fetchProductLeaderboards(granularity: StatsGranularity, quantity: Int, forced: Boolean): WooResult<List<WCTopPerformerProductModel>> {
+        return when (forced) {
+            true -> wcLeaderboardsStore.fetchProductLeaderboards(
+                site = selectedSite.get(),
+                unit = granularity,
+                quantity = quantity
+            )
+            false -> wcLeaderboardsStore.fetchCachedProductLeaderboards(
+                site = selectedSite.get(),
+                unit = granularity
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/StatsRepository.kt
@@ -1,0 +1,75 @@
+package com.woocommerce.android.ui.mystore
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.ContinuationWrapper
+import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
+import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Success
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.DASHBOARD
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS
+import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.store.WCStatsStore
+import org.wordpress.android.fluxc.store.WCStatsStore.*
+import javax.inject.Inject
+
+class StatsRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val dispatcher: Dispatcher,
+    private val wcStatsStore: WCStatsStore
+) {
+    companion object {
+        private val TAG = MyStorePresenter::class.java
+    }
+
+    private var continuationRevenueStats = ContinuationWrapper<Result<WCRevenueStatsModel?>>(DASHBOARD)
+
+    fun init() {
+        dispatcher.register(this)
+    }
+
+    fun onCleanup() {
+        dispatcher.unregister(this)
+    }
+
+    suspend fun fetchRevenueStats(
+        granularity: StatsGranularity,
+        forced: Boolean
+    ): Result<WCRevenueStatsModel?> {
+        val result =  continuationRevenueStats.callAndWait {
+            val statsPayload = FetchRevenueStatsPayload(selectedSite.get(), granularity, forced = forced)
+            dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(statsPayload))
+        }
+
+        return when(result) {
+            is Cancellation -> Result.failure(result.exception)
+            is Success -> result.value
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCRevenueStatsChanged(event: OnWCRevenueStatsChanged) {
+        if (event.causeOfChange == FETCH_REVENUE_STATS) {
+            if (event.isError) {
+                WooLog.e(DASHBOARD, "$TAG - Error fetching stats: ${event.error.message}")
+                // display a different error snackbar if the error type is not "plugin not active", since
+                // this error is already being handled by the activity class
+                val exception = StatsException(
+                    error = event.error
+                )
+                continuationRevenueStats.continueWith(Result.failure(exception))
+            } else {
+                val revenueStatsModel = wcStatsStore.getRawRevenueStats(
+                    selectedSite.get(), event.granularity, event.startDate!!, event.endDate!!
+                )
+                continuationRevenueStats.continueWith(Result.success(revenueStatsModel))
+            }
+        }
+    }
+
+    data class StatsException(val error: OrderStatsError): Exception()
+}

--- a/WooCommerce/src/main/res/drawable/ic_jetpack_logo.xml
+++ b/WooCommerce/src/main/res/drawable/ic_jetpack_logo.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+  <path
+      android:pathData="M7,7m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"
+      android:fillColor="#55BB43"/>
+  <path
+      android:pathData="M7.3943,12.6V5.8186H10.8873L7.3943,12.6ZM6.6929,8.1579H3.1998L6.6929,1.375V8.1579Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
@@ -1,41 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/label_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:baselineAligned="false"
     android:layout_marginTop="@dimen/major_100"
+    android:baselineAligned="false"
     android:gravity="center_horizontal"
     android:orientation="horizontal">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/visitors_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:gravity="center_horizontal"
-        android:orientation="vertical">
+        android:layout_weight="1">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/visitors_label"
-            android:textAppearance="?attr/textAppearanceCaption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
             android:text="@string/dashboard_stats_visitors"
-            tools:text="Visitors"/>
+            android:textAppearance="?attr/textAppearanceCaption"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Visitors" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/visitors_value"
-            android:textAppearance="?attr/textAppearanceHeadline5"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            tools:text="400"/>
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/visitors_label"
+            tools:text="400" />
 
-    </LinearLayout>
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/empty_visitor_stats_group"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:constraint_referenced_ids="empty_visitor_stats_indicator, jetpack_icon" />
+
+        <View
+            android:id="@+id/empty_visitor_stats_indicator"
+            android:layout_width="@dimen/major_200"
+            android:layout_height="@dimen/minor_100"
+            android:layout_gravity="center"
+            android:background="@color/skeleton_color"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/jetpack_icon" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/jetpack_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_50"
+            android:src="@drawable/ic_jetpack_logo"
+            app:layout_constraintStart_toEndOf="@id/empty_visitor_stats_indicator"
+            app:layout_constraintTop_toBottomOf="@id/visitors_label" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
         android:id="@+id/orders_layout"
@@ -47,20 +77,20 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/orders_label"
-            android:textAppearance="?attr/textAppearanceCaption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
             android:text="@string/dashboard_stats_orders"
-            tools:text="Orders"/>
+            android:textAppearance="?attr/textAppearanceCaption"
+            tools:text="Orders" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/orders_value"
-            android:textAppearance="?attr/textAppearanceHeadline5"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            tools:text="10"/>
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            tools:text="10" />
 
     </LinearLayout>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.PLUGIN
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.WooCommerceStore
 
-class MyStorePresenterTest: BaseUnitTest() {
+class MyStorePresenterTest : BaseUnitTest() {
     private val myStoreView: MyStoreContract.View = mock()
     private val dispatcher: Dispatcher = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
@@ -196,9 +196,10 @@ class MyStorePresenterTest: BaseUnitTest() {
     @Test
     fun `give the site is using jetpack cp, when the stats are loaded, then show an empty view for visitor stats`() =
         testBlocking {
-            whenever(selectedSite.getIfExists()).thenReturn(SiteModel().apply {
+            val site = SiteModel().apply {
                 setIsJetpackCPConnected(true)
-            })
+            }
+            whenever(selectedSite.getIfExists()).thenReturn(site)
 
             presenter.takeView(myStoreView)
             presenter.loadStats(DAYS)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
@@ -2,60 +2,38 @@ package com.woocommerce.android.ui.mystore
 
 import android.content.Context
 import android.content.SharedPreferences
-import org.mockito.kotlin.KArgumentCaptor
-import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.spy
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.mystore.StatsRepository.StatsException
+import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.setMain
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
-import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
-import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
-import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_NEW_VISITOR_STATS
-import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS
 import org.wordpress.android.fluxc.annotations.action.Action
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.leaderboards.WCTopPerformerProductModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.store.WCLeaderboardsStore
-import org.wordpress.android.fluxc.store.WCOrderStore
-import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
-import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
-import org.wordpress.android.fluxc.store.WCStatsStore
-import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
-import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
-import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
-import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.PLUGIN_NOT_ACTIVE
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import kotlin.test.assertEquals
 
-class MyStorePresenterTest {
+class MyStorePresenterTest: BaseUnitTest() {
     private val myStoreView: MyStoreContract.View = mock()
     private val dispatcher: Dispatcher = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
-    private val wcLeaderboardsStore: WCLeaderboardsStore = mock()
-    private val wcStatsStore: WCStatsStore = mock()
-    private val wcOrderStore: WCOrderStore = mock()
     private val selectedSite: SelectedSite = mock()
+    private val statsRepository: StatsRepository = mock {
+        onBlocking { it.fetchProductLeaderboards(any(), any(), any()) } doReturn Result.success(emptyList())
+        onBlocking { it.fetchRevenueStats(any(), any()) } doReturn Result.success(WCRevenueStatsModel())
+        onBlocking { it.fetchVisitorStats(any(), any()) } doReturn Result.success(emptyMap())
+        onBlocking { it.checkIfStoreHasNoOrders() } doReturn Result.success(false)
+    }
+
     private val networkStatus: NetworkStatus = mock()
 
     private lateinit var presenter: MyStorePresenter
@@ -69,16 +47,13 @@ class MyStorePresenterTest {
             MyStorePresenter(
                 dispatcher,
                 wooCommerceStore,
-                wcLeaderboardsStore,
-                wcStatsStore,
-                wcOrderStore,
+                statsRepository,
                 selectedSite,
                 networkStatus
             )
         )
 
         // Use a dummy selected site
-        doReturn(SiteModel()).whenever(selectedSite).get()
         doReturn(true).whenever(networkStatus).isConnected()
         actionCaptor = argumentCaptor()
         Dispatchers.setMain(Dispatchers.Unconfined)
@@ -93,79 +68,47 @@ class MyStorePresenterTest {
     }
 
     @Test
-    fun `Requests revenue stats data correctly`() {
-        presenter.takeView(myStoreView)
-        presenter.loadStats(StatsGranularity.DAYS)
-
-        // note that we expect two dispatches because there's one to get stats and another to get visitors
-        verify(dispatcher, times(2)).dispatch(actionCaptor.capture())
-        assertEquals(FETCH_REVENUE_STATS, actionCaptor.firstValue.type)
-
-        val payload = actionCaptor.firstValue.payload as FetchRevenueStatsPayload
-        assertEquals(StatsGranularity.DAYS, payload.granularity)
-    }
-
-    @Test
-    fun `Handles stats OnChanged result correctly`() {
-        presenter.takeView(myStoreView)
-
-        // Simulate OnChanged event from FluxC
-        val onChanged = OnWCRevenueStatsChanged(
-            1, StatsGranularity.DAYS, "2019-07-30", "2019-07-30"
+    fun `when the stats screen loads, then fetch the revenue stats`() = testBlocking {
+        whenever(statsRepository.fetchRevenueStats(any(), any())).thenReturn(
+            Result.success(WCRevenueStatsModel())
         )
-        onChanged.causeOfChange = FETCH_REVENUE_STATS
-        presenter.onWCRevenueStatsChanged(onChanged)
+        presenter.takeView(myStoreView)
+        presenter.loadStats(DAYS)
 
-        verify(myStoreView).showStats(anyOrNull(), eq(StatsGranularity.DAYS))
+        verify(statsRepository).fetchRevenueStats(DAYS, false)
+
+        verify(myStoreView).showStats(anyOrNull(), eq(DAYS))
     }
 
     @Test
-    fun `Handles stats OnChanged error result correctly`() {
-        presenter.takeView(myStoreView)
-
-        // Simulate OnChanged event from FluxC
-        val onChanged = OnWCRevenueStatsChanged(1, granularity = DAYS).apply {
-            causeOfChange = FETCH_REVENUE_STATS
-            error = OrderStatsError(OrderStatsErrorType.INVALID_PARAM)
-        }
-        presenter.onWCRevenueStatsChanged(onChanged)
-        verify(myStoreView, times(1)).showStatsError(StatsGranularity.DAYS)
-    }
-
-    @Test
-    fun `Handles FETCH-ORDERS order event correctly`() {
-        presenter.takeView(myStoreView)
-
-        // Simulate onOrderChanged event: FETCH-ORDERS - My Store TAB should refresh
-        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDERS })
-        verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
-    }
-
-    @Test
-    fun `Handles UPDATE-ORDER-STATUS order event correctly`() {
-        presenter.takeView(myStoreView)
-
-        // Simulate onOrderChanged event: UPDATE-ORDER-STATUS - My Store TAB should refresh
-        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = UPDATE_ORDER_STATUS })
-        verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
-    }
-
-    @Test
-    fun `Handles FETCH-ORDERS order event with error correctly`() {
-        presenter.takeView(myStoreView)
-
-        // Simulate onOrderChanged event: FETCH-ORDERS w/error - My Store TAB should ignore
-        presenter.onOrderChanged(
-            OnOrderChanged(0).apply {
-                causeOfChange = FETCH_ORDERS
-                error = OrderError()
-            }
+    fun `when fetching the stats revenue fails, then show an error`() = testBlocking {
+        whenever(statsRepository.fetchRevenueStats(any(), any())).thenReturn(
+            Result.failure(Exception())
         )
-        verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
+
+        presenter.takeView(myStoreView)
+        presenter.loadStats(DAYS)
+
+        verify(myStoreView, times(1)).showStatsError(DAYS)
     }
 
     @Test
-    fun `Refreshes my store on network connected event if needed`() {
+    fun `when v4 stats are not available, then show appropriate error`() = testBlocking {
+        whenever(statsRepository.fetchRevenueStats(any(), any())).thenReturn(
+            Result.failure(
+                StatsException(
+                    error = OrderStatsError(type = PLUGIN_NOT_ACTIVE)
+                )
+            )
+        )
+        presenter.takeView(myStoreView)
+        presenter.loadStats(DAYS)
+
+        verify(myStoreView).updateStatsAvailabilityError()
+    }
+
+    @Test
+    fun `given there is a pending refresh, when connection is restored, then refresh my store`() {
         presenter.takeView(myStoreView)
         doReturn(true).whenever(myStoreView).isRefreshPending
 
@@ -175,7 +118,7 @@ class MyStorePresenterTest {
     }
 
     @Test
-    fun `Does not refresh my store on network connected event if not needed`() {
+    fun `given there is a pending refresh, when connection is restored, then don't refresh my store`() {
         presenter.takeView(myStoreView)
         doReturn(false).whenever(myStoreView).isRefreshPending
 
@@ -185,7 +128,7 @@ class MyStorePresenterTest {
     }
 
     @Test
-    fun `Ignores network disconnected event correctly`() {
+    fun `when network is disconnected, then ignore the event`() {
         presenter.takeView(myStoreView)
 
         // Simulate the network disconnected event
@@ -194,139 +137,98 @@ class MyStorePresenterTest {
     }
 
     @Test
-    fun `Requests top performers stats data correctly - forced`() {
-        runBlocking {
-            whenever(
-                wcLeaderboardsStore.fetchProductLeaderboards(
-                    site = selectedSite.get(),
-                    unit = DAYS,
-                    quantity = 3
-                )
-            )
-                .thenReturn(WooResult(emptyList()))
-
-            presenter.takeView(myStoreView)
-            presenter.loadTopPerformersStats(StatsGranularity.DAYS, true)
-            verify(wcLeaderboardsStore, times(1))
-                .fetchProductLeaderboards(
-                    site = selectedSite.get(),
-                    unit = DAYS,
-                    quantity = 3
-                )
-            verify(wcLeaderboardsStore, times(0))
-                .fetchCachedProductLeaderboards(selectedSite.get(), DAYS)
-        }
-    }
-
-    @Test
-    fun `Requests top performers stats data correctly - not forced`() {
-        runBlocking {
-            whenever(
-                wcLeaderboardsStore.fetchProductLeaderboards(
-                    site = selectedSite.get(),
-                    unit = DAYS,
-                    quantity = 3
-                )
-            )
-                .thenReturn(WooResult(emptyList()))
-            presenter.takeView(myStoreView)
-            presenter.loadTopPerformersStats(StatsGranularity.DAYS, false)
-            verify(wcLeaderboardsStore, times(1))
-                .fetchProductLeaderboards(
-                    site = selectedSite.get(),
-                    unit = DAYS,
-                    quantity = 3
-                )
-            verify(wcLeaderboardsStore, times(0))
-                .fetchCachedProductLeaderboards(selectedSite.get(), DAYS)
-        }
-    }
-
-    @Test
-    fun `Handles FETCH_TOP_EARNERS_STATS event correctly`() {
+    fun `when loading top performers, then show their data`() = testBlocking {
         presenter.takeView(myStoreView)
+        presenter.loadTopPerformersStats(DAYS, false)
 
-        val topPerformers = ArrayList<WCTopPerformerProductModel>()
-        topPerformers.add(WCTopPerformerProductModel())
-        presenter.onWCTopPerformersChanged(topPerformers, DAYS)
-        verify(myStoreView, times(1)).showTopPerformers(topPerformers, StatsGranularity.DAYS)
+        verify(statsRepository).fetchProductLeaderboards(DAYS, MyStorePresenter.NUM_TOP_PERFORMERS, false)
+        verify(myStoreView).showTopPerformers(emptyList(), DAYS)
     }
 
     @Test
-    fun `Handles FETCH_TOP_EARNERS_STATS error event correctly`() {
+    fun `when force refreshing the top performers, then force fetch from repository`() = testBlocking {
         presenter.takeView(myStoreView)
+        presenter.loadTopPerformersStats(DAYS, true)
 
-        presenter.onWCTopPerformersChanged(null, StatsGranularity.DAYS)
-        verify(myStoreView, times(1)).showTopPerformersError(StatsGranularity.DAYS)
+        verify(statsRepository).fetchProductLeaderboards(DAYS, MyStorePresenter.NUM_TOP_PERFORMERS, true)
     }
 
     @Test
-    fun `Handles FETCH_HAS_ORDERS when there aren't any orders`() {
+    fun `when fetching top performers fail, then show error`() = testBlocking {
+        whenever(statsRepository.fetchProductLeaderboards(any(), any(), any()))
+            .thenReturn(Result.failure(Exception()))
+
         presenter.takeView(myStoreView)
-        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_HAS_ORDERS })
-        verify(myStoreView, times(1)).showEmptyView(true)
+        presenter.loadTopPerformersStats(DAYS)
+
+        verify(myStoreView).showTopPerformersError(DAYS)
     }
 
     @Test
-    fun `Handles FETCH_HAS_ORDERS when there are orders`() {
+    fun `when the store has no orders, then show empty view`() = testBlocking {
+        whenever(statsRepository.checkIfStoreHasNoOrders()).thenReturn(Result.success(true))
         presenter.takeView(myStoreView)
-        presenter.onOrderChanged(OnOrderChanged(1).apply { causeOfChange = FETCH_HAS_ORDERS })
-        verify(myStoreView, times(1)).showEmptyView(false)
+        presenter.loadStats(DAYS)
+        verify(myStoreView).showEmptyView(true)
     }
 
     @Test
-    fun `Handles FETCH_NEW_VISITOR_STATS event correctly`() {
+    fun `when the store has orders, then hide empty view`() = testBlocking {
+        whenever(statsRepository.checkIfStoreHasNoOrders()).thenReturn(Result.success(false))
         presenter.takeView(myStoreView)
-
-        val onChanged = OnWCStatsChanged(1, granularity = StatsGranularity.DAYS)
-        onChanged.causeOfChange = FETCH_NEW_VISITOR_STATS
-
-        presenter.onWCStatsChanged(onChanged)
-        verify(myStoreView, times(1)).showVisitorStats(mapOf(), StatsGranularity.DAYS)
+        presenter.loadStats(DAYS)
+        verify(myStoreView).showEmptyView(false)
     }
 
     @Test
-    fun `Handles FETCH_NEW_VISITOR_STATS error event correctly`() {
+    fun `when screen starts, then fetch visitor stats`() = testBlocking {
+        whenever(statsRepository.fetchVisitorStats(any(), any()))
+            .thenReturn(Result.success(emptyMap()))
+
         presenter.takeView(myStoreView)
+        presenter.loadStats(DAYS)
 
-        val onChanged = OnWCStatsChanged(1, granularity = StatsGranularity.DAYS)
-        onChanged.causeOfChange = FETCH_NEW_VISITOR_STATS
-        onChanged.error = OrderStatsError(OrderStatsErrorType.INVALID_PARAM)
-
-        presenter.onWCStatsChanged(onChanged)
-        verify(myStoreView, times(1)).showVisitorStatsError(StatsGranularity.DAYS)
+        verify(statsRepository).fetchVisitorStats(DAYS, false)
+        verify(myStoreView).showVisitorStats(any(), eq(DAYS))
     }
 
     @Test
-    fun `Show and hide stats skeleton correctly`() {
+    fun `when fetching visitor stats fails, then show visitor stats error`() = testBlocking {
+        whenever(statsRepository.fetchVisitorStats(any(), any()))
+            .thenReturn(Result.failure(Exception()))
+
         presenter.takeView(myStoreView)
-        presenter.loadStats(StatsGranularity.DAYS, forced = true)
+        presenter.loadStats(DAYS)
+
+        verify(myStoreView).showVisitorStatsError(DAYS)
+    }
+
+    @Test
+    fun `when force fetching stats, then show skeleton`() {
+        presenter.takeView(myStoreView)
+        presenter.loadStats(DAYS, forced = true)
         verify(myStoreView, times(1)).showChartSkeleton(true)
-
-        val onChanged = OnWCRevenueStatsChanged(
-            1, granularity = StatsGranularity.DAYS, startDate = "2019-07-30", endDate = "2019-07-30"
-        )
-
-        onChanged.causeOfChange = FETCH_REVENUE_STATS
-        presenter.onWCRevenueStatsChanged(onChanged)
-        verify(myStoreView, times(1)).showChartSkeleton(false)
     }
 
     @Test
-    fun `Show and hide top performers skeleton correctly`() {
-        runBlocking {
-            whenever(
-                wcLeaderboardsStore.fetchProductLeaderboards(
-                    site = selectedSite.get(),
-                    unit = DAYS,
-                    quantity = 3
-                )
-            )
-                .thenReturn(WooResult(emptyList()))
-            presenter.takeView(myStoreView)
-            presenter.loadTopPerformersStats(StatsGranularity.DAYS, forced = true)
-            verify(myStoreView, times(1)).showTopPerformersSkeleton(true)
-            verify(myStoreView, times(1)).showTopPerformersSkeleton(false)
-        }
+    fun `when data loads, then hide skeleton`() = testBlocking {
+        presenter.takeView(myStoreView)
+        presenter.loadStats(DAYS, forced = true)
+
+        verify(myStoreView).showChartSkeleton(false)
+    }
+
+    @Test
+    fun `when force refreshing top performers, then show skeleton`() = testBlocking {
+        presenter.takeView(myStoreView)
+        presenter.loadTopPerformersStats(DAYS, forced = true)
+        verify(myStoreView).showTopPerformersSkeleton(true)
+    }
+
+    @Test
+    fun `when top performers data loads, then hide skeleton`() = testBlocking {
+        presenter.takeView(myStoreView)
+        presenter.loadTopPerformersStats(DAYS, forced = true)
+        verify(myStoreView).showTopPerformersSkeleton(false)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.PLUGIN_NOT_ACTIVE
@@ -191,6 +192,20 @@ class MyStorePresenterTest: BaseUnitTest() {
         verify(statsRepository).fetchVisitorStats(DAYS, false)
         verify(myStoreView).showVisitorStats(any(), eq(DAYS))
     }
+
+    @Test
+    fun `give the site is using jetpack cp, when the stats are loaded, then show an empty view for visitor stats`() =
+        testBlocking {
+            whenever(selectedSite.getIfExists()).thenReturn(SiteModel().apply {
+                setIsJetpackCPConnected(true)
+            })
+
+            presenter.takeView(myStoreView)
+            presenter.loadStats(DAYS)
+
+            verify(statsRepository, never()).fetchVisitorStats(DAYS, false)
+            verify(myStoreView).showEmptyVisitorStatsForJetpackCP()
+        }
 
     @Test
     fun `when fetching visitor stats fails, then show visitor stats error`() = testBlocking {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4863 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This was supposed to be a small change, but the fact that the presenter was still using EventBus for all the requests, made it harder to expect an exact order of different requests, and know when to display the empty state, and when not, so I started with a bit of refactoring in order to extract all the FluxC requests to a repository, and made them suspendable, the I updated the tests.

The commits that are directly connected to Jetpack CP changes are: 8019782, 7c66eae, a6722a7 and 58c1594, the rest are for the refactoring.

### Testing instructions
##### Jetpack CP site
1. You need a Jetpack CP site for this test, if you don't have one, then create a new site, and install WCPay or Jetpack Backup, then connect your WordPress.com account.
2. Install WooCommerce if it's not installed, and create some orders.
3. Connect to the site using the app.
4. Open MyStore tab.
5. Confirm that you have an empty view instead of the visitor stats, with Jetpack's logo next to it.

##### Non-regression
Please run some smock tests for the "my store" screen, you can also check the unit tests to confirm that they cover all cases.

### Images/gif
<img width="355" alt="Screen Shot 2021-10-08 at 16 42 11" src="https://user-images.githubusercontent.com/1657201/136585443-844b9564-f2c2-4dc8-90fb-0c7382c6ad43.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
