### PR TITLE
Issue/5175 Handle invalid postcode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -391,15 +391,6 @@ class CardReaderConnectViewModel @Inject constructor(
         }
     }
 
-    private fun trackLocationFailureFetching(errorDescription: String?) {
-        tracker.track(
-            CARD_READER_LOCATION_FAILURE,
-            this.javaClass.simpleName,
-            null,
-            errorDescription,
-        )
-    }
-
     private fun onReaderConnectionFailed() {
         tracker.track(AnalyticsTracker.Stat.CARD_READER_CONNECTION_FAILED)
         WooLog.e(WooLog.T.CARD_READER, "Connecting to reader failed.")
@@ -455,6 +446,15 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private fun findLastKnowReader(readers: List<CardReader>): CardReader? {
         return readers.find { it.id == appPrefs.getLastConnectedCardReaderId() }
+    }
+
+    private fun trackLocationFailureFetching(errorDescription: String?) {
+        tracker.track(
+            CARD_READER_LOCATION_FAILURE,
+            this.javaClass.simpleName,
+            null,
+            errorDescription,
+        )
     }
 
     sealed class ListItemViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -27,7 +27,6 @@ import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.ShowCardReaderTutorial
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckBluetoothEnabled
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckLocationEnabled
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckLocationPermissions
@@ -36,16 +35,19 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEven
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.OpenPermissionsSettings
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.RequestEnableBluetooth
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.RequestLocationPermissions
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.ShowCardReaderTutorial
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.ShowUpdateInProgress
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.BluetoothDisabledError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.LocationDisabledError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MissingPermissionsError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ScanningFailedState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ScanningState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ConnectingFailedState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ConnectingState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.LocationDisabledError
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MissingPermissionsError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MultipleReadersFoundState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ReaderFoundState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ScanningFailedState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ScanningState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MissingMerchantAddressError
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.InvalidMerchantAddressPostCodeError
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel
@@ -57,11 +59,12 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class CardReaderConnectViewModel @Inject constructor(
@@ -366,27 +369,36 @@ class CardReaderConnectViewModel @Inject constructor(
                         tracker.track(CARD_READER_LOCATION_SUCCESS)
                         cardReaderManager.startConnectionToReader(cardReader, result.locationId)
                     }
-                    is CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress -> {
-                        trackLocationFailureFetching("Missing Address")
-                        viewState.value = CardReaderConnectViewState.MissingMerchantAddressError(
-                            {
-                                tracker.track(CARD_READER_LOCATION_MISSING_TAPPED)
-                                triggerOpenUrlEventAndExitIfNeeded(result)
-                            },
-                            {
-                                onCancelClicked()
-                            }
-                        )
+                    is CardReaderLocationRepository.LocationIdFetchingResult.Error -> {
+                        handleLocationFetchingError(result)
                     }
-                    is CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode -> {
-                        trackLocationFailureFetching("Invalid Postal Code")
-                        viewState.value = CardReaderConnectViewState.InvalidMerchantAddressPostCodeError(::startFlow)
+                }.exhaustive
+            }
+        }
+    }
+
+    private fun handleLocationFetchingError(result: CardReaderLocationRepository.LocationIdFetchingResult.Error) {
+        this@CardReaderConnectViewModel.coroutineContext.cancelChildren()
+        when (result) {
+            is CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress -> {
+                trackLocationFailureFetching("Missing Address")
+                viewState.value = MissingMerchantAddressError(
+                    {
+                        tracker.track(CARD_READER_LOCATION_MISSING_TAPPED)
+                        triggerOpenUrlEventAndExitIfNeeded(result)
+                    },
+                    {
+                        onCancelClicked()
                     }
-                    is CardReaderLocationRepository.LocationIdFetchingResult.Error.Other -> {
-                        trackLocationFailureFetching(result.error)
-                        onReaderConnectionFailed()
-                    }
-                }
+                )
+            }
+            is CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode -> {
+                trackLocationFailureFetching("Invalid Postal Code")
+                viewState.value = InvalidMerchantAddressPostCodeError(::startFlow)
+            }
+            is CardReaderLocationRepository.LocationIdFetchingResult.Error.Other -> {
+                trackLocationFailureFetching(result.error)
+                onReaderConnectionFailed()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -367,12 +367,7 @@ class CardReaderConnectViewModel @Inject constructor(
                         cardReaderManager.startConnectionToReader(cardReader, result.locationId)
                     }
                     is CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress -> {
-                        tracker.track(
-                            CARD_READER_LOCATION_FAILURE,
-                            this@CardReaderConnectViewModel.javaClass.simpleName,
-                            null,
-                            "Missing Address"
-                        )
+                        trackLocationFailureFetching("Missing Address")
                         viewState.value = CardReaderConnectViewState.MissingMerchantAddressError(
                             {
                                 tracker.track(CARD_READER_LOCATION_MISSING_TAPPED)
@@ -383,18 +378,26 @@ class CardReaderConnectViewModel @Inject constructor(
                             }
                         )
                     }
+                    is CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode -> {
+                        trackLocationFailureFetching("Invalid Postal Code")
+                        viewState.value = CardReaderConnectViewState.InvalidMerchantAddressPostCodeError(::startFlow)
+                    }
                     is CardReaderLocationRepository.LocationIdFetchingResult.Error.Other -> {
-                        tracker.track(
-                            CARD_READER_LOCATION_FAILURE,
-                            this@CardReaderConnectViewModel.javaClass.simpleName,
-                            null,
-                            result.error
-                        )
+                        trackLocationFailureFetching(result.error)
                         onReaderConnectionFailed()
                     }
                 }
             }
         }
