### PR TITLE
Jetpack CP: force fetching sites on site picker to run additional checks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -163,6 +163,8 @@ class SitePickerActivity :
             bundle.getString(KEY_LOGIN_SITE_URL)?.let { url ->
                 deferLoadingSitesIntoView = true
                 loginSiteUrl = url
+                // hide the sites list
+                binding.siteListContainer.isVisible = false
             }
 
             val ids = bundle.getIntArray(STATE_KEY_SITE_ID_LIST) ?: IntArray(0)
@@ -192,6 +194,8 @@ class SitePickerActivity :
             AppPrefs.getLoginSiteAddress().takeIf { it.isNotEmpty() }?.let { url ->
                 deferLoadingSitesIntoView = true
                 loginSiteUrl = url
+                // hide the sites list
+                binding.siteListContainer.isVisible = false
             }
 
             presenter.loadAndFetchSites()
@@ -317,9 +321,6 @@ class SitePickerActivity :
             }
 
             loginSiteUrl?.let {
-                // hide the site list and validate the url if we already know the connected store, which will happen
-                // if the user logged in by entering their store address
-                binding.siteListContainer.visibility = View.GONE
                 processLoginSite(it)
             }
             return
@@ -535,14 +536,19 @@ class SitePickerActivity :
         }
     }
 
