### PR TITLE
Issue/5110 quick order flag and toggle

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -41,6 +41,7 @@ object AppPrefs {
         DATABASE_DOWNGRADED,
         IS_PRODUCTS_FEATURE_ENABLED,
         IS_PRODUCT_ADDONS_ENABLED,
+        IS_QUICK_ORDER_ENABLED,
         LOGIN_USER_BYPASSED_JETPACK_REQUIRED,
         SELECTED_ORDER_LIST_TAB_POSITION,
         IMAGE_OPTIMIZE_ENABLED,
@@ -145,6 +146,10 @@ object AppPrefs {
     var isProductAddonsEnabled: Boolean
         get() = getBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, false)
         set(value) = setBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, value)
+
+    var isQuickOrderEnabled: Boolean
+        get() = getBoolean(DeletablePrefKey.IS_QUICK_ORDER_ENABLED, false)
+        set(value) = setBoolean(DeletablePrefKey.IS_QUICK_ORDER_ENABLED, value)
 
     fun getLastAppVersionCode(): Int {
         return getDeletableInt(UndeletablePrefKey.LAST_APP_VERSION_CODE)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -126,6 +126,14 @@ class AppSettingsActivity :
         }
     }
 
+    override fun onQuickOrderOptionChanged(enabled: Boolean) {
+        if (AppPrefs.isQuickOrderEnabled != enabled) {
+            isBetaOptionChanged = true
+            AppPrefs.isQuickOrderEnabled = enabled
+            setResult(RESULT_CODE_BETA_OPTIONS_CHANGED)
+        }
+    }
+
     override fun finishLogout() {
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -163,8 +163,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
         }
 
-        binding.optionBetaFeatures.optionValue = getString(R.string.settings_enable_product_addons_teaser_title)
-
         binding.optionPrivacy.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_privacySettingsFragment)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -62,6 +62,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         fun onRequestLogout()
         fun onSiteChanged()
         fun onProductAddonsOptionChanged(enabled: Boolean)
+        fun onQuickOrderOptionChanged(enabled: Boolean)
     }
 
     private lateinit var settingsListener: AppSettingsListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,6 +8,7 @@ import android.content.Context
 enum class FeatureFlag {
     DB_DOWNGRADE,
     ORDER_CREATION,
+    QUICK_ORDER,
     CARD_READER,
     JETPACK_CP,
     ORDER_FILTERS;
@@ -17,6 +18,7 @@ enum class FeatureFlag {
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
+            QUICK_ORDER,
             ORDER_CREATION,
             JETPACK_CP -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/colorSurface">
+    android:background="?attr/colorSurface"
+    android:orientation="vertical">
 
     <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/switchAddonsToggle"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         app:toggleOptionDesc="@string/settings_enable_product_addons_teaser_message"
         app:toggleOptionTitle="@string/settings_enable_product_addons_teaser_title" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <View style="@style/Woo.Divider" />
+
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+        android:id="@+id/switchQuickOrderToggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:toggleOptionDesc="@string/settings_enable_quick_order_teaser_message"
+        app:toggleOptionTitle="@string/settings_enable_quick_order_teaser_title" />
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -168,7 +168,8 @@
         android:id="@+id/option_beta_features"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:optionTitle="@string/beta_features" />
+        app:optionTitle="@string/beta_features"
+        app:optionValue="@string/beta_features_message" />
 
     <!--
         Send Feedback

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1287,6 +1287,7 @@
     <string name="privacy_settings">Privacy settings</string>
     <string name="send_feedback">Send feedback</string>
     <string name="beta_features">Beta features</string>
+    <string name="beta_features_message">View Add-ons, quick order</string>
     <string name="settings_signout">Log out</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1297,6 +1297,8 @@
     <string name="settings_enable_product_adding_teaser_message">Test out the new simple, linked and grouped product creation as we get ready to launch</string>
     <string name="settings_enable_product_addons_teaser_title">View Add-ons</string>
     <string name="settings_enable_product_addons_teaser_message">Test out viewing Order Add-ons as we get ready to launch</string>
+    <string name="settings_enable_quick_order_teaser_title">Quick order</string>
+    <string name="settings_enable_quick_order_teaser_message">Test out creating orders with minimal information as we get ready to launch</string>
     <string name="settings_enable_product_teaser_title">Product editing</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>


### PR DESCRIPTION
Closes #5110 - this PR simply adds the `QUICK_ORDER` feature flag and quick order toggle to the beta settings screen.

![toggle](https://user-images.githubusercontent.com/3903757/139472867-d524c9d5-61d6-4bfa-a1ef-616865f9170c.png)

