### PR TITLE
Issue/4957 country state datasource

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,7 +28,8 @@ class AddressViewModel @Inject constructor(
     val states: List<Location>
         get() = dataStore.getStates(viewState.country).map { it.toAppModel() }
 
-    init {
+    fun start(country: String, state: String) {
+        viewState = viewState.copy(country = country, state = state)
         loadCountriesAndStates()
     }
 
@@ -37,8 +37,9 @@ class AddressViewModel @Inject constructor(
         launch {
             // we only fetch the countries and states if they've never been fetched
             if (countries.isEmpty()) {
-                // TODO trigger loading dialog
+                viewState = viewState.copy(isLoading = true)
                 dataStore.fetchCountriesAndStates(selectedSite.get())
+                viewState = viewState.copy(isLoading = false)
             }
         }
     }
@@ -58,6 +59,7 @@ class AddressViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val country: String = "",
-        val state: String = ""
+        val state: String = "",
+        val isLoading: Boolean = false
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -4,9 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.details.OrderDetailFragmentArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
-import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WCDataStore
@@ -18,8 +16,6 @@ class AddressViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val dataStore: WCDataStore,
 ) : ScopedViewModel(savedState) {
-    private val navArgs by savedState.navArgs<OrderDetailFragmentArgs>()
-
     val countries: List<Location>
         get() {
             return dataStore.getCountries().map { it.toAppModel() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -1,12 +1,16 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel
+import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.WCDataStore
 import javax.inject.Inject
 
@@ -16,23 +20,14 @@ class AddressViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val dataStore: WCDataStore,
 ) : ScopedViewModel(savedState) {
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
+    private var viewState by viewStateData
+
     val countries: List<Location>
-        get() {
-            return dataStore.getCountries().map { it.toAppModel() }
-        }
+        get() = dataStore.getCountries().map { it.toAppModel() }
 
     val states: List<Location>
-        get() {
-            return dataStore.getStates(country).map { it.toAppModel() }
-        }
-
-    var country: String = ""
-        get() = field
-        set(value) {
-            if (value != field) {
-                field = value
-            }
-        }
+        get() = dataStore.getStates(viewState.country).map { it.toAppModel() }
 
     init {
         loadCountriesAndStates()
@@ -40,9 +35,29 @@ class AddressViewModel @Inject constructor(
 
     fun loadCountriesAndStates() {
         launch {
+            // we only fetch the countries and states if they've never been fetched
             if (countries.isEmpty()) {
+                // TODO trigger loading dialog
                 dataStore.fetchCountriesAndStates(selectedSite.get())
             }
         }
     }
+
+    fun onCountrySelected(countryCode: String) {
+        if (countryCode != viewState.country) {
+            viewState = viewState.copy(country = countryCode)
+        }
+    }
+
+    fun onStateSelected(stateCode: String) {
+        if (stateCode != viewState.country) {
+            viewState = viewState.copy(state = stateCode)
+        }
+    }
+
+    @Parcelize
+    data class ViewState(
+        val country: String = "",
+        val state: String = ""
+    ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -1,0 +1,52 @@
+package com.woocommerce.android.ui.orders.details.editing.address
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.Location
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.details.OrderDetailFragmentArgs
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.WCDataStore
+import javax.inject.Inject
+
+@HiltViewModel
+class AddressViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val selectedSite: SelectedSite,
+    private val dataStore: WCDataStore,
+) : ScopedViewModel(savedState) {
+    private val navArgs by savedState.navArgs<OrderDetailFragmentArgs>()
+
+    val countries: List<Location>
+        get() {
+            return dataStore.getCountries().map { it.toAppModel() }
+        }
+
+    val states: List<Location>
+        get() {
+            return dataStore.getStates(country).map { it.toAppModel() }
+        }
+
+    var country: String = ""
+        get() = field
+        set(value) {
+            if (value != field) {
+                field = value
+            }
+        }
+
+    init {
+        loadCountriesAndStates()
+    }
+
+    fun loadCountriesAndStates() {
+        launch {
+            if (countries.isEmpty()) {
+                dataStore.fetchCountriesAndStates(selectedSite.get())
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.details.editing.address
 
 import android.os.Bundle
 import android.view.View
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
 import com.woocommerce.android.model.Address
@@ -13,6 +14,8 @@ abstract class BaseAddressEditingFragment :
     companion object {
         const val TAG = "BaseEditAddressFragment"
     }
+
+    private val addressViewModel by hiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_orders)
 
     private var _binding: FragmentBaseEditAddressBinding? = null
     private val binding get() = _binding!!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -123,10 +123,11 @@ abstract class BaseAddressEditingFragment :
 
     @Suppress("UnusedPrivateMember")
     private fun showCountrySelectorDialog() {
+        val countries = addressViewModel.countries
         val action = OrderDetailFragmentDirections.actionGlobalItemSelectorDialog(
             addressDraft.country,
-            addressViewModel.countries.map { it.name }.toTypedArray(),
-            addressViewModel.countries.map { it.code }.toTypedArray(),
+            countries.map { it.name }.toTypedArray(),
+            countries.map { it.code }.toTypedArray(),
             SELECT_COUNTRY_REQUEST,
             getString(R.string.shipping_label_edit_address_country)
         )
@@ -135,10 +136,11 @@ abstract class BaseAddressEditingFragment :
 
     @Suppress("UnusedPrivateMember")
     private fun showStateSelectorDialog() {
+        val states = addressViewModel.states
         val action = OrderDetailFragmentDirections.actionGlobalItemSelectorDialog(
             addressDraft.state,
-            addressViewModel.states.map { it.name }.toTypedArray(),
-            addressViewModel.states.map { it.code }.toTypedArray(),
+            states.map { it.name }.toTypedArray(),
+            states.map { it.code }.toTypedArray(),
             SELECT_STATE_REQUEST,
             getString(R.string.shipping_label_edit_address_state)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -3,9 +3,12 @@ package com.woocommerce.android.ui.orders.details.editing.address
 import android.os.Bundle
 import android.view.View
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Address
+import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.details.editing.BaseOrderEditingFragment
 import org.wordpress.android.util.ActivityUtils
 
@@ -13,6 +16,8 @@ abstract class BaseAddressEditingFragment :
     BaseOrderEditingFragment(R.layout.fragment_base_edit_address) {
     companion object {
         const val TAG = "BaseEditAddressFragment"
+        const val SELECT_COUNTRY_REQUEST = "select_country_request"
+        const val SELECT_STATE_REQUEST = "select_state_request"
     }
 
     private val addressViewModel by hiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_orders)
@@ -96,5 +101,27 @@ abstract class BaseAddressEditingFragment :
         binding.address2.removeCurrentTextWatcher()
         binding.city.removeCurrentTextWatcher()
         binding.postcode.removeCurrentTextWatcher()
+    }
+
+    private fun showCountrySelectorDialog() {
+        val action = OrderDetailFragmentDirections.actionGlobalItemSelectorDialog(
+            addressDraft.country,
+            addressViewModel.countries.map { it.name }.toTypedArray(),
+            addressViewModel.countries.map { it.code }.toTypedArray(),
+            SELECT_COUNTRY_REQUEST,
+            getString(R.string.shipping_label_edit_address_country)
+        )
+        findNavController().navigateSafely(action)
+    }
+
+    private fun showStateSelectorDialog() {
+        val action = OrderDetailFragmentDirections.actionGlobalItemSelectorDialog(
+            addressDraft.state,
+            addressViewModel.countries.map { it.name }.toTypedArray(),
+            addressViewModel.countries.map { it.code }.toTypedArray(),
+            SELECT_STATE_REQUEST,
+            getString(R.string.shipping_label_edit_address_state)
+        )
+        findNavController().navigateSafely(action)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -6,10 +6,14 @@ import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.details.editing.BaseOrderEditingFragment
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressFragment
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment
 import org.wordpress.android.util.ActivityUtils
 
 abstract class BaseAddressEditingFragment :
@@ -50,6 +54,9 @@ abstract class BaseAddressEditingFragment :
         _binding = FragmentBaseEditAddressBinding.bind(view)
         storedAddress.bindToView()
         bindTextWatchers()
+
+        setupObservers()
+        setupResultHandlers()
     }
 
     override fun hasChanges() = addressDraft != storedAddress
@@ -123,5 +130,25 @@ abstract class BaseAddressEditingFragment :
             getString(R.string.shipping_label_edit_address_state)
         )
         findNavController().navigateSafely(action)
+    }
+
+    private fun setupObservers() {
+        addressViewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
+            if (new.country != old?.country) {
+                // TODO update displayed country
+            }
+            if (new.state != old?.state) {
+                // TODO update displayed state
+            }
+        }
+    }
+
+    private fun setupResultHandlers() {
+        handleResult<String>(SELECT_COUNTRY_REQUEST) {
+            addressViewModel.onCountrySelected(it)
+        }
+        handleResult<String>(SELECT_STATE_REQUEST) {
+            addressViewModel.onStateSelected(it)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -229,7 +229,7 @@ class EditShippingLabelAddressFragment :
                 }
                 is ShowCountrySelector -> {
                     val action = EditShippingLabelAddressFragmentDirections
-                        .actionEditShippingLabelAddressFragmentToItemSelectorDialog(
+                        .actionGlobalItemSelectorDialog(
                             event.currentCountryCode,
                             event.locations.map { it.name }.toTypedArray(),
                             event.locations.map { it.code }.toTypedArray(),
@@ -240,7 +240,7 @@ class EditShippingLabelAddressFragment :
                 }
                 is ShowStateSelector -> {
                     val action = EditShippingLabelAddressFragmentDirections
-                        .actionEditShippingLabelAddressFragmentToItemSelectorDialog(
+                        .actionGlobalItemSelectorDialog(
                             event.currentStateCode,
                             event.locations.map { it.name }.toTypedArray(),
                             event.locations.map { it.code }.toTypedArray(),

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -1,154 +1,168 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/major_300"
+                android:orientation="vertical">
+
+                <com.google.android.material.textview.MaterialTextView
+                    style="@style/Woo.Card.Header"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/details" />
+
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginStart="@dimen/major_100" />
+
+            </LinearLayout>
+
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/first_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_details_first_name"
+                    android:inputType="text"
+                    android:nextFocusForward="@id/last_name"
+                    app:errorEnabled="true" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/last_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_details_last_name"
+                    android:inputType="text"
+                    android:nextFocusForward="@+id/email"
+                    app:errorEnabled="true" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/email"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_details_email"
+                    android:inputType="text"
+                    android:nextFocusForward="@+id/phone"
+                    app:errorEnabled="true" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/phone"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_details_phone"
+                    android:inputType="text"
+                    android:nextFocusForward="@+id/company"
+                    app:errorEnabled="true" />
+
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/major_300"
+                android:orientation="vertical">
+
+                <com.google.android.material.textview.MaterialTextView
+                    style="@style/Woo.Card.Header"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/order_detail_address_section" />
+
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginStart="@dimen/major_100" />
+
+            </LinearLayout>
+
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/minor_100"
+                android:orientation="vertical">
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/company"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_company"
+                    android:inputType="text"
+                    android:nextFocusForward="@+id/address1"
+                    app:errorEnabled="true" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/address1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_line1"
+                    android:inputType="text"
+                    android:nextFocusForward="@+id/address2"
+                    app:errorEnabled="true" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/address2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_line2"
+                    android:inputType="text"
+                    android:nextFocusForward="@+id/city"
+                    app:errorEnabled="true" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/city"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_city"
+                    android:inputType="text"
+                    android:nextFocusForward="@+id/postcode"
+                    app:errorEnabled="true" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/postcode"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:hint="@string/order_detail_edit_address_zip"
+                    android:inputType="text"
+                    app:errorEnabled="true" />
+
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+
+        </LinearLayout>
+
+    </ScrollView>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/major_300"
-            android:orientation="vertical">
-
-            <com.google.android.material.textview.MaterialTextView
-                style="@style/Woo.Card.Header"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/details" />
-
-            <View
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100" />
-
-        </LinearLayout>
-
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/first_name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_details_first_name"
-                android:inputType="text"
-                android:nextFocusForward="@id/last_name"
-                app:errorEnabled="true" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/last_name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_details_last_name"
-                android:inputType="text"
-                android:nextFocusForward="@+id/email"
-                app:errorEnabled="true" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/email"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_details_email"
-                android:inputType="text"
-                android:nextFocusForward="@+id/phone"
-                app:errorEnabled="true" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/phone"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_details_phone"
-                android:inputType="text"
-                android:nextFocusForward="@+id/company"
-                app:errorEnabled="true" />
-
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/major_300"
-            android:orientation="vertical">
-
-            <com.google.android.material.textview.MaterialTextView
-                style="@style/Woo.Card.Header"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/order_detail_address_section" />
-
-            <View
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100" />
-
-        </LinearLayout>
-
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/minor_100"
-            android:orientation="vertical">
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/company"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_company"
-                android:inputType="text"
-                android:nextFocusForward="@+id/address1"
-                app:errorEnabled="true" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/address1"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_line1"
-                android:inputType="text"
-                android:nextFocusForward="@+id/address2"
-                app:errorEnabled="true" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/address2"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_line2"
-                android:inputType="text"
-                android:nextFocusForward="@+id/city"
-                app:errorEnabled="true" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/city"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_city"
-                android:inputType="text"
-                android:nextFocusForward="@+id/postcode"
-                app:errorEnabled="true" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/postcode"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:hint="@string/order_detail_edit_address_zip"
-                android:inputType="text"
-                app:errorEnabled="true" />
-
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-
-    </LinearLayout>
-
-</ScrollView>
+        android:layout_gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible" />
+</FrameLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -101,11 +101,6 @@
             android:name="requiresPhoneNumber"
             app:argType="boolean" />
         <action
-            android:id="@+id/action_editShippingLabelAddressFragment_to_itemSelectorDialog"
-            app:destination="@id/itemSelectorDialog"
-            app:enterAnim="@anim/activity_fade_in"
-            app:popExitAnim="@anim/activity_fade_out" />
-        <action
             android:id="@+id/action_editShippingLabelAddressFragment_to_shippingLabelAddressSuggestionFragment"
             app:destination="@id/shippingLabelAddressSuggestionFragment"
             app:enterAnim="@anim/activity_fade_in"
@@ -658,8 +653,6 @@
         android:name="com.woocommerce.android.ui.orders.details.editing.address.BillingAddressEditingFragment"
         android:label="BillingAddressEditingFragment"
         tools:layout="@layout/fragment_base_edit_address"/>
-
     <action android:id="@+id/action_global_item_selector_dialog"
         app:destination="@id/itemSelectorDialog"/>
-
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -658,4 +658,8 @@
         android:name="com.woocommerce.android.ui.orders.details.editing.address.BillingAddressEditingFragment"
         android:label="BillingAddressEditingFragment"
         tools:layout="@layout/fragment_base_edit_address"/>
+
+    <action android:id="@+id/action_global_item_selector_dialog"
+        app:destination="@id/itemSelectorDialog"/>
+
 </navigation>


### PR DESCRIPTION
Closes #4957 - my intent with this PR was to handle all the country/state data source and UI work, but it became larger than anticipated so I'm leaving some parts (mostly UI) for a subsequent PR. So this PR does the following:

* Provides a data source for country & state information
* Shows selection dialog containing country or state information (these aren't hooked up to anything yet)
* Changed the above dialog to be a global destination
* Adds an `AddressViewModel` for the address editing fragments

Note: it may look like `fragment_base_edit_address.xml` has a lot of changes, but all I did was wrap it in a `FrameLayout` so I could add a progress bar to it.