### PR TITLE
Added a link on m2 manual

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -39,6 +39,7 @@ object AppUrls {
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
     const val WOOCOMMERCE_PURCHASE_CARD_READER = "https://woocommerce.com/products/bbpos-chipper2xbt-card-reader"
-    const val WOOCOMMERCE_MANUAL_CARD_READER =
+    const val BBPOS_MANUAL_CARD_READER =
         "https://developer.bbpos.com/quick_start_guide/Chipper%202X%20BT%20Quick%20Start%20Guide.pdf"
+    const val M2_MANUAL_CARD_READER = "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
@@ -28,8 +28,12 @@ class CardReaderHubViewModel @Inject constructor(
                 ::onManageCardReaderClicked
             ),
             CardReaderHubListItemViewState(
-                UiString.UiStringRes(R.string.card_reader_manual_card_reader),
-                ::onManualCardReaderClicked
+                UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader),
+                ::onBbposManualCardReaderClicked
+            ),
+            CardReaderHubListItemViewState(
+                UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader),
+                ::onM2ManualCardReaderClicked
             ),
         )
     )
@@ -44,8 +48,12 @@ class CardReaderHubViewModel @Inject constructor(
         triggerEvent(CardReaderHubEvents.NavigateToPurchaseCardReaderFlow)
     }
 
-    private fun onManualCardReaderClicked() {
-        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow)
+    private fun onBbposManualCardReaderClicked() {
+        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.BBPOS_MANUAL_CARD_READER))
+    }
+
+    private fun onM2ManualCardReaderClicked() {
+        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.M2_MANUAL_CARD_READER))
     }
 
     sealed class CardReaderHubEvents : MultiLiveEvent.Event() {
@@ -53,9 +61,7 @@ class CardReaderHubViewModel @Inject constructor(
         object NavigateToPurchaseCardReaderFlow : CardReaderHubEvents() {
             const val url = AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER
         }
-        object NavigateToManualCardReaderFlow : CardReaderHubEvents() {
-            const val url = AppUrls.WOOCOMMERCE_MANUAL_CARD_READER
-        }
+        data class NavigateToManualCardReaderFlow(val url: String) : CardReaderHubEvents()
     }
 
     sealed class CardReaderHubViewState {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -756,7 +756,8 @@
         -->
     <string name="card_reader_manage_card_reader">Manage Card Reader</string>
     <string name="card_reader_purchase_card_reader">Order Card Reader</string>
-    <string name="card_reader_manual_card_reader">Card Reader Manual</string>
+    <string name="card_reader_bbpos_manual_card_reader">BBPOS Chipper Card Reader Manual</string>
+    <string name="card_reader_m2_manual_card_reader">Stripe M2 Card Reader Manual</string>
     <!--
         Card Reader Payments
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs.cardreader.hub
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -33,19 +34,31 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when screen shown, then manual card reader row present`() {
+    fun `when screen shown, then bbpos manual card reader row present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_manual_card_reader)
+                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader)
             }
     }
 
     @Test
-    fun `when screen shown, then manual card reader row present at the last`() {
+    fun `when screen shown, then m2 manual card reader row present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .last().matches {
-                it.label == UiString.UiStringRes(R.string.card_reader_manual_card_reader)
+            .anyMatch {
+                it.label == UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader)
             }
+    }
+
+    @Test
+    fun `when screen shown, then bbpos manual card reader row present on third position`() {
+        val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
+        assertThat(rows[2].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader))
+    }
+
+    @Test
+    fun `when screen shown, then m2 manual card reader row present at fourth last`() {
+        val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
+        assertThat(rows[3].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader))
     }
 
     @Test
@@ -71,13 +84,32 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when user clicks on manual card reader, then app opens external webview`() {
+    fun `when user clicks on bbpos manual card reader, then app opens external webview with bbpos link`() {
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
             .find {
-                it.label == UiString.UiStringRes(R.string.card_reader_manual_card_reader)
+                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader)
             }!!.onItemClicked.invoke()
 
         assertThat(viewModel.event.value)
-            .isEqualTo(CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow)
+            .isEqualTo(
+                CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow(
+                    AppUrls.BBPOS_MANUAL_CARD_READER
+                )
+            )
+    }
+
+    @Test
+    fun `when user clicks on m2 manual card reader, then app opens external webview with m2 link`() {
+        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
+            .find {
+                it.label == UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader)
+            }!!.onItemClicked.invoke()
+
+        assertThat(viewModel.event.value)
+            .isEqualTo(
+                CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow(
+                    AppUrls.M2_MANUAL_CARD_READER
+                )
+            )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5000
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Card Reader Manual -> BBPOS Chipper Card Reader Manual
* Add a link to the pdf alone with aforementioned link (Stripe M2 Card Reader Manua) – https://stripe.com/files/docs/terminal/m2_product_sheet.pdf

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Settings
2. Manage card reader
3. Notice one more row that opens https://stripe.com/files/docs/terminal/m2_product_sheet.pdf
4. Notice that Card Reader Manual -> BBPOS Chipper Card Reader Manual

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/137738424-311dc369-59fc-4267-bc5e-a0166ba2a57e.mp4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
