### PR TITLE
Issue/4973 editable address field

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -81,6 +81,20 @@ data class Address(
             state.isNotEmpty() || city.isNotEmpty()
     }
 
+    fun isEmpty(): Boolean {
+        return company.isEmpty() &&
+            firstName.isEmpty() &&
+            lastName.isEmpty() &&
+            phone.isEmpty() &&
+            country.isEmpty() &&
+            state.isEmpty() &&
+            address1.isEmpty() &&
+            address2.isEmpty() &&
+            city.isEmpty() &&
+            postcode.isEmpty() &&
+            email.isEmpty()
+    }
+
     fun toShippingLabelModel(): ShippingLabelAddress {
         return ShippingLabelAddress(
             company = company,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -97,7 +97,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
 
         binding.customerInfoBillingAddr.setTextIsSelectable(true)
-        binding.customerInfoBillingAddr.hidePencilDrawable()
+        binding.customerInfoBillingAddr.hidePencilIcon()
         binding.customerInfoBillingAddressSection.setOnClickListener(null)
     }
 
@@ -190,7 +190,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             }
         } else {
             binding.customerInfoCustomerNote.setTextIsSelectable(true)
-            binding.customerInfoCustomerNote.hidePencilDrawable()
+            binding.customerInfoCustomerNote.hidePencilIcon()
         }
     }
 
@@ -218,7 +218,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             binding.customerInfoShippingAddressSection.setOnClickListener { navigateToShippingAddressEditingView() }
         } else {
             binding.customerInfoShippingAddr.setTextIsSelectable(true)
-            binding.customerInfoShippingAddr.hidePencilDrawable()
+            binding.customerInfoShippingAddr.hidePencilIcon()
             binding.customerInfoShippingAddressSection.setOnClickListener(null)
         }
         return shippingAddress

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -57,7 +57,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         // we want to expand the billing address section when the address is empty to expose
         // the "Add billing address" view - note that the billing address is required when
         // a customer makes an order, but it will be empty once we offer order creation
