### PR TITLE
Order address editing tracks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.NetworkStatus
@@ -64,7 +65,13 @@ class OrderEditingViewModel @Inject constructor(
     fun updateCustomerOrderNote(updatedNote: String) = runWhenUpdateIsPossible {
         orderEditingRepository.updateCustomerOrderNote(
             order.localId, updatedNote
-        ).collect()
+        ).collectTracking {
+            AnalyticsTracker.track(it,
+                mapOf(
+                    AnalyticsTracker.KEY_SUBJECT to AnalyticsTracker.ORDER_EDIT_CUSTOMER_NOTE
+                )
+            )
+        }
     }
 
     fun updateShippingAddress(updatedShippingAddress: Address) = runWhenUpdateIsPossible {
@@ -104,7 +111,9 @@ class OrderEditingViewModel @Inject constructor(
         viewState = viewState.copy(replicateBothAddressesToggleActivated = enabled)
     }
 
-    private suspend fun Flow<WCOrderStore.UpdateOrderResult>.collect() {
+    private suspend fun Flow<WCOrderStore.UpdateOrderResult>.collectTracking(
+        trackAction: (Stat) -> Unit
+    ) {
         collect { result ->
             when (result) {
                 is WCOrderStore.UpdateOrderResult.OptimisticUpdateResult -> {
@@ -113,22 +122,14 @@ class OrderEditingViewModel @Inject constructor(
                     }
                 }
                 is WCOrderStore.UpdateOrderResult.RemoteUpdateResult -> {
-                    val stat = if (result.event.isError) {
-                        AnalyticsTracker.Stat.ORDER_DETAIL_EDIT_FLOW_FAILED
-                    } else {
-                        AnalyticsTracker.Stat.ORDER_DETAIL_EDIT_FLOW_COMPLETED
-                    }
-                    AnalyticsTracker.track(
-                        stat,
-                        mapOf(
-                            AnalyticsTracker.KEY_SUBJECT to AnalyticsTracker.ORDER_EDIT_CUSTOMER_NOTE
-                        )
-                    )
                     if (result.event.isError) {
                         withContext(Dispatchers.Main) {
                             viewState = viewState.copy(orderEditingFailed = true)
                         }
-                    }
+                        Stat.ORDER_DETAIL_EDIT_FLOW_FAILED
+                    } else {
+                        Stat.ORDER_DETAIL_EDIT_FLOW_COMPLETED
+                    }.let(trackAction)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -82,7 +82,13 @@ class OrderEditingViewModel @Inject constructor(
                 order.localId,
                 updatedShippingAddress.toShippingAddressModel()
             )
-        }.collect()
+        }.collectTracking {
+            AnalyticsTracker.track(it,
+                mapOf(
+                    AnalyticsTracker.KEY_SUBJECT to AnalyticsTracker.ORDER_EDIT_SHIPPING_ADDRESS
+                )
+            )
+        }
     }
 
     fun updateBillingAddress(updatedBillingAddress: Address) = runWhenUpdateIsPossible {
@@ -93,7 +99,13 @@ class OrderEditingViewModel @Inject constructor(
                 order.localId,
                 updatedBillingAddress.toBillingAddressModel()
             )
-        }.collect()
+        }.collectTracking {
+            AnalyticsTracker.track(it,
+                mapOf(
+                    AnalyticsTracker.KEY_SUBJECT to AnalyticsTracker.ORDER_EDIT_BILLING_ADDRESS
+                )
+            )
+        }
     }
 
     private suspend fun sendReplicateShippingAndBillingAddressesWith(orderAddress: Address) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -66,7 +66,8 @@ class OrderEditingViewModel @Inject constructor(
         orderEditingRepository.updateCustomerOrderNote(
             order.localId, updatedNote
         ).collectTracking {
-            AnalyticsTracker.track(it,
+            AnalyticsTracker.track(
+                it,
                 mapOf(
                     AnalyticsTracker.KEY_SUBJECT to AnalyticsTracker.ORDER_EDIT_CUSTOMER_NOTE
                 )
@@ -83,7 +84,8 @@ class OrderEditingViewModel @Inject constructor(
                 updatedShippingAddress.toShippingAddressModel()
             )
         }.collectTracking {
-            AnalyticsTracker.track(it,
+            AnalyticsTracker.track(
+                it,
                 mapOf(
                     AnalyticsTracker.KEY_SUBJECT to AnalyticsTracker.ORDER_EDIT_SHIPPING_ADDRESS
                 )
@@ -100,7 +102,8 @@ class OrderEditingViewModel @Inject constructor(
                 updatedBillingAddress.toBillingAddressModel()
             )
         }.collectTracking {
-            AnalyticsTracker.track(it,
+            AnalyticsTracker.track(
+                it,
                 mapOf(
                     AnalyticsTracker.KEY_SUBJECT to AnalyticsTracker.ORDER_EDIT_BILLING_ADDRESS
                 )


### PR DESCRIPTION
Summary
==========
Fixes issue #4899 and #4906 by extending the work done in #5030 and enabling Track handling for each individual type of Order editing.

How to Test
==========
The following events should be added and correctly triggered:

- order_detail_edit_flow_started
- order_detail_edit_flow_completed
- order_detail_edit_flow_canceled
- order_detail_edit_flow_failed

All events should have a single parameter "subject" which describes the data section. Values for this iteration should be:

- customer_note
- shipping_address
- billing_address


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
