### PR TITLE
Release V1 version of What's New

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] In-Person Payments: Long click on the readers name copies it to the clipboard
 - [*] In-Person Payments: Firmware version fully visible
+- [*] App is now able to display new feature announcement after app upgrade. [https://github.com/woocommerce/woocommerce-android/pull/5019]
 
 7.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -114,7 +114,7 @@ class MainActivityViewModel @Inject constructor(
                 if (prefs.getLastVersionWithAnnouncement() != buildConfigWrapper.versionName &&
                     cachedAnnouncement.canBeDisplayedOnAppUpgrade(buildConfigWrapper.versionName)
                 ) {
-                    WooLog.e(T.DEVICE, "Displaying Feature Announcement on main activity")
+                    WooLog.i(T.DEVICE, "Displaying Feature Announcement on main activity")
                     triggerEvent(ShowFeatureAnnouncement(it))
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -112,6 +114,7 @@ class MainActivityViewModel @Inject constructor(
                 if (prefs.getLastVersionWithAnnouncement() != buildConfigWrapper.versionName &&
                     cachedAnnouncement.canBeDisplayedOnAppUpgrade(buildConfigWrapper.versionName)
                 ) {
+                    WooLog.e(T.DEVICE, "Displaying Feature Announcement on main activity")
                     triggerEvent(ShowFeatureAnnouncement(it))
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -244,7 +244,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     override fun showLatestAnnouncementOption(announcement: FeatureAnnouncement) {
         binding.optionWhatsNew.show()
         binding.optionWhatsNew.setOnClickListener {
-            WooLog.e(T.DEVICE, "Displaying Feature Announcement from Settings menu.")
+            WooLog.i(T.DEVICE, "Displaying Feature Announcement from Settings menu.")
             findNavController()
                 .navigateSafely(
                     MainSettingsFragmentDirections.actionMainSettingsFragmentToFeatureAnnouncementDialogFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -37,14 +37,12 @@ import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
-import com.woocommerce.android.util.AnalyticsUtils
-import com.woocommerce.android.util.AppThemeUtils
-import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.*
 import com.woocommerce.android.util.FeatureFlag.CARD_READER
-import com.woocommerce.android.util.ThemeOption
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import com.woocommerce.android.util.WooLog.T
 
 @AndroidEntryPoint
 class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSettingsContract.View {
@@ -246,6 +244,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     override fun showLatestAnnouncementOption(announcement: FeatureAnnouncement) {
         binding.optionWhatsNew.show()
         binding.optionWhatsNew.setOnClickListener {
+            WooLog.e(T.DEVICE, "Displaying Feature Announcement from Settings menu.")
             findNavController()
                 .navigateSafely(
                     MainSettingsFragmentDirections.actionMainSettingsFragmentToFeatureAnnouncementDialogFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -40,7 +40,6 @@ import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlag.CARD_READER
 import com.woocommerce.android.util.ThemeOption
 import com.woocommerce.android.widgets.WooClickableSpan
@@ -245,16 +244,14 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     }
 
     override fun showLatestAnnouncementOption(announcement: FeatureAnnouncement) {
-        if (FeatureFlag.WHATS_NEW.isEnabled()) {
-            binding.optionWhatsNew.show()
-            binding.optionWhatsNew.setOnClickListener {
-                findNavController()
-                    .navigateSafely(
-                        MainSettingsFragmentDirections.actionMainSettingsFragmentToFeatureAnnouncementDialogFragment(
-                            announcement
-                        )
+        binding.optionWhatsNew.show()
+        binding.optionWhatsNew.setOnClickListener {
+            findNavController()
+                .navigateSafely(
+                    MainSettingsFragmentDirections.actionMainSettingsFragmentToFeatureAnnouncementDialogFragment(
+                        announcement
                     )
-            }
+                )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -10,7 +10,6 @@ enum class FeatureFlag {
     ORDER_CREATION,
     ORDER_EDITING,
     CARD_READER,
-    WHATS_NEW,
     JETPACK_CP;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -20,8 +19,7 @@ enum class FeatureFlag {
             }
             ORDER_CREATION,
             ORDER_EDITING,
-            JETPACK_CP,
-            WHATS_NEW -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            JETPACK_CP -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4698

### Description

This releases the V1 version of the "What's New" screen, where we show new feature announcements on app upgrade.

This PR is just for removing the feature flag and adding application log, the actual functionalities have all been tested and merged on previous PRs (as listed on #4698).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**A. main case:**
1. The test announcement is available for app version 7.3 up to 7.5, so first go to `WooCommerce/build.gradle` and edit `versionName` value to be `versionName "7.3"`, then sync Gradle.
2. Start app, and make sure you are logged in using your Automattic WordPress.com account (as the test announcement only works with it),
3. Depending on network situation:
3a. The app might show the "What's New in WooCommerce" right away,
3b. If it doesn't, then wait a bit, then switch to a different app and come back to the app to trigger the display onResume:

<img src="https://user-images.githubusercontent.com/266376/136944607-62225554-e9dd-4cb1-b7ff-385d86043c05.png" width="42%" />

4. Tap "Continue" to dismiss the dialog.
5. Go to "Settings", and make sure "What's New in WooCoommerce" option is shown.
6. Tap it, and make sure the same dialog is shown.
7. Kill app, then start it again.
8. Make sure the same dialog is no longer shown after app launch.

**B. Upgrade case:**

1. Go back to `WooCommerce/build.gradle` and edit `versionName` value to be `versionName "7.4"`, then sync Gradle.
2. Build and run the app again,
3. Make sure the dialog is shown after app start.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
