### PR TITLE
Issue/4873 3.2.0 min wcpay version

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -93,8 +93,8 @@ class CardReaderConnectViewModel @Inject constructor(
 
     // The app shouldn't store the state as connection flow gets canceled when the vm dies
     private val viewState = MutableLiveData<CardReaderConnectViewState>(ScanningState(::onCancelClicked))
-    var requiredUpdateStarted: Boolean = false
-    var connectionStarted: Boolean = false
+    private var requiredUpdateStarted: Boolean = false
+    private var connectionStarted: Boolean = false
 
     val viewStateData: LiveData<CardReaderConnectViewState> = viewState
 
@@ -318,7 +318,7 @@ class CardReaderConnectViewModel @Inject constructor(
             connectToReader(lastKnownReader)
         } else {
             viewState.value = when {
-                availableReaders.isEmpty() -> CardReaderConnectViewState.ScanningState(::onCancelClicked)
+                availableReaders.isEmpty() -> ScanningState(::onCancelClicked)
                 availableReaders.size == 1 -> buildSingleReaderFoundState(availableReaders[0])
                 availableReaders.size > 1 -> buildMultipleReadersFoundState(availableReaders)
                 else -> throw IllegalStateException("Unreachable code")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 private val SUPPORTED_COUNTRIES = listOf("US")
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-const val SUPPORTED_WCPAY_VERSION = "2.8.2"
+const val SUPPORTED_WCPAY_VERSION = "3.2.0"
 
 class CardReaderOnboardingChecker @Inject constructor(
     private val selectedSite: SelectedSite,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4873
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Sets 3.2.0 WCPay version as min version possible to use in order to be able to perform IPP
* Fixes TextButton text gravity

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Try to connect to a reader with WCPay version < 3.2.0
* Notice error
* Try to connect to a reader with WCPay version >= 3.2.0
* Notice that you can connect to it

* During first connection to a reader notice that the "skip" button is centered properly

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="374" alt="tut2" src="https://user-images.githubusercontent.com/4923871/139838964-fb816d87-af7e-4f8d-8330-2353ed9b4b52.png">
<img width="376" alt="tut1" src="https://user-images.githubusercontent.com/4923871/139838970-7f0c7e19-b289-4194-8791-7007df977077.png">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary

(will be added in the PR which will be merging the SDK branch in develop)

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
