### PR TITLE
Add card_reader_location_missing_tapped event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -267,6 +267,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         // -- Card Reader - Location
         CARD_READER_LOCATION_SUCCESS,
         CARD_READER_LOCATION_FAILURE,
+        CARD_READER_LOCATION_MISSING_TAPPED,
 
         // -- Receipts
         RECEIPT_PRINT_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_FAILURE
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_MISSING_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
@@ -355,6 +356,7 @@ class CardReaderConnectViewModel @Inject constructor(
                         )
                         viewState.value = MissingMerchantAddressError(
                             {
+                                tracker.track(CARD_READER_LOCATION_MISSING_TAPPED)
                                 triggerEvent(CardReaderConnectEvent.OpenWebView(result.url))
                             },
                             {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -3,8 +3,7 @@ package com.woocommerce.android.ui.prefs.cardreader.connect
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_FAILURE
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
@@ -542,6 +541,20 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 null,
                 "selected site missing"
             )
+        }
+
+    @Test
+    fun `given location fetching fails address, when user clicks on update address, then track tapped event`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            init()
+            whenever(locationRepository.getDefaultLocationId()).thenReturn(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress("")
+            )
+
+            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
+            (viewModel.viewStateData.value as MissingMerchantAddressError).onPrimaryActionClicked.invoke()
+
+            verify(tracker).track(CARD_READER_LOCATION_MISSING_TAPPED)
         }
 
     @Test


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #5006 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an event `card_reader_location_missing_tapped` for tracking when the merchant taps on the enter address button which will be shown when the location fetching fails due to no default address associated with the store while connecting to the card reader.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
**Your site should have the current develop (3.1.1) version of WCPay install.**

1. Remove WC pay address via wp-admin
2. Adjust `CardReaderConnectViewModel::connectToReader:332` to `val cardReaderLocationId = if (cardReader.locationId != null) null else cardReader.locationId` (this way we always fetch a location id from the backend)
3. Try to connect to a reader
4. Notice specific dialog
5. Tap on the `Enter Address` button
6. Verify in the logs that the `card_reader_location_missing_tapped` event is fired.



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
