### PR TITLE
Issue/4973 read only order addresses

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -188,6 +188,11 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
 
     private fun showShippingAddress(order: Order, isVirtualOrder: Boolean, isReadOnly: Boolean) {
         val shippingAddress = order.formatShippingInformationForDisplay()
+        if (shippingAddress.isEmpty() && isReadOnly) {
+            binding.customerInfoShippingSection.hide()
+            return
+        }
+
         when {
             isVirtualOrder -> {
                 binding.customerInfoShippingSection.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -39,7 +39,6 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         val isReallyReadOnly = isReadOnly || !FeatureFlag.ORDER_EDITING.isEnabled()
         showCustomerNote(order, isReallyReadOnly)
         showShippingAddress(order, isVirtualOrder, isReallyReadOnly)
-        // note that showing billing info must come last because we expand it if the other sections are hidden
         showBillingInfo(order, isReallyReadOnly)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -43,61 +43,44 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
     }
 
     private fun showBillingInfo(order: Order, isReadOnly: Boolean) {
-        if (isReadOnly) {
-            showReadOnlyBillingInfo(order)
-            return
-        }
-
         val billingInfo = order.formatBillingInformationForDisplay()
-        binding.customerInfoBillingAddr.setText(billingInfo, R.string.order_detail_add_billing_address)
+        if (isReadOnly && billingInfo.isEmpty()) {
+            // hide the address if it's empty but we have details like email or phone
+            if (order.billingAddress.hasInfo()) {
+                binding.customerInfoBillingAddr.hide()
+            } else {
+                // hide this entire view if shipping address is also empty
+                val shippingAddress = order.formatShippingInformationForDisplay()
+                if (shippingAddress.isEmpty()) {
+                    hide()
+                    return
+                }
+
+                // hide the entire billing section since billing address is empty
+                binding.customerInfoMorePanel.hide()
+                binding.customerInfoViewMore.hide()
+            }
+        } else {
+            binding.customerInfoBillingAddr.setText(billingInfo, R.string.order_detail_add_billing_address)
+            // we want to expand the billing address section when the address is empty to expose
+            // the "Add billing address" view - note that the billing address is required when
+            // a customer makes an order, but it will be empty once we offer order creation
+            if (billingInfo.isEmpty() && !isReadOnly) {
+                expandCustomerInfoView()
+                binding.customerInfoViewMore.hide()
+            } else {
+                binding.customerInfoViewMore.show()
+            }
+        }
 
         showBillingAddressPhoneInfo(order)
         showBillingAddressEmailInfo(order)
 
-        // we want to expand the billing address section when the address is empty to expose
-        // the "Add billing address" view - note that the billing address is required when
-        // a customer makes an order, but it will be empty once we offer order creation
-        if (billingInfo.isEmpty()) {
-            expandCustomerInfoView()
-            binding.customerInfoViewMore.hide()
-        } else {
-            binding.customerInfoViewMore.show()
+        binding.customerInfoBillingAddr.setIsReadOnly(isReadOnly)
+        if (!isReadOnly) {
+            binding.customerInfoBillingAddressSection.setOnClickListener { navigateToBillingAddressEditingView() }
         }
-
-        binding.customerInfoBillingAddr.setIsReadOnly(false)
-        binding.customerInfoBillingAddressSection.setOnClickListener { navigateToBillingAddressEditingView() }
         binding.customerInfoViewMore.setOnClickListener { onViewMoreCustomerInfoClick() }
-    }
-
-    private fun showReadOnlyBillingInfo(order: Order) {
-        val billingInfo = order.formatBillingInformationForDisplay()
-
-        if (order.billingAddress.hasInfo()) {
-            if (billingInfo.isNotEmpty()) {
-                binding.customerInfoBillingAddr.visibility = VISIBLE
-                binding.customerInfoBillingAddr.setText(billingInfo, R.string.order_detail_add_billing_address)
-                binding.customerInfoDivider2.visibility = VISIBLE
-            } else {
-                binding.customerInfoBillingAddr.visibility = GONE
-                binding.customerInfoDivider2.visibility = GONE
-            }
-
-            showBillingAddressPhoneInfo(order)
-            showBillingAddressEmailInfo(order)
-            binding.customerInfoViewMore.setOnClickListener { onViewMoreCustomerInfoClick() }
-        } else {
-            binding.customerInfoViewMore.hide()
-            binding.customerInfoMorePanel.hide()
-            binding.customerInfoViewMore.setOnClickListener(null)
-        }
-
-        val shippingAddress = order.formatShippingInformationForDisplay()
-        if (shippingAddress.isEmpty() && billingInfo.isEmpty()) {
-            hide()
-        }
-
-        binding.customerInfoBillingAddr.setIsReadOnly(true)
-        binding.customerInfoBillingAddressSection.setOnClickListener(null)
     }
 
     private fun onViewMoreCustomerInfoClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -43,13 +43,13 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
     }
 
     private fun showBillingInfo(order: Order, isReadOnly: Boolean) {
-        val billingInfo = order.formatBillingInformationForDisplay()
-        if (isReadOnly && billingInfo.isEmpty()) {
-            // hide the address if it's empty but we have details like email or phone
+        val billingAddress = order.formatBillingInformationForDisplay()
+        if (isReadOnly && billingAddress.isEmpty()) {
+            // if the address is empty but we have details like email or phone, show "No address specified"
             if (order.billingAddress.hasInfo()) {
-                binding.customerInfoBillingAddr.hide()
+                binding.customerInfoBillingAddr.setText(resources.getString(R.string.orderdetail_empty_address), 0)
             } else {
-                // hide this entire view if shipping address is also empty
+                // hide this entire view if there are no extra details and the shipping address is also empty
                 val shippingAddress = order.formatShippingInformationForDisplay()
                 if (shippingAddress.isEmpty()) {
                     hide()
@@ -61,11 +61,11 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 binding.customerInfoViewMore.hide()
             }
         } else {
-            binding.customerInfoBillingAddr.setText(billingInfo, R.string.order_detail_add_billing_address)
+            binding.customerInfoBillingAddr.setText(billingAddress, R.string.order_detail_add_billing_address)
             // we want to expand the billing address section when the address is empty to expose
             // the "Add billing address" view - note that the billing address is required when
             // a customer makes an order, but it will be empty once we offer order creation
-            if (billingInfo.isEmpty() && !isReadOnly) {
+            if (billingAddress.isEmpty() && !isReadOnly) {
                 expandCustomerInfoView()
                 binding.customerInfoViewMore.hide()
             } else {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -389,6 +389,7 @@
     <string name="order_detail_add_customer_note">Add customer note</string>
     <string name="order_detail_add_shipping_address">Add shipping address</string>
     <string name="order_detail_add_billing_address">Add billing address</string>
+    <string name="orderdetail_empty_address">No address specified</string>
 
     <!--
         Shipping label Refunds


### PR DESCRIPTION
I noticed a problem with #5014 in that the shipping address section still appears when the order is read-only and the shipping address is empty. This PR corrects that.

I also did away with the separate function to show read-only shipping info because I felt showing shipping info should be handled in a single function.

To test, verify the various sections appear as expected in both editable and read-only modes. Testing read-only can be simplified by disabling the feature flag.