-        if (order.billingAddress.isEmpty()) {
+        if (billingInfo.isEmpty()) {
             expandCustomerInfoView()
             binding.customerInfoViewMore.hide()
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -61,7 +61,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
 
         binding.customerInfoBillingAddr.setTextIsSelectable(false)
-        binding.customerInfoBillingAddr.setOnClickListener { navigateToBillingAddressEditingView() }
+        binding.customerInfoBillingAddressSection.setOnClickListener { navigateToBillingAddressEditingView() }
     }
 
     private fun showReadOnlyBillingInfo(order: Order) {
@@ -92,7 +92,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
 
         binding.customerInfoBillingAddr.setTextIsSelectable(true)
-        binding.customerInfoBillingAddr.setOnClickListener(null)
+        binding.customerInfoBillingAddressSection.setOnClickListener(null)
     }
 
     private fun onViewMoreCustomerInfoClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -208,7 +208,6 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         binding.customerInfoShippingAddr.setIsReadOnly(isReadOnly)
 
         if (!isReadOnly) {
-            binding.customerInfoShippingAddr.setIsReadOnly(false)
             binding.customerInfoShippingAddressSection.setOnClickListener { navigateToShippingAddressEditingView() }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -172,12 +172,8 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 binding.customerInfoMorePanel.expand()
                 binding.customerInfoViewMore.setOnClickListener(null)
             }
-            shippingAddress.isEmpty() -> {
-                binding.customerInfoShippingAddr.text = context.getString(R.string.orderdetail_empty_shipping_address)
-                binding.customerInfoShippingMethodSection.hide()
-            }
             else -> {
-                binding.customerInfoShippingAddr.text = shippingAddress
+                binding.customerInfoShippingAddr.setText(shippingAddress, R.string.order_detail_add_shipping_address)
                 binding.customerInfoShippingMethodSection.isVisible = order.shippingMethods.firstOrNull()?.let {
                     binding.customerInfoShippingMethod.text = it.title
                     true
@@ -187,11 +183,10 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
 
         if (FeatureFlag.ORDER_EDITING.isEnabled()) {
             binding.customerInfoShippingAddr.setTextIsSelectable(false)
-            binding.customerInfoShippingAddr.setOnClickListener { navigateToShippingAddressEditingView() }
+            binding.customerInfoShippingAddressSection.setOnClickListener { navigateToShippingAddressEditingView() }
         } else {
             binding.customerInfoShippingAddr.setTextIsSelectable(true)
-            binding.customerInfoShippingAddr.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
-            binding.customerInfoShippingAddr.setOnClickListener(null)
+            binding.customerInfoShippingAddressSection.setOnClickListener(null)
         }
         return shippingAddress
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -40,12 +40,37 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         showBillingInfo(order)
     }
 
-    private fun showBillingInfo(order: Order): String {
+    private fun showBillingInfo(order: Order) {
+        // TODO once this feature flag is removed, we can remove this check along with showReadOnlyBillingInfo()
+        if (!FeatureFlag.ORDER_EDITING.isEnabled()) {
+            showReadOnlyBillingInfo(order)
+            return
+        }
+
         val billingInfo = order.formatBillingInformationForDisplay()
+        binding.customerInfoBillingAddr.setText(billingInfo, R.string.order_detail_add_billing_address)
+
+        if (order.billingAddress.hasInfo()) {
+            showBillingAddressPhoneInfo(order)
+            showBillingAddressEmailInfo(order)
+            binding.customerInfoViewMore.setOnClickListener { onViewMoreCustomerInfoClick() }
+        } else {
+            binding.customerInfoViewMore.hide()
+            binding.customerInfoMorePanel.hide()
+            binding.customerInfoViewMore.setOnClickListener(null)
+        }
+
+        binding.customerInfoBillingAddr.setTextIsSelectable(false)
+        binding.customerInfoBillingAddr.setOnClickListener { navigateToBillingAddressEditingView() }
+    }
+
+    private fun showReadOnlyBillingInfo(order: Order) {
+        val billingInfo = order.formatBillingInformationForDisplay()
+
         if (order.billingAddress.hasInfo()) {
             if (billingInfo.isNotEmpty()) {
                 binding.customerInfoBillingAddr.visibility = VISIBLE
-                binding.customerInfoBillingAddr.text = billingInfo
+                binding.customerInfoBillingAddr.setText(billingInfo, R.string.order_detail_add_billing_address)
                 binding.customerInfoDivider2.visibility = VISIBLE
             } else {
                 binding.customerInfoBillingAddr.visibility = GONE
@@ -66,16 +91,8 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             hide()
         }
 
-        if (FeatureFlag.ORDER_EDITING.isEnabled()) {
-            binding.customerInfoBillingAddr.setTextIsSelectable(false)
-            binding.customerInfoBillingAddr.setOnClickListener { navigateToBillingAddressEditingView() }
-        } else {
-            binding.customerInfoBillingAddr.setTextIsSelectable(true)
-            binding.customerInfoBillingAddr.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
-            binding.customerInfoBillingAddr.setOnClickListener(null)
-        }
-
-        return billingInfo
+        binding.customerInfoBillingAddr.setTextIsSelectable(true)
+        binding.customerInfoBillingAddr.setOnClickListener(null)
     }
 
     private fun onViewMoreCustomerInfoClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -64,7 +64,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             binding.customerInfoViewMore.show()
         }
 
-        binding.customerInfoBillingAddr.setTextIsSelectable(false)
+        binding.customerInfoBillingAddr.setIsReadOnly(false)
         binding.customerInfoBillingAddressSection.setOnClickListener { navigateToBillingAddressEditingView() }
         binding.customerInfoViewMore.setOnClickListener { onViewMoreCustomerInfoClick() }
     }
@@ -96,8 +96,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             hide()
         }
 
-        binding.customerInfoBillingAddr.setTextIsSelectable(true)
-        binding.customerInfoBillingAddr.hidePencilIcon()
+        binding.customerInfoBillingAddr.setIsReadOnly(true)
         binding.customerInfoBillingAddressSection.setOnClickListener(null)
     }
 