+    }
+
+    private fun trackLocationFailureFetching(errorDescription: String?) {
+        tracker.track(
+            CARD_READER_LOCATION_FAILURE,
+            this.javaClass.simpleName,
+            null,
+            errorDescription,
+        )
     }
 
     private fun onReaderConnectionFailed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewState.kt
@@ -123,4 +123,14 @@ sealed class CardReaderConnectViewState(
         secondaryActionLabel = R.string.cancel,
         illustrationTopMargin = R.dimen.major_150
     )
+
+    data class InvalidMerchantAddressPostCodeError(
+        override val onPrimaryActionClicked: () -> Unit,
+    ) : CardReaderConnectViewState(
+        headerLabel = UiString.UiStringRes(R.string.card_reader_connect_invalid_postal_code_header),
+        hintLabel = R.string.card_reader_connect_invalid_postal_code_hint,
+        illustration = R.drawable.img_products_error,
+        primaryActionLabel = R.string.try_again,
+        illustrationTopMargin = R.dimen.major_150,
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
@@ -19,6 +19,9 @@ class CardReaderLocationRepository @Inject constructor(
                 is WCTerminalStoreLocationErrorType.MissingAddress -> {
                     LocationIdFetchingResult.Error.MissingAddress(type.addressEditingUrl)
                 }
+                is WCTerminalStoreLocationErrorType.InvalidPostalCode -> {
+                    LocationIdFetchingResult.Error.InvalidPostalCode
+                }
                 else -> LocationIdFetchingResult.Error.Other(result.error?.message)
             }
         } else {
@@ -29,6 +32,7 @@ class CardReaderLocationRepository @Inject constructor(
     sealed class LocationIdFetchingResult {
         sealed class Error : LocationIdFetchingResult() {
             data class MissingAddress(val url: String) : Error()
+            object InvalidPostalCode : Error()
             data class Other(val error: String?) : Error()
         }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -853,6 +853,8 @@
     <string name="card_reader_connect_failed_header">We couldn\’t connect your reader</string>
     <string name="card_reader_connect_missing_address">Please provide your store address in order to proceed</string>
     <string name="card_reader_connect_missing_address_button">Enter address</string>
+    <string name="card_reader_connect_invalid_postal_code_header">Store address postcode is invalid</string>
+    <string name="card_reader_connect_invalid_postal_code_hint">Please provide a valid postcode in your store settings and try again</string>
     <string name="card_reader_connect_scanning_failed_header">No reader connected</string>
     <string name="card_reader_connect_connecting_failed_hint">We couldn\'t connect to the reader.</string>
     <string name="card_reader_connect_missing_permissions_header">Missing required location permission</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -456,7 +456,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
             init(scanState = READER_FOUND)
 
-            verify(tracker).track(AnalyticsTracker.Stat.CARD_READER_AUTO_CONNECTION_STARTED)
+            verify(tracker).track(CARD_READER_AUTO_CONNECTION_STARTED)
         }
 
     @Test
@@ -495,7 +495,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             init(scanState = FAILED)
 
             verify(tracker).track(
-                eq(AnalyticsTracker.Stat.CARD_READER_DISCOVERY_FAILED), anyOrNull(), anyOrNull(), anyOrNull()
+                eq(CARD_READER_DISCOVERY_FAILED), anyOrNull(), anyOrNull(), anyOrNull()
             )
         }
 
@@ -505,7 +505,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             init(scanState = READER_FOUND)
 
             verify(tracker)
-                .track(AnalyticsTracker.Stat.CARD_READER_DISCOVERY_READER_DISCOVERED, mapOf("reader_count" to 1))
+                .track(CARD_READER_DISCOVERY_READER_DISCOVERED, mapOf("reader_count" to 1))
         }
 
     @Test
