### PR TITLE
Adds a UI test that checks all reviews content.

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/devices/devices_id_delete.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/devices/devices_id_delete.json
@@ -1,6 +1,6 @@
 {
     "request": {
-        "urlPattern": "/rest/v1/devices/[0-9]+/delete/(.*)",
+        "urlPattern": "/rest/v1/devices/(.*)/delete/(.*)",
         "method": "POST"
     },
     "response": {

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2130.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2130.json
@@ -1,0 +1,134 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/2130/(.*)"
+            },
+            "locale": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2130,
+                "name": "Black Coral shades",
+                "slug": "black-coral-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/black-coral-shades\/",
+                "date_created": "2020-01-28T09:54:00",
+                "date_created_gmt": "2020-01-28T09:54:00",
+                "date_modified": "2020-02-27T22:18:22",
+                "date_modified_gmt": "2020-02-27T22:18:22",
+                "type": "simple",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "",
+                "short_description": "",
+                "sku": "",
+                "price": "150",
+                "regular_price": "150",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": true,
+                "total_sales": 18,
+                "virtual": false,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": true,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": true,
+                "average_rating": "5.00",
+                "rating_count": 1,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [{
+                    "id": 2126,
+                    "date_created": "2020-01-28T09:52:57",
+                    "date_created_gmt": "2020-01-28T09:52:57",
+                    "date_modified": "2020-01-28T09:52:57",
+                    "date_modified_gmt": "2020-01-28T09:52:57",
+                    "src": "https:\/\/i2.wp.com\/automatticwidgets.wpcomstaging.com\/wp-content\/uploads\/2020\/01\/Mask-Group-1.png?fit=201%2C201&ssl=1",
+                    "name": "Mask Group-1",
+                    "alt": ""
+                }],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;<\/span>150.00<\/bdi><\/span>",
+                "related_ids": [],
+                "meta_data": [{
+                    "id": 2618,
+                    "key": "_product_addons",
+                    "value": []
+                }, {
+                    "id": 2619,
+                    "key": "_product_addons_exclude_global",
+                    "value": "0"
+                }, {
+                    "id": 2635,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                }, {
+                    "id": 4050,
+                    "key": "_last_editor_used_jetpack",
+                    "value": "classic-editor"
+                }],
+                "stock_status": "onbackorder",
+                "jetpack_publicize_connections": [],
+                "jetpack_likes_enabled": false,
+                "jetpack_sharing_enabled": true,
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2130"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                    }]
+                }
+            }        
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2131.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2131.json
@@ -1,0 +1,134 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/2131/(.*)"
+            },
+            "locale": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2131,
+                "name": "Colorado shades",
+                "slug": "colorado-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/colorado-shades\/",
+                "date_created": "2020-01-28T09:54:41",
+                "date_created_gmt": "2020-01-28T09:54:41",
+                "date_modified": "2020-01-28T10:50:00",
+                "date_modified_gmt": "2020-01-28T10:50:00",
+                "type": "simple",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "",
+                "short_description": "",
+                "sku": "",
+                "price": "100",
+                "regular_price": "135",
+                "sale_price": "100",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": true,
+                "purchasable": true,
+                "total_sales": 5,
+                "virtual": false,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": true,
+                "average_rating": "5.00",
+                "rating_count": 1,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [{
+                    "id": 2125,
+                    "date_created": "2020-01-28T09:52:56",
+                    "date_created_gmt": "2020-01-28T09:52:56",
+                    "date_modified": "2020-01-28T09:52:56",
+                    "date_modified_gmt": "2020-01-28T09:52:56",
+                    "src": "https:\/\/i1.wp.com\/automatticwidgets.wpcomstaging.com\/wp-content\/uploads\/2020\/01\/charles-1-nx1QR5dTE-unsplash.png?fit=201%2C201&ssl=1",
+                    "name": "charles-1-nx1QR5dTE-unsplash",
+                    "alt": ""
+                }],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "<del aria-hidden=\"true\"><span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;<\/span>135.00<\/bdi><\/span><\/del> <ins><span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;<\/span>100.00<\/bdi><\/span><\/ins>",
+                "related_ids": [],
+                "meta_data": [{
+                    "id": 2640,
+                    "key": "_product_addons",
+                    "value": []
+                }, {
+                    "id": 2641,
+                    "key": "_product_addons_exclude_global",
+                    "value": "0"
+                }, {
+                    "id": 2657,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                }, {
+                    "id": 4049,
+                    "key": "_last_editor_used_jetpack",
+                    "value": "classic-editor"
+                }],
+                "stock_status": "instock",
+                "jetpack_publicize_connections": [],
+                "jetpack_likes_enabled": false,
+                "jetpack_sharing_enabled": true,
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2131"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                    }]
+                }
+            }        
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2132.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2132.json
@@ -1,0 +1,134 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/2132/(.*)"
+            },
+            "locale": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2132,
+                "name": "Rose Gold shades",
+                "slug": "rose-gold-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/rose-gold-shades\/",
+                "date_created": "2020-01-28T09:54:59",
+                "date_created_gmt": "2020-01-28T09:54:59",
+                "date_modified": "2020-02-27T22:18:24",
+                "date_modified_gmt": "2020-02-27T22:18:24",
+                "type": "simple",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "",
+                "short_description": "",
+                "sku": "",
+                "price": "120",
+                "regular_price": "120",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": true,
+                "total_sales": 3,
+                "virtual": false,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": true,
+                "average_rating": "5.00",
+                "rating_count": 2,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [{
+                    "id": 2124,
+                    "date_created": "2020-01-28T09:52:54",
+                    "date_created_gmt": "2020-01-28T09:52:54",
+                    "date_modified": "2020-01-28T09:52:54",
+                    "date_modified_gmt": "2020-01-28T09:52:54",
+                    "src": "https:\/\/i1.wp.com\/automatticwidgets.wpcomstaging.com\/wp-content\/uploads\/2020\/01\/annie-theby-FlP6C5pkMKs-unsplash.png?fit=201%2C201&ssl=1",
+                    "name": "annie-theby-FlP6C5pkMKs-unsplash",
+                    "alt": ""
+                }],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;<\/span>120.00<\/bdi><\/span>",
+                "related_ids": [],
+                "meta_data": [{
+                    "id": 2662,
+                    "key": "_product_addons",
+                    "value": []
+                }, {
+                    "id": 2663,
+                    "key": "_product_addons_exclude_global",
+                    "value": "0"
+                }, {
+                    "id": 2679,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                }, {
+                    "id": 4048,
+                    "key": "_last_editor_used_jetpack",
+                    "value": "classic-editor"
+                }],
+                "stock_status": "outofstock",
+                "jetpack_publicize_connections": [],
+                "jetpack_likes_enabled": false,
+                "jetpack_sharing_enabled": true,
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2132"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                    }]
+                }
+            }        
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6154.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6154.json
@@ -1,0 +1,58 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/reviews/6154/(.*)"
+            },          
+            "locale": {
+                "matches": "(.*)"
+            }            
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+             "data": {
+                "id": 6154,
+                "date_created": "{{fnow offset='-7 days' format=customformat}}",
+                "date_created_gmt": "{{fnow offset='-7 days' format=customformat}}",
+                "product_id": 2132,
+                "status": "approved",
+                "reviewer": "Wang King",
+                "reviewer_email": "w@example.com",
+                "review": "I love these shades! They are super sturdy and stylish at the same time. I'm planning to buy them again for a birthday gift next month.",
+                "rating": 5,
+                "verified": false,
+                "reviewer_avatar_urls": {
+                    "24": "https:\/\/secure.gravatar.com\/avatar\/1683ce7f573f1af1584ea5b33bbf0e19?s=24&d=identicon&r=g",
+                    "48": "https:\/\/secure.gravatar.com\/avatar\/1683ce7f573f1af1584ea5b33bbf0e19?s=48&d=identicon&r=g",
+                    "96": "https:\/\/secure.gravatar.com\/avatar\/1683ce7f573f1af1584ea5b33bbf0e19?s=96&d=identicon&r=g"
+                },
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews\/6154"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews"
+                    }],
+                    "up": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/2132"
+                    }],
+                    "reviewer": [{
+                        "embeddable": true,
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wp\/v2\/users\/742102"
+                    }]
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6155.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6155.json
@@ -1,0 +1,58 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/reviews/6155/(.*)"
+            },          
+            "locale": {
+                "matches": "(.*)"
+            }            
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+             "data": {
+                "id": 6155,
+                "date_created": "{{fnow offset='-7 days' format=customformat}}",
+                "date_created_gmt": "{{fnow offset='-7 days' format=customformat}}",
+                "product_id": 2131,
+                "status": "approved",
+                "reviewer": "Mathilde Gerard",
+                "reviewer_email": "m@example.com",
+                "review": "Can't go outside without them anymore!",
+                "rating": 5,
+                "verified": false,
+                "reviewer_avatar_urls": {
+                    "24": "https:\/\/secure.gravatar.com\/avatar\/e4ba34574a801931a8fc2913a12bf6f0?s=24&d=identicon&r=g",
+                    "48": "https:\/\/secure.gravatar.com\/avatar\/e4ba34574a801931a8fc2913a12bf6f0?s=48&d=identicon&r=g",
+                    "96": "https:\/\/secure.gravatar.com\/avatar\/e4ba34574a801931a8fc2913a12bf6f0?s=96&d=identicon&r=g"
+                },
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews\/6155"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews"
+                    }],
+                    "up": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/2131"
+                    }],
+                    "reviewer": [{
+                        "embeddable": true,
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wp\/v2\/users\/742102"
+                    }]
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6156.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6156.json
@@ -1,0 +1,58 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/reviews/6156/(.*)"
+            },          
+            "locale": {
+                "matches": "(.*)"
+            }            
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+             "data": {
+                "id": 6156,
+                "date_created": "{{fnow offset='-5 days' format=customformat}}",
+                "date_created_gmt": "{{fnow offset='-5 days' format=customformat}}",
+                "product_id": 2130,
+                "status": "approved",
+                "reviewer": "Lucy Liu",
+                "reviewer_email": "lucy@example.com",
+                "review": "Great UV protection, I've dropped them a few times and they are still holding up perfectly.",
+                "rating": 5,
+                "verified": false,
+                "reviewer_avatar_urls": {
+                    "24": "https:\/\/secure.gravatar.com\/avatar\/7c07b96537fbe2512c7a08fce2f431e4?s=24&d=identicon&r=g",
+                    "48": "https:\/\/secure.gravatar.com\/avatar\/7c07b96537fbe2512c7a08fce2f431e4?s=48&d=identicon&r=g",
+                    "96": "https:\/\/secure.gravatar.com\/avatar\/7c07b96537fbe2512c7a08fce2f431e4?s=96&d=identicon&r=g"
+                },
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews\/6156"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews"
+                    }],
+                    "up": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/2130"
+                    }],
+                    "reviewer": [{
+                        "embeddable": true,
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wp\/v2\/users\/742102"
+                    }]
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6161.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6161.json
@@ -1,0 +1,54 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/reviews/6161/(.*)"
+            },          
+            "locale": {
+                "matches": "(.*)"
+            }            
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+             "data": {
+                "id": 6161,
+                "date_created": "{{fnow offset='-1 days' format=customformat}}",
+                "date_created_gmt": "{{fnow offset='-1 days' format=customformat}}",
+                "product_id": 2131,
+                "status": "hold",
+                "reviewer": "Mira Workman",
+                "reviewer_email": "mira@example.com",
+                "review": "Can't go outside without them anymore!",
+                "rating": 5,
+                "verified": false,
+                "reviewer_avatar_urls": {
+                    "24": "https:\/\/secure.gravatar.com\/avatar\/eb0ecee9cd38f0e1feb4aa66a515b957?s=24&d=identicon&r=g",
+                    "48": "https:\/\/secure.gravatar.com\/avatar\/eb0ecee9cd38f0e1feb4aa66a515b957?s=48&d=identicon&r=g",
+                    "96": "https:\/\/secure.gravatar.com\/avatar\/eb0ecee9cd38f0e1feb4aa66a515b957?s=96&d=identicon&r=g"
+                },
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews\/6161"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews"
+                    }],
+                    "up": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/2131"
+                    }]
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6162.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6162.json
@@ -1,0 +1,54 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/reviews/6162/(.*)"
+            },          
+            "locale": {
+                "matches": "(.*)"
+            }            
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+             "data": {
+                "id": 6162,
+                "date_created": "{{fnow offset='-1 days' format=customformat}}",
+                "date_created_gmt": "{{fnow offset='-1 days' format=customformat}}",
+                "product_id": 2132,
+                "status": "hold",
+                "reviewer": "Lydia Donin",
+                "reviewer_email": "lydia@example.com",
+                "review": "I love these shades! They are super sturdy and stylish at the same time. I'm planning to buy them again for a birthday gift next month.",
+                "rating": 4,
+                "verified": false,
+                "reviewer_avatar_urls": {
+                    "24": "https:\/\/secure.gravatar.com\/avatar\/54d8a49ef3170cf44d2bdc52133d52cf?s=24&d=identicon&r=g",
+                    "48": "https:\/\/secure.gravatar.com\/avatar\/54d8a49ef3170cf44d2bdc52133d52cf?s=48&d=identicon&r=g",
+                    "96": "https:\/\/secure.gravatar.com\/avatar\/54d8a49ef3170cf44d2bdc52133d52cf?s=96&d=identicon&r=g"
+                },
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews\/6162"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews"
+                    }],
+                    "up": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/2132"
+                    }]
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6163.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6163.json
@@ -1,0 +1,54 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/reviews/6163/(.*)"
+            },          
+            "locale": {
+                "matches": "(.*)"
+            }            
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+             "data": {
+                "id": 6163,
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{fnow format=customformat}}",
+                "date_created_gmt": "{{fnow format=customformat}}",
+                "product_id": 2132,
+                "status": "hold",
+                "reviewer": "Paytin Lubin",
+                "reviewer_email": "pa@example.com",
+                "review": "Travel in style!",
+                "rating": 5,
+                "verified": false,
+                "reviewer_avatar_urls": {
+                    "24": "https:\/\/secure.gravatar.com\/avatar\/c1204ffc1a5bc3086f26cd3b23389e16?s=24&d=identicon&r=g",
+                    "48": "https:\/\/secure.gravatar.com\/avatar\/c1204ffc1a5bc3086f26cd3b23389e16?s=48&d=identicon&r=g",
+                    "96": "https:\/\/secure.gravatar.com\/avatar\/c1204ffc1a5bc3086f26cd3b23389e16?s=96&d=identicon&r=g"
+                },
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews\/6163"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews"
+                    }],
+                    "up": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/2132"
+                    }]
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6164.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_6164.json
@@ -1,0 +1,54 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/reviews/6164/(.*)"
+            },          
+            "locale": {
+                "matches": "(.*)"
+            }            
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+             "data": {
+                "id": 6164,
+                "date_created": "{{fnow offset='-4 days' format=customformat}}",
+                "date_created_gmt": "{{fnow offset='-4 days' format=customformat}}",
+                "product_id": 2130,
+                "status": "approved",
+                "reviewer": "Marcus Curtis",
+                "reviewer_email": "marcu@example.com",
+                "review": "Don't really like them! Thought they are waterproof!",
+                "rating": 2,
+                "verified": false,
+                "reviewer_avatar_urls": {
+                    "24": "https:\/\/secure.gravatar.com\/avatar\/01164960f041ff6fe4dff330968194a4?s=24&d=identicon&r=g",
+                    "48": "https:\/\/secure.gravatar.com\/avatar\/01164960f041ff6fe4dff330968194a4?s=48&d=identicon&r=g",
+                    "96": "https:\/\/secure.gravatar.com\/avatar\/01164960f041ff6fe4dff330968194a4?s=96&d=identicon&r=g"
+                },
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews\/6164"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/reviews"
+                    }],
+                    "up": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/products\/2130"
+                    }]
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json
@@ -28,7 +28,7 @@
                 "status": "hold",
                 "reviewer": "Paytin Lubin",
                 "reviewer_email": "pa@example.com",
