### PR TITLE
Address form editing detection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
@@ -43,8 +43,8 @@ class SupportHelper {
         dialog.setOnShowListener {
             val button = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
             button.setOnClickListener {
-                val newEmail = emailEditText.getText()
-                val newName = nameEditText.getText()
+                val newEmail = emailEditText.text
+                val newName = nameEditText.text
                 if (StringUtils.isValidEmail(newEmail)) {
                     emailAndNameSelected(newEmail, newName)
                     dialog.dismiss()
@@ -106,7 +106,7 @@ private fun supportIdentityInputDialogLayout(
         R.id.support_identity_input_dialog_email_edit_text
     )
     emailSuggestion?.let {
-        emailEditText.setText(it)
+        emailEditText.text = it
         emailEditText.setSelection(0, it.length)
     }
 
@@ -114,7 +114,7 @@ private fun supportIdentityInputDialogLayout(
         R.id.support_identity_input_dialog_name_edit_text
     )
     nameSuggestion?.let {
-        nameEditText.setText(it)
+        nameEditText.text = it
     }
     nameEditText.visibility = if (isNameInputHidden) View.GONE else View.VISIBLE
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -44,15 +44,6 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
         }
     }
 
-
-    /**
-     * Same purpose of the TextWatcher but with the objective of supporting [WCMaterialOutlinedEditTextView]
-     */
-    fun onAnyTextChanged(editable: Editable?) {
-        editable?.takeIf { it.isNotEmpty() }
-            ?.let { updateDoneMenuItem() }
-    }
-
     /**
      * Descendants should return true if the user made any changes
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -44,6 +44,15 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
         }
     }
 
+
+    /**
+     * Same purpose of the TextWatcher but with the objective of supporting [WCMaterialOutlinedEditTextView]
+     */
+    fun onAnyTextChanged(editable: Editable?) {
+        editable?.takeIf { it.isNotEmpty() }
+            ?.let { updateDoneMenuItem() }
+    }
+
     /**
      * Descendants should return true if the user made any changes
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -22,15 +22,15 @@ abstract class BaseAddressEditingFragment :
     val addressDraft
         get() = binding.run {
             Address(
-                firstName = firstName.getText(),
-                lastName = lastName.getText(),
-                email = email.getText(),
-                phone = phone.getText(),
-                company = company.getText(),
-                address1 = address1.getText(),
-                address2 = address2.getText(),
-                city = city.getText(),
-                postcode = postcode.getText(),
+                firstName = firstName.text,
+                lastName = lastName.text,
+                email = email.text,
+                phone = phone.text,
+                company = company.text,
+                address1 = address1.text,
+                address2 = address2.text,
+                city = city.text,
+                postcode = postcode.text,
                 // temporary field assignments, must be replaced with actual input
                 country = storedAddress.country,
                 state = storedAddress.state
@@ -60,15 +60,15 @@ abstract class BaseAddressEditingFragment :
     }
 
     private fun Address.bindToView() {
-        binding.firstName.setText(firstName)
-        binding.lastName.setText(lastName)
-        binding.email.setText(email)
-        binding.phone.setText(phone)
-        binding.company.setText(company)
-        binding.address1.setText(address1)
-        binding.address2.setText(address2)
-        binding.city.setText(city)
-        binding.postcode.setText(postcode)
+        binding.firstName.text = firstName
+        binding.lastName.text = lastName
+        binding.email.text = email
+        binding.phone.text = phone
+        binding.company.text = company
+        binding.address1.text = address1
+        binding.address2.text = address2
+        binding.city.text = city
+        binding.postcode.text = postcode
     }
 
     private fun bindTextWatchers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
 import android.os.Bundle
+import android.text.Editable
 import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
@@ -62,5 +63,15 @@ abstract class BaseAddressEditingFragment :
         binding.address2.setText(address2)
         binding.city.setText(city)
         binding.postcode.setText(postcode)
+
+        binding.firstName.setOnTextChangedListener(::onAnyTextChanged)
+        binding.lastName.setOnTextChangedListener(::onAnyTextChanged)
+        binding.email.setOnTextChangedListener(::onAnyTextChanged)
+        binding.phone.setOnTextChangedListener(::onAnyTextChanged)
+        binding.company.setOnTextChangedListener(::onAnyTextChanged)
+        binding.address1.setOnTextChangedListener(::onAnyTextChanged)
+        binding.address2.setOnTextChangedListener(::onAnyTextChanged)
+        binding.city.setOnTextChangedListener(::onAnyTextChanged)
+        binding.postcode.setOnTextChangedListener(::onAnyTextChanged)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
 import android.os.Bundle
-import android.text.Editable
 import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
@@ -42,6 +41,7 @@ abstract class BaseAddressEditingFragment :
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentBaseEditAddressBinding.bind(view)
         storedAddress.bindToView()
+        bindTextWatchers()
     }
 
     override fun hasChanges() = addressDraft != storedAddress
@@ -63,15 +63,17 @@ abstract class BaseAddressEditingFragment :
         binding.address2.setText(address2)
         binding.city.setText(city)
         binding.postcode.setText(postcode)
+    }
 
-        binding.firstName.setOnTextChangedListener(::onAnyTextChanged)
-        binding.lastName.setOnTextChangedListener(::onAnyTextChanged)
-        binding.email.setOnTextChangedListener(::onAnyTextChanged)
-        binding.phone.setOnTextChangedListener(::onAnyTextChanged)
-        binding.company.setOnTextChangedListener(::onAnyTextChanged)
-        binding.address1.setOnTextChangedListener(::onAnyTextChanged)
-        binding.address2.setOnTextChangedListener(::onAnyTextChanged)
-        binding.city.setOnTextChangedListener(::onAnyTextChanged)
-        binding.postcode.setOnTextChangedListener(::onAnyTextChanged)
+    private fun bindTextWatchers() {
+        binding.firstName.textWatcher = textWatcher
+        binding.lastName.textWatcher = textWatcher
+        binding.email.textWatcher = textWatcher
+        binding.phone.textWatcher = textWatcher
+        binding.company.textWatcher = textWatcher
+        binding.address1.textWatcher = textWatcher
+        binding.address2.textWatcher = textWatcher
+        binding.city.textWatcher = textWatcher
+        binding.postcode.textWatcher = textWatcher
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -53,6 +53,12 @@ abstract class BaseAddressEditingFragment :
         }
     }
 
+    override fun onDestroyView() {
+        removeTextWatchers()
+        _binding = null
+        super.onDestroyView()
+    }
+
     private fun Address.bindToView() {
         binding.firstName.setText(firstName)
         binding.lastName.setText(lastName)
@@ -75,5 +81,17 @@ abstract class BaseAddressEditingFragment :
         binding.address2.textWatcher = textWatcher
         binding.city.textWatcher = textWatcher
         binding.postcode.textWatcher = textWatcher
+    }
+
+    private fun removeTextWatchers() {
+        binding.firstName.removeCurrentTextWatcher()
+        binding.lastName.removeCurrentTextWatcher()
+        binding.email.removeCurrentTextWatcher()
+        binding.phone.removeCurrentTextWatcher()
+        binding.company.removeCurrentTextWatcher()
+        binding.address1.removeCurrentTextWatcher()
+        binding.address2.removeCurrentTextWatcher()
+        binding.city.removeCurrentTextWatcher()
+        binding.postcode.removeCurrentTextWatcher()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductExternalLinkFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductExternalLinkFragment.kt
@@ -67,8 +67,8 @@ class ProductExternalLinkFragment : BaseProductFragment(R.layout.fragment_produc
         if (!isAdded) return
 
         val product = requireNotNull(productData.productDraft)
-        binding.productUrl.setText(product.externalUrl)
-        binding.productButtonText.setText(product.buttonText)
+        binding.productUrl.text = product.externalUrl
+        binding.productButtonText.text = product.buttonText
     }
 
     override fun onRequestAllowBackPress(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -104,15 +104,15 @@ class ProductInventoryFragment :
                 }
             }
             new.inventoryData.sku?.takeIfNotEqualTo(old?.inventoryData?.sku) {
-                if (binding.productSku.getText() != it) {
-                    binding.productSku.setText(it)
+                if (binding.productSku.text != it) {
+                    binding.productSku.text = it
                 }
             }
             new.inventoryData.stockQuantity?.takeIfNotEqualTo(old?.inventoryData?.stockQuantity) {
                 val quantity = StringUtils.formatCountDecimal(it, forInput = true)
 
-                if (binding.productStockQuantity.getText() != quantity) {
-                    binding.productStockQuantity.setText(quantity)
+                if (binding.productStockQuantity.text != quantity) {
+                    binding.productStockQuantity.text = quantity
                 }
             }
             new.isStockQuantityEditable?.takeIfNotEqualTo(old?.isStockQuantityEditable) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -131,7 +131,7 @@ class ProductPricingFragment :
                 prefixText = currency
             } else suffixText = currency
 
-            pricingData.regularPrice?.let { setText(it.toString()) }
+            pricingData.regularPrice?.let { text = it.toString() }
             setOnTextChangedListener {
                 val price = it.toString().toBigDecimalOrNull() ?: BigDecimal.ZERO
                 viewModel.onRegularPriceEntered(price)
@@ -143,7 +143,7 @@ class ProductPricingFragment :
                 prefixText = currency
             } else suffixText = currency
 
-            pricingData.salePrice?.let { setText(it.toString()) }
+            pricingData.salePrice?.let { text = it.toString() }
             setOnTextChangedListener {
                 val price = it.toString().toBigDecimalOrNull() ?: BigDecimal.ZERO
                 viewModel.onSalePriceEntered(price)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -131,7 +131,7 @@ class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_prod
     private fun showValue(view: WCMaterialOutlinedEditTextView, @StringRes hintRes: Int, value: Float?, unit: String?) {
         if (value != editableToFloat(view.editText?.text)) {
             val valStr = if (value != 0.0f) (value?.toString() ?: "") else ""
-            view.setText(valStr)
+            view.text = valStr
         }
         view.hint = if (unit != null) {
             getString(hintRes) + " ($unit)"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -163,5 +163,5 @@ class AddProductCategoryFragment : BaseFragment(R.layout.fragment_add_product_ca
         progressDialog = null
     }
 
-    private fun getCategoryName() = binding.productCategoryName.getText()
+    private fun getCategoryName() = binding.productCategoryName.text
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
@@ -95,11 +95,11 @@ class ProductDownloadDetailsFragment :
         viewModel.productDownloadDetailsViewStateData.observe(
             owner = viewLifecycleOwner,
             observer = { old, new ->
-                new.fileDraft.url.takeIfNotEqualTo(binding.productDownloadUrl.getText()) {
-                    binding.productDownloadUrl.setText(it)
+                new.fileDraft.url.takeIfNotEqualTo(binding.productDownloadUrl.text) {
+                    binding.productDownloadUrl.text = it
                 }
-                new.fileDraft.name.takeIfNotEqualTo(binding.productDownloadName.getText()) {
-                    binding.productDownloadName.setText(it)
+                new.fileDraft.name.takeIfNotEqualTo(binding.productDownloadName.text) {
+                    binding.productDownloadName.text = it
                 }
                 new.showDoneButton.takeIfNotEqualTo(old?.showDoneButton) {
                     showDoneMenuItem(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
@@ -53,8 +53,8 @@ class ProductDownloadsSettingsFragment : BaseProductFragment(R.layout.fragment_p
     private fun initFromProductDraft() {
         fun Number.formatLimitAndExpiry(): String = if (this.toLong() == -1L) "" else this.toString()
         val product = requireNotNull(viewModel.getProduct().productDraft)
-        binding.productDownloadLimit.setText(product.downloadLimit.formatLimitAndExpiry())
-        binding.productDownloadExpiry.setText(product.downloadExpiry.formatLimitAndExpiry())
+        binding.productDownloadLimit.text = product.downloadLimit.formatLimitAndExpiry()
+        binding.productDownloadExpiry.text = product.downloadExpiry.formatLimitAndExpiry()
     }
 
     private fun setupListeners() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductMenuOrderFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductMenuOrderFragment.kt
@@ -26,7 +26,7 @@ class ProductMenuOrderFragment : BaseProductSettingsFragment(R.layout.fragment_p
 
         _binding = FragmentProductMenuOrderBinding.bind(view)
 
-        binding.productMenuOrder.setText(navArgs.menuOrder.toString())
+        binding.productMenuOrder.text = navArgs.menuOrder.toString()
     }
 
     override fun onDestroyView() {
@@ -40,7 +40,7 @@ class ProductMenuOrderFragment : BaseProductSettingsFragment(R.layout.fragment_p
 
     override fun getChangesResult(): Pair<String, Any> = ARG_MENU_ORDER to getMenuOrder()
 
-    private fun getMenuOrder() = StringUtils.stringToInt(binding.productMenuOrder.getText())
+    private fun getMenuOrder() = StringUtils.stringToInt(binding.productMenuOrder.text)
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSlugFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSlugFragment.kt
@@ -25,7 +25,7 @@ class ProductSlugFragment : BaseProductSettingsFragment(R.layout.fragment_produc
 
         _binding = FragmentProductSlugBinding.bind(view)
 
-        binding.editSlug.setText(navArgs.slug)
+        binding.editSlug.text = navArgs.slug
     }
 
     override fun onDestroyView() {
@@ -42,7 +42,7 @@ class ProductSlugFragment : BaseProductSettingsFragment(R.layout.fragment_produc
     /**
      * As with the web, we trim the string and replace any spaces with hyphens
      */
-    private fun getSlug() = binding.editSlug.getText().trim().replace(" ", "-")
+    private fun getSlug() = binding.editSlug.text.trim().replace(" ", "-")
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
@@ -50,7 +50,7 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
 
         if (selectedVisibility == PASSWORD_PROTECTED.toString()) {
             (savedInstanceState?.getString(ARG_PASSWORD) ?: navArgs.password)?.let { password ->
-                binding.editPassword.setText(password)
+                binding.editPassword.text = password
                 showPassword(password.isNotBlank())
             }
         }
@@ -141,7 +141,7 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
         }
     }
 