@@ -514,7 +514,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             init(scanState = MULTIPLE_READERS_FOUND)
 
             verify(tracker)
-                .track(AnalyticsTracker.Stat.CARD_READER_DISCOVERY_READER_DISCOVERED, mapOf("reader_count" to 2))
+                .track(CARD_READER_DISCOVERY_READER_DISCOVERED, mapOf("reader_count" to 2))
         }
 
     @Test
@@ -532,6 +532,24 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 "CardReaderConnectViewModel",
                 null,
                 "Missing Address"
+            )
+        }
+
+    @Test
+    fun `given location fetching invalid postcode, when user clicks on connect to reader button, then track failure`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            init()
+            whenever(locationRepository.getDefaultLocationId()).thenReturn(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode
+            )
+
+            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
+
+            verify(tracker).track(
+                CARD_READER_LOCATION_FAILURE,
+                "CardReaderConnectViewModel",
+                null,
+                "Invalid Postal Code"
             )
         }
 
@@ -608,6 +626,22 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             verify(cardReaderManager, never()).startConnectionToReader(reader, locationId)
             assertThat(viewModel.viewStateData.value).isInstanceOf(
                 CardReaderConnectViewState.MissingMerchantAddressError::class.java
+            )
+        }
+
+    @Test
+    fun `given location fetching invalid postcode, when user clicks on connect button, then invalid pc error state`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            init()
+            whenever(locationRepository.getDefaultLocationId()).thenReturn(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode
+            )
+
+            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
+
+            verify(cardReaderManager, never()).startConnectionToReader(reader, locationId)
+            assertThat(viewModel.viewStateData.value).isInstanceOf(
+                CardReaderConnectViewState.InvalidMerchantAddressPostCodeError::class.java
             )
         }
 
@@ -753,7 +787,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
 
             verify(tracker)
-                .track(AnalyticsTracker.Stat.CARD_READER_CONNECTION_TAPPED)
+                .track(CARD_READER_CONNECTION_TAPPED)
         }
 
     @Test
@@ -765,7 +799,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             reader.onConnectClicked()
 
             verify(tracker)
-                .track(AnalyticsTracker.Stat.CARD_READER_CONNECTION_TAPPED)
+                .track(CARD_READER_CONNECTION_TAPPED)
         }
 
     @Test
@@ -808,7 +842,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
             readerStatusFlow.emit(CardReaderStatus.Connected(reader))
 
-            verify(tracker).track(AnalyticsTracker.Stat.CARD_READER_CONNECTION_SUCCESS)
+            verify(tracker).track(CARD_READER_CONNECTION_SUCCESS)
         }
 
     @Test
@@ -851,7 +885,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             readerStatusFlow.emit(CardReaderStatus.Connecting)
             readerStatusFlow.emit(CardReaderStatus.NotConnected)
 
