### PR TITLE
Issue/4806 suspendable add order note

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -651,16 +651,6 @@ class OrderDetailViewModel @Inject constructor(
     @Subscribe(threadMode = MAIN)
     fun onOrderChanged(event: OnOrderChanged) {
         when (event.causeOfChange) {
-            WCOrderAction.POST_ORDER_NOTE -> {
-                if (event.isError) {
-                    AnalyticsTracker.track(
-                        Stat.ORDER_NOTE_ADD_FAILED,
-                        prepareTracksEventsDetails(event)
-                    )
-                } else {
-                    AnalyticsTracker.track(Stat.ORDER_NOTE_ADD_SUCCESS)
-                }
-            }
             WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING -> {
                 if (event.isError) {
                     AnalyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD
 import com.woocommerce.android.model.OrderNote
@@ -23,6 +24,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import javax.inject.Inject
 
 @HiltViewModel
@@ -94,16 +96,28 @@ class AddOrderNoteViewModel @Inject constructor(
 
         val note = addOrderNoteViewState.draftNote
         launch {
-            if (orderDetailRepository.addOrderNote(order.identifier, order.remoteId, note)) {
+            val onOrderChanged = orderDetailRepository.addOrderNote(order.identifier, order.remoteId, note)
+            if (!onOrderChanged.isError) {
+                AnalyticsTracker.track(Stat.ORDER_NOTE_ADD_SUCCESS)
                 addOrderNoteViewState = addOrderNoteViewState.copy(isProgressDialogShown = false)
                 triggerEvent(ShowSnackbar(R.string.add_order_note_added))
                 triggerEvent(ExitWithResult(note))
             } else {
+                AnalyticsTracker.track(
+                    Stat.ORDER_NOTE_ADD_FAILED,
+                    prepareTracksEventsDetails(onOrderChanged)
+                )
                 addOrderNoteViewState = addOrderNoteViewState.copy(isProgressDialogShown = false)
                 triggerEvent(ShowSnackbar(R.string.add_order_note_error))
             }
         }
     }
+
+    private fun prepareTracksEventsDetails(event: OnOrderChanged) = mapOf(
+        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+        AnalyticsTracker.KEY_ERROR_TYPE to event.error.type.toString(),
+        AnalyticsTracker.KEY_ERROR_DESC to event.error.message
+    )
 
     fun onBackPressed() {
         if (addOrderNoteViewState.draftNote.note.trim().isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -6,15 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CREATE_ORDER_REFUND_ITEM_QUANTITY_DIALOG_OPENED
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CREATE_ORDER_REFUND_PRODUCT_AMOUNT_DIALOG_OPENED
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CREATE_ORDER_REFUND_SELECT_ALL_ITEMS_BUTTON_TAPPED
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CREATE_ORDER_REFUND_SUMMARY_REFUND_BUTTON_TAPPED
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CREATE_ORDER_REFUND_TAB_CHANGED
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.REFUND_CREATE
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.REFUND_CREATE_FAILED
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.REFUND_CREATE_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
 import com.woocommerce.android.extensions.calculateTotals
 import com.woocommerce.android.extensions.isCashPayment
 import com.woocommerce.android.extensions.isEqualTo
@@ -62,6 +54,7 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
 import org.wordpress.android.fluxc.store.WCGatewayStore
 import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
@@ -433,8 +426,7 @@ class IssueRefundViewModel @Inject constructor(
 
                         refundSummaryState.refundReason?.let { reason ->
                             if (reason.isNotBlank()) {
-                                val note = OrderNote(note = reason, isCustomerNote = false)
-                                orderDetailRepository.addOrderNote(order.identifier, order.remoteId, note)
+                                addOrderNote(reason)
                             }
                         }
 
@@ -447,6 +439,20 @@ class IssueRefundViewModel @Inject constructor(
             } else {
                 triggerEvent(ShowSnackbar(R.string.offline_error))
             }
+        }
+    }
+
+    private suspend fun addOrderNote(reason: String) {
+        val note = OrderNote(note = reason, isCustomerNote = false)
+        val onOrderChanged = orderDetailRepository
+            .addOrderNote(order.identifier, order.remoteId, note)
+        if (!onOrderChanged.isError) {
+            AnalyticsTracker.track(ORDER_NOTE_ADD_SUCCESS)
+        } else {
+            AnalyticsTracker.track(
+                ORDER_NOTE_ADD_FAILED,
+                prepareTracksEventsDetails(onOrderChanged)
+            )
         }
     }
 
@@ -716,6 +722,12 @@ class IssueRefundViewModel @Inject constructor(
         return calculatePartialShippingSubtotal(selectedShippingLinesId)
             .add(calculatePartialShippingTaxes(selectedShippingLinesId))
     }
+
+    private fun prepareTracksEventsDetails(event: OnOrderChanged) = mapOf(
+        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+        AnalyticsTracker.KEY_ERROR_TYPE to event.error.type.toString(),
+        AnalyticsTracker.KEY_ERROR_DESC to event.error.message
+    )
 
     private enum class InputValidationState {
         TOO_HIGH,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
@@ -27,6 +27,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -142,7 +145,9 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(true).whenever(networkStatus).isConnected()
             doReturn(testOrder).whenever(repository).getOrder(REMOTE_ORDER_ID)
-            doReturn(true).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.remoteId), any())
+            doReturn(
+                OnOrderChanged(0)
+            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.remoteId), any())
 
             initViewModel()
 
@@ -195,7 +200,9 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(true).whenever(networkStatus).isConnected()
             doReturn(testOrder).whenever(repository).getOrder(REMOTE_ORDER_ID)
-            doReturn(false).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.remoteId), any())
+            doReturn(
+                OnOrderChanged(0).apply { this.error = OrderError(GENERIC_ERROR) }
+            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.remoteId), any())
 
             initViewModel()
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2152-98c4c8e750eaac7f8197e92085766c91be6b80d2'
+    fluxCVersion = 'develop-930debb797406f41ef42f04f691e819a6eba25f0'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-7e80cb55cc31cdb77420b03709b697f5cc56adb2'
+    fluxCVersion = '2152-98c4c8e750eaac7f8197e92085766c91be6b80d2'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4806
<!-- Id number of the GitHub issue this PR addresses. -->

"Do not merge" label - we need to update FluxC's hash before merging this PR.

[Based on FluxC's PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2152)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR refactors addOrderNote into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

Changes to the behavior
1. When the endpoint returns a successful empty response, FluxC returns an error instead of a success.
2. Removes "Request_Timeout" - FluxC always returns a result or times-out -> there is no need to implement any timeout in the client app.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open detail of an order
2. Tap on the "Add note" button
3. Type something and tap on "Add"
4. Verify a success event is tracked
5. Verify the note is visible in wp admin
6. Tap on "Issue refund" in the app
7. Select all items
8. Tap on next
9. Enter a reason for refund
10. Tap on Refund
4. Verify a success event is tracked
5. Verify the reason for refund is visible in wp admin

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
