### PR TITLE
Fix lint comments on PRs

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -346,7 +346,8 @@ task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.
 {{violation.message}}
 """
     violations = [
-            ["CHECKSTYLE", ".", ".*/build/.*\\.xml\$", "Checkstyle"]
+            ["CHECKSTYLE", ".", ".*/build/.*/checkstyle/.*\\.xml\$", "CheckStyle"],
+            ["CHECKSTYLE", ".", ".*/build/.*/detekt/.*\\.xml\$", "Detekt"]
     ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ tasks.register("detektAll", Detekt) {
 
     reports {
         html.enabled = true
-        xml.enabled = false
+        xml.enabled = true
         txt.enabled = false
     }
 }


### PR DESCRIPTION
### Description
While testing https://github.com/woocommerce/woocommerce-android/pull/4757 I found that the `comments-to-github` plugin configuration is broken and that, consequently, the details about `checkstyle` and `detekt` issues are not published on PRs. 

This PR fixes the plugin configuration by: 
- Pointing to the right report folders.
- Enabling XML reports for Detekt, as this is the preferred format for the plugin.


### Testing instructions
- Create a new branch from this one. 
- Introduce some changes in the code that break `checkstyle` or `detekt` rules.
- Commit the new branch and open a PR (draft is ok).
- Verify that the lint step fails and that the details are published in the PR.

To make it easier for the reviewer, I'll leave my test PR open until this one has been reviewed: https://github.com/woocommerce/woocommerce-android/pull/5046. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
