### PR TITLE
Improve compatibility with Chromebook devices

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest package="com.woocommerce.android"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Mark the camera as optional, as the back camera is missing from some ChromeOS devices-->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+
     <!-- Normal permissions, access automatically granted to app -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -135,7 +135,7 @@ object ProductImagesUtils {
         }
     }
 
-    private fun hasCamera(context: Context): Boolean =
+    fun hasCamera(context: Context): Boolean =
         context.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -267,8 +267,11 @@ class ProductImagesFragment :
                 it.findViewById<View>(R.id.textChooser)?.setOnClickListener {
                     viewModel.onShowStorageChooserButtonClicked()
                 }
-                it.findViewById<View>(R.id.textCamera)?.setOnClickListener {
-                    viewModel.onShowCameraButtonClicked()
+                it.findViewById<View>(R.id.textCamera)?.apply {
+                    isVisible = ProductImagesUtils.hasCamera(context)
+                    setOnClickListener {
+                        viewModel.onShowCameraButtonClicked()
+                    }
                 }
                 it.findViewById<View>(R.id.textWPMediaLibrary)?.setOnClickListener {
                     viewModel.onShowWPMediaPickerButtonClicked()


### PR DESCRIPTION
### Description
As discussed internally (p1632321393446600-slack-C6H8C3G23), Google Play doesn't show the app for many Chromebooks, and the reasons are:
- Chromebook devices have only a single camera, that's considered a front camera, and since Android for historical reasons considers the system feature `android.hardware.camera` as back camera, those devices don't offer this feature (https://developer.android.com/topic/arc/manifest#unsupported-hardware-features)
- The app requests the Camera permission to allow capturing images and uploading them for products, and this implicitly adds the feature `android.hardware.camera` as required.

If we dump the list of features the app requests currently using `aapt`, we get this:
```
  uses-feature: name='tools.fastlane.screengrab.cleanstatusbar'
  uses-feature: name='android.hardware.bluetooth'
  uses-implied-feature: name='android.hardware.bluetooth' reason='requested android.permission.BLUETOOTH permission, requested android.permission.BLUETOOTH_ADMIN permission, and targetSdkVersion > 4'
  uses-feature: name='android.hardware.camera'
  uses-implied-feature: name='android.hardware.camera' reason='requested android.permission.CAMERA permission'
  uses-feature: name='android.hardware.faketouch'
  uses-implied-feature: name='android.hardware.faketouch' reason='default feature for all apps'
  uses-feature: name='android.hardware.location'
  uses-implied-feature: name='android.hardware.location' reason='requested android.permission.ACCESS_COARSE_LOCATION permission, and requested android.permission.ACCESS_FINE_LOCATION permission'
  uses-feature: name='android.hardware.wifi'
  uses-implied-feature: name='android.hardware.wifi' reason='requested android.permission.ACCESS_WIFI_STATE permission'
```
and if we check the list of features Chromebook devices support (taken from Google Play console for Acer Chromebook 15 as an example), we get this:
```
android.hardware.audio.output, android.hardware.bluetooth, android.hardware.bluetooth_le,
android.hardware.camera.any, android.hardware.camera.front, android.hardware.faketouch,
android.hardware.location, android.hardware.location.network, android.hardware.microphone,
android.hardware.ram.normal, android.hardware.screen.landscape, android.hardware.screen.portrait,
android.hardware.type.pc, android.hardware.wifi, android.software.activities_on_secondary_displays,
android.software.autofill, android.software.backup, android.software.cant_save_state,
android.software.companion_device_setup, android.software.cts, android.software.freeform_window_management,
android.software.input_methods, android.software.midi, android.software.picture_in_picture, android.software.print,
android.software.verified_boot, android.software.voice_recognizers, android.software.webview,
com.google.android.feature.EXCHANGE_6_2, com.google.android.feature.GOOGLE_BUILD,
com.google.android.feature.GOOGLE_EXPERIENCE, org.chromium.arc, org.chromium.arc.device_management,
org.chromium.arc.video.encode_dynamic_bitrate
```

So this confirms that the feature that's missing from the device is `android.hardware.camera`

After the changes done in this PR, the feature dump using `aapt` is changed to this:
```
  uses-feature-not-required: name='android.hardware.camera'
  uses-feature: name='tools.fastlane.screengrab.cleanstatusbar'
  uses-feature: name='android.hardware.bluetooth'
  uses-implied-feature: name='android.hardware.bluetooth' reason='requested android.permission.BLUETOOTH permission, requested android.permission.BLUETOOTH_ADMIN permission, and targetSdkVersion > 4'
  uses-feature: name='android.hardware.faketouch'
  uses-implied-feature: name='android.hardware.faketouch' reason='default feature for all apps'
  uses-feature: name='android.hardware.location'
  uses-implied-feature: name='android.hardware.location' reason='requested android.permission.ACCESS_COARSE_LOCATION permission, and requested android.permission.ACCESS_FINE_LOCATION permission'
  uses-feature: name='android.hardware.wifi'
  uses-implied-feature: name='android.hardware.wifi' reason='requested android.permission.ACCESS_WIFI_STATE permission'
```


### Testing instructions
#### Test the app with a front camera device only
1. If you have a device that satisfies this then use it, instead create an emulator that doesn't have a back camera, and has only a front one (options available in the advanced settings)
2. If you are using the emulator, then install an alternative camera, as the default camera keeps crashing when using a back camera.
3. Open the app, then open product details
4. Click on add image.
5. Select the camera option.
6. Confirm that the flow works without issues.

#### Device with no cameras
I don't have a device that doesn't have any camera, and the emulator is broken on this side (a 10 year bug that's not fixed: https://issuetracker.google.com/issues/36925409), so to test this, I hardcoded the value of `ProductImagesUtils#hasCamera` to `false`
For the test, just confirm that the option camera is not part of the sources for picking a product image.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->