### PR TITLE
Issue/4909 order address state selector

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -44,6 +44,10 @@ class AddressViewModel @Inject constructor(
         }
     }
 
+    fun hasCountries() = countries.isNotEmpty()
+
+    fun hasStates() = states.isNotEmpty()
+
     fun getCountryCodeFromCountryName(countryName: String): String {
         return countries.find { it.name == countryName }?.code ?: countryName
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -46,7 +46,7 @@ abstract class BaseAddressEditingFragment :
                 city = city.text,
                 postcode = postcode.text,
                 country = addressViewModel.getCountryCodeFromCountryName(countrySpinner.getText()),
-                state = storedAddress.state // TODO nbradbury add state spinner
+                state = stateSpinner.getText()
             )
         }
 
@@ -63,6 +63,10 @@ abstract class BaseAddressEditingFragment :
 
         binding.countrySpinner.setClickListener {
             showCountrySelectorDialog()
+        }
+
+        binding.stateSpinner.setClickListener {
+            showStateSelectorDialog()
         }
 
         setupObservers()
@@ -90,6 +94,7 @@ abstract class BaseAddressEditingFragment :
         binding.city.text = city
         binding.postcode.text = postcode
         binding.countrySpinner.setText(getCountryLabelByCountryCode())
+        binding.stateSpinner.setText(state)
         binding.replicateAddressSwitch.setOnCheckedChangeListener { _, isChecked ->
             sharedViewModel.onReplicateAddressSwitchChanged(isChecked)
         }