-    private fun getPassword() = binding.editPassword.getText()
+    private fun getPassword() = binding.editPassword.text
 }
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/AddProductTagView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/AddProductTagView.kt
@@ -55,10 +55,10 @@ class AddProductTagView @JvmOverloads constructor(
         binding.addTagsEditText.setOnTextChangedListener(cb)
     }
 
-    fun getEnteredTag() = binding.addTagsEditText.getText()
+    fun getEnteredTag() = binding.addTagsEditText.text
 
     fun clearEnteredTag() {
-        binding.addTagsEditText.setText("")
+        binding.addTagsEditText.text = ""
     }
 
     private fun addTag(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -273,7 +273,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         binding.termEditText.setOnEditorActionListener { termName ->
             if (termName.isNotBlank() && !assignedTermsAdapter.containsTerm(termName)) {
                 addTerm(termName)
-                binding.termEditText.setText("")
+                binding.termEditText.text = ""
             }
             true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
@@ -30,7 +30,7 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
         requireActivity().title = getString(R.string.product_rename_attribute)
 
         if (savedInstanceState == null) {
-            binding.attributeName.setText(navArgs.attributeName)
+            binding.attributeName.text = navArgs.attributeName
         }
 
         binding.attributeName.setOnEditorActionListener { attributeName: String ->
@@ -58,7 +58,7 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        val attributeName = binding.attributeName.getText()
+        val attributeName = binding.attributeName.text
         navigateBack(attributeName)
         return false
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -50,6 +50,10 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
             value?.let { binding.editText.addTextChangedListener(it) }
         }
 
+    var text: String
+        get() = binding.editText.text.toString()
+        set(value) = binding.editText.setText(value)
+
     init {
         if (attrs != null) {
             val a = context.obtainStyledAttributes(
@@ -71,7 +75,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
 
                 // Set the startup text
                 a.getString(R.styleable.WCMaterialOutlinedSpinnerView_android_text)?.let {
-                    setText(it)
+                    text = it
                 }
 
                 isEnabled = a.getBoolean(R.styleable.WCMaterialOutlinedCurrencyEditTextView_android_enabled, true)
@@ -80,12 +84,6 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
             }
         }
     }
-
-    fun setText(selectedText: String) {
-        binding.editText.setText(selectedText)
-    }
-
-    fun getText() = binding.editText.text.toString()
 
     fun removeCurrentTextWatcher() {
         textWatcher?.let { binding.editText.removeTextChangedListener(it) }
@@ -98,8 +96,8 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
      * events.
      */
     fun setTextIfDifferent(newText: String) {
-        if (getText() != newText) {
-            setText(newText)
+        if (text != newText) {
+            text = newText
             binding.editText.setSelection(newText.length)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.text.Editable
 import android.text.InputFilter
+import android.text.TextWatcher
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.LayoutInflater
@@ -37,11 +38,18 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     @AttrRes defStyleAttr: Int = R.attr.wcMaterialOutlinedEditTextViewStyle
 ) : TextInputLayout(ctx, attrs, defStyleAttr) {
-    private val binding = ViewMaterialOutlinedEdittextBinding.inflate(LayoutInflater.from(context), this)
-
     companion object {
         private const val KEY_SUPER_STATE = "WC-OUTLINED-EDITTEXT-VIEW-SUPER-STATE"
     }
+
+    private val binding = ViewMaterialOutlinedEdittextBinding.inflate(LayoutInflater.from(context), this)
+
+    var textWatcher: TextWatcher? = null
+        set(value) {
+            field = value
+            value?.let { binding.editText.addTextChangedListener(it) }
+        }
+
     init {
         if (attrs != null) {
             val a = context.obtainStyledAttributes(
@@ -78,6 +86,11 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     }
 
     fun getText() = binding.editText.text.toString()
+
+    fun removeCurrentTextWatcher() {
+        textWatcher?.let { binding.editText.removeTextChangedListener(it) }
+        textWatcher = null
+    }
 
     /**
      * Updates the text only if the current content is different from the supplied one.


### PR DESCRIPTION
Summary
==========
Fixes issue #4977 by connecting the Address Form EditTexts with the `BaseOrderEditingFragment` TextWatcher, taking advantage of the already existent features of state change control. Since the Address Form uses a lot `WCMaterialOutlinedEditTextView` component for UI composing, it was required to extend the component a little bit so it could support custom `TextWatchers`. 

It's also worth noting that these changes made detekt complain about the current state of the `WCMaterialOutlinedEditTextView` class, and considering how small this PR was, I decided to refactor some parts instead of silence the issue with Suppress annotations.

⚠️ The `done` button still does nothing since the data submission is not done yet.

Screenshots
==========
| Untouched empty form | After starting editing | Trying to leave with changes |
| ------------- | ------------- | ------------- |
| ![Screenshot_20211013_110018](https://user-images.githubusercontent.com/5920403/137148178-c9a360fe-3114-48e6-99c6-fc2d13cd8469.png) | ![Screenshot_20211013_110022](https://user-images.githubusercontent.com/5920403/137148201-8e11ff2c-e29d-4578-94bb-6aed10e3a6b9.png) | ![Screenshot_20211013_110026](https://user-images.githubusercontent.com/5920403/137148222-24ed4cf0-683a-4251-a520-d8f0521393ad.png) |

How to Test
==========
1. Enter any Order details and select at least to edit the Billing Address
2. Edit any of the fields and verify if the `done` button appears, verify if removing the changes to the original state makes the `done` button go away
3. Try to hit the `X` button with some changes and verify if the discard warning shows up, verify if the `keep editing` and `discard` button works as expected
4. Try to hit the `done` button and verify if the view returns to the Order Details with no unexpected warnings.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
