### PR TITLE
Show zendesk tickets on zendesk notification click

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -50,7 +50,8 @@ class MainActivityViewModel @Inject constructor(
         notification?.let {
             // update current selectSite based on the current notification
             val currentSite = selectedSite.get()
-            if (it.remoteSiteId != currentSite.siteId) {
+            val isSiteSpecificNotification = it.remoteSiteId != 0L
+            if (isSiteSpecificNotification && it.remoteSiteId != currentSite.siteId) {
                 // Update selected store
                 siteStore.getSiteBySiteId(it.remoteSiteId)?.let { updatedSite ->
                     selectedSite.set(updatedSite)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5100
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When an agent/HE replies to a zendesk ticket, the application displays a notification. However, when the user taps on the notification, the app displays the main screen of the app instead of displaying list of open tickets where tickets with unread messages are displayed in bold. This PR fixes this issue.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to App settings
2. Tap on Help & Support
3. Tap on Contact Support
4. Send a message to Zendesk
5. Go back to the main screen of the app
6. Put the app into background
7. Go to Zendesk on the Web and reply to the ticket
8. Notice Android displays a system notification
9. Tap on the notification and list of tickets is shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2261188/139264834-501e67c7-646d-4b41-b405-50c2e4aa800c.mp4





- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
