### PR TITLE
Update login library to check only `isJetpackConnected` when checking jetpack's status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlinVersion = '1.5.31'
     ext.navigationVersion = '2.3.5'
     ext.daggerVersion = '2.39.1'
-    ext.wordPressLoginVersion = 'develop-7bd412f6ce70795a5220fa62aaacda6d512d7ed2'
+    ext.wordPressLoginVersion = '72-ac1f21cc0b8fdf7d9721d0e939fe932932b07038'
     ext.detektVersion = '1.18.1'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlinVersion = '1.5.31'
     ext.navigationVersion = '2.3.5'
     ext.daggerVersion = '2.39.1'
-    ext.wordPressLoginVersion = '72-ac1f21cc0b8fdf7d9721d0e939fe932932b07038'
+    ext.wordPressLoginVersion = 'develop-6f134975e1aca6fe1962a112b6d91e3cd6fdd7d5'
     ext.detektVersion = '1.18.1'
 
     repositories {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #4857

### Description
The PR https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/72 updates the login library behavior to check only the flag `isJetpackConnected` for self hosted sites to confirm the Jetpack connection, which is the original behavior we had before, and also needed for Jetpack Connection Package support.
There is still some changes needed to properly handle loading states when trying to connect to a Jetpack Connection Package site, but I prefer to do them in a separate PR to have clearer testing instructions.

### Testing instructions
Nothing should be changed by the changes now, just confirm that there is no regression when connecting to atomic sites and self-hosted jetpack sites.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
