### PR TITLE
Issue/4806 delete shipment tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -9,9 +9,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.*
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.ContinuationWrapper
-import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
-import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Success
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.ORDERS
 import dagger.hilt.android.scopes.ViewModelScoped
@@ -23,10 +20,8 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
-import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.*
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -45,7 +45,6 @@ import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.model.order.OrderIdSet
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_ADD
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.model.Order
@@ -33,6 +34,7 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.order.OrderIdSet
 import org.wordpress.android.fluxc.model.order.toIdSet
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import javax.inject.Inject
 
 @OpenClassOnDebug
@@ -200,13 +202,18 @@ class OrderFulfillViewModel @Inject constructor(
 
     private fun deleteOrderShipmentTracking(shipmentTracking: OrderShipmentTracking) {
         launch {
-            val deletedShipment = repository.deleteOrderShipmentTracking(
+            val onOrderChanged = repository.deleteOrderShipmentTracking(
                 orderIdSet.id, orderIdSet.remoteOrderId, shipmentTracking.toDataModel()
             )
-            if (deletedShipment) {
+            if (!onOrderChanged.isError) {
+                AnalyticsTracker.track(Stat.ORDER_TRACKING_DELETE_SUCCESS)
                 viewState = viewState.copy(shouldRefreshShipmentTracking = true)
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_delete_success))
             } else {
+                AnalyticsTracker.track(
+                    Stat.ORDER_TRACKING_DELETE_FAILED,
+                    prepareTracksEventsDetails(onOrderChanged)
+                )
                 onDeleteShipmentTrackingReverted(shipmentTracking)
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_delete_error))
             }
@@ -218,6 +225,12 @@ class OrderFulfillViewModel @Inject constructor(
             triggerEvent(ExitWithResult(true, key = KEY_REFRESH_SHIPMENT_TRACKING_RESULT))
         } else triggerEvent(Exit)
     }
+
+    private fun prepareTracksEventsDetails(event: OnOrderChanged) = mapOf(
+        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+        AnalyticsTracker.KEY_ERROR_TYPE to event.error.type.toString(),
+        AnalyticsTracker.KEY_ERROR_DESC to event.error.message
+    )
 
     @Parcelize
     data class ViewState(

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2150-7aa8b35409f4e268eeefbfc8566d349da5e196ad'
+    fluxCVersion = '2151-c813e4fe8e5e8a1adeceebdde502f2d0935dd7d4'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2151-c813e4fe8e5e8a1adeceebdde502f2d0935dd7d4'
+    fluxCVersion = '2151-d96535b2df12f4133290c557e831f9518446aae6'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4806
<!-- Id number of the GitHub issue this PR addresses. -->

"Do not merge" label - we need to update FluxC's hash before merging this PR.

[Based on FluxC's PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2151)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR refactors deleteOrderShipmentTracking into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

Changes to the behavior
1. When the endpoint returns a successful empty response, FluxC returns an error instead of a success.
2. Removes "Request_Timeout" - FluxC always returns a result or times-out -> there is no need to implement any timeout in the client app.
3. Fixes coroutineContext used for addOrderShipmentTracking - it was running on the main thread

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open detail of an order
2. Tap on "Add tracking"
3. Fill the number of carrier 
3. Tap on "Save" - check `ORDER_TRACKING_ADD_SUCCESS` is tracked
4. Confirm the tracking is created - verify it in wpadmin
5. Go back to the app and delete the tracking - check `ORDER_TRACKING_DELETE_SUCCESS` is tracked
6. Confirm the tracking is removed - verify it in wpadmin

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
