### PR TITLE
Fix address editing toggle replication state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -94,7 +94,9 @@ class OrderEditingViewModel @Inject constructor(
             order.localId,
             orderAddress.toShippingAddressModel(),
             orderAddress.toBillingAddressModel(
-                customEmail = order.billingAddress.email
+                customEmail = orderAddress.email
+                    .takeIf { it.isNotEmpty() }
+                    ?: order.billingAddress.email
             )
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -107,12 +107,6 @@ abstract class BaseAddressEditingFragment :
         binding.postcode.textWatcher = textWatcher
     }
 
-    internal fun Address.bindAsAddressReplicationToggleState() {
-        (this == storedAddress)
-            .apply { binding.replicateAddressSwitch.isChecked = this }
-            .also { sharedViewModel.onReplicateAddressSwitchChanged(it) }
-    }
-
     private fun showCountrySelectorDialog() {
         val countries = addressViewModel.countries
         val action = OrderDetailFragmentDirections.actionGlobalItemSelectorDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -77,7 +77,8 @@ abstract class BaseAddressEditingFragment :
         updateStateViews()
     }
 
-    override fun hasChanges() = addressDraft != storedAddress
+    override fun hasChanges() =
+        (addressDraft != storedAddress) || binding.replicateAddressSwitch.isChecked
 
     override fun onStop() {
         super.onStop()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -102,6 +102,7 @@ abstract class BaseAddressEditingFragment :
         binding.stateEditText.text = state
         binding.replicateAddressSwitch.setOnCheckedChangeListener { _, isChecked ->
             sharedViewModel.onReplicateAddressSwitchChanged(isChecked)
+            updateDoneMenuItem()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
@@ -19,8 +19,5 @@ class BillingAddressEditingFragment : BaseAddressEditingFragment() {
     override fun onViewBound(binding: FragmentBaseEditAddressBinding) {
         binding.addressSectionHeader.text = getString(R.string.order_detail_billing_address_section)
         binding.replicateAddressSwitch.text = getString(R.string.order_detail_use_as_shipping_address)
-        sharedViewModel.order.shippingAddress
-            .copy(email = storedAddress.email)
-            .bindAsAddressReplicationToggleState()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
@@ -19,7 +19,6 @@ class BillingAddressEditingFragment : BaseAddressEditingFragment() {
     override fun onViewBound(binding: FragmentBaseEditAddressBinding) {
         binding.addressSectionHeader.text = getString(R.string.order_detail_billing_address_section)
         binding.replicateAddressSwitch.text = getString(R.string.order_detail_use_as_shipping_address)
-        binding.replicateAddressSwitch.visibility = View.VISIBLE
         sharedViewModel.order.shippingAddress
             .copy(email = storedAddress.email)
             .bindAsAddressReplicationToggleState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
-import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -20,7 +20,6 @@ class ShippingAddressEditingFragment : BaseAddressEditingFragment() {
         binding.email.visibility = View.GONE
         binding.addressSectionHeader.text = getString(R.string.order_detail_shipping_address_section)
         binding.replicateAddressSwitch.text = getString(R.string.order_detail_use_as_billing_address)
-        binding.replicateAddressSwitch.visibility = View.VISIBLE
         sharedViewModel.order.billingAddress.copy(email = "")
             .bindAsAddressReplicationToggleState()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -20,7 +20,5 @@ class ShippingAddressEditingFragment : BaseAddressEditingFragment() {
         binding.email.visibility = View.GONE
         binding.addressSectionHeader.text = getString(R.string.order_detail_shipping_address_section)
         binding.replicateAddressSwitch.text = getString(R.string.order_detail_use_as_billing_address)
-        sharedViewModel.order.billingAddress.copy(email = "")
-            .bindAsAddressReplicationToggleState()
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -169,7 +169,6 @@
                     android:layout_marginEnd="@dimen/major_100"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    android:visibility="gone"
                     app:layout_constraintTop_toBottomOf="@+id/product_sku" />
 
             </com.woocommerce.android.widgets.WCElevatedLinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -185,8 +185,9 @@
                     android:id="@+id/replicate_address_switch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/major_100"
                     android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:checked="false"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/product_sku" />


### PR DESCRIPTION
Summary
==========
This PR improves the address replication toggle inside the Address editing views to deliver a better user experience. Now the toggle state is never pre-configured based on the Shipping and Billing data, it's always set as unchecked, and when it's checked, the `done` button shows up by itself, allowing Address replication only when the merchant strictly wants it, avoiding accidental data replication between both Addresses.

Screenshots
==========
https://user-images.githubusercontent.com/5920403/139093627-f1030c74-260b-45cd-a59a-509be97e102b.mp4

How to Test
==========
1. Go to the Order Details of an Order containing at least the Shipping or Billing address configured
2. Select one existent Address data to edit, check the `use as` toggle and verify that the `done` button shows up
3. Hit the `done` button and verify if the Address was correctly replicated
4. Enter the replicated Address editing view, verify that the `use as` toggle remains unchecked


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
