### PR TITLE
Filtering out the current product from the product selection list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
@@ -58,7 +58,8 @@ class ProductSelectionListViewModel @Inject constructor(
     private var loadJob: Job? = null
     private var searchJob: Job? = null
 
-    private val excludedProductIds = navArgs.excludedProductIds.toList()
+    private val excludedProductIds
+        get() = navArgs.excludedProductIds.toList().plus(navArgs.remoteProductId)
 
     init {
         if (_productList.value == null) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
@@ -172,6 +172,4 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
             val remoteProductIds = products.map { it.remoteId }
             assertFalse(remoteProductIds.contains(PRODUCT_REMOTE_ID))
         }
-
-
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
@@ -56,12 +56,12 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Displays the product list view correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        val mutableProductList = productList.toMutableList().apply {
+        val expectedProductList = productList.toMutableList().apply {
             excludedProductIds.forEach { excludedIds ->
                 this.removeIf { it.remoteId == excludedIds }
             }
         }
-        doReturn(mutableProductList).whenever(productRepository).fetchProductList(
+        doReturn(expectedProductList).whenever(productRepository).fetchProductList(
             excludedProductIds = excludedProductIds
         )
 
@@ -72,7 +72,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
             it?.let { products.addAll(it) }
         }
 
-        assertThat(products).isEqualTo(mutableProductList)
+        assertThat(products).isEqualTo(expectedProductList)
 
         val remoteProductIds = products.map { it.remoteId }
         assertFalse(remoteProductIds.contains(EXCLUDED_PRODUCT_REMOTE_ID))
@@ -150,13 +150,13 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
     @Test
     fun `Should exclude the current product from product selection list`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            val mutableProductList = productList.toMutableList().apply {
+            val expectedProductList = productList.toMutableList().apply {
                 excludedProductIds.forEach { excludedIds ->
                     this.removeIf { it.remoteId == excludedIds }
                 }
             }
 
-            doReturn(mutableProductList).whenever(productRepository).fetchProductList(
+            doReturn(expectedProductList).whenever(productRepository).fetchProductList(
                 excludedProductIds = excludedProductIds
             )
 
@@ -167,7 +167,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
                 it?.let { products.addAll(it) }
             }
 
-            assertThat(products).isEqualTo(mutableProductList)
+            assertThat(products).isEqualTo(expectedProductList)
 
             val remoteProductIds = products.map { it.remoteId }
             assertFalse(remoteProductIds.contains(PRODUCT_REMOTE_ID))


### PR DESCRIPTION
Fixes #4521
### Description
Currently the user can add a product under upsell/cross-sell products of itself.
It is not meaningful to have the product listed under upsell/cross-sell products of itself.
So the current product should be excluded from product selection list screen.
### Demo

https://user-images.githubusercontent.com/4975407/137851965-3c856f39-49b4-4e1c-8547-1f4cb2d04168.mp4

https://user-images.githubusercontent.com/4975407/137851929-e8f976de-c44a-42f9-b147-e96285bb1cd3.mp4

### Testing instructions
#### Test Case 1:
Given that I have products “A”, “B”, “C”, “D”
And Then I click the product “A”
When I navigate to add products selection Page for Upsells/Cross-sells
Then I should be able to see products “B”, “C”, “”D
And  I should not see product “A”
#### Test Case 2:
Given that I have products “A”, “B”, “C”, “D”
And Then I click the product “A” which has upsell/cross-sell product - “B”
When I navigate to edit products selection Page for Upsells/Cross-sells
Then I should be able to see product “B”
And  Then I click “AddProducts” button
Then I should be able to see products “C”, “D”
And I should not see product “A” ( which is the product itself )
And I should not see product “B” ( which is already added product )