### PR TITLE
Make bottom Jetpack banner better accommodate bigger font sizes.

### DIFF
--- a/WooCommerce/src/main/res/layout/view_jetpack_benefits_bottom_banner.xml
+++ b/WooCommerce/src/main/res/layout/view_jetpack_benefits_bottom_banner.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/major_350"
+    android:layout_height="wrap_content"
     android:background="@color/jetpack_black">
 
     <ImageView

--- a/WooCommerce/src/main/res/layout/view_jetpack_benefits_bottom_banner.xml
+++ b/WooCommerce/src/main/res/layout/view_jetpack_benefits_bottom_banner.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:minHeight="@dimen/major_350"
     android:background="@color/jetpack_black">
 
     <ImageView


### PR DESCRIPTION
### Description
After doing a bit more testing on different devices, I found that the Jetpack bottom banner still get cut off on some devices. Here's my attempt to make things look better on all font sizes.

### Testing instructions
Run and test on different font sizes, make sure the top and bottom text are not cut off on all cases.

### Images/gif
| Before | After |
|-|-|
| <img src="https://user-images.githubusercontent.com/266376/137851544-3183cdc9-6e21-4069-86e7-e9477cf7dc48.png"> | <img src="https://user-images.githubusercontent.com/266376/137851645-b36ab8e1-3da1-42ea-a9c5-4645369b48fb.png"> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
