### PR TITLE
Fix state selection incorrect data mapping

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -36,11 +36,7 @@ class AddressViewModel @Inject constructor(
 
     fun start(countryCode: String, stateCode: String) {
         loadCountriesAndStates(countryCode, stateCode)
-
-        viewState.copy(
-            countryLocation = getCountryLocationFromCode(countryCode),
-            stateLocation = getStateLocationFromCode(stateCode)
-        ).applyChangesSafely()
+        viewState.applyCountryStateChangesSafely(countryCode, stateCode)
     }
 
     private fun loadCountriesAndStates(countryCode: String, stateCode: String) {
@@ -50,10 +46,8 @@ class AddressViewModel @Inject constructor(
                 viewState = viewState.copy(isLoading = true)
                 dataStore.fetchCountriesAndStates(selectedSite.get())
                 viewState.copy(
-                    isLoading = false,
-                    countryLocation = getCountryLocationFromCode(countryCode),
-                    stateLocation = getStateLocationFromCode(stateCode)
-                ).applyChangesSafely()
+                    isLoading = false
+                ).applyCountryStateChangesSafely(countryCode, stateCode)
             }
         }
     }
@@ -100,12 +94,17 @@ class AddressViewModel @Inject constructor(
      * we need to make sure that we updated the Country code before applying everything else to avoid
      * looking into a outdated state information
      */
-    private fun ViewState.applyChangesSafely() = apply {
+    private fun ViewState.applyCountryStateChangesSafely(countryCode: String, stateCode: String) {
+        val countryLocation = getCountryLocationFromCode(countryCode)
+
         viewState = viewState.copy(
-            countryLocation = this.countryLocation
+            countryLocation = countryLocation
         )
 
-        viewState = this
+        viewState = this.copy(
+            countryLocation = countryLocation,
+            stateLocation = getStateLocationFromCode(stateCode)
+        )
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -37,10 +37,10 @@ class AddressViewModel @Inject constructor(
     fun start(countryCode: String, stateCode: String) {
         loadCountriesAndStates(countryCode, stateCode)
 
-        viewState = viewState.copy(
+        viewState.copy(
             countryLocation = getCountryLocationFromCode(countryCode),
             stateLocation = getStateLocationFromCode(stateCode)
-        )
+        ).applyChangesSafely()
     }
 
     private fun loadCountriesAndStates(countryCode: String, stateCode: String) {
@@ -49,11 +49,11 @@ class AddressViewModel @Inject constructor(
             if (countries.isEmpty()) {
                 viewState = viewState.copy(isLoading = true)
                 dataStore.fetchCountriesAndStates(selectedSite.get())
-                viewState = viewState.copy(
+                viewState.copy(
                     isLoading = false,
                     countryLocation = getCountryLocationFromCode(countryCode),
                     stateLocation = getStateLocationFromCode(stateCode)
-                )
+                ).applyChangesSafely()
             }
         }
     }
@@ -93,6 +93,19 @@ class AddressViewModel @Inject constructor(
                 stateLocation = getStateLocationFromCode(stateCode)
             )
         }
+    }
+
+    /**
+     * State data acquisition depends on the Country configuration, so when updating the ViewState
+     * we need to make sure that we updated the Country code before applying everything else to avoid
+     * looking into a outdated state information
+     */
+    private fun ViewState.applyChangesSafely() = apply {
+        viewState = viewState.copy(
+            countryLocation = this.countryLocation
+        )
+
+        viewState = this
     }
 
     @Parcelize


### PR DESCRIPTION
Summary
==========
Fixes issue #5107 and #5108 by creating a mechanism to update the Country data before doing any change to the Country State code, this bug was happening because when we're doing this copy operation:

```
viewState = viewState.copy(
            countryLocation = getCountryLocationFromCode(countryCode),
            stateLocation = getStateLocationFromCode(stateCode)
        )
```

The `getStateLocationFromCode` function uses the Country code to update to the correct data:

```
dataStore.getStates(viewState.countryLocation.code).map { it.toAppModel() }
```

But if we're updating both Country and State at once, the Country location won't be updated into the ViewState yet, and the State location may be acquired from an outdated Country source.

How to Reproduce
==========
##Scenario 1 (#5108)
1. Go to an Order, select Shipping or Billing address, configure the Country as `Brazil` and the State as `Minas Gerais` and click `done`
2. Go back to the orders list, open back the same Order details, and open again the same Address editing view, verify that the state instead of showing `Minas Gerais`, will be displaying `Madagascar`, but Madagascar is a Country with no relation with Brazilian states. Minas Gerais state code is MG, and Madagascar country code is also MG, but since the state list wasn't updated yet during the `start` method, the State data list is a copy of the world country list, accidentally matching with an incorrect code.

##Scenario 2 (#5107)
1. Go to an Order, select Shipping or Billing address, configure the Country as `Brazil` and the State as `Amapá` and click `done`
2. Go back to the orders list, open back the same Order details, and open again the same Address editing view, verify that the state instead of showing `Amapá`, will be displaying `AP`, because since the State list isn't updated yet and contains the World country list, there's no Country matching the `AP` code, so the `getStateNameFromCode` returns the State code instead of the name.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
