### PR TITLE
Set min wcpay suported version to 3.2.1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 private val SUPPORTED_COUNTRIES = listOf("US")
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-const val SUPPORTED_WCPAY_VERSION = "3.2.0"
+const val SUPPORTED_WCPAY_VERSION = "3.2.1"
 
 class CardReaderOnboardingChecker @Inject constructor(
     private val selectedSite: SelectedSite,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Following the discussion that 3.2.0 contains fatal incompatibilities with PHP 7.2, it's better to be on the safe side and set min version to 3.2.1

https://github.com/woocommerce/woocommerce-android/pull/5132
