### PR TITLE
Create billing address view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -78,8 +78,15 @@ class OrderEditingViewModel @Inject constructor(
         }.collect()
     }
 
-    fun updateBillingAddress(billingAddress: Address) = runWhenUpdateIsPossible {
-
+    fun updateBillingAddress(updatedBillingAddress: Address) = runWhenUpdateIsPossible {
+        if (viewState.replicateBothAddressesToggleActivated == true) {
+            sendReplicateShippingAndBillingAddressesWith(updatedBillingAddress)
+        } else {
+            orderEditingRepository.updateOrderAddress(
+                order.localId,
+                updatedBillingAddress.toBillingAddressModel()
+            )
+        }.collect()
     }
 
     private suspend fun sendReplicateShippingAndBillingAddressesWith(orderAddress: Address) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -68,7 +68,7 @@ class OrderEditingViewModel @Inject constructor(
     }
 
     fun updateShippingAddress(updatedShippingAddress: Address) = runWhenUpdateIsPossible {
-        if (viewState.useAsOtherAddressIsChecked == true) {
+        if (viewState.replicateBothAddressesToggleActivated == true) {
             sendReplicateShippingAndBillingAddressesWith(updatedShippingAddress)
         } else {
             orderEditingRepository.updateOrderAddress(
@@ -79,8 +79,7 @@ class OrderEditingViewModel @Inject constructor(
     }
 
     fun updateBillingAddress(billingAddress: Address) = runWhenUpdateIsPossible {
-        // Will be implemented in future PRs, making a unrelated call to avoid lint issues
-        billingAddress.hasInfo()
+
     }
 
     private suspend fun sendReplicateShippingAndBillingAddressesWith(orderAddress: Address) =
@@ -93,7 +92,7 @@ class OrderEditingViewModel @Inject constructor(
         )
 
     fun onReplicateAddressSwitchChanged(enabled: Boolean) {
-        viewState = viewState.copy(useAsOtherAddressIsChecked = enabled)
+        viewState = viewState.copy(replicateBothAddressesToggleActivated = enabled)
     }
 
     private suspend fun Flow<WCOrderStore.UpdateOrderResult>.collect() {
@@ -136,6 +135,6 @@ class OrderEditingViewModel @Inject constructor(
     data class ViewState(
         val orderEdited: Boolean? = null,
         val orderEditingFailed: Boolean? = null,
-        val useAsOtherAddressIsChecked: Boolean? = null
+        val replicateBothAddressesToggleActivated: Boolean? = null
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -13,8 +13,10 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.details.editing.BaseOrderEditingFragment
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 
+@AndroidEntryPoint
 abstract class BaseAddressEditingFragment :
     BaseOrderEditingFragment(R.layout.fragment_base_edit_address) {
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
+import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -16,6 +17,11 @@ class BillingAddressEditingFragment : BaseAddressEditingFragment() {
     override fun getFragmentTitle() = getString(R.string.order_detail_billing_address_section)
 
     override fun onViewBound(binding: FragmentBaseEditAddressBinding) {
-        // TODO("Not yet implemented")
+        binding.addressSectionHeader.text = getString(R.string.order_detail_billing_address_section)
+        binding.replicateAddressSwitch.text = getString(R.string.order_detail_use_as_shipping_address)
+        binding.replicateAddressSwitch.visibility = View.VISIBLE
+        sharedViewModel.order.shippingAddress
+            .copy(email = storedAddress.email)
+            .bindAsAddressReplicationToggleState()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
@@ -2,8 +2,8 @@ package com.woocommerce.android.ui.orders.details.editing.address
 
 import android.view.View
 import com.woocommerce.android.R
-import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
 import com.woocommerce.android.model.Address
 
 class BillingAddressEditingFragment : BaseAddressEditingFragment() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
 import android.view.View
-import com.google.android.material.switchmaterial.SwitchMaterial
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -15,17 +15,13 @@ class ShippingAddressEditingFragment : BaseAddressEditingFragment() {
 
     override fun saveChanges() = sharedViewModel.updateShippingAddress(addressDraft)
 
-    override fun onViewBound(binding: FragmentBaseEditAddressBinding) {
-        bindReplicateAddressSwitchView(binding.replicateAddressSwitch)
-        binding.email.visibility = View.GONE
-        binding.addressSectionHeader.text = getString(R.string.order_detail_shipping_address_section)
-    }
-
     override fun getFragmentTitle() = getString(R.string.order_detail_shipping_address_section)
 
-    private fun bindReplicateAddressSwitchView(switch: SwitchMaterial) {
-        switch.visibility = View.VISIBLE
-        switch.text = getString(R.string.order_detail_use_as_billing_address)
+    override fun onViewBound(binding: FragmentBaseEditAddressBinding) {
+        binding.email.visibility = View.GONE
+        binding.addressSectionHeader.text = getString(R.string.order_detail_shipping_address_section)
+        binding.replicateAddressSwitch.text = getString(R.string.order_detail_use_as_billing_address)
+        binding.replicateAddressSwitch.visibility = View.VISIBLE
         sharedViewModel.order.billingAddress.copy(email = "")
             .bindAsAddressReplicationToggleState()
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -391,6 +391,7 @@
     <string name="order_detail_add_billing_address">Add billing address</string>
     <string name="orderdetail_empty_address">No address specified</string>
     <string name="order_detail_use_as_billing_address">Use as Billing Address</string>
+    <string name="order_detail_use_as_shipping_address">Use as Shipping Address</string>
 
     <!--
         Shipping label Refunds


### PR DESCRIPTION
Summary
==========
Fixes issue #4901 by creating the Billing Address editing view counterpart of the already implemented Shipping one at https://github.com/woocommerce/woocommerce-android/pull/5017 using the same strategy of extending the `BaseAddressEditingFragment`

Screenshots
==========
| Shipping & Billing with same data  | `use as Shipping address` should be activated | Shipping & Billing with different data  | `use as Shipping address` should be deactivated |
| ------------- | ------------- | ------------- | ------------- |
| ![Screenshot_20211025_115200](https://user-images.githubusercontent.com/5920403/138719143-b628e333-5fc3-46b7-bcc0-7c18ab4a85a6.png) | ![Screenshot_20211025_115209](https://user-images.githubusercontent.com/5920403/138719158-995c7367-e038-4da1-a76f-cd29c6cb0f2d.png) | ![Screenshot_20211025_115249](https://user-images.githubusercontent.com/5920403/138719219-365529ad-8e87-4285-8342-f9af96a4cdb0.png) | ![Screenshot_20211025_115254](https://user-images.githubusercontent.com/5920403/138719236-36b6a0b5-fb01-468a-a0b5-beda0c12befb.png) |

How to Test
==========
## Scenario 1
1. Go to the Order Details of any existent Order
2. Go to the Billing Address section and click to edit or add one
3. Edit any field and verify if the `done` button is displaying as expected
4. Verify that clicking on the `done` button effectively updates the Billing Address using the optimistic update strategy
5. Now back at the Order Details, verify if the information is displayed correctly at the view and matches with the Billing information displayed just the same at the site.

## Scenario 2
1. Go to the Order Details of any existent Order
2. Go to the Billing Address section and click to edit or add one
3. Verify that the `use as Shipping Address` toggle is deactivated if Shipping and Billing Addresses are different from one another
4. Edit any field and verify if the `done` button is displaying as expected
5. Verify that when editing the Billing Address, if the `use as Shipping Address` toggle is activated, the Shipping address will be updated too, but keeping the original email there
6. After submitting the Address to both Shipping and Billing, verify if the Billing Address Editing view displays the `use as Shipping Address` toggle activated.
7. 
## Scenario 3
1. Go to the Order Details of any existent Order
2. Go to the Shipping Address section and click to edit or add one
3. Verify that the `use as Billing Address` toggle is deactivated if Shipping and Billing Addresses are different from one another
4. Edit any field and verify if the `done` button is displaying as expected
5. Verify that when editing the Shipping Address, if the `use as Billing Address` toggle is activated, the Billing address will be updated too, but keeping the original email there
6. After submitting the Address to both Shipping and Billing, verify if the Shipping Address Editing view displays the `use as Billing Address` toggle already activated.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
