### PR TITLE
Issue/4993 handle remove card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -295,7 +295,8 @@ class CardReaderPaymentViewModel
                     TRY_ANOTHER_READ_METHOD -> R.string.card_reader_payment_try_another_read_method_prompt
                     TRY_ANOTHER_CARD -> R.string.card_reader_payment_try_another_card_prompt
                     CHECK_MOBILE_DEVICE -> R.string.card_reader_payment_check_mobile_device_prompt
-                })
+                }
+            )
         } ?: run {
             WooLog.e(WooLog.T.CARD_READER, "Got SDK message when cardReaderPaymentViewModel is in ${viewState.value}")
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -285,20 +285,17 @@ class CardReaderPaymentViewModel
 
     private fun handleAdditionalInfo(type: AdditionalInfoType) {
         (viewState.value as? CollectPaymentState)?.let { collectPaymentState ->
-            when (type) {
-                RETRY_CARD -> R.string.card_reader_payment_retry_card_prompt
-                INSERT_CARD -> null // noop - collect payment screen is currently shown
-                INSERT_OR_SWIPE_CARD -> null // noop - collect payment screen is currently shown
-                SWIPE_CARD -> null // noop - collect payment screen is currently shown
-                REMOVE_CARD -> null // noop - processing payment screen always shows "remove card" message
-                MULTIPLE_CONTACTLESS_CARDS_DETECTED ->
-                    R.string.card_reader_payment_multiple_contactless_cards_detected_prompt
-                TRY_ANOTHER_READ_METHOD -> R.string.card_reader_payment_try_another_read_method_prompt
-                TRY_ANOTHER_CARD -> R.string.card_reader_payment_try_another_card_prompt
-                CHECK_MOBILE_DEVICE -> R.string.card_reader_payment_check_mobile_device_prompt
-            }?.let { hint ->
-                viewState.value = collectPaymentState.copy(hintLabel = hint)
-            }
+            collectPaymentState.copy(
+                hintLabel = when (type) {
+                    RETRY_CARD -> R.string.card_reader_payment_retry_card_prompt
+                    INSERT_CARD, INSERT_OR_SWIPE_CARD, SWIPE_CARD -> R.string.card_reader_payment_collect_payment_hint
+                    REMOVE_CARD -> R.string.card_reader_payment_remove_card_prompt
+                    MULTIPLE_CONTACTLESS_CARDS_DETECTED ->
+                        R.string.card_reader_payment_multiple_contactless_cards_detected_prompt
+                    TRY_ANOTHER_READ_METHOD -> R.string.card_reader_payment_try_another_read_method_prompt
+                    TRY_ANOTHER_CARD -> R.string.card_reader_payment_try_another_card_prompt
+                    CHECK_MOBILE_DEVICE -> R.string.card_reader_payment_check_mobile_device_prompt
+                })
         } ?: run {
             WooLog.e(WooLog.T.CARD_READER, "Got SDK message when cardReaderPaymentViewModel is in ${viewState.value}")
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -285,7 +285,7 @@ class CardReaderPaymentViewModel
 
     private fun handleAdditionalInfo(type: AdditionalInfoType) {
         (viewState.value as? CollectPaymentState)?.let { collectPaymentState ->
-            collectPaymentState.copy(
+            viewState.value = collectPaymentState.copy(
                 hintLabel = when (type) {
                     RETRY_CARD -> R.string.card_reader_payment_retry_card_prompt
                     INSERT_CARD, INSERT_OR_SWIPE_CARD, SWIPE_CARD -> R.string.card_reader_payment_collect_payment_hint

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -744,8 +744,8 @@
     -->
     <string name="card_reader_tap_or_insert">Tap or insert to pay</string>
     <string name="card_reader_payment_collect_payment_hint" translatable="false">@string/card_reader_tap_or_insert</string>
-    <string name="card_reader_payment_processing_payment_hint" translatable="false">@string/card_reader_payment_remove_card_prompt</string>
-    <string name="card_reader_payment_capturing_payment_hint" translatable="false">@string/card_reader_payment_remove_card_prompt</string>
+    <string name="card_reader_payment_processing_payment_hint" translatable="false">@string/please_wait</string>
+    <string name="card_reader_payment_capturing_payment_hint" translatable="false">@string/please_wait</string>
 
     <string name="card_reader_payment_collect_payment_loading_hint" translatable="false">@string/please_wait</string>
     <string name="card_reader_payment_collect_payment_loading_header">Getting ready to collect payment</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -143,11 +143,11 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given collect payment shown, when MULTIPLE_CARDS_DETECTED received, then collect payment hint updated`() =
+    fun `given collect payment shown, when INSERT_CARD received, then collect payment hint updated`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
-                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(MULTIPLE_CONTACTLESS_CARDS_DETECTED))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(INSERT_CARD))
                 }
             }
 
@@ -158,7 +158,64 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
-                .isEqualTo(R.string.card_reader_payment_multiple_contactless_cards_detected_prompt)
+                .isEqualTo(R.string.card_reader_payment_collect_payment_hint)
+        }
+
+    @Test
+    fun `given collect payment shown, when INSERT_OR_SWIPE_CARD received, then collect payment hint updated`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
+                flow {
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(INSERT_OR_SWIPE_CARD))
+                }
+            }
+
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(CollectingPayment) }
+            }
+
+            viewModel.start()
+
+            assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
+                .isEqualTo(R.string.card_reader_payment_collect_payment_hint)
+        }
+
+    @Test
+    fun `given collect payment shown, when SWIPE_CARD received, then collect payment hint updated`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
+                flow {
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(SWIPE_CARD))
+                }
+            }
+
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(CollectingPayment) }
+            }
+
+            viewModel.start()
+
+            assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
+                .isEqualTo(R.string.card_reader_payment_collect_payment_hint)
+        }
+
+    @Test
+    fun `given collect payment shown, when REMOVE_CARD received, then collect payment hint updated`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
+                flow {
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(REMOVE_CARD))
+                }
+            }
+
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(CollectingPayment) }
+            }
+
+            viewModel.start()
+
+            assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
+                .isEqualTo(R.string.card_reader_payment_remove_card_prompt)
         }
 
     @Test
@@ -197,6 +254,25 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
                 .isEqualTo(R.string.card_reader_payment_try_another_read_method_prompt)
+        }
+
+    @Test
+    fun `given collect payment shown, when MULTIPLE_CARDS_DETECTED received, then collect payment hint updated`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
+                flow {
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(MULTIPLE_CONTACTLESS_CARDS_DETECTED))
+                }
+            }
+
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(CollectingPayment) }
+            }
+
+            viewModel.start()
+
+            assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
+                .isEqualTo(R.string.card_reader_payment_multiple_contactless_cards_detected_prompt)
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4993 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Stripe Terminal SDK v1 didn't pause the payment flow while a card was inserted in the card reader. However, it seems that SDK v2 pauses the flow. This causes a UX problem since the app keeps showing "Reader is ready - Insert or tap to pay", but it  actually waits for the removal of the card.

This PR updates the hint on the "Collect Payment" step when "remove/swipe/insert" events are received. This fixes the UX issues, since the app shows "Please remove card" hint when the "remove_card" event is received.

This PR also replaces "Please remove card" events on the processing/capturing steps since we know the card is not inserted anymore on these steps.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open detail of an unpaid order
2. Tap on Collect Payment
3. Wait until the app shows "Reader is ready - Insert or tap to pay" step
4. Insert the card into the card reader
5. Notice the app shows "Please remove card" and waits for the removal of the card
6. Remove the card and notice the payment finishes successfully 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