-            verify(tracker).track(AnalyticsTracker.Stat.CARD_READER_CONNECTION_FAILED)
+            verify(tracker).track(CARD_READER_CONNECTION_FAILED)
         }
 
     @Test
@@ -1079,6 +1113,33 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.string.card_reader_connect_missing_address_button)
             assertThat(viewModel.viewStateData.value!!.secondaryActionLabel)
                 .isEqualTo(R.string.cancel)
+            assertThat(viewModel.viewStateData.value!!.illustration)
+                .isEqualTo(R.drawable.img_products_error)
+            assertThat(viewModel.viewStateData.value!!.illustrationTopMargin)
+                .isEqualTo(R.dimen.major_150)
+        }
+
+    @Test
+    fun `given invalid postcode state, when connecting to reader, then correct labels and illustrations shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            init(scanState = READER_FOUND)
+            readerStatusFlow.emit(CardReaderStatus.NotConnected)
+            whenever(locationRepository.getDefaultLocationId()).thenReturn(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode
+            )
+
+            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(
+                CardReaderConnectViewState.InvalidMerchantAddressPostCodeError::class.java
+            )
+            assertThat(viewModel.viewStateData.value!!.headerLabel)
+                .isEqualTo(UiStringRes(R.string.card_reader_connect_invalid_postal_code_header))
+            assertThat(viewModel.viewStateData.value!!.hintLabel)
+                .isEqualTo(R.string.card_reader_connect_invalid_postal_code_hint)
+            assertThat(viewModel.viewStateData.value!!.primaryActionLabel)
+                .isEqualTo(R.string.try_again)
+            assertThat(viewModel.viewStateData.value!!.secondaryActionLabel).isNull()
             assertThat(viewModel.viewStateData.value!!.illustration)
                 .isEqualTo(R.drawable.img_products_error)
             assertThat(viewModel.viewStateData.value!!.illustrationTopMargin)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.SCANNING
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.BluetoothDisabledError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ConnectingFailedState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.InvalidMerchantAddressPostCodeError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.ConnectingState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.LocationDisabledError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewState.MissingPermissionsError
@@ -896,6 +897,22 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             readerStatusFlow.emit(CardReaderStatus.NotConnected)
 
             (viewModel.viewStateData.value as ConnectingFailedState).onPrimaryActionClicked()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(ScanningState::class.java)
+        }
+
+    @Test
+    fun `given invalid postcode screen shown, when user clicks on retry, then flow restarted`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            init()
+
+            whenever(locationRepository.getDefaultLocationId()).thenReturn(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode
+            )
+
+            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
+
+            (viewModel.viewStateData.value as InvalidMerchantAddressPostCodeError).onPrimaryActionClicked()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(ScanningState::class.java)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.prefs.cardreader.connect
 
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
@@ -80,4 +80,24 @@ class CardReaderLocationRepositoryTest : BaseUnitTest() {
                 CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress(url)
             )
         }
+
+    @Test
+    fun `given store returns invalid postcode error, when get default location, then invalid pc error returned`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val url = "https://wordpress.com"
+            whenever(wcPayStore.getStoreLocationForSite(any())).thenReturn(
+                WCTerminalStoreLocationResult(
+                    WCTerminalStoreLocationError(WCTerminalStoreLocationErrorType.InvalidPostalCode),
+                )
+            )
+
+            // WHEN
+            val result = repository.getDefaultLocationId()
+
+            // THEN
+            assertThat(result).isEqualTo(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode
+            )
+        }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-103f0d961befe7580a691a064c1acbaec1cd33c1'
+    fluxCVersion = 'develop-644f4ae8048ad2b774f185c858ac886f0057526f'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5175 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds specific handling of invalid postcode error

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Change line `CardReaderConnectViewModel:360` on `val cardReaderLocationId = if (cardReader.locationId != null) null else cardReader.locationId`
* In general settings of your store use invalid postal code
* Try to connect to any reader
* Notice specific error
* Fix the postal code and try to connect again
* Notice that you can connect

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![image](https://user-images.githubusercontent.com/4923871/140701380-1fbd9d89-f9d7-4ed1-a8ae-25bf1278ac6f.png)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