@@ -182,15 +181,14 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         // TODO right now we only make the text selectable when the feature flag is NOT enabled to
         // mimic the existing behavior. We can remove this when the feature flag is removed
         if (isEditable) {
-            binding.customerInfoCustomerNote.setTextIsSelectable(false)
+            binding.customerInfoCustomerNote.setIsReadOnly(false)
             binding.customerInfoCustomerNoteSection.setOnClickListener {
                 val action =
                     OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment()
                 findNavController().navigateSafely(action)
             }
         } else {
-            binding.customerInfoCustomerNote.setTextIsSelectable(true)
-            binding.customerInfoCustomerNote.hidePencilIcon()
+            binding.customerInfoCustomerNote.setIsReadOnly(true)
         }
     }
 
@@ -214,11 +212,10 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
 
         if (FeatureFlag.ORDER_EDITING.isEnabled()) {
-            binding.customerInfoShippingAddr.setTextIsSelectable(false)
+            binding.customerInfoShippingAddr.setIsReadOnly(false)
             binding.customerInfoShippingAddressSection.setOnClickListener { navigateToShippingAddressEditingView() }
         } else {
-            binding.customerInfoShippingAddr.setTextIsSelectable(true)
-            binding.customerInfoShippingAddr.hidePencilIcon()
+            binding.customerInfoShippingAddr.setIsReadOnly(true)
             binding.customerInfoShippingAddressSection.setOnClickListener(null)
         }
         return shippingAddress

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -97,6 +97,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
 
         binding.customerInfoBillingAddr.setTextIsSelectable(true)
+        binding.customerInfoBillingAddr.hidePencilDrawable()
         binding.customerInfoBillingAddressSection.setOnClickListener(null)
     }
 
@@ -189,6 +190,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             }
         } else {
             binding.customerInfoCustomerNote.setTextIsSelectable(true)
+            binding.customerInfoCustomerNote.hidePencilDrawable()
         }
     }
 
@@ -216,6 +218,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             binding.customerInfoShippingAddressSection.setOnClickListener { navigateToShippingAddressEditingView() }
         } else {
             binding.customerInfoShippingAddr.setTextIsSelectable(true)
+            binding.customerInfoShippingAddr.hidePencilDrawable()
             binding.customerInfoShippingAddressSection.setOnClickListener(null)
         }
         return shippingAddress

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -37,13 +37,12 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         isReadOnly: Boolean
     ) {
         showCustomerNote(order, isReadOnly)
-        showShippingAddress(order, isVirtualOrder)
-        showBillingInfo(order)
+        showShippingAddress(order, isVirtualOrder, isReadOnly)
+        showBillingInfo(order, isReadOnly)
     }
 
