### PR TITLE
Issue/4806 add shipment tracking suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -661,16 +661,6 @@ class OrderDetailViewModel @Inject constructor(
                     AnalyticsTracker.track(Stat.ORDER_NOTE_ADD_SUCCESS)
                 }
             }
-            WCOrderAction.ADD_ORDER_SHIPMENT_TRACKING -> {
-                if (event.isError) {
-                    AnalyticsTracker.track(
-                        Stat.ORDER_TRACKING_ADD_FAILED,
-                        prepareTracksEventsDetails(event)
-                    )
-                } else {
-                    AnalyticsTracker.track(Stat.ORDER_TRACKING_ADD_SUCCESS)
-                }
-            }
             WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING -> {
                 if (event.isError) {
                     AnalyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_SHIPMENT_TRACKING_ADD_BUTTON_TAPPED
 import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.tools.NetworkStatus
@@ -23,6 +24,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import javax.inject.Inject
 import org.wordpress.android.fluxc.utils.DateUtils as FluxCDateUtils
 
@@ -128,11 +130,17 @@ class AddOrderShipmentTrackingViewModel @Inject constructor(
                 trackingLink = addOrderShipmentTrackingViewState.trackingLink
             )
 
-            if (orderDetailRepository.addOrderShipmentTracking(orderId, shipmentTracking)) {
+            val onOrderChanged = orderDetailRepository.addOrderShipmentTracking(orderId, shipmentTracking)
+            if (!onOrderChanged.isError) {
+                AnalyticsTracker.track(Stat.ORDER_TRACKING_ADD_SUCCESS)
                 addOrderShipmentTrackingViewState = addOrderShipmentTrackingViewState.copy(showLoadingProgress = false)
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_added))
                 triggerEvent(ExitWithResult(shipmentTracking))
             } else {
+                AnalyticsTracker.track(
+                    Stat.ORDER_TRACKING_ADD_FAILED,
+                    prepareTracksEventsDetails(onOrderChanged)
+                )
                 addOrderShipmentTrackingViewState = addOrderShipmentTrackingViewState.copy(showLoadingProgress = false)
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_error))
             }
@@ -160,6 +168,12 @@ class AddOrderShipmentTrackingViewModel @Inject constructor(
             true
         }
     }
+
+    private fun prepareTracksEventsDetails(event: OnOrderChanged) = mapOf(
+        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+        AnalyticsTracker.KEY_ERROR_TYPE to event.error.type.toString(),
+        AnalyticsTracker.KEY_ERROR_DESC to event.error.message
+    )
 
     override fun onCleared() {
         super.onCleared()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
@@ -1,13 +1,5 @@
 package com.woocommerce.android.ui.orders.tracking
 
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argThat
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import com.woocommerce.android.R
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.tools.NetworkStatus
@@ -23,7 +15,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.*
 import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
@@ -52,7 +48,7 @@ class AddOrderShipmentTrackingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Add order shipment tracking when network is available - success`() = runBlockingTest {
-        doReturn(true).whenever(repository).addOrderShipmentTracking(any(), any())
+        doReturn(OnOrderChanged(0)).whenever(repository).addOrderShipmentTracking(any(), any())
 
         val events = mutableListOf<Event>()
         viewModel.event.observeForever { events.add(it) }
@@ -76,7 +72,8 @@ class AddOrderShipmentTrackingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Add order shipment tracking fails`() = runBlockingTest {
-        doReturn(false).whenever(repository).addOrderShipmentTracking(any(), any())
+        doReturn(OnOrderChanged(0).also { it.error = OrderError(type = GENERIC_ERROR, message = "") })
+            .whenever(repository).addOrderShipmentTracking(any(), any())
 
         val events = mutableListOf<Event>()
         viewModel.event.observeForever { events.add(it) }

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-c1bcc383b2c3a0ffad749999ed3f4b041062fd5b'
+    fluxCVersion = '2150-7aa8b35409f4e268eeefbfc8566d349da5e196ad'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
Review from one reviewer should be enough, thanks!

<!-- Remember about a good descriptive title. -->

Partially issue: #4806
<!-- Id number of the GitHub issue this PR addresses. -->

[Based on FluxC's PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2150)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR refactors addOrderShipmentTracking into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

Changes to the behavior
1. When the endpoint returns a successful empty response, FluxC returns an error instead of silently consuming the event.
2. Removes "Request_Timeout" - FluxC always returns a result or times-out -> there is no need to implement any timeout in the client app.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open detail of an order
2. Tap on "Add tracking"
3. Fill Carrier and tracking number
4. Tap on Add
5. Notice the tracking is added
6. Open wp-admin and verify the tracking is there

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
