### PR TITLE
Fix middle ellipsize

### DIFF
--- a/WooCommerce/src/main/res/layout/card_reader_connect_reader_item.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_connect_reader_item.xml
@@ -31,6 +31,7 @@
         android:layout_marginTop="0dp"
         android:layout_marginEnd="0dp"
         android:ellipsize="middle"
+        android:paddingEnd="@dimen/minor_25"
         android:singleLine="true"
         android:textColor="@color/color_on_surface_high"
         android:textSize="@dimen/text_minor_100"
@@ -38,7 +39,8 @@
         app:layout_constraintEnd_toStartOf="@+id/readers_found_reader_connect_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/readers_found_reader_connect_button"
-        tools:text="CHB124817924121212481792412121248179241212" />
+        tools:text="CHB124817924121212481792412121248179241212"
+        tools:ignore="RtlSymmetry" />
 
     <TextView
         android:id="@+id/readers_found_reader_type"

--- a/WooCommerce/src/main/res/layout/card_reader_connect_reader_item.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_connect_reader_item.xml
@@ -31,6 +31,7 @@
         android:layout_marginTop="0dp"
         android:layout_marginEnd="0dp"
         android:ellipsize="middle"
+        android:paddingStart="@dimen/minor_25"
         android:paddingEnd="@dimen/minor_25"
         android:singleLine="true"
         android:textColor="@color/color_on_surface_high"
@@ -39,8 +40,7 @@
         app:layout_constraintEnd_toStartOf="@+id/readers_found_reader_connect_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/readers_found_reader_connect_button"
-        tools:text="CHB124817924121212481792412121248179241212"
-        tools:ignore="RtlSymmetry" />
+        tools:text="CHB124817924121212481792412121248179241212" />
 
     <TextView
         android:id="@+id/readers_found_reader_type"
@@ -50,6 +50,8 @@
         android:layout_marginVertical="0dp"
         android:layout_marginEnd="0dp"
         android:ellipsize="middle"
+        android:paddingStart="@dimen/minor_25"
+        android:paddingEnd="@dimen/minor_25"
         android:singleLine="true"
         app:layout_constraintBottom_toBottomOf="@id/readers_found_reader_connect_button"
         app:layout_constraintEnd_toStartOf="@+id/readers_found_reader_connect_button"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4748 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

It seems the OS doesn't handle the "middle" ellipsize correctly - it's weird, but I don't have any other explanation. Our layout seems to be setup correctly and even "show layout bounds" displays the bounds correctly. Since this is a minor thing not worth investigating, I decided to add a dummy 2dp padding to limit cases in which the text gets cut off.

P.S. I suppressed RTL symmetry warning - I believe it's a false positive since we want to have the padding always only on the side where the button and textview "touch" each other.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- apply [this patch](https://cloudup.com/cExqg6eoPa2) or somehow simulate multiple readers found state with long reader names
1. Tap on app settings
2. Tap on in person payments
3. Tap on Manage card reader
4. Tap on Connect to card reader
5. Notice the reader name doesn't get cut off

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| -- | -- |
| ![Screenshot_20211011-131727_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/136785521-d0593f60-7ed3-4412-97c5-b1b5462f2b69.jpg) | ![Screenshot_20211011-132921_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/136785542-b8c6c0dd-5d64-48ca-92f3-17d46b32fd25.jpg) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
