### PR TITLE
 shipping label: update image on learn more screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -109,7 +109,7 @@ class OrderNavigator @Inject constructor() {
                     R.string.shipping_label_more_information_heading,
                     R.string.shipping_label_more_information_message,
                     R.string.shipping_label_more_information_link,
-                    R.drawable.img_woo_desk_character,
+                    R.drawable.img_print_with_phone,
                     LearnMoreAboutShippingLabels
                 )
                 fragment.findNavController().navigateSafely(action)

--- a/WooCommerce/src/main/res/layout/fragment_info_screen.xml
+++ b/WooCommerce/src/main/res/layout/fragment_info_screen.xml
@@ -29,7 +29,7 @@
             android:layout_width="wrap_content"
             android:layout_height="@dimen/image_major_150"
             android:layout_marginTop="@dimen/major_200"
-            android:src="@drawable/img_woo_desk_character"
+            android:src="@drawable/img_print_with_phone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/info_heading"


### PR DESCRIPTION
Fixes #4885

## Changes

OrderNavigation.kt to set the correct image on the Learn more screen as per Figma details. 

## Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/137150971-74d7ce9b-c05c-4a0c-b3c2-54150513bd1e.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/137151019-3539ccbd-86ac-48f4-a9ed-bb7e9664bb0e.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/137151060-42e2a8aa-50d9-42df-b490-2a891d14fb12.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/137151106-4ba78f22-8694-40df-8b91-ead356cbfec2.png" width="350"/> |

## Steps to reproduce

- Open the app (the store needs to have the Shipping Labels enabled)
- Go to the orders screen
- Click on an order
- tap on the "Learn more about creating shipping labels with your mobile device"
- Note the updated image

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
