### PR TITLE
Issue/5163 Use of the non deprecated compiler arg

### DIFF
--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -26,7 +26,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += [
-                "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+                "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
         ]
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5163 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I noticed that the compiler complains that we use deprecated `-Xuse-experimental` flag which will be removed in the next version. This PR replaces it with `-Xopt-in` as per https://kotlinlang.org/docs/opt-in-requirements.html

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