-    private fun showBillingInfo(order: Order) {
-        // TODO once this feature flag is removed, we can remove this check along with showReadOnlyBillingInfo()
-        if (!FeatureFlag.ORDER_EDITING.isEnabled()) {
+    private fun showBillingInfo(order: Order, isReadOnly: Boolean) {
+        if (isReadOnly || !FeatureFlag.ORDER_EDITING.isEnabled()) {
             showReadOnlyBillingInfo(order)
             return
         }
@@ -192,7 +191,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
     }
 
-    private fun showShippingAddress(order: Order, isVirtualOrder: Boolean): String {
+    private fun showShippingAddress(order: Order, isVirtualOrder: Boolean, isReadOnly: Boolean): String {
         val shippingAddress = order.formatShippingInformationForDisplay()
         when {
             isVirtualOrder -> {
@@ -211,7 +210,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             }
         }
 
-        if (FeatureFlag.ORDER_EDITING.isEnabled()) {
+        if (FeatureFlag.ORDER_EDITING.isEnabled() && !isReadOnly) {
             binding.customerInfoShippingAddr.setIsReadOnly(false)
             binding.customerInfoShippingAddressSection.setOnClickListener { navigateToShippingAddressEditingView() }
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCActionableEmptyLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCActionableEmptyLabel.kt
@@ -36,4 +36,8 @@ class WCActionableEmptyLabel @JvmOverloads constructor(ctx: Context, attrs: Attr
     fun setTextIsSelectable(value: Boolean) {
         binding.notEmptyLabel.setTextIsSelectable(value)
     }
+
+    fun hidePencilDrawable() {
+        binding.notEmptyLabel.setCompoundDrawables(null, null, null, null)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCActionableEmptyLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCActionableEmptyLabel.kt
@@ -33,11 +33,10 @@ class WCActionableEmptyLabel @JvmOverloads constructor(ctx: Context, attrs: Attr
         }
     }
 
-    fun setTextIsSelectable(value: Boolean) {
-        binding.notEmptyLabel.setTextIsSelectable(value)
-    }
-
-    fun hidePencilIcon() {
-        binding.notEmptyLabel.setCompoundDrawables(null, null, null, null)
+    fun setIsReadOnly(readOnly: Boolean) {
+        binding.notEmptyLabel.setTextIsSelectable(readOnly)
+        if (readOnly) {
+            binding.notEmptyLabel.setCompoundDrawables(null, null, null, null)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCActionableEmptyLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCActionableEmptyLabel.kt
@@ -37,7 +37,7 @@ class WCActionableEmptyLabel @JvmOverloads constructor(ctx: Context, attrs: Attr
         binding.notEmptyLabel.setTextIsSelectable(value)
     }
 
-    fun hidePencilDrawable() {
+    fun hidePencilIcon() {
         binding.notEmptyLabel.setCompoundDrawables(null, null, null, null)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCActionableEmptyLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCActionableEmptyLabel.kt
@@ -33,6 +33,9 @@ class WCActionableEmptyLabel @JvmOverloads constructor(ctx: Context, attrs: Attr
         }
     }
 
+    /**
+     * When the view is read-only, we make the text selectable and hide the pencil icon
+     */
     fun setIsReadOnly(readOnly: Boolean) {
         binding.notEmptyLabel.setTextIsSelectable(readOnly)
         if (readOnly) {

--- a/WooCommerce/src/main/res/layout/fragment_order_fulfill.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_fulfill.xml
@@ -43,7 +43,7 @@
             tools:visibility="visible" />
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/customerInfo_customerNote"
+            android:id="@+id/customerInfo_NoteForCustomer"
             style="@style/Woo.Card.Body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -22,7 +21,7 @@
             style="@style/Woo.Card.Header"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/customer_information"/>
+            android:text="@string/customer_information" />
 
         <!-- Label: Customer note -->
         <LinearLayout
@@ -60,11 +59,12 @@
             android:id="@+id/customerInfo_shippingSection"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/major_100"
+            android:layout_marginBottom="@dimen/minor_100"
             android:focusable="true"
             android:orientation="vertical">
 
             <LinearLayout
+                android:id="@+id/customerInfo_shippingAddressSection"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
@@ -73,7 +73,7 @@
                 <View
                     style="@style/Woo.Divider"
                     android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginEnd="@dimen/minor_00"/>
+                    android:layout_marginEnd="@dimen/minor_00" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/customerInfo_shippingLabel"
@@ -81,17 +81,12 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/minor_50"
-                    android:text="@string/orderdetail_shipping_details"/>
+                    android:text="@string/orderdetail_shipping_details" />
 
-                <com.google.android.material.textview.MaterialTextView
+                <com.woocommerce.android.widgets.WCActionableEmptyLabel
                     android:id="@+id/customerInfo_shippingAddr"
-                    style="@style/Woo.Card.Body"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:drawableEnd="@drawable/ic_edit_pencil"
-                    android:drawablePadding="@dimen/major_100"
-                    android:textIsSelectable="true"
-                    tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+                    android:layout_height="wrap_content" />
 
             </LinearLayout>
 
@@ -102,14 +97,14 @@
                 android:layout_height="wrap_content"
                 android:focusable="true"
                 android:orientation="vertical"
-                tools:visibility="visible"
-                android:visibility="visible">
+                android:visibility="visible"
+                tools:visibility="visible">
 
                 <View
                     style="@style/Woo.Divider"
-                    android:layout_marginTop="@dimen/major_100"
                     android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginEnd="@dimen/minor_00"/>
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/minor_00" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/customerInfo_shippingMethodLabel"
@@ -117,14 +112,14 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/minor_50"
-                    android:text="@string/orderdetail_shipping_method"/>
+                    android:text="@string/orderdetail_shipping_method" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/customerInfo_shippingMethod"
                     style="@style/Woo.Card.Body"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    tools:text="International Priority Mail Express Flat Rate"/>
+                    tools:text="International Priority Mail Express Flat Rate" />
             </LinearLayout>
 
         </LinearLayout>
@@ -150,8 +145,8 @@
                 <View
                     android:id="@+id/customerInfo_divider"
                     style="@style/Woo.Divider"
-                    android:layout_marginEnd="@dimen/minor_00"
                     android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/minor_00"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
@@ -185,18 +180,18 @@
                     app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingLabel"
                     tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <!-- Divider -->
             <View
                 android:id="@+id/customerInfo_divider2"
                 style="@style/Woo.Divider"
-                android:layout_marginTop="@dimen/major_100"
                 android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
                 android:layout_marginEnd="@dimen/minor_00"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingAddressSection"/>
+                app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingAddressSection" />
 
             <!-- Billing Phone -->
             <com.google.android.material.textview.MaterialTextView
@@ -211,7 +206,7 @@
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider2"
-                tools:text="123-456-7890"/>
+                tools:text="123-456-7890" />
 
             <!-- Call or message button -->
             <ImageButton
@@ -223,7 +218,7 @@
                 android:scaleType="center"
                 android:src="@drawable/ic_menu_more_vert_compat"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider2"/>
+                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider2" />
 
             <!-- Divider -->
             <View
@@ -233,7 +228,7 @@
                 android:layout_marginEnd="@dimen/minor_00"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_callOrMessageBtn"/>
+                app:layout_constraintTop_toBottomOf="@+id/customerInfo_callOrMessageBtn" />
 
             <!-- Email Address -->
             <com.google.android.material.textview.MaterialTextView
@@ -248,7 +243,7 @@
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider3"
-                tools:text="email@example.com"/>
+                tools:text="email@example.com" />
 
             <!-- Email Button -->
             <ImageButton
@@ -262,7 +257,7 @@
                 android:scaleType="center"
                 android:src="@drawable/ic_email_compat"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider3"/>
+                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider3" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <!-- VIEW MORE Button -->
@@ -270,19 +265,19 @@
             android:id="@+id/customerInfo_viewMore"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:clickable="true"
-            android:focusable="true"
             android:background="?attr/selectableItemBackground"
+            android:clickable="true"
             android:contentDescription="@string/orderdetail_show_billing"
+            android:focusable="true"
+            android:orientation="horizontal"
             tools:visibility="visible">
 
             <View
                 android:id="@+id/customerInfo_divider4"
                 style="@style/Woo.Divider"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"/>
+                app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_viewMoreButtonTitle"
@@ -292,14 +287,14 @@
                 android:layout_weight="1"
                 android:clickable="false"
                 android:focusable="false"
+                android:importantForAccessibility="no"
                 android:paddingStart="@dimen/major_100"
                 android:paddingEnd="@dimen/major_100"
-                android:importantForAccessibility="no"
                 android:text="@string/orderdetail_show_billing"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider4"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/customerInfo_viewMoreButtonImage"
-                app:layout_constraintBottom_toBottomOf="parent"/>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider4" />
 
             <ImageView
                 android:id="@+id/customerInfo_viewMoreButtonImage"
@@ -310,10 +305,10 @@
                 android:focusable="false"
                 android:importantForAccessibility="no"
                 android:padding="@dimen/minor_100"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider4"
-                app:layout_constraintEnd_toEndOf="parent"
+                android:src="@drawable/ic_arrow_down"
                 app:layout_constraintBottom_toBottomOf="parent"
-                android:src="@drawable/ic_arrow_down" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider4" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -12,8 +12,7 @@
         android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible">
+        app:layout_constraintTop_toTopOf="parent">
 
         <!-- Card Title -->
         <com.google.android.material.textview.MaterialTextView
@@ -59,9 +58,9 @@
             android:id="@+id/customerInfo_shippingSection"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/minor_100"
             android:focusable="true"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/minor_100">
 
             <LinearLayout
                 android:id="@+id/customerInfo_shippingAddressSection"
@@ -103,7 +102,6 @@
                 <View
                     style="@style/Woo.Divider"
                     android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginTop="@dimen/major_100"
                     android:layout_marginEnd="@dimen/minor_00" />
 
                 <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -163,20 +163,14 @@
                     app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider" />
 
                 <!-- Billing Address -->
-                <com.google.android.material.textview.MaterialTextView
+                <com.woocommerce.android.widgets.WCActionableEmptyLabel
                     android:id="@+id/customerInfo_billingAddr"
-                    style="@style/Woo.Card.Body"
-                    android:layout_width="0dp"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/minor_50"
-                    android:drawableEnd="@drawable/ic_edit_pencil"
-                    android:drawablePadding="@dimen/major_100"
-                    android:textAlignment="viewStart"
-                    android:textIsSelectable="true"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingLabel"
-                    tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+                    app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingLabel" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -388,6 +388,7 @@
     <string name="order_detail_billing_address_section">Billing Address</string>
     <string name="order_detail_add_customer_note">Add customer note</string>
     <string name="order_detail_add_shipping_address">Add shipping address</string>
+    <string name="order_detail_add_billing_address">Add billing address</string>
 
     <!--
         Shipping label Refunds

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -315,7 +315,6 @@
     <string name="orderdetail_track_shipment">Track shipment</string>
     <string name="orderdetail_copy_tracking_number">Copy tracking number</string>
     <string name="orderdetail_delete_tracking">Delete tracking</string>
-    <string name="orderdetail_empty_shipping_address">No address specified.</string>
     <string name="orderdetail_shipping_notice">This order is using extensions to calculate shipping. The shipping methods shown might be incomplete.</string>
     <string name="orderdetail_issue_refund_button">Issue refund</string>
     <string name="orderdetail_collect_payment_button">Collect Payment</string>
@@ -388,6 +387,7 @@
     <string name="order_detail_shipping_address_section">Shipping Address</string>
     <string name="order_detail_billing_address_section">Billing Address</string>
     <string name="order_detail_add_customer_note">Add customer note</string>
+    <string name="order_detail_add_shipping_address">Add shipping address</string>
 
     <!--
         Shipping label Refunds


### PR DESCRIPTION
Closes #4973 - This PR uses the new `WCActionableEmptyLabel` to enable editing/adding both billing and shipping addresses. This was a bit more involved than expected due to having to handle read-only addresses when the feature flag isn't enabled, or when called from the order fulfillment flow.

As discussed on Slack, when the billing address is missing (which it will be when we enable order creation) we expand the billing address to ensure the user sees the "Add billing address" button.

![Screenshot_20211014_114128](https://user-images.githubusercontent.com/3903757/137351383-c703c674-9ac8-4c6e-beb4-ec4c2d72a1b2.png)


