### PR TITLE
Disable Detekt TooManyFunctions rule

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android
 
 import javax.inject.Inject
 
-@Suppress("TooManyFunctions")
 class AppPrefsWrapper @Inject constructor() {
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
         AppPrefs.getReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
@@ -1,18 +1,19 @@
-@file:Suppress("TooManyFunctions", "ComplexMethod")
+@file:Suppress("ComplexMethod")
 
 package com.woocommerce.android.extensions
 
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.WooLog
+import org.apache.commons.io.FileUtils.byteCountToDisplaySize
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import org.wordpress.android.fluxc.model.WCSSRModel
-import java.text.SimpleDateFormat
-import java.util.*
-import org.apache.commons.io.FileUtils.byteCountToDisplaySize
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
 
 const val MISSING_VALUE = "Info not found"
 const val HEADING_SSR = "### System Status Report generated via the WooCommerce Android app ### \n"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
@@ -21,7 +21,6 @@ import javax.inject.Singleton
  * Shows the standard uploading arrow animated notification icon to signify that images are being uploaded
  */
 @Singleton
-@Suppress("TooManyFunctions")
 class ProductImagesNotificationHandler @Inject constructor(
     val context: Context
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
@@ -29,7 +29,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.random.Random
 
-@Suppress("TooManyFunctions")
 @Singleton
 class NotificationMessageHandler @Inject constructor(
     private val accountStore: AccountStore,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutionException
 import javax.inject.Inject
 import javax.inject.Singleton
 
-@Suppress("TooManyFunctions")
 @Singleton
 class WooNotificationBuilder @Inject constructor(private val context: Context) {
     fun isNotificationsEnabled(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -58,8 +58,7 @@ import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
 
-// TODO Extract logic out of MainActivity to reduce size and remove this @Suppress("TooManyFunctions")
-@Suppress("TooManyFunctions")
+// TODO Extract logic out of MainActivity to reduce size
 @AndroidEntryPoint
 class MainActivity :
     AppUpgradeActivity(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.ui.base.BasePresenter
 import com.woocommerce.android.ui.base.BaseView
 import org.wordpress.android.fluxc.model.SiteModel
 
-@Suppress("TooManyFunctions")
 interface MainContract {
     interface Presenter : BasePresenter<View> {
         fun userIsLoggedIn(): Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -24,7 +24,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-@Suppress("TooManyFunctions")
 @ExperimentalCoroutinesApi
 class MediaFileUploadHandler @Inject constructor(
     private val notificationHandler: ProductImagesNotificationHandler,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -23,7 +23,6 @@ import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PhoneUtils
 import com.woocommerce.android.widgets.AppRatingDialog
 
-@Suppress("TooManyFunctions")
 class OrderDetailCustomerInfoView @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -21,7 +21,6 @@ import javax.inject.Singleton
 
 @OpenClassOnDebug
 @Singleton
-@Suppress("TooManyFunctions")
 class ShippingLabelRepository @Inject constructor(
     private val shippingLabelStore: WCShippingLabelStore,
     private val selectedSite: SelectedSite

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -31,7 +31,6 @@ import javax.inject.Inject
 import kotlin.math.ceil
 
 @HiltViewModel
-@Suppress("TooManyFunctions")
 class EditShippingLabelPackagesViewModel @Inject constructor(
     savedState: SavedStateHandle,
     parameterRepository: ParameterRepository,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -21,7 +21,6 @@ private val SUPPORTED_COUNTRIES = listOf("US")
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 const val SUPPORTED_WCPAY_VERSION = "2.8.2"
 
-@Suppress("TooManyFunctions")
 class CardReaderOnboardingChecker @Inject constructor(
     private val selectedSite: SelectedSite,
     private val appPrefsWrapper: AppPrefsWrapper,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
@@ -39,7 +39,6 @@ import javax.inject.Inject
 private const val PERCENT_100: Int = 100
 
 @HiltViewModel
-@Suppress("TooManyFunctions")
 class CardReaderUpdateViewModel @Inject constructor(
     private val cardReaderManager: CardReaderManager,
     private val tracker: AnalyticsTrackerWrapper,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjuste
 import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjusted.PriceType.PercentageBased
 import javax.inject.Inject
 
-@Suppress("TooManyFunctions")
 @HiltViewModel
 class OrderedAddonViewModel @Inject constructor(
     savedState: SavedStateHandle,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -27,7 +27,9 @@ import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.WCSavedState
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.PhotonUtils
-import java.util.*
+import java.util.ArrayList
+import java.util.HashSet
+import java.util.Locale
 
 /**
  * Custom recycler which displays images from the WP media library
@@ -131,7 +133,6 @@ class WPMediaGalleryView @JvmOverloads constructor(
             areItemsTheSame(oldItemPosition, newItemPosition)
     }
 
-    @Suppress("TooManyFunctions")
     private inner class WPMediaLibraryGalleryAdapter : RecyclerView.Adapter<WPMediaViewHolder>() {
         private val imageList = mutableListOf<Product.Image>()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooAnimUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooAnimUtils.kt
@@ -24,7 +24,6 @@ private const val DEGREES_0 = 0f
 private const val DEGREES_360 = 360f
 private const val PIVOT_CENTER = 0.5f
 
-@Suppress("TooManyFunctions")
 object WooAnimUtils {
     enum class Duration {
         SHORT,

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <ManuallySuppressedIssues />
   <CurrentIssues>
     <ID>ComplexCondition:ProductImageViewerFragment.kt$ProductImageViewerFragment$(show &amp;&amp; binding.fakeToolbar.visibility == View.VISIBLE) || (!show &amp;&amp; binding.fakeToolbar.visibility != View.VISIBLE)</ID>
     <ID>ComplexCondition:ReviewListAdapter.kt$ReviewListAdapter$it.remoteId == review.remoteId &amp;&amp; it.review == review.review &amp;&amp; it.read == (review.read != false) &amp;&amp; it.status == review.status</ID>
@@ -281,59 +281,6 @@
     <ID>TooGenericExceptionCaught:TokenProvider.kt$TokenProvider$e: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:WooLogViewerActivity.kt$WooLogViewerActivity$e: Exception</ID>
     <ID>TooGenericExceptionThrown:ActionableEmptyView.kt$ActionableEmptyView$throw RuntimeException("$context: ActionableEmptyView must have a title (aevTitle)")</ID>
-    <ID>TooManyFunctions:AddAttributeTermsFragment.kt$AddAttributeTermsFragment : BaseProductFragment</ID>
-    <ID>TooManyFunctions:AddProductCategoryViewModel.kt$AddProductCategoryViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:AppPrefs.kt$AppPrefs$AppPrefs</ID>
-    <ID>TooManyFunctions:CardReaderConnectViewModel.kt$CardReaderConnectViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:CardReaderPaymentViewModel.kt$CardReaderPaymentViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:CreateShippingLabelViewModel.kt$CreateShippingLabelViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:DateExt.kt$com.woocommerce.android.extensions.DateExt.kt</ID>
-    <ID>TooManyFunctions:DateUtils.kt$DateUtils</ID>
-    <ID>TooManyFunctions:EditShippingLabelAddressFragment.kt$EditShippingLabelAddressFragment : BaseFragmentBackPressListener</ID>
-    <ID>TooManyFunctions:EditShippingLabelAddressViewModel.kt$EditShippingLabelAddressViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:IssueRefundViewModel.kt$IssueRefundViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:LoginActivity.kt$LoginActivity : AppCompatActivityLoginListenerGoogleListenerPrologueFinishedListenerHasAndroidInjectorLoginNoJetpackListenerListener</ID>
-    <ID>TooManyFunctions:MagicLinkInterceptRepository.kt$MagicLinkInterceptRepository</ID>
-    <ID>TooManyFunctions:MainActivity.kt$MainActivity : AppUpgradeActivityViewMainNavigationRouterMainNavigationListenerOnDestinationChangedListenerPromoDialogListener</ID>
-    <ID>TooManyFunctions:MainNavigationRouter.kt$MainNavigationRouter</ID>
-    <ID>TooManyFunctions:MyStoreContract.kt$MyStoreContract$View : BaseView</ID>
-    <ID>TooManyFunctions:MyStoreStatsView.kt$MyStoreStatsView : MaterialCardViewOnChartValueSelectedListenerBarChartGestureListener</ID>
-    <ID>TooManyFunctions:OrderDetailFragment.kt$OrderDetailFragment : BaseFragmentOrderProductActionListener</ID>
-    <ID>TooManyFunctions:OrderDetailRepository.kt$OrderDetailRepository</ID>
-    <ID>TooManyFunctions:OrderDetailViewModel.kt$OrderDetailViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:OrderFulfillViewModel.kt$OrderFulfillViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:OrderListFragment.kt$OrderListFragment : TopLevelFragmentOrderStatusListListenerOnQueryTextListenerOnActionExpandListenerOrderListListener</ID>
-    <ID>TooManyFunctions:OrderListViewModel.kt$OrderListViewModel : ScopedViewModelLifecycleOwner</ID>
-    <ID>TooManyFunctions:Product.kt$Product : ParcelableIProduct</ID>
-    <ID>TooManyFunctions:ProductDetailCardBuilder.kt$ProductDetailCardBuilder</ID>
-    <ID>TooManyFunctions:ProductDetailFragment.kt$ProductDetailFragment : BaseProductFragmentOnGalleryImageInteractionListener</ID>
-    <ID>TooManyFunctions:ProductDetailRepository.kt$ProductDetailRepository</ID>
-    <ID>TooManyFunctions:ProductDetailViewModel.kt$ProductDetailViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:ProductFilterListViewModel.kt$ProductFilterListViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:ProductImagesFragment.kt$ProductImagesFragment : BaseProductEditorFragmentOnGalleryImageInteractionListener</ID>
-    <ID>TooManyFunctions:ProductImagesViewModel.kt$ProductImagesViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:ProductListFragment.kt$ProductListFragment : TopLevelFragmentOnProductClickListenerProductSortAndFilterListenerOnLoadMoreListenerOnQueryTextListenerOnActionExpandListener</ID>
-    <ID>TooManyFunctions:ProductListViewModel.kt$ProductListViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:ReviewDetailRepository.kt$ReviewDetailRepository</ID>
-    <ID>TooManyFunctions:ReviewListAdapter.kt$ReviewListAdapter : SectionedRecyclerViewAdapter</ID>
-    <ID>TooManyFunctions:ReviewListFragment.kt$ReviewListFragment : TopLevelFragmentItemDecorationListenerOnReviewClickListener</ID>
-    <ID>TooManyFunctions:ReviewListRepository.kt$ReviewListRepository</ID>
-    <ID>TooManyFunctions:ReviewListViewModel.kt$ReviewListViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:Section.kt$Section</ID>
-    <ID>TooManyFunctions:SectionedRecyclerViewAdapter.kt$SectionedRecyclerViewAdapter : Adapter</ID>
-    <ID>TooManyFunctions:ShippingCustomsAdapter.kt$ShippingCustomsFormListener</ID>
-    <ID>TooManyFunctions:SitePickerContract.kt$SitePickerContract$Presenter : BasePresenter</ID>
-    <ID>TooManyFunctions:SitePickerContract.kt$SitePickerContract$View : BaseView</ID>
-    <ID>TooManyFunctions:StringUtils.kt$StringUtils$StringUtils</ID>
-    <ID>TooManyFunctions:StyleAttrUtils.kt$StyleAttrUtils$StyleAttrUtils</ID>
-    <ID>TooManyFunctions:TerminalWrapper.kt$TerminalWrapper</ID>
-    <ID>TooManyFunctions:UnifiedLoginTracker.kt$UnifiedLoginTracker</ID>
-    <ID>TooManyFunctions:VariationDetailCardBuilder.kt$VariationDetailCardBuilder</ID>
-    <ID>TooManyFunctions:VariationDetailViewModel.kt$VariationDetailViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:VariationListFragment.kt$VariationListFragment : BaseFragmentBackPressListenerOnLoadMoreListener</ID>
-    <ID>TooManyFunctions:VariationListViewModel.kt$VariationListViewModel : ScopedViewModel</ID>
-    <ID>TooManyFunctions:WooLog.kt$WooLog$WooLog</ID>
-    <ID>TooManyFunctions:ZendeskHelper.kt$ZendeskHelper</ID>
     <ID>TopLevelPropertyNaming:ZendeskHelper.kt$private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500</ID>
     <ID>TopLevelPropertyNaming:ZendeskHelper.kt$private const val maxLogfileLength: Int = 63000 // Max characters allowed in the system status report field</ID>
     <ID>TopLevelPropertyNaming:ZendeskHelper.kt$private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"</ID>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -8,7 +8,7 @@ complexity:
     ignoreDefaultParameters: true
     ignoreAnnotated: ['Inject']
   TooManyFunctions:
-    ignoreOverridden: true
+    active: false
 
 formatting:
   active: true

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErr
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.PaymentData
-import com.woocommerce.android.cardreader.payments.PaymentInfo
 import com.woocommerce.android.cardreader.internal.payments.actions.CancelPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus
@@ -21,12 +20,13 @@ import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymen
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction.ProcessPaymentStatus
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import com.woocommerce.android.cardreader.payments.PaymentInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList")
 internal class PaymentManager(
     private val terminalWrapper: TerminalWrapper,
     private val cardReaderStore: CardReaderStore,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5052
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We are constantly running into errors with TooManyFunctions from Detekt. In most of the cases, we are ignoring/suppressing the warning, which is a symptom that it’s not serving us well.
By default the error happens on classes with more than 11 functions.

It is very hard to give a proper threshold number of when to consider things are getting out of hand in terms of number of functions. Specially because this check ignores function length. Plus, we already have a check for LargeClass that kind of warns us of the same problem -> class is doing too many things

### Testing instructions
Nothing to test. Just run the app check it compiles fine and Detekt passes successfully. 
