### PR TITLE
Reverted support for multi store notification

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,10 @@
 - [***] In-Person Payments: Added support for accepting In-Person Card Payments in the US
 - [*] Help & Support: A site's System Status Report can now be found, copied, and shared from Settings > Help & Support > System Status Report [https://github.com/woocommerce/woocommerce-android/pull/4890]
 
+7.6.1
+-----
+- [*] Reverted the support for multi store notifications due to a bug with new order notifications not being received.
+
 7.6
 -----
 - [***] Product Images: uploading will continue now in background to allow merchants to continue their other tasks without getting blocked [https://github.com/woocommerce/woocommerce-android/pull/4720]

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -141,6 +141,12 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths"/>
         </provider>
+
+        <receiver android:name=".AppUpdateReceiver" android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUpdateReceiver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUpdateReceiver.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.woocommerce.android.push.FCMRegistrationIntentService
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+
+/**
+ * This is needed temporary to force re-registering the token with backend, to update the `selected_blog_id`
+ */
+class AppUpdateReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED) {
+            WooLog.d(T.NOTIFS, "Received action ACTION_MY_PACKAGE_REPLACED, register notifications token")
+            FCMRegistrationIntentService.enqueueWork(context)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationRegistrationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationRegistrationHandler.kt
@@ -25,7 +25,7 @@ class NotificationRegistrationHandler @Inject constructor(
             val payload = RegisterDevicePayload(
                 gcmToken = token,
                 appKey = NotificationStore.NotificationAppKey.WOOCOMMERCE,
-                site = null
+                site = selectedSite.get()
             )
             dispatcher.dispatch(NotificationActionBuilder.newRegisterDeviceAction(payload))
         }


### PR DESCRIPTION
There are a bunch of reviews complaining about notifications after upgrading to v7.6. This is the version where we enabled multi store notification support.

We are unable to identify the exact steps and scenario for the issue. 

#### Some points to note:
- This issue looks like it’s happening after updating the app from v7.5 to v7.6.
- This is only happening in android, for now and iOS is working fine.
- This is only happening for new order notifications and review notifications seems to be working fine.
- This is only happening to some stores and not all the stores and we have not been able to find the root cause of this.

I tested with 3 stores. I was able to reproduce the update issue consistently when updating from v7.5 -> v7.6 for Paolo’s test site: https://mywootesting.mystagingwebsite.com/. i.e. I am able to receive notifications when I submit an order from this store in 7.5 but as soon as as I update the app, the notifications don’t come in.

- I then deleted the app and installed v7.6 fresh again and still can’t see the notifications for that store. But one weird thing is that, when I test sending the same notification again for the same order, from the MC console, I can receive it in the app.
- I deleted the app again and installed v7.5 fresh again and can see the notifications now for the same store.
- Then I installed v7.6 again -> this time I changed this line in the app to send the currently selected site when registering FCM token. And I was able to receive new order notifications in the app again.

**Another important point is that I tested from a new device that never had WooCommerce installed before. When I tested from my normal testing device, the notifications worked as expected.**

### Testing instructions
#### Testing the fix
- Install 7.5-rc-3.apk [from GitHub](https://github.com/woocommerce/woocommerce-android/releases/tag/7.5-rc-3) in a new device.
- Log in and select a non-WP.com store.
- Submit an order to the selected store.
- Observe successful notification in the app.
- Upgrade to 7.6-rc-2.apk [from GitHub](https://github.com/woocommerce/woocommerce-android/releases/tag/7.6-rc-2).
- Submit another order to the selected store.
- Observe no notification in received in the app.
- Pull the changes from this PR.
- Open the app.
- Submit an order to the selected store.
- Observe successful notification in the app.

#### Testing token registration on app update
- If you are using Android Studio for testing, then please build the APK using the menu Build -> Build Bundle(s)/APK(s) -> Build APK, then install it manually using the cli: `adb install -t -r WooCommerce-wasabi-debug.apk`
- If you are using the test APK from this PR, then it should be OK.
- After you install the APK, please check for the following log entries (either using LogCat, or by opening the app and checking the logs):
```
 D/WooCommerce-NOTIFS: Received action ACTION_MY_PACKAGE_REPLACED, register notifications token
 D/WooCommerce-NOTIFS: Sending FCM token to our remote services: {redacted}
```

cc @astralbodies @jkmassel this is targeted towards the `release/7.7` branch and would require a new beta release.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.