### PR TITLE
Remove order editing feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.9
 -----
-
+[**] Merchants can now edit shipping & billing addresses from orders. [https://github.com/woocommerce/woocommerce-android/pull/5106]
 
 7.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.9
 -----
-[**] Merchants can now edit shipping & billing addresses from orders. [https://github.com/woocommerce/woocommerce-android/pull/5106]
+[**] Merchants can now edit Customer Notes, shipping, and billing addresses from orders. [https://github.com/woocommerce/woocommerce-android/pull/5106]
 
 7.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -19,7 +19,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderCustomerHelper
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PhoneUtils
 import com.woocommerce.android.widgets.AppRatingDialog
 
@@ -36,10 +35,8 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         isReadOnly: Boolean
     ) {
         showCustomerNote(order, isReadOnly)
-        // customer note editing is available but address editing is still behind a feature flag
-        val isReadOnlyOrDisabled = isReadOnly || !FeatureFlag.ORDER_EDITING.isEnabled()
-        showShippingAddress(order, isVirtualOrder, isReadOnlyOrDisabled)
-        showBillingInfo(order, isReadOnlyOrDisabled)
+        showShippingAddress(order, isVirtualOrder, isReadOnly)
+        showBillingInfo(order, isReadOnly)
     }
 
     private fun showBillingInfo(order: Order, isReadOnly: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,7 +8,6 @@ import android.content.Context
 enum class FeatureFlag {
     DB_DOWNGRADE,
     ORDER_CREATION,
-    ORDER_EDITING,
     CARD_READER,
     JETPACK_CP;
 
@@ -18,7 +17,6 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
             ORDER_CREATION,
-            ORDER_EDITING,
             JETPACK_CP -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
         }


### PR DESCRIPTION
Summary
==========
Fixes issue #4911 and #4912 by delivering the Order Editing feature to general availability.

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
