### PR TITLE
Moves mocks-reading functions to a separate class

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/JSONArray+iterator.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/JSONArray+iterator.kt
@@ -4,5 +4,5 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 // Found at https://www.baeldung.com/kotlin/iterate-over-jsonarray
-operator fun JSONArray.iterator(): Iterator<JSONObject>
-    = (0 until length()).asSequence().map { get(it) as JSONObject }.iterator()
+operator fun JSONArray.iterator(): Iterator<JSONObject> =
+    (0 until length()).asSequence().map { get(it) as JSONObject }.iterator()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/JSONArray+iterator.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/JSONArray+iterator.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.screenshots.util
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+// Found at https://www.baeldung.com/kotlin/iterate-over-jsonarray
+operator fun JSONArray.iterator(): Iterator<JSONObject>
+    = (0 until length()).asSequence().map { get(it) as JSONObject }.iterator()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/MocksReader.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/MocksReader.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.screenshots.util
+
+import androidx.test.platform.app.InstrumentationRegistry
+import org.json.JSONArray
+import org.json.JSONObject
+
+class MocksReader {
+
+    fun readAllReviewsToArray(): JSONArray {
+        val reviewsWireMockFileName = "mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json"
+        val reviewsWireMockString = this.readAssetsFile(reviewsWireMockFileName)
+        val reviewsWireMockJSON = JSONObject(reviewsWireMockString)
+        return reviewsWireMockJSON
+            .getJSONObject("response")
+            .getJSONObject("jsonBody")
+            .getJSONArray("data")
+    }
+
+    private fun readAssetsFile(fileName: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().context
+        return appContext.assets.open(fileName).bufferedReader().use { it.readText() }
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/MocksReader.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/MocksReader.kt
@@ -5,7 +5,6 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 class MocksReader {
-
     fun readAllReviewsToArray(): JSONArray {
         val reviewsWireMockFileName = "mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json"
         val reviewsWireMockString = this.readAssetsFile(reviewsWireMockFileName)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -9,9 +9,9 @@ import com.woocommerce.android.screenshots.login.WelcomeScreen
 import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
 import com.woocommerce.android.screenshots.util.ReviewData
 import com.woocommerce.android.screenshots.util.MocksReader
+import com.woocommerce.android.screenshots.util.iterator
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -43,14 +43,13 @@ class ReviewsUITest : TestBase() {
     fun reviewListShowsAllReviews() {
         val reviewsJSONArray = MocksReader().readAllReviewsToArray()
 
-        for (i in 0 until reviewsJSONArray.length()) {
-            val reviewContainer: JSONObject = reviewsJSONArray.getJSONObject(i)
+        for (review in reviewsJSONArray.iterator()) {
             val currentReview = ReviewData(
-                reviewContainer.getInt("product_id"),
-                reviewContainer.getString("status"),
-                reviewContainer.getString("reviewer"),
-                reviewContainer.getString("review"),
-                reviewContainer.getInt("rating")
+                review.getInt("product_id"),
+                review.getString("status"),
+                review.getString("reviewer"),
+                review.getString("review"),
+                review.getInt("rating")
             )
 
             ReviewsListScreen()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.main
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.helpers.InitializationRule
@@ -9,6 +8,7 @@ import com.woocommerce.android.screenshots.TabNavComponent
 import com.woocommerce.android.screenshots.login.WelcomeScreen
 import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
 import com.woocommerce.android.screenshots.util.ReviewData
+import com.woocommerce.android.screenshots.util.MocksReader
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.json.JSONObject
@@ -41,16 +41,10 @@ class ReviewsUITest : TestBase() {
 
     @Test
     fun reviewListShowsAllReviews() {
-        val reviewsWireMockFileName = "mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json"
-        val reviewsWireMockString = readAssetsFile(reviewsWireMockFileName)
-        val reviewsWireMockJSON = JSONObject(reviewsWireMockString)
-        val reviewsJSONResponse = reviewsWireMockJSON
-            .getJSONObject("response")
-            .getJSONObject("jsonBody")
-            .getJSONArray("data")
+        val reviewsJSONArray = MocksReader().readAllReviewsToArray()
 
-        for (i in 0 until reviewsJSONResponse.length()) {
-            val reviewContainer: JSONObject = reviewsJSONResponse.getJSONObject(i)
+        for (i in 0 until reviewsJSONArray.length()) {
+            val reviewContainer: JSONObject = reviewsJSONArray.getJSONObject(i)
             val currentReview = ReviewData(
                 reviewContainer.getInt("product_id"),
                 reviewContainer.getString("status"),
@@ -66,10 +60,5 @@ class ReviewsUITest : TestBase() {
                 .assertSingleReviewScreen(currentReview)
                 .goBackToReviewsScreen()
         }
-    }
-
-    private fun readAssetsFile(fileName: String): String {
-        val appContext = InstrumentationRegistry.getInstrumentation().context
-        return appContext.assets.open(fileName).bufferedReader().use { it.readText() }
     }
 }


### PR DESCRIPTION
### Description
As [suggested](https://github.com/woocommerce/woocommerce-android/pull/5051#discussion_r735205758) by @mokagio, it makes sense to extract the code related to mocks JSONs reading to a separate class. It's the only change presented in this PR.

### Testing instructions
Runing `reviewListShowsAllReviews` test from `ReviewsUITest.kt` and seeing it pass should be enough.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.