### PR TITLE
Release order customer note editing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -36,10 +36,11 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         isVirtualOrder: Boolean, // don't display shipping section for virtual products
         isReadOnly: Boolean
     ) {
-        val isReallyReadOnly = isReadOnly || !FeatureFlag.ORDER_EDITING.isEnabled()
-        showCustomerNote(order, isReallyReadOnly)
-        showShippingAddress(order, isVirtualOrder, isReallyReadOnly)
-        showBillingInfo(order, isReallyReadOnly)
+        showCustomerNote(order, isReadOnly)
+        // customer note editing is available but address editing is still behind a feature flag
+        val isReadOnlyOrDisabled = isReadOnly || !FeatureFlag.ORDER_EDITING.isEnabled()
+        showShippingAddress(order, isVirtualOrder, isReadOnlyOrDisabled)
+        showBillingInfo(order, isReadOnlyOrDisabled)
     }
 
     private fun showBillingInfo(order: Order, isReadOnly: Boolean) {


### PR DESCRIPTION
Closes #4910 - this simple PR enables order customer note editing in the release build. Customer address editing is still behind a feature flag.

To test, change the `ORDER_EDITING` feature to disabled and verify that the customer note - but not the addresses - can still be edited.