### PR TITLE
Add manual to in-person payments menu

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -39,4 +39,6 @@ object AppUrls {
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
     const val WOOCOMMERCE_PURCHASE_CARD_READER = "https://woocommerce.com/products/bbpos-chipper2xbt-card-reader"
+    const val WOOCOMMERCE_MANUAL_CARD_READER =
+        "https://developer.bbpos.com/quick_start_guide/Chipper%202X%20BT%20Quick%20Start%20Guide.pdf"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubFragment.kt
@@ -44,6 +44,9 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
+                is CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow -> {
+                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+                }
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
@@ -26,7 +26,11 @@ class CardReaderHubViewModel @Inject constructor(
             CardReaderHubListItemViewState(
                 UiString.UiStringRes(R.string.card_reader_manage_card_reader),
                 ::onManageCardReaderClicked
-            )
+            ),
+            CardReaderHubListItemViewState(
+                UiString.UiStringRes(R.string.card_reader_manual_card_reader),
+                ::onManualCardReaderClicked
+            ),
         )
     )
 
@@ -40,10 +44,17 @@ class CardReaderHubViewModel @Inject constructor(
         triggerEvent(CardReaderHubEvents.NavigateToPurchaseCardReaderFlow)
     }
 
+    private fun onManualCardReaderClicked() {
+        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow)
+    }
+
     sealed class CardReaderHubEvents : MultiLiveEvent.Event() {
         object NavigateToCardReaderDetail : CardReaderHubEvents()
         object NavigateToPurchaseCardReaderFlow : CardReaderHubEvents() {
             const val url = AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER
+        }
+        object NavigateToManualCardReaderFlow : CardReaderHubEvents() {
+            const val url = AppUrls.WOOCOMMERCE_MANUAL_CARD_READER
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -738,6 +738,7 @@
         -->
     <string name="card_reader_manage_card_reader">Manage Card Reader</string>
     <string name="card_reader_purchase_card_reader">Order Card Reader</string>
+    <string name="card_reader_manual_card_reader">Card Reader Manual</string>
     <!--
         Card Reader Payments
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -33,6 +33,14 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when screen shown, then manual card reader row present`() {
+        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
+            .anyMatch {
+                it.label == UiString.UiStringRes(R.string.card_reader_manual_card_reader)
+            }
+    }
+
+    @Test
     fun `when user clicks on manage card reader, then app navigates to card reader detail screen`() {
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
             .find {
@@ -52,5 +60,16 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.event.value)
             .isEqualTo(CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow)
+    }
+
+    @Test
+    fun `when user clicks on manual card reader, then app opens external webview`() {
+        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
+            .find {
+                it.label == UiString.UiStringRes(R.string.card_reader_manual_card_reader)
+            }!!.onItemClicked.invoke()
+
+        assertThat(viewModel.event.value)
+            .isEqualTo(CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -41,6 +41,14 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when screen shown, then manual card reader row present at the last`() {
+        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
+            .last().matches {
+                it.label == UiString.UiStringRes(R.string.card_reader_manual_card_reader)
+            }
+    }
+
+    @Test
     fun `when user clicks on manage card reader, then app navigates to card reader detail screen`() {
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
             .find {


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Closes: #4998 
<!-- Id number of the GitHub issue this PR addresses. -->

### Note
This needs to go into 7.7 release. 
cc: @jkmassel 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds Card Reader Manual option to in-person payments menu. You can find more info here pdfdoF-cg-p2


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Tap on settings from `My Store`
2. Tap on In-person payments option
3. Verify that you see `Card Reader Manual` as one of the options in there
4. Tap on `Card Reader Manual` and make sure the Card Reader Manual PDF opens


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1331230/137074744-d3cf3671-f490-4c8d-8211-a973606e02ec.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
