### PR TITLE
Issue/5153 Accessibility connected state improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -5,6 +5,7 @@ import android.text.method.LinkMovementMethod
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import org.wordpress.android.util.DisplayUtils.dpToPx
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppUrls
@@ -13,6 +14,7 @@ import com.woocommerce.android.R.color
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentCardReaderDetailBinding
 import com.woocommerce.android.extensions.exhaustive
+import com.woocommerce.android.extensions.expandHitArea
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.setDrawableColor
@@ -31,6 +33,8 @@ import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.util.copyToClipboard
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+
+private const val HIT_AREA_EXPANSION_DP = 16
 
 @AndroidEntryPoint
 class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_detail) {
@@ -96,8 +100,9 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                             UiHelpers.setTextOrHide(enforcedUpdateTv, state.enforceReaderUpdate)
                             enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
                             with(readerNameTv) {
-                                UiHelpers.setTextOrHide(readerNameTv, state.readerName)
+                                UiHelpers.setTextOrHide(this, state.readerName)
                                 setOnLongClickListener { state.onReaderNameLongClick(); true }
+                                expandHitArea(0, dpToPx(requireContext(), HIT_AREA_EXPANSION_DP))
                             }
                             UiHelpers.setTextOrHide(readerBatteryTv, state.readerBattery)
                             UiHelpers.setTextOrHide(readerFirmwareVersionTv, state.readerFirmwareVersion)

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
@@ -35,7 +35,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
-        android:layout_marginBottom="0dp"
+        android:layout_marginBottom="@dimen/minor_100"
         android:letterSpacing="0.15"
         android:text="@string/card_reader_detail_connected_header"
         android:textColor="@color/color_on_surface_medium"
@@ -50,7 +50,7 @@
         android:layout_marginEnd="0dp"
         android:paddingHorizontal="@dimen/major_100"
         android:background="?attr/selectableItemBackground"
-        android:paddingVertical="@dimen/minor_100"
+        android:paddingVertical="@dimen/minor_50"
         android:layout_marginBottom="0dp"
         tools:text="CHB204909005931" />
 

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
@@ -35,7 +35,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
-        android:layout_marginBottom="@dimen/minor_100"
+        android:layout_marginBottom="@dimen/minor_50"
         android:letterSpacing="0.15"
         android:text="@string/card_reader_detail_connected_header"
         android:textColor="@color/color_on_surface_medium"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
@@ -35,7 +35,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
-        android:layout_marginBottom="@dimen/minor_50"
+        android:layout_marginBottom="0dp"
         android:letterSpacing="0.15"
         android:text="@string/card_reader_detail_connected_header"
         android:textColor="@color/color_on_surface_medium"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
@@ -38,7 +38,7 @@
         android:layout_marginBottom="@dimen/minor_100"
         android:letterSpacing="0.15"
         android:text="@string/card_reader_detail_connected_header"
-        android:textColor="@color/color_on_surface_disabled"
+        android:textColor="@color/color_on_surface_medium"
         android:textSize="@dimen/text_minor_60" />
 
     <com.google.android.material.textview.MaterialTextView
@@ -50,7 +50,7 @@
         android:layout_marginEnd="0dp"
         android:paddingHorizontal="@dimen/major_100"
         android:background="?attr/selectableItemBackground"
-        android:paddingVertical="@dimen/minor_50"
+        android:paddingVertical="@dimen/minor_100"
         android:layout_marginBottom="0dp"
         tools:text="CHB204909005931" />
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
The PR improves the situation with accessibility on the connected state screen

Closes: #5153 
Closes: #5088 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Increases touch area for the serial number touch-to-copy
* Makes "CONNECTED READER" darker/lighter depending on a theme

Both changes still don't pass the accessibility scanner criteria, but I consider them a good balance between design and being accessible. @AnirudhBhat wdyt? Also, I wouldn't change anything related to the link (#5154) because we have clickable not only the link but the whole layout

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Connect to a reader and visually evaluate the changes

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


![screencap-2021-11-03T131534 158Z](https://user-images.githubusercontent.com/4923871/140066989-f7b2c3f1-75a7-49d1-9ef7-139b1979c336.png)
![screencap-2021-11-03T131433 541Z](https://user-images.githubusercontent.com/4923871/140066995-b7c35e6d-f70f-4913-be1a-66db7fc2024a.png)
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
