### PR TITLE
Update order reader url

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -41,7 +41,7 @@ object AppUrls {
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
-    const val WOOCOMMERCE_PURCHASE_CARD_READER = "https://woocommerce.com/products/bbpos-chipper2xbt-card-reader"
+    const val WOOCOMMERCE_PURCHASE_CARD_READER = "https://woocommerce.com/in-person-payments/"
     const val BBPOS_MANUAL_CARD_READER =
         "https://developer.bbpos.com/quick_start_guide/Chipper%202X%20BT%20Quick%20Start%20Guide.pdf"
     const val M2_MANUAL_CARD_READER = "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -118,6 +118,18 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when user clicks on purchase card reader, then app opens external webview with in-person-payments link`() {
+        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
+            .find {
+                it.label == UiString.UiStringRes(R.string.card_reader_purchase_card_reader)
+            }!!.onItemClicked.invoke()
+
+        assertThat(
+            (viewModel.event.value as CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow).url
+        ).isEqualTo(AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER)
+    }
+
+    @Test
     fun `when user clicks on bbpos manual card reader, then app opens external webview with bbpos link`() {
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
             .find {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Goal of this PR is to replace "Order Card Reader" url https://woocommerce.com/products/bbpos-chipper2xbt-card-reader with https://woocommerce.com/in-person-payments/. We plan to add support for M2 readers and the generic url will allow us to update the webpage without the need to release a new version of the app.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Tap on APp settings
2. Tap on In Person Payments
3. Tap on Order Card Reader
4. Notice the update url is loaded

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
