### PR TITLE
Define new style to TextButtons that aligns text to the start

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 6
     directory: "/"
     schedule:
       interval: "daily"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -273,7 +273,7 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_viewMoreButtonTitle"
-                style="@style/Woo.Button.TextButton"
+                style="@style/Woo.Button.TextButton.TextStart"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"

--- a/WooCommerce/src/main/res/layout/order_detail_note_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_note_list.xml
@@ -52,7 +52,7 @@
                 app:srcCompat="@drawable/ic_add"/>
 
             <com.google.android.material.textview.MaterialTextView
-                style="@style/Woo.Button.TextButton"
+                style="@style/Woo.Button.TextButton.TextStart"
                 android:paddingStart="@dimen/minor_00"
                 android:paddingEnd="@dimen/minor_00"
                 android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
@@ -217,7 +217,7 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/shippingLabelItem_viewMoreButtonTitle"
-                style="@style/Woo.Button.TextButton"
+                style="@style/Woo.Button.TextButton.TextStart"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
@@ -227,7 +227,6 @@
                 android:paddingStart="@dimen/major_100"
                 android:paddingEnd="@dimen/major_100"
                 android:text="@string/orderdetail_shipping_label_item_show_shipping"
-                android:textAlignment="textStart"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/shippingLabelItem_viewMoreButtonImage"
                 app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/wc_actionable_empty_label.xml
+++ b/WooCommerce/src/main/res/layout/wc_actionable_empty_label.xml
@@ -6,13 +6,12 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/emptyLabel"
-        style="@style/Woo.Button.TextButton"
+        style="@style/Woo.Button.TextButton.TextStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:clickable="false"
         android:drawableStart="@drawable/ic_add"
         android:drawablePadding="@dimen/major_100"
-        android:gravity="center_vertical"
         android:textColor="@color/color_icon_secondary"
         tools:text="@string/order_detail_add_customer_note" />
 

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -424,6 +424,9 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
         <item name="iconTint">@color/button_fg_selector</item>
+    </style>
+
+    <style name="Woo.Button.TextButton.TextStart" parent="Woo.Button.TextButton">
         <item name="android:gravity">center_vertical|start</item>
         <item name="android:textAlignment">gravity</item>
     </style>


### PR DESCRIPTION
Closes: #5147

### Description
We are reusing the same style: `Woo.Button.TextButton`  for `Buttons` and `TextViews` in distinctively. This leads to issues with text alignment such as the one discussed [here](https://github.com/woocommerce/woocommerce-android/pull/5132#discussion_r740970939). This happens because by default, Buttons align text to center and text views to the start, but they are depending on the same style. 

`Woo.Button.TextButton` was modified [here](https://github.com/woocommerce/woocommerce-android/commit/4cf553a209cfea35d5ad833a8c2b508e167bd078) to fix RTL issues, but it had unwanted side effects over buttons that expected to have their text align to the center. 

Proposed solution is 
- Remove these lines from style Woo.Button.TextButton
```xml
      <item name="android:gravity">center_vertical|start</item>
      <item name="android:textAlignment">gravity</item>
```

- Create a new style like Woo.Button.TextButton.TextStart so that all MaterialTextVIew use this new style.


So we ensure any usage of `Woo.Button.TextButton` style done by a `TextView`  now uses the new style `Woo.Button.TextButton.TextStart` that will guarantee proper text alignment. Hope this once and for all fixes issues with text aligment 😅 

### Unrelated 

There is also an unrelated change in this PR. We have some dependabot PR onHold as we cannot update some dependencies until we bump android `compileSdk` version to 31. For that I'm incrementing the `open-pull-requests-limit` to 6, so we keep getting a fair amount of dependency updates while we have other PRs on hold

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

