### PR TITLE
Issue/5112 quick order view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -27,12 +27,10 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentOrderListBinding
-import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -40,11 +38,8 @@ import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.OrderStatusListView
-import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
-import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
-import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
 import com.woocommerce.android.ui.orders.quickorder.QuickOrderDialog
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -434,11 +434,7 @@ class OrderListFragment :
     }
 
     private fun showQuickOrderDialog() {
-        val action = OrderListFragmentDirections.actionOrderListFragmentToQuickOrderDialog(
-            viewModel.getStoreCurrencyCode(),
-            viewModel.getStoreDecimals()
-        )
-        findNavController().navigateSafely(action)
+        findNavController().navigate(R.id.action_orderListFragment_to_quickOrderDialog)
     }
 
     private fun hideEmptyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -434,7 +434,11 @@ class OrderListFragment :
     }
 
     private fun showQuickOrderDialog() {
-        findNavController().navigate(R.id.action_orderListFragment_to_quickOrderDialog)
+        val action = OrderListFragmentDirections.actionOrderListFragmentToQuickOrderDialog(
+            viewModel.getStoreCurrencyCode(),
+            viewModel.getStoreDecimals()
+        )
+        findNavController().navigateSafely(action)
     }
 
     private fun hideEmptyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -304,7 +304,7 @@ class OrderListFragment :
                 true
             }
             R.id.menu_add -> {
-                // TODO nbradbury - show quick order view
+                showQuickOrderDialog()
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -431,6 +431,10 @@ class OrderListFragment :
 
     private fun showOrderFilters() {
         findNavController().navigate(R.id.action_orderListFragment_to_orderFilterListFragment)
+    }
+
+    private fun showQuickOrderDialog() {
+        findNavController().navigate(R.id.action_orderListFragment_to_quickOrderDialog)
     }
 
     private fun hideEmptyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -51,6 +51,7 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING
 import org.wordpress.android.login.util.getColorFromAttribute
 import org.wordpress.android.util.DisplayUtils
+import java.math.BigDecimal
 import java.util.*
 import javax.inject.Inject
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
@@ -432,8 +433,8 @@ class OrderListFragment :
     }
 
     private fun initializeResultHandlers() {
-        handleResult<String>(QuickOrderDialog.KEY_QUICK_ORDER_RESULT) {
-            // TODO nbradbury
+        handleResult<BigDecimal>(QuickOrderDialog.KEY_QUICK_ORDER_RESULT) {
+            // TODO nbradbury create order using the passed price
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -27,10 +27,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentOrderListBinding
+import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.FeatureFeedbackSettings
+import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -38,8 +40,12 @@ import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.OrderStatusListView
+import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
+import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
+import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
+import com.woocommerce.android.ui.orders.quickorder.QuickOrderDialog
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.FeatureFlag
@@ -179,6 +185,7 @@ class OrderListFragment :
         }
 
         initializeViewModel()
+        initializeResultHandlers()
         initializeTabs()
 
         if (isFilterEnabled) {
@@ -426,6 +433,12 @@ class OrderListFragment :
             new.filterCount.takeIfNotEqualTo(old?.filterCount) { filterCount ->
                 binding.orderFiltersCard.updateFilterSelection(filterCount)
             }
+        }
+    }
+
+    private fun initializeResultHandlers() {
+        handleResult<String>(QuickOrderDialog.KEY_QUICK_ORDER_RESULT) {
+            // TODO nbradbury
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -55,7 +55,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderSummariesFetched
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.util.Locale
+import java.util.*
 import javax.inject.Inject
 
 private const val EMPTY_VIEW_THROTTLE = 250L
@@ -495,6 +495,11 @@ class OrderListViewModel @Inject constructor(
         activatePagedListWrapper(pagedListWrapper)
     }
 
+    fun getStoreCurrencyCode() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: ""
+
+    fun getStoreDecimals() =
+        wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber ?: DEFAULT_DECIMAL_PRECISION
+
     sealed class OrderListEvent : Event() {
         data class ShowErrorSnack(@StringRes val messageRes: Int) : OrderListEvent()
         object ShowOrderFilters : OrderListEvent()
@@ -506,4 +511,8 @@ class OrderListViewModel @Inject constructor(
         val arePaymentGatewaysFetched: Boolean = false,
         val filterCount: Int = 0
     ) : Parcelable
+
+    companion object {
+        private const val DEFAULT_DECIMAL_PRECISION = 2
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -495,11 +495,6 @@ class OrderListViewModel @Inject constructor(
         activatePagedListWrapper(pagedListWrapper)
     }
 
-    fun getStoreCurrencyCode() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: ""
-
-    fun getStoreDecimals() =
-        wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber ?: DEFAULT_DECIMAL_PRECISION
-
     sealed class OrderListEvent : Event() {
         data class ShowErrorSnack(@StringRes val messageRes: Int) : OrderListEvent()
         object ShowOrderFilters : OrderListEvent()
@@ -511,8 +506,4 @@ class OrderListViewModel @Inject constructor(
         val arePaymentGatewaysFetched: Boolean = false,
         val filterCount: Int = 0
     ) : Parcelable
-
-    companion object {
-        private const val DEFAULT_DECIMAL_PRECISION = 2
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -55,7 +55,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderSummariesFetched
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 
 private const val EMPTY_VIEW_THROTTLE = 250L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.DisplayUtils
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -48,8 +47,6 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         binding.imageClose.setOnClickListener {
             findNavController().navigateUp()
         }
-
-        ActivityUtils.showKeyboard(binding.editPrice)
 
         setupObservers(binding)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -2,17 +2,20 @@ package com.woocommerce.android.ui.orders.quickorder
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogQuickOrderBinding
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.DisplayUtils
 
 @AndroidEntryPoint
 class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setStyle(STYLE_NORMAL, R.style.Theme_Woo_Dialog)
+        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -26,9 +29,16 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
                 (DisplayUtils.getDisplayPixelHeight(context) * RATIO).toInt()
             )
         }
-        requireDialog().setTitle(R.string.quickorder_dialog_title)
 
         val binding = DialogQuickOrderBinding.bind(view)
+        ActivityUtils.showKeyboard(binding.editPrice)
+
+        val toolbar = binding.toolbar.toolbar
+        toolbar.setTitle(R.string.quickorder_dialog_title)
+        toolbar.navigationIcon = ContextCompat.getDrawable(requireActivity(), R.drawable.ic_gridicons_cross_24dp)
+        toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
-import java.math.BigDecimal
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -60,8 +59,8 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         )
 
         viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
-            new.currentPrice.takeIfNotEqualTo(old?.currentPrice) {
-                binding.buttonDone.isEnabled = it > BigDecimal.ZERO
+            new.isDoneButtonEnabled.takeIfNotEqualTo(old?.isDoneButtonEnabled) {
+                binding.buttonDone.isEnabled = new.isDoneButtonEnabled
             }
         }
     }
@@ -77,7 +76,6 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
 
     companion object {
         const val KEY_QUICK_ORDER_RESULT = "quick_order_result"
-        // TODO nbradbury tablet?
         private const val HEIGHT_RATIO = 0.6
         private const val WIDTH_RATIO = 0.9
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -34,8 +34,8 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         requireDialog().window?.let { window ->
             window.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
             window.setLayout(
-                (DisplayUtils.getDisplayPixelWidth() * RATIO).toInt(),
-                (DisplayUtils.getDisplayPixelHeight(context) * RATIO).toInt()
+                (DisplayUtils.getDisplayPixelWidth() * WIDTH_RATIO).toInt(),
+                (DisplayUtils.getDisplayPixelHeight(context) * HEIGHT_RATIO).toInt()
             )
         }
 
@@ -77,6 +77,8 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
 
     companion object {
         const val KEY_QUICK_ORDER_RESULT = "quick_order_result"
-        private const val RATIO = 0.95 // TODO nbradbury tablet?
+        // TODO nbradbury tablet?
+        private const val HEIGHT_RATIO = 0.6
+        private const val WIDTH_RATIO = 0.9
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -17,8 +17,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
-    @Inject
-    internal lateinit var currencyFormatter: CurrencyFormatter
+    @Inject internal lateinit var currencyFormatter: CurrencyFormatter
 
     private val viewModel: QuickOrderViewModel by viewModels()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -2,11 +2,10 @@ package com.woocommerce.android.ui.orders.quickorder
 
 import android.os.Bundle
 import android.view.View
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.DialogQuickOrderBinding
@@ -19,9 +18,9 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
-    @Inject lateinit var currencyFormatter: CurrencyFormatter
+    @Inject internal lateinit var currencyFormatter: CurrencyFormatter
 
-    private val navArgs: QuickOrderDialogArgs by navArgs()
+    private val viewModel: QuickOrderViewModel by viewModels()
     private var currentPrice = BigDecimal.ZERO
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -32,7 +31,6 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireDialog().setTitle(R.string.quickorder_dialog_title)
         requireDialog().window?.let { window ->
             window.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
             window.setLayout(
@@ -42,19 +40,14 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         }
 
         val binding = DialogQuickOrderBinding.bind(view)
-
-        val toolbar = binding.toolbar.toolbar
-        toolbar.setTitle(R.string.quickorder_dialog_title)
-        toolbar.navigationIcon = ContextCompat.getDrawable(requireActivity(), R.drawable.ic_gridicons_cross_24dp)
-        toolbar.setNavigationOnClickListener {
+        binding.imageClose.setOnClickListener {
             findNavController().navigateUp()
         }
 
-        binding.editPrice.initView(navArgs.currency, navArgs.decimals, currencyFormatter)
-        binding.editPrice.setValue(BigDecimal.ZERO)
+        binding.editPrice.initView(viewModel.currencyCode, viewModel.decimals, currencyFormatter)
         binding.editPrice.value.observe(
             this,
-            Observer {
+            {
                 binding.buttonDone.isEnabled = it > BigDecimal.ZERO
                 currentPrice = it
             }
@@ -69,6 +62,6 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
     }
 
     companion object {
-        const val RATIO = 0.95
+        const val RATIO = 0.95 // TODO nbradbury tablet?
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -4,11 +4,11 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.DialogQuickOrderBinding
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
@@ -18,7 +18,8 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
-    @Inject internal lateinit var currencyFormatter: CurrencyFormatter
+    @Inject
+    internal lateinit var currencyFormatter: CurrencyFormatter
 
     private val viewModel: QuickOrderViewModel by viewModels()
     private var currentPrice = BigDecimal.ZERO
@@ -53,6 +54,10 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
             }
         )
 
+        binding.buttonDone.setOnClickListener {
+            returnResult()
+        }
+
         ActivityUtils.showKeyboard(binding.editPrice)
     }
 
@@ -61,7 +66,12 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         AnalyticsTracker.trackViewShown(this)
     }
 
+    private fun returnResult() {
+        navigateBackWithResult(KEY_QUICK_ORDER_RESULT, currentPrice)
+    }
+
     companion object {
-        const val RATIO = 0.95 // TODO nbradbury tablet?
+        const val KEY_QUICK_ORDER_RESULT = "quick_order_result"
+        private const val RATIO = 0.95 // TODO nbradbury tablet?
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -10,30 +10,28 @@ import org.wordpress.android.util.DisplayUtils
 
 @AndroidEntryPoint
 class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
-    companion object {
-        private const val WIDTH_RATIO = 0.35f
-        private const val HEIGHT_RATIO = 0.8f
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog)
+        setStyle(STYLE_NORMAL, R.style.Theme_Woo_Dialog)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Specify transition animations
-        dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
+        requireDialog().setTitle(R.string.quickorder_dialog_title)
+        requireDialog().window?.let { window ->
+            window.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
+            window.setLayout(
+                (DisplayUtils.getDisplayPixelWidth() * RATIO).toInt(),
+                (DisplayUtils.getDisplayPixelHeight(context) * RATIO).toInt()
+            )
+        }
+        requireDialog().setTitle(R.string.quickorder_dialog_title)
 
         val binding = DialogQuickOrderBinding.bind(view)
     }
 
-    override fun onStart() {
-        super.onStart()
-        requireDialog().window!!.setLayout(
-            (DisplayUtils.getDisplayPixelWidth() * WIDTH_RATIO).toInt(),
-            (DisplayUtils.getDisplayPixelHeight(context) * HEIGHT_RATIO).toInt()
-        )
+    companion object {
+        const val RATIO = 0.9
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -21,6 +22,7 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     private val navArgs: QuickOrderDialogArgs by navArgs()
+    private var currentPrice = BigDecimal.ZERO
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -50,6 +52,14 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
 
         binding.editPrice.initView(navArgs.currency, navArgs.decimals, currencyFormatter)
         binding.editPrice.setValue(BigDecimal.ZERO)
+        binding.editPrice.value.observe(
+            this,
+            Observer {
+                binding.buttonDone.isEnabled = it > BigDecimal.ZERO
+                currentPrice = it
+            }
+        )
+
         ActivityUtils.showKeyboard(binding.editPrice)
     }
 
@@ -59,6 +69,6 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
     }
 
     companion object {
-        const val RATIO = 0.9
+        const val RATIO = 0.95
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -41,20 +41,12 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         }
 
         val binding = DialogQuickOrderBinding.bind(view)
-        binding.imageClose.setOnClickListener {
-            findNavController().navigateUp()
-        }
-
         binding.editPrice.initView(viewModel.currencyCode, viewModel.decimals, currencyFormatter)
-        binding.editPrice.value.observe(
-            this,
-            {
-                viewModel.currentPrice = it
-            }
-        )
-
         binding.buttonDone.setOnClickListener {
             returnResult()
+        }
+        binding.imageClose.setOnClickListener {
+            findNavController().navigateUp()
         }
 
         ActivityUtils.showKeyboard(binding.editPrice)
@@ -63,6 +55,13 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
     }
 
     private fun setupObservers(binding: DialogQuickOrderBinding) {
+        binding.editPrice.value.observe(
+            this,
+            {
+                viewModel.currentPrice = it
+            }
+        )
+
         viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.currentPrice.takeIfNotEqualTo(old?.currentPrice) {
                 binding.buttonDone.isEnabled = it > BigDecimal.ZERO

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -59,8 +59,8 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         )
 
         viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
-            new.isDoneButtonEnabled.takeIfNotEqualTo(old?.isDoneButtonEnabled) {
-                binding.buttonDone.isEnabled = new.isDoneButtonEnabled
+            new.isDoneButtonEnabled.takeIfNotEqualTo(old?.isDoneButtonEnabled) { isEnabled ->
+                binding.buttonDone.isEnabled = isEnabled
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -5,14 +5,23 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.DialogQuickOrderBinding
+import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.DisplayUtils
+import java.math.BigDecimal
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
+
+    private val navArgs: QuickOrderDialogArgs by navArgs()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog)
@@ -31,7 +40,6 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         }
 
         val binding = DialogQuickOrderBinding.bind(view)
-        ActivityUtils.showKeyboard(binding.editPrice)
 
         val toolbar = binding.toolbar.toolbar
         toolbar.setTitle(R.string.quickorder_dialog_title)
@@ -39,6 +47,15 @@ class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
         toolbar.setNavigationOnClickListener {
             findNavController().navigateUp()
         }
+
+        binding.editPrice.initView(navArgs.currency, navArgs.decimals, currencyFormatter)
+        binding.editPrice.setValue(BigDecimal.ZERO)
+        ActivityUtils.showKeyboard(binding.editPrice)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderDialog.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.orders.quickorder
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.DialogFragment
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.DialogQuickOrderBinding
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.DisplayUtils
+
+@AndroidEntryPoint
+class QuickOrderDialog : DialogFragment(R.layout.dialog_quick_order) {
+    companion object {
+        private const val WIDTH_RATIO = 0.35f
+        private const val HEIGHT_RATIO = 0.8f
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Specify transition animations
+        dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
+
+        val binding = DialogQuickOrderBinding.bind(view)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        requireDialog().window!!.setLayout(
+            (DisplayUtils.getDisplayPixelWidth() * WIDTH_RATIO).toInt(),
+            (DisplayUtils.getDisplayPixelHeight(context) * HEIGHT_RATIO).toInt()
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.math.BigDecimal
 import javax.inject.Inject
 
 @OpenClassOnDebug
@@ -27,9 +28,15 @@ class QuickOrderViewModel @Inject constructor(
     val decimals: Int
         get() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber ?: DEFAULT_DECIMAL_PRECISION
 
+    var currentPrice: BigDecimal
+        get() = viewState.currentPrice
+        set(value) {
+            viewState = viewState.copy(currentPrice = value)
+        }
+
     @Parcelize
     data class ViewState(
-        val dummyValue: Int = 0
+        val currentPrice: BigDecimal = BigDecimal.ZERO
     ) : Parcelable
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderViewModel.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.ui.orders.quickorder
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.annotations.OpenClassOnDebug
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+@OpenClassOnDebug
+@HiltViewModel
+class QuickOrderViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val selectedSite: SelectedSite,
+    private val wooCommerceStore: WooCommerceStore
+) : ScopedViewModel(savedState) {
+    final val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
+    internal var viewState by viewStateLiveData
+
+    val currencyCode: String
+        get() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: ""
+
+    val decimals: Int
+        get() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber ?: DEFAULT_DECIMAL_PRECISION
+
+    @Parcelize
+    data class ViewState(
+        val dummyValue: Int = 0
+    ) : Parcelable
+
+    companion object {
+        private const val DEFAULT_DECIMAL_PRECISION = 2
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/quickorder/QuickOrderViewModel.kt
@@ -31,12 +31,16 @@ class QuickOrderViewModel @Inject constructor(
     var currentPrice: BigDecimal
         get() = viewState.currentPrice
         set(value) {
-            viewState = viewState.copy(currentPrice = value)
+            viewState = viewState.copy(
+                currentPrice = value,
+                isDoneButtonEnabled = value > BigDecimal.ZERO
+            )
         }
 
     @Parcelize
     data class ViewState(
-        val currentPrice: BigDecimal = BigDecimal.ZERO
+        val currentPrice: BigDecimal = BigDecimal.ZERO,
+        val isDoneButtonEnabled: Boolean = false
     ) : Parcelable
 
     companion object {

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -10,7 +10,15 @@
 
     <include
         android:id="@+id/toolbar"
-        layout="@layout/view_toolbar"/>
+        layout="@layout/view_toolbar" />
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/Woo.TextView.Caption"
+        android:layout_width="match_parent"
+        android:textSize="@dimen/text_minor_125"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/quickorder_enter_amount" />
 
     <com.woocommerce.android.widgets.CurrencyEditText
         android:id="@+id/editPrice"

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -8,9 +8,26 @@
     android:padding="@dimen/major_100"
     tools:context=".ui.orders.quickorder.QuickOrderDialog">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/view_toolbar" />
+    <ImageView
+        android:id="@+id/imageClose"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:contentDescription="@string/close"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_gridicons_cross_24dp" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/quickorder_dialog_title"
+        android:textAppearance="@style/TextAppearance.Woo.CollapsingToolbar.Collapsed"
+        android:textSize="@dimen/text_minor_125"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.textview.MaterialTextView
         style="@style/Woo.TextView.Caption"
@@ -19,7 +36,9 @@
         android:gravity="center"
         android:text="@string/quickorder_enter_amount"
         android:textSize="@dimen/text_minor_125"
-        app:layout_constraintBottom_toTopOf="@+id/editPrice" />
+        app:layout_constraintBottom_toTopOf="@+id/editPrice"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <com.woocommerce.android.widgets.CurrencyEditText
         android:id="@+id/editPrice"
@@ -29,6 +48,8 @@
         android:imeOptions="flagNoExtractUi"
         android:textSize="@dimen/text_major_150"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:hint="0.00" />
 

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/color_surface"
+    android:orientation="vertical"
+    android:padding="@dimen/major_100">
+
+    <com.woocommerce.android.widgets.CurrencyEditText
+        android:id="@+id/editPrice"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:imeOptions="flagNoExtractUi"
+        android:textSize="@dimen/text_major_200"
+        tools:hint="0.00" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonDone"
+        style="@style/Woo.Button.Colored"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="@string/done" />
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -5,7 +5,8 @@
     android:layout_height="match_parent"
     android:background="@color/color_surface"
     android:orientation="vertical"
-    android:padding="@dimen/major_100">
+    android:padding="@dimen/major_100"
+    tools:context=".ui.orders.quickorder.QuickOrderDialog">
 
     <com.woocommerce.android.widgets.CurrencyEditText
         android:id="@+id/editPrice"

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_surface"
-    android:padding="@dimen/major_100"
+    android:paddingVertical="@dimen/major_100"
     tools:context=".ui.orders.quickorder.QuickOrderDialog">
 
     <ImageView
@@ -14,6 +14,8 @@
         android:layout_height="wrap_content"
         android:background="?android:attr/selectableItemBackground"
         android:contentDescription="@string/close"
+        android:paddingStart="@dimen/major_100"
+        android:paddingEnd="@dimen/major_100"
         app:layout_constraintBottom_toBottomOf="@+id/titleText"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/titleText"
@@ -70,6 +72,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
+        android:paddingStart="@dimen/major_100"
+        android:paddingEnd="@dimen/major_100"
         android:text="@string/done"
         app:layout_constraintBottom_toBottomOf="parent" />
 

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_surface"
-    android:orientation="vertical"
     android:padding="@dimen/major_100"
     tools:context=".ui.orders.quickorder.QuickOrderDialog">
 
@@ -15,10 +15,11 @@
     <com.google.android.material.textview.MaterialTextView
         style="@style/Woo.TextView.Caption"
         android:layout_width="match_parent"
-        android:textSize="@dimen/text_minor_125"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:text="@string/quickorder_enter_amount" />
+        android:text="@string/quickorder_enter_amount"
+        android:textSize="@dimen/text_minor_125"
+        app:layout_constraintBottom_toTopOf="@+id/editPrice" />
 
     <com.woocommerce.android.widgets.CurrencyEditText
         android:id="@+id/editPrice"
@@ -27,6 +28,8 @@
         android:gravity="center"
         android:imeOptions="flagNoExtractUi"
         android:textSize="@dimen/text_major_150"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:hint="0.00" />
 
     <com.google.android.material.button.MaterialButton
@@ -35,6 +38,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
-        android:text="@string/done" />
+        android:text="@string/done"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -8,6 +8,10 @@
     android:padding="@dimen/major_100"
     tools:context=".ui.orders.quickorder.QuickOrderDialog">
 
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/view_toolbar"/>
+
     <com.woocommerce.android.widgets.CurrencyEditText
         android:id="@+id/editPrice"
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -26,7 +26,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:imeOptions="flagNoExtractUi"
-        android:textSize="@dimen/text_major_200"
+        android:textSize="@dimen/text_major_150"
         tools:hint="0.00" />
 
     <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -70,9 +70,8 @@
         style="@style/Woo.Button.Colored"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
         android:enabled="false"
-        android:paddingStart="@dimen/major_100"
-        android:paddingEnd="@dimen/major_100"
         android:text="@string/done"
         app:layout_constraintBottom_toBottomOf="parent" />
 

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -14,17 +14,18 @@
         android:layout_height="wrap_content"
         android:background="?android:attr/selectableItemBackground"
         android:contentDescription="@string/close"
+        app:layout_constraintBottom_toBottomOf="@+id/titleText"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/titleText"
         app:srcCompat="@drawable/ic_gridicons_cross_24dp" />
 
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/titleText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:text="@string/quickorder_dialog_title"
         android:textAppearance="@style/TextAppearance.Woo.CollapsingToolbar.Collapsed"
-        android:textSize="@dimen/text_minor_125"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -30,7 +30,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <View
+        android:id="@+id/divider"
+        style="@style/Woo.Divider"
+        android:layout_marginTop="@dimen/major_100"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop="@+id/captionText"
+        app:layout_constraintTop_toBottomOf="@+id/titleText" />
+
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/captionText"
         style="@style/Woo.TextView.Caption"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/dialog_quick_order.xml
+++ b/WooCommerce/src/main/res/layout/dialog_quick_order.xml
@@ -38,7 +38,6 @@
         android:layout_marginTop="@dimen/major_100"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop="@+id/captionText"
         app:layout_constraintTop_toBottomOf="@+id/titleText" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -13,6 +13,10 @@
             android:id="@+id/action_myStore_to_jetpackBenefitsDialog"
             app:destination="@id/jetpackBenefitsDialog" />
     </fragment>
+    <dialog
+        android:id="@+id/quickOrderDialog"
+        android:name="com.woocommerce.android.ui.orders.quickorder.QuickOrderDialog"
+        android:label="QuickOrderDialog" />
     <fragment
         android:id="@+id/orders"
         android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"
@@ -35,6 +39,11 @@
         <action
             android:id="@+id/action_orderListFragment_to_orderFilterListFragment"
             app:destination="@id/nav_graph_order_filters"
+            app:enterAnim="@anim/activity_fade_in"
+            app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_orderListFragment_to_quickOrderDialog"
+            app:destination="@id/quickOrderDialog"
             app:enterAnim="@anim/activity_fade_in"
             app:popExitAnim="@anim/activity_fade_out" />
     </fragment>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -16,16 +16,7 @@
     <dialog
         android:id="@+id/quickOrderDialog"
         android:name="com.woocommerce.android.ui.orders.quickorder.QuickOrderDialog"
-        android:label="QuickOrderDialog">
-        <argument
-            android:name="currency"
-            app:argType="string"
-            app:nullable="false" />
-        <argument
-            android:name="decimals"
-            app:argType="integer"
-            app:nullable="false" />
-    </dialog>
+        android:label="QuickOrderDialog" />
     <fragment
         android:id="@+id/orders"
         android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -16,7 +16,16 @@
     <dialog
         android:id="@+id/quickOrderDialog"
         android:name="com.woocommerce.android.ui.orders.quickorder.QuickOrderDialog"
-        android:label="QuickOrderDialog" />
+        android:label="QuickOrderDialog">
+        <argument
+            android:name="currency"
+            app:argType="string"
+            app:nullable="false" />
+        <argument
+            android:name="decimals"
+            app:argType="integer"
+            app:nullable="false" />
+    </dialog>
     <fragment
         android:id="@+id/orders"
         android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -267,7 +267,11 @@
     <string name="orderlist_quickorder_wip_message_enabled">We are working on making it easier for you to take payments from your device! For now, tap the "+" button and you\'ll be able to create an order with the amount you want to collect.</string>
     <string name="orderlist_quickorder_wip_message_disabled">We are working on making it easier for you to take payments from your device! Enable it in Settings &gt; Beta features.</string>
     <string name="orderlist_quickorder_menu">Quick order</string>
+    <!--
+        Quick Order
+    -->
     <string name="quickorder_dialog_title">Take payment</string>
+    <string name="quickorder_enter_amount">Enter amount</string>
     <!--
         Order Filters
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -267,6 +267,7 @@
     <string name="orderlist_quickorder_wip_message_enabled">We are working on making it easier for you to take payments from your device! For now, tap the "+" button and you\'ll be able to create an order with the amount you want to collect.</string>
     <string name="orderlist_quickorder_wip_message_disabled">We are working on making it easier for you to take payments from your device! Enable it in Settings &gt; Beta features.</string>
     <string name="orderlist_quickorder_menu">Quick order</string>
+    <string name="quickorder_dialog_title">Take payment</string>
     <!--
         Order Filters
     -->


### PR DESCRIPTION
Closes #5112 - This PR introduces the "quick order" screen and related view model. No order is created yet, this is simply the UI for it.

To test:

* Make sure the Quick Order beta feature is enabled
* Go to the order list
* Tap the + icon
* Verify that the quick order dialog shows the correct currency
* Switch to another store that uses a different currency
* Verify that the quick order dialog shows the different currency
* Verify that the dialog appears correctly in both light and dark modes

![us](https://user-images.githubusercontent.com/3903757/140559763-ab60a4a2-a1b3-4ab0-b982-b064419a6c28.png)

![nonus](https://user-images.githubusercontent.com/3903757/140559785-6182eb1d-7216-461c-aa84-f5aa97828128.png)

![dark](https://user-images.githubusercontent.com/3903757/140559796-2d34b47d-5eb7-400c-8992-caff741c689f.png)


