### PR TITLE
AddTalkBack support for connection flow during IPP

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -81,7 +81,11 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                     )
                     is CardReaderDetailViewModel.CardReaderDetailEvent.CardReaderDisconnected ->
                         binding.readerDisconnectedState.cardReaderDetailConnectBtn.announceForAccessibility(
-                            getString(event.text)
+                            getString(event.accessibilityDisconnectedText)
+                        )
+                    is CardReaderDetailViewModel.CardReaderDetailEvent.CardReaderConnected ->
+                        binding.readerConnectedState.primaryActionBtn.announceForAccessibility(
+                            getString(event.accessibilityConnectedText)
                         )
                     else -> event.isHandled = false
                 }
@@ -97,9 +101,6 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 when (state) {
                     is ConnectedState -> {
                         with(binding.readerConnectedState) {
-                            primaryActionBtn.announceForAccessibility(
-                                getString(R.string.card_reader_accessibility_reader_is_connected)
-                            )
                             UiHelpers.setTextOrHide(enforcedUpdateTv, state.enforceReaderUpdate)
                             enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
                             with(readerNameTv) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -79,6 +79,10 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                         event.readersName,
                         event.readersName
                     )
+                    is CardReaderDetailViewModel.CardReaderDetailEvent.CardReaderDisconnected ->
+                        binding.readerDisconnectedState.cardReaderDetailConnectBtn.announceForAccessibility(
+                            getString(event.text)
+                        )
                     else -> event.isHandled = false
                 }
             }