-    override fun showSkeleton(show: Boolean) {
-        if (deferLoadingSitesIntoView) {
-            return
-        }
-
+    override fun showLoadingView(show: Boolean) {
         when (show) {
-            true -> skeletonView.show(binding.sitesRecycler, R.layout.skeleton_site_picker, delayed = true)
-            false -> skeletonView.hide()
+            true -> {
+                if (loginSiteUrl.isNullOrEmpty()) {
+                    skeletonView.show(binding.sitesRecycler, R.layout.skeleton_site_picker, delayed = true)
+                } else {
+                    binding.progressBar.isVisible = true
+                }
+            }
+            false -> {
+                skeletonView.hide()
+                binding.progressBar.isVisible = false
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -544,10 +544,12 @@ class SitePickerActivity :
                 } else {
                     binding.progressBar.isVisible = true
                 }
+                binding.loginEpilogueButtonBar.root.isVisible = false
             }
             false -> {
                 skeletonView.hide()
                 binding.progressBar.isVisible = false
+                binding.loginEpilogueButtonBar.root.isVisible = true
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
@@ -36,7 +36,7 @@ interface SitePickerContract {
         fun siteVerificationPassed(site: SiteModel)
         fun siteVerificationFailed(site: SiteModel)
         fun siteVerificationError(site: SiteModel)
-        fun showSkeleton(show: Boolean)
+        fun showLoadingView(show: Boolean)
         fun userVerificationCompleted()
         fun showProgressDialog(@StringRes title: Int)
         fun hideProgressDialog()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -32,7 +32,7 @@ class SitePickerPresenter
 ) : SitePickerContract.Presenter {
     private var view: SitePickerContract.View? = null
 
-    private var wooSitesHasBeenFetched = false
+    private var hasFetchedWooSites = false
 
     override fun takeView(view: SitePickerContract.View) {
         dispatcher.register(this)
@@ -47,7 +47,7 @@ class SitePickerPresenter
     override fun getWooCommerceSites(): List<SiteModel> {
         val currentWooSites = wooCommerceStore.getWooCommerceSites()
         return if (!FeatureFlag.JETPACK_CP.isEnabled() ||
-            wooSitesHasBeenFetched ||
+            hasFetchedWooSites ||
             currentWooSites.none { it.isJetpackCPConnected }
         ) {
             currentWooSites
@@ -90,7 +90,7 @@ class SitePickerPresenter
             if (result.isError) {
                 WooLog.e(T.LOGIN, "Site error [${result.error.type}] : ${result.error.message}")
             } else {
-                wooSitesHasBeenFetched = true
+                hasFetchedWooSites = true
                 view?.showStoreList(result.model!!)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -75,7 +75,7 @@ class SitePickerPresenter
         if (wcSites.isNotEmpty()) {
             view?.showStoreList(wcSites)
         } else {
-            view?.showSkeleton(true)
+            view?.showLoadingView(true)
         }
         fetchSitesFromAPI()
     }
@@ -83,7 +83,7 @@ class SitePickerPresenter
     override fun fetchSitesFromAPI() {
         coroutineScope.launch {
             val result = wooCommerceStore.fetchWooCommerceSites()
-            view?.showSkeleton(false)
+            view?.showLoadingView(false)
             if (result.isError) {
                 WooLog.e(T.LOGIN, "Site error [${result.error.type}] : ${result.error.message}")
             } else {
@@ -95,9 +95,9 @@ class SitePickerPresenter
 
     override fun fetchUpdatedSiteFromAPI(site: SiteModel) {
         coroutineScope.launch {
-            view?.showSkeleton(true)
+            view?.showLoadingView(true)
             val result = wooCommerceStore.fetchWooCommerceSite(site)
-            view?.showSkeleton(false)
+            view?.showLoadingView(false)
             if (result.isError) {
                 WooLog.e(T.LOGIN, "Site error [${result.error.type}] : ${result.error.message}")
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -46,7 +46,10 @@ class SitePickerPresenter
 
     override fun getWooCommerceSites(): List<SiteModel> {
         val currentWooSites = wooCommerceStore.getWooCommerceSites()
-        return if (wooSitesHasBeenFetched || currentWooSites.none { it.isJetpackCPConnected }) {
+        return if (!FeatureFlag.JETPACK_CP.isEnabled() ||
+            wooSitesHasBeenFetched ||
+            currentWooSites.none { it.isJetpackCPConnected }
+        ) {
             currentWooSites
         } else {
             emptyList()

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -70,6 +70,16 @@
                     tools:listitem="@layout/site_picker_item" />
             </LinearLayout>
 
+            <ProgressBar
+                android:id="@+id/progress_bar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/login_user_info"
+                android:visibility="gone"/>
+
             <include
                 android:id="@+id/login_user_info"
                 layout="@layout/view_login_user_info"


### PR DESCRIPTION
Closes: #4857 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Since currently we need to run some additional checks for sites that use Jetpack CP, and since those checks are part of `WooCommerceStore` and not `SiteStore`, we need to force fetching the sites on the site picker, instead of relying on the sites that exist on the database, since the sites fetched using `SiteStore` by the login library might not contain accurate data.
The current implementation of the `SitePicker` always fetches the sites, but if there are sites in the DB, it doesn't show the loading view, this PR changes this by forcing the loading view if one of the sites is using Jetpack CP.

|Scenario | Before | After |
| --- | ------ | ------ |
| Login using site's URL | ![login_site_url_before](https://user-images.githubusercontent.com/1657201/139302890-9d092474-de93-4c4c-855b-857eaf3a4df8.gif) |  ![login_site_url_after](https://user-images.githubusercontent.com/1657201/139302917-aa781151-8607-49c6-81b5-46e606d80aa4.gif) |
| Login using WPCom account |  ![login_wpcom_before](https://user-images.githubusercontent.com/1657201/139303046-6fe5ae18-7ef9-43f4-a1d0-a0d5459874f4.gif) | ![login_wpcom_after](https://user-images.githubusercontent.com/1657201/139303062-e17a8238-5d20-4f54-86a7-c3c553ba06ae.gif) |

### Testing instructions
#### No Regression
Confirm that there is no regression when using an account that's not connected to any Jetpack CP sites.

#### Jetpack CP sites
##### Login using WPCom
1. You need a site that uses a Jetpack CP plugin (WCPay preferably)
2. Open the app and connect using your WordPress.com account
3. When you get to the site picker, confirm that you see the skeleton view, before seeing a complete list of the sites.

##### Login using the site's URL
1. You need a site that uses a Jetpack CP plugin (WCPay preferably)
2. Open the app and connect using the site's URL
3. When you get to the site picker, confirm that you see a circular progress bar, and then the app connects you automatically.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
