### PR TITLE
Refresh Zendesk UI when agent replies to ticket

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
@@ -24,6 +24,6 @@ class FCMMessageService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         WooLog.v(T.NOTIFS, "Received message from Firebase")
-        notificationMessageHandler.onNewMessageReceived(message.data)
+        notificationMessageHandler.onNewMessageReceived(message.data, applicationContext)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.push
 
+import android.content.Context
 import android.os.Build
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
@@ -10,6 +11,7 @@ import com.woocommerce.android.extensions.NotificationsUnseenReviewsEvent
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.model.isOrderNotification
 import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.util.NotificationsUtils
 import com.woocommerce.android.util.WooLog.T.NOTIFS
 import com.woocommerce.android.util.WooLogWrapper
@@ -38,10 +40,12 @@ class NotificationMessageHandler @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val resourceProvider: ResourceProvider,
     private val notificationBuilder: WooNotificationBuilder,
-    private val analyticsTracker: NotificationAnalyticsTracker
+    private val analyticsTracker: NotificationAnalyticsTracker,
+    private val zendeskHelper: ZendeskHelper,
 ) {
     companion object {
-        private const val PUSH_TYPE_ZENDESK = "zendesk"
+        private const val KEY_PUSH_TYPE_ZENDESK = "zendesk"
+        private const val KEY_ZENDESK_REQUEST_ID = "zendesk_sdk_request_id"
         // All Zendesk push notifications will show the same notification, so hopefully this will be a unique ID
         private const val ZENDESK_PUSH_NOTIFICATION_ID = 1999999999
 
@@ -59,7 +63,7 @@ class NotificationMessageHandler @Inject constructor(
     }
 
     @Suppress("ReturnCount", "ComplexMethod")
-    fun onNewMessageReceived(messageData: Map<String, String>) {
+    fun onNewMessageReceived(messageData: Map<String, String>, appContext: Context) {
         if (!accountStore.hasAccessToken()) {
             wooLogWrapper.e(NOTIFS, "User is not logged in!")
             return
@@ -70,7 +74,9 @@ class NotificationMessageHandler @Inject constructor(
             return
         }
 
-        if (messageData["type"] == PUSH_TYPE_ZENDESK) {
+        if (messageData["type"] == KEY_PUSH_TYPE_ZENDESK) {
+            // Make sure the UI gets refreshed so the user can see the reply
+            zendeskHelper.refreshRequest(appContext, messageData[KEY_ZENDESK_REQUEST_ID])
             val zendeskNote = NotificationModel(
                 noteId = ZENDESK_PUSH_NOTIFICATION_ID,
                 remoteNoteId = ZENDESK_PUSH_NOTIFICATION_ID.toLong()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5097 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates/refreshes zendesk UI when an agent/HE replies to a Zendesk ticket while the ticket is currently visible on the UI.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Help&Support (either from the login screen or app settings)
2. Click on Contact Support
3. Send a message
4. Go to Zendesk in a browser
5. Reply to the ticket
6. Notice the reply appears in the app +-2 seconds after you send it

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2261188/139259342-1e6ea990-cde0-4b7b-aed2-b1e002b078ab.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