@@ -93,6 +97,9 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 when (state) {
                     is ConnectedState -> {
                         with(binding.readerConnectedState) {
+                            primaryActionBtn.announceForAccessibility(
+                                getString(R.string.card_reader_accessibility_reader_is_connected)
+                            )
                             UiHelpers.setTextOrHide(enforcedUpdateTv, state.enforceReaderUpdate)
                             enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
                             with(readerNameTv) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs.cardreader.detail
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -134,6 +135,12 @@ class CardReaderDetailViewModel @Inject constructor(
             if (!disconnectionResult) {
                 WooLog.e(WooLog.T.CARD_READER, "Disconnection from reader has failed")
                 showNotConnectedState()
+            } else {
+                triggerEvent(
+                    CardReaderDetailEvent.CardReaderDisconnected(
+                        R.string.card_reader_accessibility_reader_is_disconnected
+                    )
+                )
             }
         }
     }
@@ -164,6 +171,9 @@ class CardReaderDetailViewModel @Inject constructor(
 
     sealed class CardReaderDetailEvent : Event() {
         data class CopyReadersNameToClipboard(val readersName: String) : CardReaderDetailEvent()
+        data class CardReaderDisconnected(
+            @StringRes val text: Int = R.string.card_reader_accessibility_reader_is_disconnected
+        ) : CardReaderDetailEvent()
     }
 
     sealed class ViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -54,13 +54,25 @@ class CardReaderDetailViewModel @Inject constructor(
             cardReaderManager.readerStatus.collect { status ->
                 when (status) {
                     is Connected -> {
+                        triggerEvent(
+                            CardReaderDetailEvent.CardReaderConnected(
+                                R.string.card_reader_accessibility_reader_is_connected
+                            )
+                        )
                         softwareUpdateAvailabilityJob = launch {
                             cardReaderManager.softwareUpdateAvailability.collect(
                                 ::handleSoftwareUpdateAvailability
                             )
                         }
                     }
-                    else -> showNotConnectedState()
+                    else -> {
+                        triggerEvent(
+                            CardReaderDetailEvent.CardReaderDisconnected(
+                                R.string.card_reader_accessibility_reader_is_disconnected
+                            )
+                        )
+                        showNotConnectedState()
+                    }
                 }.exhaustive
             }
         }
@@ -135,12 +147,6 @@ class CardReaderDetailViewModel @Inject constructor(
             if (!disconnectionResult) {
                 WooLog.e(WooLog.T.CARD_READER, "Disconnection from reader has failed")
                 showNotConnectedState()
-            } else {
-                triggerEvent(
-                    CardReaderDetailEvent.CardReaderDisconnected(
-                        R.string.card_reader_accessibility_reader_is_disconnected
-                    )
-                )
             }
         }
     }
@@ -172,7 +178,12 @@ class CardReaderDetailViewModel @Inject constructor(
     sealed class CardReaderDetailEvent : Event() {
         data class CopyReadersNameToClipboard(val readersName: String) : CardReaderDetailEvent()
         data class CardReaderDisconnected(
-            @StringRes val text: Int = R.string.card_reader_accessibility_reader_is_disconnected
+            @StringRes val accessibilityDisconnectedText: Int =
+                R.string.card_reader_accessibility_reader_is_disconnected
+        ) : CardReaderDetailEvent()
+        data class CardReaderConnected(
+            @StringRes val accessibilityConnectedText: Int =
+                R.string.card_reader_accessibility_reader_is_connected
         ) : CardReaderDetailEvent()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -12,6 +12,8 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
@@ -65,7 +67,10 @@ class CardReaderDetailViewModel @Inject constructor(
                             )
                         }
                     }
-                    else -> {
+                    is Connecting -> {
+                        showNotConnectedState()
+                    }
+                    is NotConnected -> {
                         triggerEvent(
                             CardReaderDetailEvent.CardReaderDisconnected(
                                 R.string.card_reader_accessibility_reader_is_disconnected

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -964,6 +964,7 @@
     <!--
         Card reader Accessibility
     -->
+    <string name="card_reader_accessibility_reader_is_connected">Reader is connected</string>
     <string name="card_reader_accessibility_reader_is_disconnected">Reader is disconnected</string>
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -962,6 +962,11 @@
     <string name="card_reader_tutorial_charged_detail">Your reader takes about three hours to fully charge</string>
 
     <!--
+        Card reader Accessibility
+    -->
+    <string name="card_reader_accessibility_reader_is_disconnected">Reader is disconnected</string>
+
+    <!--
         Notifications
     -->
     <string name="new_notifications">%d new notifications</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailab
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.CardReaderDetailEvent.CardReaderDisconnected
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.CardReaderDetailEvent.CopyReadersNameToClipboard
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.ConnectedState
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.Loading
@@ -361,6 +362,42 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verify(tracker).track(AnalyticsTracker.Stat.CARD_READER_DISCONNECT_TAPPED)
+        }
+
+    @Test
+    fun `when card reader disconnected successfully, then trigger accessibility announcement`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            initConnectedState()
+            whenever(cardReaderManager.disconnectReader()).thenReturn(true)
+            val viewModel = createViewModel()
+
+            // WHEN
+            (viewModel.viewStateData.value as ConnectedState).primaryButtonState!!.onActionClicked()
+
+            // THEN
+            assertThat(viewModel.event.value)
+                .isEqualTo(
+                    CardReaderDisconnected(R.string.card_reader_accessibility_reader_is_disconnected)
+                )
+        }
+
+    @Test
+    fun `when card reader disconnection fails, then do not trigger accessibility announcement`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            initConnectedState()
+            whenever(cardReaderManager.disconnectReader()).thenReturn(false)
+            val viewModel = createViewModel()
+
+            // WHEN
+            (viewModel.viewStateData.value as ConnectedState).primaryButtonState!!.onActionClicked()
+
+            // THEN
+            assertThat(viewModel.event.value)
+                .isNotEqualTo(
+                    CardReaderDisconnected(R.string.card_reader_accessibility_reader_is_disconnected)
+                )
         }
 
     private fun verifyNotConnectedState(viewModel: CardReaderDetailViewModel) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5171 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds TalkBack support for IPP connection flow.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Enable TalkBack by navigating to settings -> Accessibility -> TalkBack
2. Open the WooCommerce app and navigate to the settings screen
3. Open the `In-Person Payments` option 
4. Tap the `Connect to the reader` button
5. Ensure TalkBack announces different states of the connection flow

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Release notes regarding Accessibility is added in this PR https://github.com/woocommerce/woocommerce-android/pull/5167

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
