### PR TITLE
Refactor OrderShipmentProvidersRepository to use fetch order shipment providers suspended functions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModel.kt
@@ -107,11 +107,6 @@ class AddOrderTrackingProviderListViewModel @Inject constructor(
         triggerEvent(ExitWithResult(carrier))
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        shipmentProvidersRepository.onCleanup()
-    }
-
     @Parcelize
     data class ViewState(
         val showSkeleton: Boolean = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepository.kt
@@ -1,42 +1,20 @@
 package com.woocommerce.android.ui.orders.tracking
 
-import com.woocommerce.android.AppConstants
 import com.woocommerce.android.model.OrderShipmentProvider
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.tracking.OrderShipmentProvidersRepository.RequesResult.EMPTY
-import com.woocommerce.android.ui.orders.tracking.OrderShipmentProvidersRepository.RequesResult.ERROR
-import com.woocommerce.android.ui.orders.tracking.OrderShipmentProvidersRepository.RequesResult.SUCCESS
-import com.woocommerce.android.util.ContinuationWrapper
-import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
-import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Success
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.ORDERS
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import javax.inject.Inject
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderShipmentProvidersChanged
-import javax.inject.Inject
 
 class OrderShipmentProvidersRepository @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val orderStore: WCOrderStore,
-    private val dispatcher: Dispatcher
+    private val orderStore: WCOrderStore
 ) {
-    init {
-        dispatcher.register(this)
-    }
-
-    fun onCleanup() {
-        dispatcher.unregister(this)
-    }
-
-    private var continuationFetchTrackingProviders = ContinuationWrapper<RequesResult>(ORDERS)
 
     suspend fun fetchOrderShipmentProviders(orderIdentifier: OrderIdentifier): List<OrderShipmentProvider>? {
         // Check db first
@@ -55,40 +33,20 @@ class OrderShipmentProvidersRepository @Inject constructor(
             )
             return null
         }
-        val result = continuationFetchTrackingProviders.callAndWaitUntilTimeout(AppConstants.REQUEST_TIMEOUT) {
-            val payload = FetchOrderShipmentProvidersPayload(selectedSite.get(), order)
-            dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentProvidersAction(payload))
-        }
-        return when (result) {
-            is Cancellation -> null
-            is Success -> when (result.value) {
-                SUCCESS -> getShipmentProvidersFromDB()
-                EMPTY -> emptyList()
-                else -> null
+        val payload = FetchOrderShipmentProvidersPayload(selectedSite.get(), order)
+        val result = orderStore.fetchOrderShipmentProviders(payload)
+        return when {
+            result.rowsAffected == 0 -> {
+                emptyList()
             }
+            result.isError -> {
+                WooLog.e(ORDERS, "Error fetching shipment providers : ${result.error.message}")
+                null
+            }
+            else -> getShipmentProvidersFromDB()
         }
     }
 
     private fun getShipmentProvidersFromDB(): List<OrderShipmentProvider> =
         orderStore.getShipmentProvidersForSite(selectedSite.get()).map { it.toAppModel() }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onOrderShipmentProviderChanged(event: OnOrderShipmentProvidersChanged) {
-        when {
-            event.isError -> {
-                WooLog.e(ORDERS, "Error fetching shipment providers : ${event.error.message}")
-                continuationFetchTrackingProviders.continueWith(ERROR)
-            }
-            event.rowsAffected == 0 -> {
-                WooLog.e(ORDERS, "Error fetching shipment providers : empty list")
-                continuationFetchTrackingProviders.continueWith(EMPTY)
-            }
-            else -> continuationFetchTrackingProviders.continueWith(SUCCESS)
-        }
-    }
-
-    private enum class RequesResult {
-        SUCCESS, ERROR, EMPTY
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepository.kt
@@ -35,13 +35,13 @@ class OrderShipmentProvidersRepository @Inject constructor(
         val payload = FetchOrderShipmentProvidersPayload(selectedSite.get(), order)
         val result = orderStore.fetchOrderShipmentProviders(payload)
         return when {
-            result.rowsAffected == 0 -> {
-                WooLog.e(ORDERS, "Error fetching shipment providers : empty list")
-                emptyList()
-            }
             result.isError -> {
                 WooLog.e(ORDERS, "Error fetching shipment providers : ${result.error.message}")
                 null
+            }
+            result.rowsAffected == 0 -> {
+                WooLog.e(ORDERS, "Error fetching shipment providers : empty list")
+                emptyList()
             }
             else -> getShipmentProvidersFromDB()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepository.kt
@@ -15,7 +15,6 @@ class OrderShipmentProvidersRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val orderStore: WCOrderStore
 ) {
-
     suspend fun fetchOrderShipmentProviders(orderIdentifier: OrderIdentifier): List<OrderShipmentProvider>? {
         // Check db first
         val providersInDb = getShipmentProvidersFromDB()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepository.kt
@@ -37,6 +37,7 @@ class OrderShipmentProvidersRepository @Inject constructor(
         val result = orderStore.fetchOrderShipmentProviders(payload)
         return when {
             result.rowsAffected == 0 -> {
+                WooLog.e(ORDERS, "Error fetching shipment providers : empty list")
                 emptyList()
             }
             result.isError -> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -22,6 +22,7 @@ import java.util.Date
 object OrderTestUtils {
     const val TEST_LOCAL_SITE_ID = 1
     const val TEST_ORDER_STATUS_COUNT = 20
+    const val ORDER_IDENTIFIER = "1-1-1"
 
     /**
      * Generates an array containing multiple [WCOrderModel] objects.

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
@@ -26,7 +26,6 @@ import kotlin.test.assertEquals
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class AddOrderShipmentTrackingViewModelTest : BaseUnitTest() {
-
     private val networkStatus: NetworkStatus = mock()
     private val repository: OrderDetailRepository = mock()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.tracking
 import com.woocommerce.android.R
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.orders.OrderTestUtils.ORDER_IDENTIFIER
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.tracking.AddOrderShipmentTrackingViewModel.SaveTrackingPrefsEvent
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -25,9 +26,6 @@ import kotlin.test.assertEquals
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class AddOrderShipmentTrackingViewModelTest : BaseUnitTest() {
-    companion object {
-        private const val ORDER_IDENTIFIER = "1-1-1"
-    }
 
     private val networkStatus: NetworkStatus = mock()
     private val repository: OrderDetailRepository = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModelTest.kt
@@ -26,7 +26,6 @@ import org.robolectric.RobolectricTestRunner
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class AddOrderTrackingProviderListViewModelTest : BaseUnitTest() {
-
     private val orderDetailRepository: OrderDetailRepository = mock()
     private val shipmentProvidersRepository: OrderShipmentProvidersRepository = mock()
     private val resourceProvider: ResourceProvider = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModelTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.whenever
 import com.woocommerce.android.R
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.OrderShipmentProvider
+import com.woocommerce.android.ui.orders.OrderTestUtils.ORDER_IDENTIFIER
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.tracking.AddOrderTrackingProviderListViewModel.ViewState
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -25,9 +26,6 @@ import org.robolectric.RobolectricTestRunner
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class AddOrderTrackingProviderListViewModelTest : BaseUnitTest() {
-    companion object {
-        private const val ORDER_IDENTIFIER = "1-1-1"
-    }
 
     private val orderDetailRepository: OrderDetailRepository = mock()
     private val shipmentProvidersRepository: OrderShipmentProvidersRepository = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepositoryTest.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class OrderShipmentProvidersRepositoryTest : BaseUnitTest() {
-
     private val orderStore: WCOrderStore = mock()
     private val selectedSite: SelectedSite = mock()
     private val siteModel = SiteModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepositoryTest.kt
@@ -1,0 +1,110 @@
+package com.woocommerce.android.ui.orders.tracking
+
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.orders.OrderTestUtils.ORDER_IDENTIFIER
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
+import org.wordpress.android.fluxc.store.WCOrderStore
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class OrderShipmentProvidersRepositoryTest : BaseUnitTest() {
+
+    private val orderStore: WCOrderStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val siteModel = SiteModel()
+    private val order = OrderTestUtils.generateOrder()
+    private val providers = OrderTestUtils.generateOrderShipmentProviders()
+
+    private lateinit var repository: OrderShipmentProvidersRepository
+
+    @Before
+    fun setup() {
+        repository = OrderShipmentProvidersRepository(selectedSite, orderStore)
+        doReturn(siteModel).whenever(selectedSite).get()
+        doReturn(order).whenever(orderStore).getOrderByIdentifier(ORDER_IDENTIFIER)
+    }
+
+    @Test
+    fun `When there are shipment providers in local db`() = runBlockingTest {
+        // When there are shipment providers in local db
+        doReturn(providers).whenever(orderStore).getShipmentProvidersForSite(siteModel)
+
+        val result = repository.fetchOrderShipmentProviders(ORDER_IDENTIFIER)
+
+        // Then should return the local db shipment providers
+        assertThat(result).isNotEmpty
+        verify(orderStore, times(1)).getShipmentProvidersForSite(siteModel)
+        // And won't fetch shipment providers from the network
+        verify(orderStore, times(0)).fetchOrderShipmentProviders(any())
+        assertThat(providers.map { it.toAppModel() }).isEqualTo(result)
+    }
+
+    @Test
+    fun `When there are NO shipment providers in local db`() = runBlockingTest {
+        // When there are NO shipment providers in local db
+        doReturn(
+            emptyList<WCOrderShipmentProviderModel>(),
+            providers
+        ).whenever(orderStore).getShipmentProvidersForSite(siteModel)
+
+        // Then should fetch shipment providers from the network
+        val onChanged = WCOrderStore.OnOrderShipmentProvidersChanged(providers.size)
+        doReturn(onChanged).whenever(orderStore).fetchOrderShipmentProviders(any())
+
+        val result = repository.fetchOrderShipmentProviders(ORDER_IDENTIFIER)
+
+        // And return the updated shipment providers from the local db
+        verify(orderStore, times(1)).fetchOrderShipmentProviders(any())
+        verify(orderStore, times(2)).getShipmentProvidersForSite(siteModel)
+        assertThat(providers.map { it.toAppModel() }).isEqualTo(result)
+    }
+
+    @Test
+    fun `When there are NO rows affected`() = runBlockingTest {
+        // When there are NO rows affected
+        doReturn(emptyList<WCOrderShipmentProviderModel>()).whenever(orderStore).getShipmentProvidersForSite(siteModel)
+
+        val onChanged = WCOrderStore.OnOrderShipmentProvidersChanged(0)
+        doReturn(onChanged).whenever(orderStore).fetchOrderShipmentProviders(any())
+
+        val result = repository.fetchOrderShipmentProviders(ORDER_IDENTIFIER)
+
+        // Then return an empty list
+        verify(orderStore, times(1)).fetchOrderShipmentProviders(any())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `When something goes wrong`() = runBlockingTest {
+        // When something goes wrong
+        doReturn(emptyList<WCOrderShipmentProviderModel>()).whenever(orderStore).getShipmentProvidersForSite(siteModel)
+
+        val onChanged = WCOrderStore.OnOrderShipmentProvidersChanged(0).also {
+            it.error = WCOrderStore.OrderError(message = "Something goes wrong")
+        }
+        doReturn(onChanged).whenever(orderStore).fetchOrderShipmentProviders(any())
+
+        val result = repository.fetchOrderShipmentProviders(ORDER_IDENTIFIER)
+
+        // Then return null
+        verify(orderStore, times(1)).fetchOrderShipmentProviders(any())
+        assertThat(result).isNull()
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2168-248ce7bd3996cf5a92bc0fa23ee474773c784d6b'
+    fluxCVersion = '2181-84f68d24a293cf2e9e0116af53d86d59296bb02a'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
Refactor OrderShipmentProvidersRepository to use fetch order shipment providers suspended functions

Closes: #5141 

### Description
Update OrderShipmentProvidersRepository and replace the use of Continuation with calling the suspended functions in FluxC directly (wordpress-mobile/WordPress-FluxC-Android#2173).

[Warning] This PR depends on [this one](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2176)
