### PR TITLE
Removes ViewModel scope on OrderDetailRepository

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -349,7 +349,6 @@ class CardReaderPaymentViewModel
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     public override fun onCleared() {
         super.onCleared()
-        orderRepository.onCleanup()
         paymentDataForRetry?.let {
             cardReaderManager.cancelPayment(it)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -25,9 +25,7 @@ import org.wordpress.android.fluxc.store.*
 import org.wordpress.android.fluxc.store.WCOrderStore.*
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class OrderDetailRepository @Inject constructor(
     private val orderStore: WCOrderStore,
     private val productStore: WCProductStore,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -9,12 +9,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.*
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.ContinuationWrapper
-import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
-import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Success
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.ORDERS
-import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -23,9 +19,7 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
-import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.*
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -37,12 +31,9 @@ import org.wordpress.android.fluxc.store.WCOrderStore.*
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import javax.inject.Inject
+import javax.inject.Singleton
 
-/*
-ViewModelScope fixes a memory leak related to EventBus subscription. See PR-4780 for details.
-Can be safely removed as soon as we remove EventBus from here.
- */
-@ViewModelScoped
+@Singleton
 class OrderDetailRepository @Inject constructor(
     private val dispatcher: Dispatcher,
     private val orderStore: WCOrderStore,
@@ -55,10 +46,6 @@ class OrderDetailRepository @Inject constructor(
 
     init {
         dispatcher.register(this)
-    }
-
-    fun onCleanup() {
-        dispatcher.unregister(this)
     }
 
     suspend fun fetchOrder(orderIdentifier: OrderIdentifier): Order? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -15,12 +15,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.*
-import org.greenrobot.eventbus.EventBus
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode.MAIN
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -121,7 +121,6 @@ class OrderDetailViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        orderDetailRepository.onCleanup()
         dispatcher.unregister(this)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -23,7 +23,6 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.*
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentCollectibilityChecker
-import com.woocommerce.android.ui.orders.details.OrderDetailRepository.OnProductImageChanged
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.FeatureFlag
@@ -45,13 +44,14 @@ import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCOrderAction
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.model.order.OrderIdSet
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.utils.sumBy
 import javax.inject.Inject
 
@@ -647,8 +647,13 @@ class OrderDetailViewModel @Inject constructor(
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = MAIN)
-    fun onProductImageChanged(event: OnProductImageChanged) {
-        viewState = viewState.copy(refreshedProductId = event.remoteProductId)
+    fun onProductChanged(event: OnProductChanged) {
+        /**
+         * This will be triggered if we fetched a product via ProduictImageMap so we could get its image.
+         */
+        if (event.causeOfChange == FETCH_SINGLE_PRODUCT && !event.isError) {
+            viewState = viewState.copy(refreshedProductId = event.remoteProductId)
+        }
     }
 
     private fun prepareTracksEventsDetails(event: OnOrderChanged) = mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -93,7 +93,6 @@ class OrderFulfillViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        repository.onCleanup()
     }
 
     private fun displayOrderDetails(order: Order) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
@@ -135,7 +135,6 @@ class AddOrderNoteViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        orderDetailRepository.onCleanup()
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -684,7 +684,6 @@ class CreateShippingLabelViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         shippingLabelRepository.clearCache()
-        orderDetailRepository.onCleanup()
     }
 
     private fun BigDecimal.format(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -308,11 +308,6 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        orderDetailRepository.onCleanup()
-    }
-
     private fun Order.getShippableItems(): List<Order.Item> {
         val refunds = orderDetailRepository.getOrderRefunds(identifier.toIdSet().remoteOrderId)
         return refunds.getNonRefundedProducts(items)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModel.kt
@@ -175,11 +175,6 @@ class AddOrderShipmentTrackingViewModel @Inject constructor(
         AnalyticsTracker.KEY_ERROR_DESC to event.error.message
     )
 
-    override fun onCleared() {
-        super.onCleared()
-        orderDetailRepository.onCleanup()
-    }
-
     @Parcelize
     data class ViewState(
         val isSelectedProviderCustom: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModel.kt
@@ -110,7 +110,6 @@ class AddOrderTrackingProviderListViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         shipmentProvidersRepository.onCleanup()
-        orderDetailRepository.onCleanup()
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -689,11 +689,6 @@ class IssueRefundViewModel @Inject constructor(
         }
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        orderDetailRepository.onCleanup()
-    }
-
     private fun getRefundableShippingLineIds(): List<Long> {
         val availableShippingLines = allShippingLineIds.toMutableList()
         refunds.forEach {

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2152-98c4c8e750eaac7f8197e92085766c91be6b80d2'
+    fluxCVersion = '2153-e05f4426b8dce7d9cd068d172a2e61b63f52433b'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4806
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR is a final PR in the #4806 series - the goal was to remove event bus from OrderDetailRepository and make the OrderDetailRepository stateless.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Smoke test the app

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
