### PR TITLE
Set toggle viewModel state to false when leaving the Address editing …

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -83,10 +83,11 @@ abstract class BaseAddressEditingFragment :
         (addressDraft != storedAddress) || binding.replicateAddressSwitch.isChecked
 
     override fun onStop() {
-        super.onStop()
+        sharedViewModel.onReplicateAddressSwitchChanged(false)
         activity?.let {
             ActivityUtils.hideKeyboard(it)
         }
+        super.onStop()
     }
 
     private fun Address.bindToView() {


### PR DESCRIPTION
Summary
==========
Fixes issue #5161 by making sure that when we leave any Address editing fragment we set the ViewModel toggle state to deactivated, matching the UI behavior.

How to Reproduce
==========
1. Open an Order containing both Shipping & Billing addresses, edit one of them, mark the `use as` toggle as activated and hit `done`. Verify that both addresses got updated.
2. Enter either Shipping or Billing address editing view, edit any information, DO NOT mark the `use as` toggle and hit `done`, verify that even so both addresses got updated when it shouldn't, since the `use as` toggle was deactivated.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