-                "review": "<p>Travel in style!<\/p>\n",
+                "review": "Travel in style!",
                 "rating": 5,
                 "verified": false,
                 "reviewer_avatar_urls": {
@@ -55,8 +55,8 @@
                 "status": "hold",
                 "reviewer": "Lydia Donin",
                 "reviewer_email": "lydia@example.com",
-                "review": "<p>I love these shades! They are super sturdy and stylish at the same time. I\u2019m planning to buy them again for a birthday gift next month.<\/p>\n",
-                "rating": 5,
+                "review": "I love these shades! They are super sturdy and stylish at the same time. I'm planning to buy them again for a birthday gift next month.",
+                "rating": 4,
                 "verified": false,
                 "reviewer_avatar_urls": {
                     "24": "https:\/\/secure.gravatar.com\/avatar\/54d8a49ef3170cf44d2bdc52133d52cf?s=24&d=identicon&r=g",
@@ -82,7 +82,7 @@
                 "status": "hold",
                 "reviewer": "Mira Workman",
                 "reviewer_email": "mira@example.com",
-                "review": "<p>Can\u2019t go outside without them anymore!<\/p>\n",
+                "review": "Can't go outside without them anymore!",
                 "rating": 5,
                 "verified": false,
                 "reviewer_avatar_urls": {
@@ -109,8 +109,8 @@
                 "status": "approved",
                 "reviewer": "Marcus Curtis",
                 "reviewer_email": "marcu@example.com",
-                "review": "<p>Such a great product!<\/p>\n",
-                "rating": 5,
+                "review": "Don't really like them! Thought they are waterproof!",
+                "rating": 2,
                 "verified": false,
                 "reviewer_avatar_urls": {
                     "24": "https:\/\/secure.gravatar.com\/avatar\/01164960f041ff6fe4dff330968194a4?s=24&d=identicon&r=g",
@@ -136,7 +136,7 @@
                 "status": "approved",
                 "reviewer": "Lucy Liu",
                 "reviewer_email": "lucy@example.com",
-                "review": "<p>Great UV protection, I've dropped them a few times and they are still holding up perfectly.<\/p>\n",
+                "review": "Great UV protection, I've dropped them a few times and they are still holding up perfectly.",
                 "rating": 5,
                 "verified": false,
                 "reviewer_avatar_urls": {
@@ -167,7 +167,7 @@
                 "status": "approved",
                 "reviewer": "Wang King",
                 "reviewer_email": "w@example.com",
-                "review": "<p>I love these shades! They are super sturdy and stylish at the same time. I'm planning to buy them again for a birthday gift next month.<\/p>\n",
+                "review": "I love these shades! They are super sturdy and stylish at the same time. I'm planning to buy them again for a birthday gift next month.",
                 "rating": 5,
                 "verified": false,
                 "reviewer_avatar_urls": {
@@ -198,7 +198,7 @@
                 "status": "approved",
                 "reviewer": "Mathilde Gerard",
                 "reviewer_email": "m@example.com",
-                "review": "<p>Can't go outside without them anymore!<\/p>\n",
+                "review": "Can't go outside without them anymore!",
                 "rating": 5,
                 "verified": false,
                 "reviewer_avatar_urls": {

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/notifications/notifications_list.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/notifications/notifications_list.json
@@ -1,0 +1,52 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/rest/v1.1/notifications/",
+        "queryParameters": {
+            "fields": {
+                "equalTo": "id,note_hash"
+            },
+            "locale": {
+                "matches": "(.*)"
+            },
+            "number": {
+                "equalTo": "200"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "last_seen_time": "1587953258",
+            "number": 9,
+            "notes": [{
+                "id": 3937001537,
+                "note_hash": 3655803429
+            }, {
+                "id": 4609018123,
+                "note_hash": 3391211851
+            }, {
+                "id": 4580103513,
+                "note_hash": 3536667496
+            }, {
+                "id": 4431304171,
+                "note_hash": 1457869790
+            }, {
+                "id": 4431303676,
+                "note_hash": 281139589
+            }, {
+                "id": 4431300867,
+                "note_hash": 2884267786
+            }, {
+                "id": 4431298454,
+                "note_hash": 3984335560
+            }, {
+                "id": 4431297656,
+                "note_hash": 3407802981
+            }, {
+                "id": 3928326026,
+                "note_hash": 3507881464
+            }]         
+        }   
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/notifications/notifications_read.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/notifications/notifications_read.json
@@ -1,0 +1,18 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPathPattern": "/rest/v1.1/notifications/read/(.*)",
+        "queryParameters": {
+            "locale": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "updated": [],
+            "success": true
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/notifications/rest_v11_notifications.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/notifications/rest_v11_notifications.json
@@ -1,10 +1,10 @@
 {
     "request": {
         "method": "GET",
-        "urlPath": "/rest/v1.1/notifications/",
+        "urlPathPattern": "/rest/v1.1/notifications/",
         "queryParameters": {
             "fields": {
-                "matches": "(.*)id(.*)note_hash(.*)"
+                "equalTo": "id,type,read,body,subject,timestamp,meta,note_hash"
             },
             "locale": {
                 "matches": "(.*)"

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/notifications/rest_v11_notifications_list.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/notifications/rest_v11_notifications_list.json
@@ -1,0 +1,52 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/notifications/",
+        "queryParameters": {
+            "fields": {
+                "equalTo": "id,note_hash"
+            },
+            "locale": {
+                "matches": "(.*)"
+            },
+            "number": {
+                "equalTo": "200"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "last_seen_time": "1587953258",
+            "number": 9,
+            "notes": [{
+                "id": 3937001537,
+                "note_hash": 3655803429
+            }, {
+                "id": 4609018123,
+                "note_hash": 3391211851
+            }, {
+                "id": 4580103513,
+                "note_hash": 3536667496
+            }, {
+                "id": 4431304171,
+                "note_hash": 1457869790
+            }, {
+                "id": 4431303676,
+                "note_hash": 281139589
+            }, {
+                "id": 4431300867,
+                "note_hash": 2884267786
+            }, {
+                "id": 4431298454,
+                "note_hash": 3984335560
+            }, {
+                "id": 4431297656,
+                "note_hash": 3407802981
+            }, {
+                "id": 3928326026,
+                "note_hash": 3507881464
+            }]         
+        }   
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/wpcom/feature_announcements.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/wpcom/feature_announcements.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/wpcom/v2/mobile/feature-announcements/(.*)",
+        "queryParameters": { }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "announcements": []
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -46,17 +46,4 @@ class ScreenshotTest : TestBase() {
         MyStoreScreen()
             .then<MyStoreScreen> { it.stats.switchToStatsDashboardYearsTab() }
     }
-
-    @Test
-    fun mocksDemo() {
-        WelcomeScreen
-            .logoutIfNeeded()
-            .selectLogin()
-            // Connect a WooCommerce store by URL
-            .proceedWith(BuildConfig.SCREENSHOTS_URL)
-            .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)
-            .proceedWith(BuildConfig.SCREENSHOTS_PASSWORD)
-
-        Thread.sleep(1000000)
-    }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
@@ -39,4 +39,18 @@ class ReviewsListScreen : Screen {
 
         return SingleReviewScreen()
     }
+
+    fun scrollToReview(reviewTitle: String): ReviewsListScreen {
+        Espresso.onView(ViewMatchers.withId(LIST_VIEW)).perform(
+            RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
+                ViewMatchers.hasDescendant(
+                    ViewMatchers.withText(
+                        reviewTitle
+                    )
+                ), ViewActions.scrollTo()
+            )
+        )
+
+        return ReviewsListScreen()
+    }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
@@ -1,5 +1,10 @@
 package com.woocommerce.android.screenshots.reviews
 
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.TabNavComponent
 import com.woocommerce.android.screenshots.util.Screen
@@ -18,6 +23,20 @@ class ReviewsListScreen : Screen {
     fun selectReview(index: Int): SingleReviewScreen {
         val correctedIndex = index + 1 // account for the header
         selectItemAtIndexInRecyclerView(correctedIndex, LIST_VIEW, REVIEW_ICON)
+        return SingleReviewScreen()
+    }
+
+    fun selectReviewByTitle(reviewTitle: String): SingleReviewScreen {
+        Espresso.onView(ViewMatchers.withId(LIST_VIEW)).perform(
+            RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
+                ViewMatchers.hasDescendant(
+                    ViewMatchers.withText(
+                        reviewTitle
+                    )
+                ), ViewActions.click()
+            )
+        )
+
         return SingleReviewScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
@@ -3,11 +3,15 @@ package com.woocommerce.android.screenshots.reviews
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.TabNavComponent
+import com.woocommerce.android.screenshots.util.CustomMatchers
 import com.woocommerce.android.screenshots.util.Screen
+import com.woocommerce.android.ui.main.Review
+import org.hamcrest.Matchers
 
 class ReviewsListScreen : Screen {
     companion object {
@@ -52,6 +56,40 @@ class ReviewsListScreen : Screen {
                 ViewActions.scrollTo()
             )
         )
+
+        return ReviewsListScreen()
+    }
+
+    fun assertReviewCard(review: Review): ReviewsListScreen {
+        // Assert that review has an expected hierarchy and content
+        Espresso.onView(
+            Matchers.allOf(
+                ViewMatchers.withChild(ViewMatchers.withId(R.id.notif_icon)),
+                ViewMatchers.withChild(
+                    Matchers.allOf(
+                        ViewMatchers.withId(R.id.notif_title),
+                        ViewMatchers.withText(review.title)
+                    )
+                ),
+                ViewMatchers.withChild(
+                    Matchers.allOf(
+                        ViewMatchers.withId(R.id.notif_desc),
+                        ViewMatchers.withText(review.content)
+                    )
+                ),
+                ViewMatchers.withChild(ViewMatchers.withId(R.id.notif_rating))
+            )
+        )
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        // Assert that review has an expected rating
+        Espresso.onView(
+            Matchers.allOf(
+                ViewMatchers.withId(R.id.notif_rating),
+                ViewMatchers.hasSibling(ViewMatchers.withText(review.title))
+            )
+        )
+            .check(ViewAssertions.matches(CustomMatchers().withStarsNumber((review.rating))))
 
         return ReviewsListScreen()
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
@@ -9,8 +9,8 @@ import androidx.test.espresso.matcher.ViewMatchers
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.TabNavComponent
 import com.woocommerce.android.screenshots.util.CustomMatchers
+import com.woocommerce.android.screenshots.util.ReviewData
 import com.woocommerce.android.screenshots.util.Screen
-import com.woocommerce.android.ui.main.Review
 import org.hamcrest.Matchers
 
 class ReviewsListScreen : Screen {
@@ -60,7 +60,7 @@ class ReviewsListScreen : Screen {
         return ReviewsListScreen()
     }
 
-    fun assertReviewCard(review: Review): ReviewsListScreen {
+    fun assertReviewCard(review: ReviewData): ReviewsListScreen {
         // Assert that review has an expected hierarchy and content
         Espresso.onView(
             Matchers.allOf(

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
@@ -33,7 +33,8 @@ class ReviewsListScreen : Screen {
                     ViewMatchers.withText(
                         reviewTitle
                     )
-                ), ViewActions.click()
+                ),
+                ViewActions.click()
             )
         )
 
@@ -47,7 +48,8 @@ class ReviewsListScreen : Screen {
                     ViewMatchers.withText(
                         reviewTitle
                     )
-                ), ViewActions.scrollTo()
+                ),
+                ViewActions.scrollTo()
             )
         )
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/SingleReviewScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/SingleReviewScreen.kt
@@ -1,7 +1,13 @@
 package com.woocommerce.android.screenshots.reviews
 
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
 import com.woocommerce.android.R
+import com.woocommerce.android.screenshots.util.CustomMatchers
 import com.woocommerce.android.screenshots.util.Screen
+import com.woocommerce.android.ui.main.Review
+import org.hamcrest.Matchers
 
 class SingleReviewScreen : Screen {
     companion object {
@@ -13,5 +19,46 @@ class SingleReviewScreen : Screen {
     fun goBackToReviewsScreen(): ReviewsListScreen {
         pressBack()
         return ReviewsListScreen()
+    }
+
+     fun assertSingleReviewScreen(review: Review): SingleReviewScreen{
+        // Navigation bar
+        Espresso.onView(
+            Matchers.allOf(
+                ViewMatchers.withId(R.id.toolbar),
+                ViewMatchers.withChild(ViewMatchers.withContentDescription("Navigate up")),
+                ViewMatchers.withChild(ViewMatchers.withText("Review"))
+            )
+        )
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        Espresso.onView(ViewMatchers.withContentDescription("Navigate up"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        // Review top bar
+        Espresso.onView(ViewMatchers.withId(R.id.review_product_icon))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        Espresso.onView(ViewMatchers.withId(R.id.review_product_name))
+            .check(ViewAssertions.matches(ViewMatchers.withText(review.product)))
+        Espresso.onView(ViewMatchers.withContentDescription("View the product"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        // Review 'core'
+        Espresso.onView(ViewMatchers.withId(R.id.review_gravatar))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        Espresso.onView(ViewMatchers.withId(R.id.review_user_name))
+            .check(ViewAssertions.matches(ViewMatchers.withText(review.reviewer)))
+        Espresso.onView(ViewMatchers.withId(R.id.review_time)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        Espresso.onView(ViewMatchers.withId(R.id.review_rating_bar))
+            .check(ViewAssertions.matches(CustomMatchers().withStarsNumber(review.rating)))
+        Espresso.onView(ViewMatchers.withId(R.id.review_description))
+            .check(ViewAssertions.matches(ViewMatchers.withText(review.review)))
+        // Flow buttons
+        Espresso.onView(ViewMatchers.withId(R.id.review_trash))
+            .check(ViewAssertions.matches(ViewMatchers.withText("Trash")))
+        Espresso.onView(ViewMatchers.withId(R.id.review_spam))
+            .check(ViewAssertions.matches(ViewMatchers.withText("Spam")))
+        Espresso.onView(ViewMatchers.withId(R.id.review_approve))
+            .check(ViewAssertions.matches(ViewMatchers.withText(review.approveButtonTitle)))
+
+        return SingleReviewScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/SingleReviewScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/SingleReviewScreen.kt
@@ -5,8 +5,8 @@ import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.util.CustomMatchers
+import com.woocommerce.android.screenshots.util.ReviewData
 import com.woocommerce.android.screenshots.util.Screen
-import com.woocommerce.android.ui.main.Review
 import org.hamcrest.Matchers
 
 class SingleReviewScreen : Screen {
@@ -21,7 +21,7 @@ class SingleReviewScreen : Screen {
         return ReviewsListScreen()
     }
 
-    fun assertSingleReviewScreen(review: Review): SingleReviewScreen {
+    fun assertSingleReviewScreen(review: ReviewData): SingleReviewScreen {
         // Navigation bar
         Espresso.onView(
             Matchers.allOf(

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/SingleReviewScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/SingleReviewScreen.kt
@@ -21,7 +21,7 @@ class SingleReviewScreen : Screen {
         return ReviewsListScreen()
     }
 
-     fun assertSingleReviewScreen(review: Review): SingleReviewScreen{
+    fun assertSingleReviewScreen(review: Review): SingleReviewScreen {
         // Navigation bar
         Espresso.onView(
             Matchers.allOf(

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/CustomMatchers.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/CustomMatchers.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.screenshots.util
+
+import android.view.View
+import androidx.appcompat.widget.AppCompatRatingBar
+import androidx.test.espresso.matcher.BoundedMatcher
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+
+class CustomMatchers {
+    fun withStarsNumber(expectedStars: Int): Matcher<View?> {
+        return object : BoundedMatcher<View?, AppCompatRatingBar>(AppCompatRatingBar::class.java) {
+            override fun describeTo(description: Description) {
+                description.appendText("Expected review rating: $expectedStars")
+            }
+
+            override fun matchesSafely(ratingBar: AppCompatRatingBar): Boolean {
+                return ratingBar.rating == expectedStars.toFloat()
+            }
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/ReviewData.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/ReviewData.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.screenshots.util
+
+val productsMap = mapOf(
+    2132 to "Rose Gold shades",
+    2131 to "Colorado shades",
+    2130 to "Black Coral shades"
+)
+
+data class ReviewData(
+    val productID: Int,
+    val status: String,
+    val reviewer: String,
+    val review: String,
+    val rating: Int
+) {
+    val product = productsMap[productID]
+    val title = "$reviewer left a review on $product"
+    val content = if (status == "hold") "Pending Review • $review" else review
+    val approveButtonTitle = if (status == "hold") "Approve" else "Approved"
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/ReviewData.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/ReviewData.kt
@@ -1,5 +1,14 @@
 package com.woocommerce.android.screenshots.util
 
+// While the test data for reviews is obtained from
+// "mappings/jetpack-blogs/wc/reviews/products_reviews_all.json",
+// this file does not contain human-readable product descriptions,
+// but only products ID. The perfect solution would be to
+// retrieve the human readable descriptions by product IDs from
+// "mappings/jetpack-blogs/wc/products/products.json",
+// I honestly had no time to finish this before project ETA.
+// This is something TODO in case of project extension.
+// Instead, I'm using this map.
 val productsMap = mapOf(
     2132 to "Rose Gold shades",
     2131 to "Colorado shades",

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -22,10 +22,10 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-
 
 @HiltAndroidTest
 class ReviewsUITest : TestBase() {
@@ -40,11 +40,6 @@ class ReviewsUITest : TestBase() {
 
     @Before
     fun setUp() {
-
-        //val str = readFileText("mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json")
-        //println(str)
-        //Thread.sleep(1000000)
-
         WelcomeScreen
             .logoutIfNeeded()
             .selectLogin()
@@ -57,34 +52,32 @@ class ReviewsUITest : TestBase() {
 
     @Test
     fun reviewListShowsAllReviews() {
+        val productsMap = mapOf(
+            2132 to "Rose Gold shades",
+            2131 to "Colorado shades",
+            2130 to "Black Coral shades"
+        )
 
-        val statuses = arrayOf("hold", "approved")
-        val reviewers = arrayOf("Paytin Lubin", "Marcus Curtis")
-        val products = arrayOf("Rose Gold shades", "Black Coral shades")
-        val reviews = arrayOf("Travel in style!", "Don't really like them! Thought they are waterproof!")
-        val ratings = arrayOf(5, 2)
+        val str = readAssetsFile("mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json")
+        val json = JSONObject(str)
+        val reviews = json.getJSONObject("response").getJSONObject("jsonBody").getJSONArray("data")
 
-        /*
-        val status = "approved"
-        val reviewer = "Marcus Curtis"
-        val product = "Black Coral shades"
-        val review = "Don't really like them! Thought they are waterproof!"
-        val rating = 2
-        */
-
-        for (i in 0..statuses.size-1) {
-
-            val status = statuses[i]
-            val reviewer = reviewers[i]
-            val product = products[i]
-            val review = reviews[i]
-            val rating = ratings[i]
+        for (i in 0 until reviews.length()) {
+            val reviewContainer: JSONObject = reviews.getJSONObject(i)
+            val status = reviewContainer.getString("status")
+            val reviewer = reviewContainer.getString("reviewer")
+            val productID = reviewContainer.getInt("product_id")
+            val product = productsMap[productID]
+            val review = reviewContainer.getString("review")
+            val rating = reviewContainer.getInt("rating")
 
             val reviewTitle = "$reviewer left a review on $product"
             val reviewContent = if (status == "hold") "Pending Review • $review" else review
             val reviewApproveButtonTitle = if (status == "hold") "Approve" else "Approved"
 
             Thread.sleep(3000)
+
+            ReviewsListScreen().scrollToReview(reviewTitle)
 
             // Assert a review card by its hierarchy and content
             val reviewCard: ViewInteraction = onView(

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -59,12 +59,12 @@ class ReviewsUITest : TestBase() {
 
     @Test
     fun reviewListShowsAllReviews() {
-        val str = readAssetsFile("mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json")
-        val json = JSONObject(str)
-        val reviews = json.getJSONObject("response").getJSONObject("jsonBody").getJSONArray("data")
+        val reviewsWireMockString = readAssetsFile("mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json")
+        val reviewsWireMockJSON = JSONObject(reviewsWireMockString)
+        val reviewsJSONResponse = reviewsWireMockJSON.getJSONObject("response").getJSONObject("jsonBody").getJSONArray("data")
 
-        for (i in 0 until reviews.length()) {
-            val reviewContainer: JSONObject = reviews.getJSONObject(i)
+        for (i in 0 until reviewsJSONResponse.length()) {
+            val reviewContainer: JSONObject = reviewsJSONResponse.getJSONObject(i)
             val currentReview = Review(
                 reviewContainer.getInt("product_id"),
                 reviewContainer.getString("status"),

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -1,0 +1,160 @@
+package com.woocommerce.android.ui.main
+
+import android.view.View
+import androidx.appcompat.widget.AppCompatRatingBar
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.BoundedMatcher
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.R
+import com.woocommerce.android.helpers.InitializationRule
+import com.woocommerce.android.helpers.TestBase
+import com.woocommerce.android.screenshots.TabNavComponent
+import com.woocommerce.android.screenshots.login.WelcomeScreen
+import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
+import com.woocommerce.android.screenshots.reviews.SingleReviewScreen
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.allOf
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+
+@HiltAndroidTest
+class ReviewsUITest : TestBase() {
+    @get:Rule(order = 0)
+    val rule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val initRule = InitializationRule()
+
+    @get:Rule(order = 3)
+    var activityRule = ActivityTestRule(MainActivity::class.java)
+
+    @Before
+    fun setUp() {
+
+        //val str = readFileText("mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json")
+        //println(str)
+        //Thread.sleep(1000000)
+
+        WelcomeScreen
+            .logoutIfNeeded()
+            .selectLogin()
+            .proceedWith(BuildConfig.SCREENSHOTS_URL)
+            .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)
+            .proceedWith(BuildConfig.SCREENSHOTS_PASSWORD)
+
+        TabNavComponent().gotoReviewsScreen()
+    }
+
+    @Test
+    fun reviewListShowsAllReviews() {
+
+        val statuses = arrayOf("hold", "approved")
+        val reviewers = arrayOf("Paytin Lubin", "Marcus Curtis")
+        val products = arrayOf("Rose Gold shades", "Black Coral shades")
+        val reviews = arrayOf("Travel in style!", "Don't really like them! Thought they are waterproof!")
+        val ratings = arrayOf(5, 2)
+
+        /*
+        val status = "approved"
+        val reviewer = "Marcus Curtis"
+        val product = "Black Coral shades"
+        val review = "Don't really like them! Thought they are waterproof!"
+        val rating = 2
+        */
+
+        for (i in 0..statuses.size-1) {
+
+            val status = statuses[i]
+            val reviewer = reviewers[i]
+            val product = products[i]
+            val review = reviews[i]
+            val rating = ratings[i]
+
+            val reviewTitle = "$reviewer left a review on $product"
+            val reviewContent = if (status == "hold") "Pending Review • $review" else review
+            val reviewApproveButtonTitle = if (status == "hold") "Approve" else "Approved"
+
+            Thread.sleep(3000)
+
+            // Assert a review card by its hierarchy and content
+            val reviewCard: ViewInteraction = onView(
+                allOf(
+                    withChild(withId(R.id.notif_icon)),
+                    withChild(allOf(withId(R.id.notif_title), withText(reviewTitle))),
+                    withChild(allOf(withId(R.id.notif_desc), withText(reviewContent))),
+                    withChild(withId(R.id.notif_rating))
+                )
+            )
+                .check(matches(isDisplayed()))
+
+            // Assert that a specific review has an expected rating
+            onView(
+                allOf(
+                    withId(R.id.notif_rating),
+                    hasSibling(withText(reviewTitle))
+                )
+            )
+                .check(matches(withStarsNumber(rating)))
+
+            ReviewsListScreen().selectReviewByTitle(reviewTitle)
+
+            // Assert separate review screen:
+            // Navigation bar
+            onView(
+                allOf(
+                    withId(R.id.toolbar),
+                    withChild(withContentDescription("Navigate up")),
+                    withChild(withText("Review"))
+                )
+            )
+                .check(matches(isDisplayed()))
+
+            onView(withContentDescription("Navigate up")).check(matches(isDisplayed()))
+            // Review top bar
+            onView(withId(R.id.review_product_icon)).check(matches(isDisplayed()))
+            onView(withId(R.id.review_product_name)).check(matches(withText(product)))
+            onView(withContentDescription("View the product")).check(matches(isDisplayed()))
+            // Review 'core'
+            onView(withId(R.id.review_gravatar)).check(matches(isDisplayed()))
+            onView(withId(R.id.review_user_name)).check(matches(withText(reviewer)))
+            onView(withId(R.id.review_time)).check(matches(isDisplayed()))
+            onView(withId(R.id.review_rating_bar)).check(matches(withStarsNumber(rating)))
+            onView(withId(R.id.review_description)).check(matches(withText(review)))
+            // Flow buttons
+            onView(withId(R.id.review_trash)).check(matches(withText("Trash")))
+            onView(withId(R.id.review_spam)).check(matches(withText("Spam")))
+            onView(withId(R.id.review_approve)).check(matches(withText(reviewApproveButtonTitle)))
+
+            SingleReviewScreen().goBackToReviewsScreen()
+        }
+
+        Thread.sleep(10000000)
+    }
+
+    private fun withStarsNumber(expectedStars: Int): Matcher<View?>? {
+        return object : BoundedMatcher<View?, AppCompatRatingBar>(AppCompatRatingBar::class.java) {
+            override fun describeTo(description: Description) {
+                description.appendText("Expected review rating: $expectedStars")
+            }
+
+            override fun matchesSafely(ratingBar: AppCompatRatingBar): Boolean {
+                return ratingBar.rating == expectedStars.toFloat()
+            }
+        }
+    }
+
+    fun readAssetsFile(fileName: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().context
+        return appContext.assets.open(fileName).bufferedReader().use { it.readText() }
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -1,26 +1,15 @@
 package com.woocommerce.android.ui.main
 
-import android.view.View
-import androidx.appcompat.widget.AppCompatRatingBar
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.BoundedMatcher
-import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
-import com.woocommerce.android.R
 import com.woocommerce.android.helpers.InitializationRule
 import com.woocommerce.android.helpers.TestBase
 import com.woocommerce.android.screenshots.TabNavComponent
 import com.woocommerce.android.screenshots.login.WelcomeScreen
 import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
-import com.woocommerce.android.screenshots.reviews.SingleReviewScreen
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.hamcrest.Description
-import org.hamcrest.Matcher
-import org.hamcrest.Matchers.allOf
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
@@ -85,76 +74,15 @@ class ReviewsUITest : TestBase() {
             )
 
             Thread.sleep(3000)
-            ReviewsListScreen().scrollToReview(currentReview.title)
-            assertReviewCard(currentReview)
-
-            ReviewsListScreen().selectReviewByTitle(currentReview.title)
-            assertSingleReviewScreen(currentReview)
-            SingleReviewScreen().goBackToReviewsScreen()
+            ReviewsListScreen()
+                .scrollToReview(currentReview.title)
+                .assertReviewCard(currentReview)
+                .selectReviewByTitle(currentReview.title)
+                .assertSingleReviewScreen(currentReview)
+                .goBackToReviewsScreen()
         }
 
         Thread.sleep(10000000)
-    }
-
-    private fun assertReviewCard(review: Review) {
-        onView(
-            allOf(
-                withChild(withId(R.id.notif_icon)),
-                withChild(allOf(withId(R.id.notif_title), withText(review.title))),
-                withChild(allOf(withId(R.id.notif_desc), withText(review.content))),
-                withChild(withId(R.id.notif_rating))
-            )
-        )
-            .check(matches(isDisplayed()))
-
-        // Assert that a specific review has an expected rating
-        onView(
-            allOf(
-                withId(R.id.notif_rating),
-                hasSibling(withText(review.title))
-            )
-        )
-            .check(matches(withStarsNumber(review.rating)))
-    }
-
-    private fun assertSingleReviewScreen(review: Review) {
-        // Navigation bar
-        onView(
-            allOf(
-                withId(R.id.toolbar),
-                withChild(withContentDescription("Navigate up")),
-                withChild(withText("Review"))
-            )
-        )
-            .check(matches(isDisplayed()))
-
-        onView(withContentDescription("Navigate up")).check(matches(isDisplayed()))
-        // Review top bar
-        onView(withId(R.id.review_product_icon)).check(matches(isDisplayed()))
-        onView(withId(R.id.review_product_name)).check(matches(withText(review.product)))
-        onView(withContentDescription("View the product")).check(matches(isDisplayed()))
-        // Review 'core'
-        onView(withId(R.id.review_gravatar)).check(matches(isDisplayed()))
-        onView(withId(R.id.review_user_name)).check(matches(withText(review.reviewer)))
-        onView(withId(R.id.review_time)).check(matches(isDisplayed()))
-        onView(withId(R.id.review_rating_bar)).check(matches(withStarsNumber(review.rating)))
-        onView(withId(R.id.review_description)).check(matches(withText(review.review)))
-        // Flow buttons
-        onView(withId(R.id.review_trash)).check(matches(withText("Trash")))
-        onView(withId(R.id.review_spam)).check(matches(withText("Spam")))
-        onView(withId(R.id.review_approve)).check(matches(withText(review.approveButtonTitle)))
-    }
-
-    private fun withStarsNumber(expectedStars: Int): Matcher<View?> {
-        return object : BoundedMatcher<View?, AppCompatRatingBar>(AppCompatRatingBar::class.java) {
-            override fun describeTo(description: Description) {
-                description.appendText("Expected review rating: $expectedStars")
-            }
-
-            override fun matchesSafely(ratingBar: AppCompatRatingBar): Boolean {
-                return ratingBar.rating == expectedStars.toFloat()
-            }
-        }
     }
 
     private fun readAssetsFile(fileName: String): String {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -8,31 +8,13 @@ import com.woocommerce.android.helpers.TestBase
 import com.woocommerce.android.screenshots.TabNavComponent
 import com.woocommerce.android.screenshots.login.WelcomeScreen
 import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
+import com.woocommerce.android.screenshots.util.ReviewData
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-
-val productsMap = mapOf(
-    2132 to "Rose Gold shades",
-    2131 to "Colorado shades",
-    2130 to "Black Coral shades"
-)
-
-data class Review(
-    val productID: Int,
-    val status: String,
-    val reviewer: String,
-    val review: String,
-    val rating: Int
-) {
-    val product = productsMap[productID]
-    val title = "$reviewer left a review on $product"
-    val content = if (status == "hold") "Pending Review • $review" else review
-    val approveButtonTitle = if (status == "hold") "Approve" else "Approved"
-}
 
 @HiltAndroidTest
 class ReviewsUITest : TestBase() {
@@ -69,7 +51,7 @@ class ReviewsUITest : TestBase() {
 
         for (i in 0 until reviewsJSONResponse.length()) {
             val reviewContainer: JSONObject = reviewsJSONResponse.getJSONObject(i)
-            val currentReview = Review(
+            val currentReview = ReviewData(
                 reviewContainer.getInt("product_id"),
                 reviewContainer.getString("status"),
                 reviewContainer.getString("reviewer"),

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.main
 import android.view.View
 import androidx.appcompat.widget.AppCompatRatingBar
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers.*
@@ -80,7 +79,7 @@ class ReviewsUITest : TestBase() {
             ReviewsListScreen().scrollToReview(reviewTitle)
 
             // Assert a review card by its hierarchy and content
-            val reviewCard: ViewInteraction = onView(
+            onView(
                 allOf(
                     withChild(withId(R.id.notif_icon)),
                     withChild(allOf(withId(R.id.notif_title), withText(reviewTitle))),
@@ -134,7 +133,7 @@ class ReviewsUITest : TestBase() {
         Thread.sleep(10000000)
     }
 
-    private fun withStarsNumber(expectedStars: Int): Matcher<View?>? {
+    private fun withStarsNumber(expectedStars: Int): Matcher<View?> {
         return object : BoundedMatcher<View?, AppCompatRatingBar>(AppCompatRatingBar::class.java) {
             override fun describeTo(description: Description) {
                 description.appendText("Expected review rating: $expectedStars")
@@ -146,7 +145,7 @@ class ReviewsUITest : TestBase() {
         }
     }
 
-    fun readAssetsFile(fileName: String): String {
+    private fun readAssetsFile(fileName: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().context
         return appContext.assets.open(fileName).bufferedReader().use { it.readText() }
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -59,9 +59,13 @@ class ReviewsUITest : TestBase() {
 
     @Test
     fun reviewListShowsAllReviews() {
-        val reviewsWireMockString = readAssetsFile("mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json")
+        val reviewsWireMockFileName = "mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json"
+        val reviewsWireMockString = readAssetsFile(reviewsWireMockFileName)
         val reviewsWireMockJSON = JSONObject(reviewsWireMockString)
-        val reviewsJSONResponse = reviewsWireMockJSON.getJSONObject("response").getJSONObject("jsonBody").getJSONArray("data")
+        val reviewsJSONResponse = reviewsWireMockJSON
+            .getJSONObject("response")
+            .getJSONObject("jsonBody")
+            .getJSONArray("data")
 
         for (i in 0 until reviewsJSONResponse.length()) {
             val reviewContainer: JSONObject = reviewsJSONResponse.getJSONObject(i)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -77,7 +77,6 @@ class ReviewsUITest : TestBase() {
                 reviewContainer.getInt("rating")
             )
 
-            Thread.sleep(3000)
             ReviewsListScreen()
                 .scrollToReview(currentReview.title)
                 .assertReviewCard(currentReview)
@@ -85,8 +84,6 @@ class ReviewsUITest : TestBase() {
                 .assertSingleReviewScreen(currentReview)
                 .goBackToReviewsScreen()
         }
-
-        Thread.sleep(10000000)
     }
 
     private fun readAssetsFile(fileName: String): String {


### PR DESCRIPTION
### Description
This PR introduces a UI test that checks the content of the reviews list, and every individual review screen. It uses [Espresso](https://developer.android.com/training/testing/espresso/basics) matches to build assertions.

Please note that out of 23 changed files, 17 are WireMock files that were missing. WireMock has a [read-only](https://github.com/wiremock/wiremock/blob/01178a8b2719c7633beebd3a4e3e7ea3b95a89eb/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java#L36) 🤯 `failOnUnmatchedRequests` [setting](https://github.com/wiremock/wiremock/issues/795#issuecomment-343313593), with default being `true`, that will force the test to fail in case of even a single unmatched request. So, while the test was technically passing (all assertions passed) without the added JSONs, I still had to add them 😢 .

More on the test specifics in the additional code comments.

### Testing instructions

1. Make sure you use the latest revision of mobile secrets
2. Use the gradle.properties from mobile secrets
3. To avoid possible Emulator flakiness, create a fresh Emulator instance. I tested under Pixel 4a API 30
4. Run `reviewListShowsAllReviews` test from `ReviewsUITest.kt` ~> it should pass

<img width="604" alt="Screenshot 2021-10-22 at 15 28 23" src="https://user-images.githubusercontent.com/73365754/138455723-76d2549b-b018-4c4d-b6d3-9fdaa7755a1e.png">

### Possible issues
I'm not sure how this will behave on the setups with lower performance. So far, I'm not using any conditional or simple sleeps.

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.