### PR TITLE
Issue/4989 single source of connect truth refactored

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenter.kt
@@ -40,7 +40,7 @@ class AppSettingsPresenter @Inject constructor(
 
     override fun clearCardReaderData() {
         coroutineScope.launch {
-            if (cardReaderManager.isInitialized) {
+            if (cardReaderManager.initialized) {
                 cardReaderManager.disconnectReader()
                 cardReaderManager.clearCachedCredentials()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -183,7 +183,6 @@ class CardReaderConnectViewModel @Inject constructor(
     private fun onCardReaderManagerInitialized(cardReaderManager: CardReaderManager) {
         launch {
             this@CardReaderConnectViewModel.cardReaderManager = cardReaderManager
-            updateConnectionFlowState(requiredUpdateStarted = false, connectionStarted = false)
             launch { listenToConnectionStatus() }
             launch { listenToSoftwareUpdateStatus() }
             startScanningIfNotStarted()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -456,7 +456,6 @@ class CardReaderConnectViewModel @Inject constructor(
 
     sealed class ListItemViewState {
         object ScanningInProgressListItem : ListItemViewState() {
-
             val label = UiStringRes(R.string.card_reader_connect_scanning_progress)
 
             @DrawableRes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -8,18 +8,44 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_FAILURE
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_MISSING_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
-import com.woocommerce.android.cardreader.connection.*
-import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.*
+import com.woocommerce.android.cardreader.connection.CardReader
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Failed
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.ReadersFound
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Started
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Succeeded
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.SpecificReader
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateInProgress
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.*
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.*
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.ShowCardReaderTutorial
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckBluetoothEnabled
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckLocationEnabled
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckLocationPermissions
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.InitializeCardReaderManager
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.OpenLocationSettings
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.OpenPermissionsSettings
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.RequestEnableBluetooth
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.RequestLocationPermissions
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.ShowUpdateInProgress
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.BluetoothDisabledError
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.LocationDisabledError
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MissingPermissionsError
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ScanningFailedState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ScanningState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ConnectingFailedState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ConnectingState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MultipleReadersFoundState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ReaderFoundState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel
@@ -31,10 +57,11 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.*
+import javax.inject.Inject
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
-import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class CardReaderConnectViewModel @Inject constructor(
@@ -291,7 +318,7 @@ class CardReaderConnectViewModel @Inject constructor(
             connectToReader(lastKnownReader)
         } else {
             viewState.value = when {
-                availableReaders.isEmpty() -> ScanningState(::onCancelClicked)
+                availableReaders.isEmpty() -> CardReaderConnectViewState.ScanningState(::onCancelClicked)
                 availableReaders.size == 1 -> buildSingleReaderFoundState(availableReaders[0])
                 availableReaders.size > 1 -> buildMultipleReadersFoundState(availableReaders)
                 else -> throw IllegalStateException("Unreachable code")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -268,7 +268,11 @@ class CardReaderConnectViewModel @Inject constructor(
     }
 
     private fun onBluetoothStateVerified() {
-        triggerEvent(InitializeCardReaderManager(::onCardReaderManagerInitialized))
+        if (!cardReaderManager.isInitialized) {
+            triggerEvent(InitializeCardReaderManager(::onCardReaderManagerInitialized))
+        } else {
+            onCardReaderManagerInitialized(cardReaderManager)
+        }
     }
 
     private suspend fun startScanning() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -8,44 +8,18 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_FAILURE
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_SUCCESS
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_MISSING_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
-import com.woocommerce.android.cardreader.connection.CardReader
-import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
-import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Failed
-import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.ReadersFound
-import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Started
-import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Succeeded
-import com.woocommerce.android.cardreader.connection.CardReaderStatus
-import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
-import com.woocommerce.android.cardreader.connection.SpecificReader
+import com.woocommerce.android.cardreader.connection.*
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.*
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateInProgress
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckBluetoothEnabled
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckLocationEnabled
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckLocationPermissions
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.InitializeCardReaderManager
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.OpenLocationSettings
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.OpenPermissionsSettings
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.RequestEnableBluetooth
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.RequestLocationPermissions
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.ShowCardReaderTutorial
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.ShowUpdateInProgress
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.BluetoothDisabledError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ConnectingFailedState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ConnectingState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.LocationDisabledError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MissingPermissionsError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MultipleReadersFoundState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ReaderFoundState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ScanningFailedState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ScanningState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.*
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.*
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel
@@ -57,14 +31,9 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -255,6 +224,8 @@ class CardReaderConnectViewModel @Inject constructor(
                     updateConnectionFlowState(requiredUpdateStarted = true)
                     triggerEvent(ShowUpdateInProgress)
                 }
+            } else {
+                updateConnectionFlowState(requiredUpdateStarted = false)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -455,7 +455,6 @@ class CardReaderConnectViewModel @Inject constructor(
     }
 
     sealed class ListItemViewState {
-
         object ScanningInProgressListItem : ListItemViewState() {
 
             val label = UiStringRes(R.string.card_reader_connect_scanning_progress)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -76,7 +76,7 @@ class AppSettingsPresenterTest {
     fun `cleanPaymentsData with initialized manager should disconnect reader`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            whenever(cardReaderManager.isInitialized).thenReturn(true)
+            whenever(cardReaderManager.initialized).thenReturn(true)
 
             // WHEN
             appSettingsPresenter.clearCardReaderData()
@@ -91,7 +91,7 @@ class AppSettingsPresenterTest {
     fun `cleanPaymentsData with not initialized manager should not disconnect reader`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            whenever(cardReaderManager.isInitialized).thenReturn(false)
+            whenever(cardReaderManager.initialized).thenReturn(false)
 
             // WHEN
             appSettingsPresenter.clearCardReaderData()

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @Suppress("TooManyFunctions")
 interface CardReaderManager {
-    val isInitialized: Boolean
+    val initialized: Boolean
     val readerStatus: StateFlow<CardReaderStatus>
     val softwareUpdateStatus: Flow<SoftwareUpdateStatus>
     val softwareUpdateAvailability: Flow<SoftwareUpdateAvailability>

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -39,7 +39,7 @@ internal class CardReaderManagerImpl(
 
     private lateinit var application: Application
 
-    override val isInitialized: Boolean
+    override val initialized: Boolean
         get() {
             return terminal.isInitialized()
         }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -74,14 +74,14 @@ class CardReaderManagerImplTest {
     fun `when terminal is initialized, then isInitialized returns true`() {
         whenever(terminalWrapper.isInitialized()).thenReturn(true)
 
-        assertThat(cardReaderManager.isInitialized).isTrue()
+        assertThat(cardReaderManager.initialized).isTrue()
     }
 
     @Test
     fun `when terminal is not initialized, then isInitialized returns false`() {
         whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
-        assertThat(cardReaderManager.isInitialized).isFalse()
+        assertThat(cardReaderManager.initialized).isFalse()
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR refactors `issue/4989-single-source-of-connect-truth`. 

Here are the refactoring it includes
1. Remove ConnectionFlowScope
2. Remove ConnectionFlowState
3. Remove Mutex used while updating ConnectionFlowState
4. Re-arrange method order for better readability

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The whole connection flow has to be retested:

1. The flow without an update
2. The flow with an update
3. The flow with update and update cancelation
4. The flow with an update and connection cancellation (before update started)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
