### PR TITLE
Issue/5082 order address state name

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -26,14 +26,24 @@ class AddressViewModel @Inject constructor(
         get() = dataStore.getCountries().map { it.toAppModel() }
 
     val states: List<Location>
-        get() = dataStore.getStates(viewState.countryCode).map { it.toAppModel() }
+        get() = dataStore.getStates(viewState.countryLocation.code).map { it.toAppModel() }
 
-    fun start(country: String, state: String) {
-        viewState = viewState.copy(countryCode = country, stateCode = state)
+    val countryLocation: Location
+        get() = viewState.countryLocation
+
+    val stateLocation: Location
+        get() = viewState.stateLocation
+
+    fun start(countryCode: String, stateCode: String) {
         loadCountriesAndStates()
+
+        viewState = viewState.copy(
+            countryLocation = getCountryLocationFromCode(countryCode),
+            stateLocation = getStateLocationFromCode(stateCode)
+        )
     }
 
-    fun loadCountriesAndStates() {
+    private fun loadCountriesAndStates() {
         launch {
             // we only fetch the countries and states if they've never been fetched
             if (countries.isEmpty()) {
@@ -48,38 +58,43 @@ class AddressViewModel @Inject constructor(
 
     fun hasStates() = states.isNotEmpty()
 
-    fun getCountryCodeFromCountryName(countryName: String): String {
-        return countries.find { it.name == countryName }?.code ?: countryName
-    }
-
-    fun getCountryNameFromCountryCode(countryCode: String): String {
+    private fun getCountryNameFromCode(countryCode: String): String {
         return countries.find { it.code == countryCode }?.name ?: countryCode
     }
 
-    fun getStateCodeFromStateName(stateName: String): String {
-        return states.find { it.name == stateName }?.code ?: stateName
+    private fun getCountryLocationFromCode(countryCode: String): Location {
+        return Location(countryCode, getCountryNameFromCode(countryCode))
     }
 
-    fun getStateNameFromStateCode(stateCode: String): String {
+    private fun getStateNameFromCode(stateCode: String): String {
         return states.find { it.code == stateCode }?.name ?: stateCode
     }
 
+    private fun getStateLocationFromCode(stateCode: String): Location {
+        return Location(stateCode, getStateNameFromCode(stateCode))
+    }
+
     fun onCountrySelected(countryCode: String) {
-        if (countryCode != viewState.countryCode) {
-            viewState = viewState.copy(countryCode = countryCode)
+        if (countryCode != viewState.countryLocation.code) {
+            viewState = viewState.copy(
+                countryLocation = getCountryLocationFromCode(countryCode),
+                stateLocation = Location("", "")
+            )
         }
     }
 
     fun onStateSelected(stateCode: String) {
-        if (stateCode != viewState.stateCode) {
-            viewState = viewState.copy(stateCode = stateCode)
+        if (stateCode != viewState.stateLocation.code) {
+            viewState = viewState.copy(
+                stateLocation = getStateLocationFromCode(stateCode)
+            )
         }
     }
 
     @Parcelize
     data class ViewState(
-        val countryCode: String = "",
-        val stateCode: String = "",
+        val countryLocation: Location = Location("", ""),
+        val stateLocation: Location = Location("", ""),
         val isLoading: Boolean = false
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -56,6 +56,14 @@ class AddressViewModel @Inject constructor(
         return countries.find { it.code == countryCode }?.name ?: countryCode
     }
 
+    fun getStateCodeFromStateName(stateName: String): String {
+        return states.find { it.name == stateName }?.code ?: stateName
+    }
+
+    fun getStateNameFromStateCode(stateCode: String): String {
+        return states.find { it.code == stateCode }?.name ?: stateCode
+    }
+
     fun onCountrySelected(countryCode: String) {
         if (countryCode != viewState.countryCode) {
             viewState = viewState.copy(countryCode = countryCode)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -35,7 +35,7 @@ class AddressViewModel @Inject constructor(
         get() = viewState.stateLocation
 
     fun start(countryCode: String, stateCode: String) {
-        loadCountriesAndStates()
+        loadCountriesAndStates(countryCode, stateCode)
 
         viewState = viewState.copy(
             countryLocation = getCountryLocationFromCode(countryCode),
@@ -43,13 +43,17 @@ class AddressViewModel @Inject constructor(
         )
     }
 
-    private fun loadCountriesAndStates() {
+    private fun loadCountriesAndStates(countryCode: String, stateCode: String) {
         launch {
             // we only fetch the countries and states if they've never been fetched
             if (countries.isEmpty()) {
                 viewState = viewState.copy(isLoading = true)
                 dataStore.fetchCountriesAndStates(selectedSite.get())
-                viewState = viewState.copy(isLoading = false)
+                viewState = viewState.copy(
+                    isLoading = false,
+                    countryLocation = getCountryLocationFromCode(countryCode),
+                    stateLocation = getStateLocationFromCode(stateCode)
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -37,6 +37,13 @@ abstract class BaseAddressEditingFragment :
 
     val addressDraft
         get() = binding.run {
+            val country = addressViewModel.getCountryCodeFromCountryName(countrySpinner.getText())
+            val state = if (stateEditText.isVisible) {
+                stateEditText.text
+            } else {
+                addressViewModel.getStateCodeFromStateName(stateSpinner.getText())
+            }
+
             Address(
                 firstName = firstName.text,
                 lastName = lastName.text,
@@ -47,8 +54,8 @@ abstract class BaseAddressEditingFragment :
                 address2 = address2.text,
                 city = city.text,
                 postcode = postcode.text,
-                country = addressViewModel.getCountryCodeFromCountryName(countrySpinner.getText()),
-                state = stateEditText.text
+                country = country,
+                state = state
             )
         }
 
@@ -97,7 +104,7 @@ abstract class BaseAddressEditingFragment :
         binding.city.text = city
         binding.postcode.text = postcode
         binding.countrySpinner.setText(getCountryLabelByCountryCode())
-        binding.stateSpinner.setText(state)
+        binding.stateSpinner.setText(addressViewModel.getStateNameFromStateCode(state))
         binding.stateEditText.text = state
         binding.replicateAddressSwitch.setOnCheckedChangeListener { _, isChecked ->
             sharedViewModel.onReplicateAddressSwitchChanged(isChecked)
@@ -176,7 +183,7 @@ abstract class BaseAddressEditingFragment :
                 updateStateViews()
             }
             new.stateCode.takeIfNotEqualTo(old?.stateCode) {
-                binding.stateSpinner.setText(it)
+                binding.stateSpinner.setText(addressViewModel.getStateNameFromStateCode(it))
                 binding.stateEditText.text = it
                 updateDoneMenuItem()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -119,11 +119,7 @@ abstract class BaseAddressEditingFragment :
         binding.stateEditText.textWatcher = textWatcher
     }
 
-    private fun shouldShowStateSpinner(): Boolean {
-        return addressViewModel.countryLocation.code.isNotEmpty() &&
-            addressViewModel.hasCountries() &&
-            addressViewModel.hasStates()
-    }
+    private fun shouldShowStateSpinner() = addressViewModel.hasStates()
 
     /**
      * When the country is empty, or we don't have country or state data, we show an editText


### PR DESCRIPTION
Closes #5082 - This PR changes the order address state spinners to show the state name rather than the state code. To do this, I modified `AddressViewModel` to store a location pair (code, name) for both the country and state addresses. I also cleaned up some of the logic, and fixed a bug caused by not updating the viewState after the initial country/state fetch.

To test, verify that when a country with states is selected, the full state name is displayed.