@@ -146,10 +151,10 @@ abstract class BaseAddressEditingFragment :
                 updateDoneMenuItem()
             }
             new.stateCode.takeIfNotEqualTo(old?.stateCode) {
-                // TODO nbradbury update displayed state
+                binding.stateSpinner.setText(it)
             }
             new.isLoading.takeIfNotEqualTo(old?.isLoading) {
-                binding.progressBar.isVisible = new.isLoading
+                binding.progressBar.isVisible = it
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -154,7 +154,6 @@ abstract class BaseAddressEditingFragment :
 
     @Suppress("UnusedPrivateMember")
     private fun showStateSelectorDialog() {
-        // TODO nbradbury check we have a country first
         val states = addressViewModel.states
         val action = OrderDetailFragmentDirections.actionGlobalItemSelectorDialog(
             addressDraft.state,
@@ -168,24 +167,23 @@ abstract class BaseAddressEditingFragment :
 
     private fun setupObservers() {
         addressViewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
-            new.countryCode.takeIfNotEqualTo(old?.countryCode) {
-                if (old?.countryCode != null) {
+            // skip when the viewState is first initialized
+            if (old != null) {
+                new.countryCode.takeIfNotEqualTo(old.countryCode) {
                     binding.countrySpinner.setText(addressViewModel.getCountryNameFromCountryCode(it))
                     binding.stateSpinner.setText("")
                     binding.stateEditText.text = ""
                     updateDoneMenuItem()
                     updateStateViews()
                 }
-            }
-            new.stateCode.takeIfNotEqualTo(old?.stateCode) {
-                if (old?.stateCode != null) {
+                new.stateCode.takeIfNotEqualTo(old.stateCode) {
                     binding.stateSpinner.setText(it)
                     binding.stateEditText.text = it
                     updateDoneMenuItem()
                 }
-            }
-            new.isLoading.takeIfNotEqualTo(old?.isLoading) {
-                binding.progressBar.isVisible = it
+                new.isLoading.takeIfNotEqualTo(old.isLoading) {
+                    binding.progressBar.isVisible = it
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -169,16 +169,20 @@ abstract class BaseAddressEditingFragment :
     private fun setupObservers() {
         addressViewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.countryCode.takeIfNotEqualTo(old?.countryCode) {
-                binding.countrySpinner.setText(addressViewModel.getCountryNameFromCountryCode(it))
-                binding.stateSpinner.setText("")
-                binding.stateEditText.text = ""
-                updateDoneMenuItem()
-                updateStateViews()
+                if (old?.countryCode != null) {
+                    binding.countrySpinner.setText(addressViewModel.getCountryNameFromCountryCode(it))
+                    binding.stateSpinner.setText("")
+                    binding.stateEditText.text = ""
+                    updateDoneMenuItem()
+                    updateStateViews()
+                }
             }
             new.stateCode.takeIfNotEqualTo(old?.stateCode) {
-                binding.stateSpinner.setText(it)
-                binding.stateEditText.text = it
-                updateDoneMenuItem()
+                if (old?.stateCode != null) {
+                    binding.stateSpinner.setText(it)
+                    binding.stateEditText.text = it
+                    updateDoneMenuItem()
+                }
             }
             new.isLoading.takeIfNotEqualTo(old?.isLoading) {
                 binding.progressBar.isVisible = it

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -170,6 +170,8 @@ abstract class BaseAddressEditingFragment :
         addressViewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.countryCode.takeIfNotEqualTo(old?.countryCode) {
                 binding.countrySpinner.setText(addressViewModel.getCountryNameFromCountryCode(it))
+                binding.stateSpinner.setText("")
+                binding.stateEditText.text = ""
                 updateDoneMenuItem()
                 updateStateViews()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -167,24 +167,21 @@ abstract class BaseAddressEditingFragment :
 
     private fun setupObservers() {
         addressViewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
-            // skip when the viewState is first initialized
-            if (old != null) {
-                new.countryCode.takeIfNotEqualTo(old.countryCode) {
-                    binding.countrySpinner.setText(addressViewModel.getCountryNameFromCountryCode(it))
-                    // clear the state when the country is changed
-                    binding.stateSpinner.setText("")
-                    binding.stateEditText.text = ""
-                    updateDoneMenuItem()
-                    updateStateViews()
-                }
-                new.stateCode.takeIfNotEqualTo(old.stateCode) {
-                    binding.stateSpinner.setText(it)
-                    binding.stateEditText.text = it
-                    updateDoneMenuItem()
-                }
-                new.isLoading.takeIfNotEqualTo(old.isLoading) {
-                    binding.progressBar.isVisible = it
-                }
+            new.countryCode.takeIfNotEqualTo(old?.countryCode) {
+                binding.countrySpinner.setText(addressViewModel.getCountryNameFromCountryCode(it))
+                // clear the state when the country is changed
+                binding.stateSpinner.setText("")
+                binding.stateEditText.text = ""
+                updateDoneMenuItem()
+                updateStateViews()
+            }
+            new.stateCode.takeIfNotEqualTo(old?.stateCode) {
+                binding.stateSpinner.setText(it)
+                binding.stateEditText.text = it
+                updateDoneMenuItem()
+            }
+            new.isLoading.takeIfNotEqualTo(old?.isLoading) {
+                binding.progressBar.isVisible = it
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -182,6 +182,9 @@ abstract class BaseAddressEditingFragment :
             }
             new.isLoading.takeIfNotEqualTo(old?.isLoading) {
                 binding.progressBar.isVisible = it
+                if (old?.isLoading == true) {
+                    updateStateViews()
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -48,7 +48,7 @@ abstract class BaseAddressEditingFragment :
                 city = city.text,
                 postcode = postcode.text,
                 country = addressViewModel.getCountryCodeFromCountryName(countrySpinner.getText()),
-                state = stateSpinner.getText()
+                state = stateEditText.text
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -178,6 +178,7 @@ abstract class BaseAddressEditingFragment :
             new.stateCode.takeIfNotEqualTo(old?.stateCode) {
                 binding.stateSpinner.setText(it)
                 binding.stateEditText.text = it
+                updateDoneMenuItem()
             }
             new.isLoading.takeIfNotEqualTo(old?.isLoading) {
                 binding.progressBar.isVisible = it

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -171,6 +171,7 @@ abstract class BaseAddressEditingFragment :
             if (old != null) {
                 new.countryCode.takeIfNotEqualTo(old.countryCode) {
                     binding.countrySpinner.setText(addressViewModel.getCountryNameFromCountryCode(it))
+                    // clear the state when the country is changed
                     binding.stateSpinner.setText("")
                     binding.stateEditText.text = ""
                     updateDoneMenuItem()

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -161,6 +161,15 @@
                     android:hint="@string/shipping_label_edit_address_country"
                     android:inputType="text" />
 
+                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                    android:id="@+id/stateSpinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:hint="@string/shipping_label_edit_address_state"
+                    android:inputType="text" />
+
                 <com.google.android.material.switchmaterial.SwitchMaterial
                     android:id="@+id/replicate_address_switch"
                     android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -161,6 +161,17 @@
                     android:hint="@string/shipping_label_edit_address_country"
                     android:inputType="text" />
 
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/stateEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:hint="@string/shipping_label_edit_address_state"
+                    android:inputType="text"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
                 <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
                     android:id="@+id/stateSpinner"
                     android:layout_width="match_parent"


### PR DESCRIPTION
Closes #4909 - This PR adds the state selector to both the order shipping and billing address screens.

Test A:
- Open an order that has a shipping address with a country
- Tap shipping address
- Tap the state spinner
- Choose a different state
- Tap the Done button
- Verify the state was changed and it displays correctly

Test B:
- Open an order that has a shipping address without a country
- Tap shipping address and notice the state is shown as an editText
- Tap the country field and select a country
- Note the state changes to a spinner
- Choose a state
- Tap the Done button
- Verify the state was changed and it displays correctly

Test C:
- Open an order that has a shipping address with a country and a state
- Tap shipping address
- Tap the country spinner
- Choose a different country
- Notice the state field is cleared since the country changed

![address](https://user-images.githubusercontent.com/3903757/138773573-493e7a4d-4b00-45bc-a45f-eed347e6ddd2.gif)




