### PR TITLE
Issue/4936 Connect dialog is visible after required update finished

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -41,7 +41,7 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T, @IdRes destinati
  * @param [destinationId] an destinationId, that used to navigate up from the specified destination
  *
  */
-fun <T> Fragment.navigateBackWithResultFromDestination(key: String, result: T, @IdRes destinationId: Int) {
+fun <T> Fragment.navigateToParentWithResult(key: String, result: T, @IdRes destinationId: Int) {
     if (findNavController().currentDestination?.id != destinationId) {
         findNavController().popBackStack(destinationId, false)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -31,19 +31,18 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T, @IdRes destinati
 }
 
 /**
- * A helper function that pops back stack to the [destinationId] and then invokes
- * [navigateBackWithResult]
+ * A helper function that pops back stack to the [childId] and then invokes [navigateBackWithResult]
  * This is useful for scenarios when the fragment returning result doesn't know who their parent is since
  * they can be added to the navigation graph from various places of the app
  *
  * @param [key] A unique string that is the same as the one used in [handleResult]
  * @param [result] A result value to be returned
- * @param [destinationId] an destinationId, that used to navigate up from the specified destination
+ * @param [childId] an destinationId, that used to navigate up from the specified destination
  *
  */
-fun <T> Fragment.navigateToParentWithResult(key: String, result: T, @IdRes destinationId: Int) {
-    if (findNavController().currentDestination?.id != destinationId) {
-        findNavController().popBackStack(destinationId, false)
+fun <T> Fragment.navigateToParentWithResult(key: String, result: T, @IdRes childId: Int) {
+    if (findNavController().currentDestination?.id != childId) {
+        findNavController().popBackStack(childId, false)
     }
     navigateBackWithResult(key, result, null)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -33,6 +33,8 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T, @IdRes destinati
 /**
  * A helper function that pops back stack to the [destinationId] and then invokes
  * [navigateBackWithResult]
+ * This is useful for scenarios when the fragment returning result doesn't know who their parent is since
+ * they can be added to the navigation graph from various places of the app
  *
  * @param [key] A unique string that is the same as the one used in [handleResult]
  * @param [result] A result value to be returned

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -4,7 +4,6 @@ import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.R
 
 /**
  * A helper function that sets the submitted key-value pair in the Fragment's SavedStateHandle. The value can be

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -4,6 +4,7 @@ import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
 
 /**
  * A helper function that sets the submitted key-value pair in the Fragment's SavedStateHandle. The value can be
@@ -28,6 +29,22 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T, @IdRes destinati
     } else {
         findNavController().navigateUp()
     }
+}
+
+/**
+ * A helper function that pops back stack to the [destinationId] and then invokes
+ * [navigateBackWithResult]
+ *
+ * @param [key] A unique string that is the same as the one used in [handleResult]
+ * @param [result] A result value to be returned
+ * @param [destinationId] an destinationId, that used to navigate up from the specified destination
+ *
+ */
+fun <T> Fragment.navigateBackWithResultFromDestination(key: String, result: T, @IdRes destinationId: Int) {
+    if (findNavController().currentDestination?.id != destinationId) {
+        findNavController().popBackStack(R.id.cardReaderConnectDialogFragment, false)
+    }
+    navigateBackWithResult(key, result, null)
 }
 
 /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -42,7 +42,7 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T, @IdRes destinati
  */
 fun <T> Fragment.navigateBackWithResultFromDestination(key: String, result: T, @IdRes destinationId: Int) {
     if (findNavController().currentDestination?.id != destinationId) {
-        findNavController().popBackStack(R.id.cardReaderConnectDialogFragment, false)
+        findNavController().popBackStack(destinationId, false)
     }
     navigateBackWithResult(key, result, null)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -27,7 +27,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.databinding.CardReaderConnectDialogBinding
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
-import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.navigateBackWithResultFromDestination
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckBluetoothEnabled
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckLocationEnabled
@@ -220,7 +220,11 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
                         .navigateSafely(R.id.action_cardReaderConnectDialogFragment_to_cardReaderOnboardingFragment)
                 }
                 is ExitWithResult<*> -> {
-                    navigateBackWithResult(KEY_CONNECT_TO_READER_RESULT, event.data as Boolean)
+                    navigateBackWithResultFromDestination(
+                        key = KEY_CONNECT_TO_READER_RESULT,
+                        result = event.data as Boolean,
+                        destinationId = R.id.cardReaderConnectDialogFragment,
+                    )
                 }
                 is CardReaderConnectViewModel.CardReaderConnectEvent.ShowToast ->
                     ToastUtils.showToast(requireContext(), getString(event.message))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -223,7 +223,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
                     navigateToParentWithResult(
                         key = KEY_CONNECT_TO_READER_RESULT,
                         result = event.data as Boolean,
-                        destinationId = R.id.cardReaderConnectDialogFragment,
+                        childId = R.id.cardReaderConnectDialogFragment,
                     )
                 }
                 is CardReaderConnectViewModel.CardReaderConnectEvent.ShowToast ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -27,7 +27,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.databinding.CardReaderConnectDialogBinding
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
-import com.woocommerce.android.extensions.navigateBackWithResultFromDestination
+import com.woocommerce.android.extensions.navigateToParentWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckBluetoothEnabled
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckLocationEnabled
@@ -220,7 +220,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
                         .navigateSafely(R.id.action_cardReaderConnectDialogFragment_to_cardReaderOnboardingFragment)
                 }
                 is ExitWithResult<*> -> {
-                    navigateBackWithResultFromDestination(
+                    navigateToParentWithResult(
                         key = KEY_CONNECT_TO_READER_RESULT,
                         result = event.data as Boolean,
                         destinationId = R.id.cardReaderConnectDialogFragment,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CircleProgressOverlayView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CircleProgressOverlayView.kt
@@ -8,6 +8,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.animation.LinearInterpolator
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.getColorCompat
 import org.wordpress.android.util.DisplayUtils.dpToPx
 import java.lang.Math.toDegrees
 import kotlin.math.acos
@@ -34,9 +35,9 @@ class CircleProgressOverlayView @JvmOverloads constructor(
             invalidate()
         }
 
-    private var progressColor: Int = context.getColor(R.color.color_on_primary)
-    private var restColor: Int = context.getColor(R.color.color_on_secondary)
-    private var borderColor: Int = context.getColor(R.color.color_accent_1)
+    private var progressColor: Int = context.getColorCompat(R.color.color_on_primary)
+    private var restColor: Int = context.getColorCompat(R.color.color_on_secondary)
+    private var borderColor: Int = context.getColorCompat(R.color.color_accent_1)
     private var borderSizePx: Int = dpToPx(context, 2)
 
     private val progressPaint by lazy {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4936 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The problem is the following:
* "Connected" event comes before "update finished" event
* `CardReaderConnectDialogFragment` pops up the back stack, closing `CardReaderUpdateDialogFragment`
* "update finished" never arrives
* `CardReaderConnectDialogFragment` stays visible

The PR adds a workaround:
* It checks what is the most top fragment in the back stack
* If this is not `CardReaderConnectDialogFragment` it firstly pops everything to this fragment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
 Using attached patch:
* Try to connect to a reader from settings
* Try to collect money
* Notice that "connect" dialog disappears

Try the same without required update

[Patch_for_testing.txt](https://github.com/woocommerce/woocommerce-android/files/7321973/Patch_for_testing.txt)
### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
