### PR TITLE
Issue/4970 check stripe account address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -33,7 +33,7 @@ class CardReaderOnboardingChecker @Inject constructor(
     @Suppress("ReturnCount", "ComplexMethod")
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         if (!networkStatus.isConnected()) return NoConnectionError
-        val countryCode = getCountryCode()
+        val countryCode = getStoreCountryCode()
         if (!isCountrySupported(countryCode)) return StoreCountryNotSupported(countryCode)
 
         val fetchSitePluginsResult = wooStore.fetchSitePlugins(selectedSite.get())
@@ -46,6 +46,7 @@ class CardReaderOnboardingChecker @Inject constructor(
 
         val paymentAccount = wcPayStore.loadAccount(selectedSite.get()).model ?: return GenericError
 
+        if (!isCountrySupported(paymentAccount.country))  return StripeAccountCountryNotSupported(paymentAccount.country)
         if (!isWCPaySetupCompleted(paymentAccount)) return WcpaySetupNotCompleted
         if (isWCPayInTestModeWithLiveStripeAccount(paymentAccount)) return WcpayInTestModeWithLiveStripeAccount
         if (isStripeAccountUnderReview(paymentAccount)) return StripeAccountUnderReview
@@ -63,7 +64,7 @@ class CardReaderOnboardingChecker @Inject constructor(
         return OnboardingCompleted
     }
 
-    private suspend fun getCountryCode(): String? {
+    private suspend fun getStoreCountryCode(): String? {
         return withContext(dispatchers.io) {
             wooStore.getStoreCountryCode(selectedSite.get()) ?: null.also {
                 WooLog.e(WooLog.T.CARD_READER, "Store's country code not found.")
@@ -171,6 +172,11 @@ sealed class CardReaderOnboardingState {
      * or the merchant violates the terms of service
      */
     object StripeAccountRejected : CardReaderOnboardingState()
+
+    /**
+     * The Stripe account is attached to an address in one of the unsupported countries.
+     */
+    data class StripeAccountCountryNotSupported(val countryCode: String?) : CardReaderOnboardingState()
 
     /**
      * Generic error - for example, one of the requests failed.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -34,7 +34,7 @@ class CardReaderOnboardingChecker @Inject constructor(
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         if (!networkStatus.isConnected()) return NoConnectionError
         val countryCode = getCountryCode()
-        if (!isCountrySupported(countryCode)) return CountryNotSupported(countryCode)
+        if (!isCountrySupported(countryCode)) return StoreCountryNotSupported(countryCode)
 
         val fetchSitePluginsResult = wooStore.fetchSitePlugins(selectedSite.get())
         if (fetchSitePluginsResult.isError) return GenericError
@@ -119,7 +119,7 @@ sealed class CardReaderOnboardingState {
     /**
      * Store is not located in one of the supported countries.
      */
-    data class CountryNotSupported(val countryCode: String?) : CardReaderOnboardingState()
+    data class StoreCountryNotSupported(val countryCode: String?) : CardReaderOnboardingState()
 
     /**
      * WCPay plugin is not installed on the store.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -46,7 +46,7 @@ class CardReaderOnboardingChecker @Inject constructor(
 
         val paymentAccount = wcPayStore.loadAccount(selectedSite.get()).model ?: return GenericError
 
-        if (!isCountrySupported(paymentAccount.country))  return StripeAccountCountryNotSupported(paymentAccount.country)
+        if (!isCountrySupported(paymentAccount.country)) return StripeAccountCountryNotSupported(paymentAccount.country)
         if (!isWCPaySetupCompleted(paymentAccount)) return WcpaySetupNotCompleted
         if (isWCPayInTestModeWithLiveStripeAccount(paymentAccount)) return WcpayInTestModeWithLiveStripeAccount
         if (isStripeAccountUnderReview(paymentAccount)) return StripeAccountUnderReview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -106,6 +106,12 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     viewState.value = OnboardingViewState.NoConnectionErrorState(
                         onRetryButtonActionClicked = ::refreshState
                     )
+                is CardReaderOnboardingState.StripeAccountCountryNotSupported ->
+                    viewState.value = OnboardingViewState.UnsupportedCountryState(
+                        convertCountryCodeToCountry(state.countryCode),
+                        ::onContactSupportClicked,
+                        ::onLearnMoreClicked
+                    )
             }.exhaustive
         }
     }
@@ -124,6 +130,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
             is CardReaderOnboardingState.StripeAccountPendingRequirement -> "account_pending_requirements"
             CardReaderOnboardingState.StripeAccountRejected -> "account_rejected"
             CardReaderOnboardingState.StripeAccountUnderReview -> "account_under_review"
+            is CardReaderOnboardingState.StripeAccountCountryNotSupported -> "account_country_not_supported"
             CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount -> "wcpay_in_test_mode_with_live_account"
             CardReaderOnboardingState.WcpayNotActivated -> "wcpay_not_activated"
             CardReaderOnboardingState.WcpayNotInstalled -> "wcpay_not_installed"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -39,7 +39,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
         refreshState()
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "ComplexMethod")
     private fun refreshState() {
         launch {
             viewState.value = OnboardingViewState.LoadingState
@@ -122,6 +122,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
         }
     }
 
+    @Suppress("ComplexMethod")
     private fun getTrackingReason(state: CardReaderOnboardingState): String? =
         when (state) {
             CardReaderOnboardingState.OnboardingCompleted -> null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -48,7 +48,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
             when (state) {
                 CardReaderOnboardingState.OnboardingCompleted ->
                     triggerEvent(OnboardingEvent.Continue)
-                is CardReaderOnboardingState.CountryNotSupported ->
+                is CardReaderOnboardingState.StoreCountryNotSupported ->
                     viewState.value = OnboardingViewState.UnsupportedCountryState(
                         convertCountryCodeToCountry(state.countryCode),
                         ::onContactSupportClicked,
@@ -119,7 +119,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
     private fun getTrackingReason(state: CardReaderOnboardingState): String? =
         when (state) {
             CardReaderOnboardingState.OnboardingCompleted -> null
-            is CardReaderOnboardingState.CountryNotSupported -> "country_not_supported"
+            is CardReaderOnboardingState.StoreCountryNotSupported -> "country_not_supported"
             CardReaderOnboardingState.StripeAccountOverdueRequirement -> "account_overdue_requirements"
             is CardReaderOnboardingState.StripeAccountPendingRequirement -> "account_pending_requirements"
             CardReaderOnboardingState.StripeAccountRejected -> "account_rejected"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -116,6 +116,46 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when account country not supported, then STRIPE_COUNTRY_NOT_SUPPORTED returned`() = testBlocking {
+        whenever(wcPayStore.loadAccount(site)).thenReturn(
+            buildPaymentAccountResult(
+                countryCode = "unsupported country abc"
+            )
+        )
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountCountryNotSupported::class.java)
+    }
+
+    @Test
+    fun `when account country supported, then ACCOUNT_COUNTRY_NOT_SUPPORTED not returned`() = testBlocking {
+        whenever(wcPayStore.loadAccount(site)).thenReturn(
+            buildPaymentAccountResult(
+                countryCode = "US"
+            )
+        )
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isNotInstanceOf(CardReaderOnboardingState.StripeAccountCountryNotSupported::class.java)
+    }
+
+    @Test
+    fun `given country in lower case, when country supported, then ACCOUNT_COUNTRY_NOT_SUPPORTED not returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    countryCode = "us"
+                )
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isNotInstanceOf(CardReaderOnboardingState.StripeAccountCountryNotSupported::class.java)
+        }
+
+    @Test
     fun `when woocommerce payments plugin not installed, then WCPAY_NOT_INSTALLED returned`() =
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -385,6 +385,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         hadOverdueRequirements: Boolean = false,
         liveAccount: Boolean = true,
         testModeEnabled: Boolean? = false,
+        countryCode: String = "US",
     ) = WooResult(
         WCPaymentAccountResult(
             status,
@@ -393,7 +394,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             currentDeadline = null,
             statementDescriptor = "",
             storeCurrencies = WCPaymentAccountResult.WCPayAccountStatusEnum.StoreCurrencies("", listOf()),
-            country = "US",
+            country = countryCode,
             isCardPresentEligible = true,
             isLive = liveAccount,
             testMode = testModeEnabled

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -68,41 +68,41 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when store country not supported, then COUNTRY_NOT_SUPPORTED returned`() = testBlocking {
+    fun `when store country not supported, then STORE_COUNTRY_NOT_SUPPORTED returned`() = testBlocking {
         whenever(wooStore.getStoreCountryCode(site)).thenReturn("unsupported country abc")
 
         val result = checker.getOnboardingState()
 
-        assertThat(result).isInstanceOf(CardReaderOnboardingState.CountryNotSupported::class.java)
+        assertThat(result).isInstanceOf(CardReaderOnboardingState.StoreCountryNotSupported::class.java)
     }
 
     @Test
-    fun `when store country supported, then COUNTRY_NOT_SUPPORTED not returned`() = testBlocking {
+    fun `when store country supported, then STORE_COUNTRY_NOT_SUPPORTED not returned`() = testBlocking {
         whenever(wooStore.getStoreCountryCode(site)).thenReturn("US")
 
         val result = checker.getOnboardingState()
 
-        assertThat(result).isNotInstanceOf(CardReaderOnboardingState.CountryNotSupported::class.java)
+        assertThat(result).isNotInstanceOf(CardReaderOnboardingState.StoreCountryNotSupported::class.java)
     }
 
     @Test
-    fun `given country code in lower case, when store country supported, then COUNTRY_NOT_SUPPORTED not returned`() =
+    fun `given country in lower case, when store country supported, then STORE_COUNTRY_NOT_SUPPORTED not returned`() =
         testBlocking {
             whenever(wooStore.getStoreCountryCode(site)).thenReturn("us")
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isNotInstanceOf(CardReaderOnboardingState.CountryNotSupported::class.java)
+            assertThat(result).isNotInstanceOf(CardReaderOnboardingState.StoreCountryNotSupported::class.java)
         }
 
     @Test
-    fun `when country code is not found, then COUNTRY_NOT_SUPPORTED returned`() =
+    fun `when country code is not found, then STORE_COUNTRY_NOT_SUPPORTED returned`() =
         testBlocking {
             whenever(wooStore.getStoreCountryCode(site)).thenReturn(null)
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isInstanceOf(CardReaderOnboardingState.CountryNotSupported::class.java)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StoreCountryNotSupported::class.java)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -41,10 +41,21 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when country not supported, then country not supported state shown`() =
+    fun `when store country not supported, then country not supported state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(UnsupportedCountryState::class.java)
+        }
+
+    @Test
+    fun `when account country not supported, then country not supported state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(""))
 
             val viewModel = createVM()
 
@@ -255,7 +266,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when country not supported, then event tracked`() =
+    fun `when store country not supported, then event tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
@@ -264,6 +275,20 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             verify(tracker).track(
                 AnalyticsTracker.Stat.CARD_PRESENT_ONBOARDING_NOT_COMPLETED, mapOf("reason" to "country_not_supported")
+            )
+        }
+
+    @Test
+    fun `when account country not supported, then event tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(""))
+
+            createVM()
+
+            verify(tracker).track(
+                AnalyticsTracker.Stat.CARD_PRESENT_ONBOARDING_NOT_COMPLETED,
+                mapOf("reason" to "account_country_not_supported")
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -75,7 +75,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given country not supported, when learn more clicked, then app shows learn more section`() =
+    fun `given store country not supported, when learn more clicked, then app shows learn more section`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
@@ -88,7 +88,33 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given country not supported, when contact support clicked, then app navigates to support screen`() =
+    fun `given store country not supported, when contact support clicked, then app navigates to support screen`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
+            val viewModel = createVM()
+
+            (viewModel.viewStateData.value as UnsupportedCountryState).onContactSupportActionClicked.invoke()
+
+            assertThat(viewModel.event.value)
+                .isInstanceOf(CardReaderOnboardingViewModel.OnboardingEvent.NavigateToSupport::class.java)
+        }
+
+    @Test
+    fun `given account country not supported, when learn more clicked, then app shows learn more section`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(""))
+            val viewModel = createVM()
+
+            (viewModel.viewStateData.value as UnsupportedCountryState).onLearnMoreActionClicked.invoke()
+
+            assertThat(viewModel.event.value)
+                .isInstanceOf(CardReaderOnboardingViewModel.OnboardingEvent.ViewLearnMore::class.java)
+        }
+
+    @Test
+    fun `given account country not supported, when contact support clicked, then app navigates to support screen`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -44,7 +44,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when country not supported, then country not supported state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.CountryNotSupported(""))
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
 
             val viewModel = createVM()
 
@@ -55,7 +55,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when country not supported, then current store country name shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.CountryNotSupported("US"))
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported("US"))
             val viewModel = createVM()
 
             val countryName = (viewModel.viewStateData.value as UnsupportedCountryState).headerLabel.params[0]
@@ -67,7 +67,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `given country not supported, when learn more clicked, then app shows learn more section`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.CountryNotSupported(""))
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
             val viewModel = createVM()
 
             (viewModel.viewStateData.value as UnsupportedCountryState).onLearnMoreActionClicked.invoke()
@@ -80,7 +80,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `given country not supported, when contact support clicked, then app navigates to support screen`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.CountryNotSupported(""))
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
             val viewModel = createVM()
 
             (viewModel.viewStateData.value as UnsupportedCountryState).onContactSupportActionClicked.invoke()
@@ -258,7 +258,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when country not supported, then event tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.CountryNotSupported(""))
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
 
             createVM()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -117,7 +117,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `given account country not supported, when contact support clicked, then app navigates to support screen`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
+                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(""))
             val viewModel = createVM()
 
             (viewModel.viewStateData.value as UnsupportedCountryState).onContactSupportActionClicked.invoke()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4970 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the onboarding checker. The app previously checked country of the store but didn't check the country of the Stripe account connected to the store. In most cases, these two will be identical in production. However, we decided to handle even the edge case scenario in which the user has store in US but the stripe account is connected to a non-US address.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Switch to a store which is located in the US but the connected Stripe account is associated with a non-US address (I created a store on ninja, feel free to dm me and I'll send you credentials if you don't want to setup your own store)
2. Open app settings
3. Tap on In Person payments
4. Notice, "Country not supported" screen is shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/2261188/136811972-6b5f98f3-4587-4123-9441-d480fb43dcdb.gif" width="250px" />
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
