### PR TITLE
Add unit tests for stripe m2 card reader manual icon display logic

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -66,10 +66,20 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when screen shown, then m2 manual card reader row present`() {
+    fun `when screen shown, then m2 manual card reader icon present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader)
+                it.label == UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader) &&
+                    it.icon == R.drawable.ic_card_reader_manual
+            }
+    }
+
+    @Test
+    fun `when screen shown, then bbpos chipper manual card reader icon present`() {
+        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
+            .anyMatch {
+                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader) &&
+                    it.icon == R.drawable.ic_card_reader_manual
             }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -66,7 +66,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when screen shown, then m2 manual card reader icon present`() {
+    fun `when screen shown, then m2 manual card reader row present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
                 it.label == UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader) &&
@@ -75,7 +75,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when screen shown, then bbpos chipper manual card reader icon present`() {
+    fun `when screen shown, then bbpos chipper manual card reader row present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
                 it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader) &&


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5151 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds missing unit tests for stripe m2 card reader manual icon display logic

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Ensuring the CI passes unit tests should be enough 🙂 


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
