### PR TITLE
Ignore s3 dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,9 @@ updates:
       # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
       # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968
       - dependency-name: "com.github.tomakehurst:wiremock"
+      # Our libraries that are stored in S3 have a custom versioning scheme which doesn't work with
+      # dependapot.
+      - dependency-name: "org.wordpress:utils"
+      - dependency-name: "org.wordpress:fluxc"
+      - dependency-name: "org.wordpress.fluxc.plugins:woocommerce"
+      - dependency-name: "org.wordpress:login"


### PR DESCRIPTION
We use a different versioning scheme for our libraries that we store in S3. Specifically, we have `xx-xxx` version format for non-production builds. As far as I can tell we can't ignore this version format for auto-updates.

Since there is no production vs development separation in our metadata files in S3, the version that's last published will be considered the latest update and if we can't ignore custom version schemes, it'll create incorrect PRs most of the time such as https://github.com/woocommerce/woocommerce-android/pull/5044. So, this PR disables Dependabot for our libraries that are stored in S3.

---

In case I am missing an option, [here is the documentation for the `ignore` configuration for Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore). Note that there is a way to ignore versions, such as semver patch/minor/major or certain versions, but I don't think it'd work if we were to try to give it a `*-*` pattern. I am not a ruby developer, so maybe someone with more Ruby experience can verify that. [Here is where the ignore clause seems to be taken into account.](https://github.com/dependabot/dependabot-core/blob/35032ea1459b48e93dea8c9d6b0c3f7417dce014/gradle/lib/dependabot/gradle/update_checker/version_finder.rb#L96-L109) cc @AliSoftware 

Edit: I just realized that `develop-xxx` is an acceptable "production" version for `develop` branch, so the configuration for ignoring versions have to be a bit more sophisticated if it were to work. In my opinion it's best to ignore the Dependabot for our libraries, especially since we are already planning to build a reverse-dependabot for our needs.