### PR TITLE
Added mocks necessary to open individual product screens with no warnings from WireMock.

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2123.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2123.json
@@ -1,0 +1,134 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/2123/(.*)"
+            },
+            "locale": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2123,
+                "name": "Malaya shades",
+                "slug": "malaya-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/malaya-shades\/",
+                "date_created": "2020-01-28T09:53:10",
+                "date_created_gmt": "2020-01-28T09:53:10",
+                "date_modified": "2020-01-28T09:57:27",
+                "date_modified_gmt": "2020-01-28T09:57:27",
+                "type": "simple",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "",
+                "short_description": "",
+                "sku": "",
+                "price": "140",
+                "regular_price": "140",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": true,
+                "total_sales": 14,
+                "virtual": false,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": false,
+                "average_rating": "0.00",
+                "rating_count": 0,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [{
+                    "id": 2128,
+                    "date_created": "2020-01-28T09:52:59",
+                    "date_created_gmt": "2020-01-28T09:52:59",
+                    "date_modified": "2020-01-28T09:52:59",
+                    "date_modified_gmt": "2020-01-28T09:52:59",
+                    "src": "https:\/\/i1.wp.com\/automatticwidgets.wpcomstaging.com\/wp-content\/uploads\/2020\/01\/Mask-Group.png?fit=201%2C201&ssl=1",
+                    "name": "Mask Group",
+                    "alt": ""
+                }],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;<\/span>140.00<\/bdi><\/span>",
+                "related_ids": [],
+                "meta_data": [{
+                    "id": 2574,
+                    "key": "_product_addons",
+                    "value": []
+                }, {
+                    "id": 2575,
+                    "key": "_product_addons_exclude_global",
+                    "value": "0"
+                }, {
+                    "id": 2591,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                }, {
+                    "id": 4047,
+                    "key": "_last_editor_used_jetpack",
+                    "value": "classic-editor"
+                }],
+                "stock_status": "instock",
+                "jetpack_publicize_connections": [],
+                "jetpack_likes_enabled": false,
+                "jetpack_sharing_enabled": true,
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2123"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                    }]
+                }
+            }        
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2129.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/products/products_2129.json
@@ -1,0 +1,134 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/products/2129/(.*)"
+            },
+            "locale": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2129,
+                "name": "Akoya Pearl shades",
+                "slug": "akoya-pearl-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/akoya-pearl-shades\/",
+                "date_created": "2020-01-28T09:53:36",
+                "date_created_gmt": "2020-01-28T09:53:36",
+                "date_modified": "2020-01-28T09:57:12",
+                "date_modified_gmt": "2020-01-28T09:57:12",
+                "type": "simple",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "",
+                "short_description": "",
+                "sku": "",
+                "price": "110",
+                "regular_price": "110",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": true,
+                "total_sales": 5,
+                "virtual": false,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": false,
+                "average_rating": "0.00",
+                "rating_count": 0,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [{
+                    "id": 2127,
+                    "date_created": "2020-01-28T09:52:58",
+                    "date_created_gmt": "2020-01-28T09:52:58",
+                    "date_modified": "2020-01-28T09:52:58",
+                    "date_modified_gmt": "2020-01-28T09:52:58",
+                    "src": "https:\/\/i0.wp.com\/automatticwidgets.wpcomstaging.com\/wp-content\/uploads\/2020\/01\/Mask-Group-2.png?fit=200%2C201&ssl=1",
+                    "name": "Mask Group-2",
+                    "alt": ""
+                }],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;<\/span>110.00<\/bdi><\/span>",
+                "related_ids": [],
+                "meta_data": [{
+                    "id": 2596,
+                    "key": "_product_addons",
+                    "value": []
+                }, {
+                    "id": 2597,
+                    "key": "_product_addons_exclude_global",
+                    "value": "0"
+                }, {
+                    "id": 2613,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                }, {
+                    "id": 4051,
+                    "key": "_last_editor_used_jetpack",
+                    "value": "classic-editor"
+                }],
+                "stock_status": "instock",
+                "jetpack_publicize_connections": [],
+                "jetpack_likes_enabled": false,
+                "jetpack_sharing_enabled": true,
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2129"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                    }]
+                }
+            }       
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/taxes/taxes_classes.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/taxes/taxes_classes.json
@@ -1,0 +1,51 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/taxes/classes/(.*)"
+            },                    
+            "locale": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": [{
+                "slug": "standard",
+                "name": "Standard rate",
+                "_links": {
+                    "collection": [{
+                        "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/taxes/classes"
+                    }]
+                }
+            }, {
+                "slug": "reduced-rate",
+                "name": "Reduced rate",
+                "_links": {
+                    "collection": [{
+                        "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/taxes/classes"
+                    }]
+                }
+            }, {
+                "slug": "zero-rate",
+                "name": "Zero rate",
+                "_links": {
+                    "collection": [{
+                        "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/taxes/classes"
+                    }]
+                }
+            }]
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/sites/rest_sites_161477129.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/sites/rest_sites_161477129.json
@@ -4,7 +4,12 @@
         "urlPathPattern": "/rest/v1.(1|2)/sites/161477129",
         "queryParameters": {
             "fields": {
-                "matches": "(.*)ID,URL,name,description,jetpack,visible,is_private,options,plan,capabilities,quota,icon,meta(.*)"
+                "contains": "ID",
+                "contains": "URL",
+                "contains": "name",
+                "contains": "description",
+                "contains": "jetpack",
+                "contains": "plan"
             },
             "locale": {
                 "matches": "(.*)"

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/sites/sites_posts_password.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/sites/sites_posts_password.json
@@ -1,0 +1,25 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/sites/161477129/posts/(.*)",
+        "queryParameters": {
+            "fields": {
+                "equalTo": "password"
+            },            
+            "locale": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "password": ""
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+            "Cache-Control": "no-cache, must-revalidate, max-age=0"
+        }
+    }
+}


### PR DESCRIPTION
This is a preparation for Products List UI test automation.

### Description
As was mentioned in #5051, WireMock will force test fail in case of unmatched requests, even if the request has nothing to do with the test, and all information needed for the test is displayed correctly. This is what happens with products list, or to be more precise, in case of opening every individual product page.

This PR simply adds these missing mocks.

### Testing instructions
1. Run existing `reviewListShowsAllReviews` UI test, it should pass.
2. By adding a `Thread.sleep` or by setting a breakpoint (and running the test in debug mode) after login in `ReviewsUITest.setUp()` method, make sure you are able to browse the app while WireMock is running. Once this is done, open products list and open the screen for every individual product (five of them). During this, keep the Android Studio _Logcat_ opened in the background, and make sure you **don't** see any errors about unmatched requests similar to this one:

<img width="1286" alt="Screenshot 2021-11-03 at 15 42 33" src="https://user-images.githubusercontent.com/73365754/140073195-ca5db5cb-0bd4-4edd-98db-55f68f06f483.png">


A fast way to do this is to type in e.g. `closest` into Logcat searchbox, to filter out unrelated messages. You can additionally make sure that you **can** see the error about unmatched request once you open the Orders list.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.