### PR TITLE
Enable push notifications all for stores

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationAnalyticsTracker.kt
@@ -3,20 +3,24 @@ package com.woocommerce.android.push
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Notification
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.PreferencesWrapper
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class NotificationAnalyticsTracker @Inject constructor(
+    private val selectedSite: SelectedSite,
     private val preferencesWrapper: PreferencesWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
     fun trackNotificationAnalytics(stat: AnalyticsTracker.Stat, notification: Notification) {
+        val isFromSelectedSite = selectedSite.getIfExists()?.siteId == notification.remoteSiteId
         val properties = mutableMapOf<String, Any>()
         properties["notification_note_id"] = notification.remoteNoteId
         properties["notification_type"] = notification.noteType.name
         properties["push_notification_token"] = preferencesWrapper.getFCMToken() ?: ""
+        properties["is_from_selected_site"] = isFromSelectedSite == true
         analyticsTrackerWrapper.track(stat, properties)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationRegistrationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationRegistrationHandler.kt
@@ -25,7 +25,7 @@ class NotificationRegistrationHandler @Inject constructor(
             val payload = RegisterDevicePayload(
                 gcmToken = token,
                 appKey = NotificationStore.NotificationAppKey.WOOCOMMERCE,
-                site = selectedSite.get()
+                site = null
             )
             dispatcher.dispatch(NotificationActionBuilder.newRegisterDeviceAction(payload))
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -935,8 +935,8 @@
     -->
     <string name="new_notifications">%d new notifications</string>
     <string name="more_notifications">and %d more.</string>
-    <string name="notification_order_title">You have 1 new order! 🎉</string>
-    <string name="notification_review_title">You have 1 new review! 🌟</string>
+    <string name="notification_order_title">You have a new order! 🎉</string>
+    <string name="notification_review_title">You have a new review! 🌟</string>
     <!--
         Product Review Detail
     -->


### PR DESCRIPTION
Closes: #4525 

We had disabled support for notifications for all stores because of some complaints we got from our merchants. The issue was identified and fixed in the API side. So we are once again enabling notifications for all stores.

This PR changes the following:
- Do not send `selected_blog_id` when registering FCM token for registration. This ensures that notifications will be initiated for all active stores in the app.
- The notification title for new order and new review notification was changed from `You have 1 new order` -> `You have a new order`.
- Also added a new event prop to the `PUSH_NOTIFICATION_RECEIVED` and `PUSH_NOTIFICATION_TAPPED` to capture if the notification received is for the currently active site in the app or for a different site. This will allow us to analyse if this feature is helpful for merchants with more than 1 active store.

### Testing instructions
Please follow the testing guide mentioned in `p91TBi-5ZX` to test this PR.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.