### PR TITLE
issue/ 5026 Update stripeterminal SDK to 2.3.1

### DIFF
--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 
-    implementation "com.stripe:stripeterminal:2.2.0"
+    implementation "com.stripe:stripeterminal:2.3.1"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5026
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Updates the stripe terminal SDK to 2.3.1 version

Changelog:

2.3.1 - 2021-09-22
* Fix: Resolved an issue with class loading in the SDK
2.3.0 - 2021-09-21
Note: This release has an issue with loading internal classes and should not be used. Update to 2.3.1 instead.

* Fix: Resolved issue that led to some optional reader updates being incorrectly marked as required.

* Fix: Removed ClassNotFoundException: com.stripe.cots.CotsAdapterProvider stacktrace on SDK initialization. See issue 155 for details.

* New: Use retrieveSetupIntent to get any SetupIntents that were created outside of your app.

* Update: fields in the Reader class have been added/removed. All newly added fields correspond to the same values returned by the Stripe API

  * Added id, networkStatus, label, baseUrl, ipAddress, livemode
  *Removed ipReader, cotsDescriptor

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just go through all the flows: connection, payment, update

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
