### PR TITLE
Increment Stripe terminal SDK version to 2.4.1

### DIFF
--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 
-    implementation "com.stripe:stripeterminal:2.3.1"
+    implementation "com.stripe:stripeterminal:2.4.1"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5077 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Update the Stripe terminal SDK to version v2.4.1

### Changelog
**2.4.1 - 2021-10-25**
Fix: Removed Android 12 bluetooth permissions. See issue 171 for details.

**2.4.0 - 2021-10-21**
New: Strong Customer Authentication (SCA) support was added for internet readers.
Update: EMV online processing timeout increased from 15s to 30s. Note that this timeout isn't used by Chipper devices.
Remove: Remove Machine Driven Registration. It's been moved to the DeviceManagementSDK.
Fix: Amex cards no longer decline when used via Apple Pay. See issue 166 for details.

https://github.com/stripe/stripe-terminal-android/releases/tag/v2.4.1

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just go through all the flows: connection, payment, update


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
