### PR TITLE
Image upload: improve Flow usage in MediaFilesRepository

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.ResourceProvider
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
@@ -33,16 +32,6 @@ class MediaFilesRepository @Inject constructor(
     private val dispatchers: CoroutineDispatchers,
     private val resourceProvider: ResourceProvider
 ) {
-    private lateinit var producerScope: ProducerScope<UploadResult>
-
-    init {
-        dispatcher.register(this)
-    }
-
-    fun onCleanup() {
-        dispatcher.unregister(this)
-    }
-
     suspend fun fetchMedia(localUri: String): MediaModel? {
         return withContext(dispatchers.io) {
             val mediaModel = ProductImagesUtils.mediaModelFromLocalUri(
@@ -60,18 +49,17 @@ class MediaFilesRepository @Inject constructor(
     }
 
     fun uploadMedia(localMediaModel: MediaModel, stripLocation: Boolean = true): Flow<UploadResult> {
-        if (::producerScope.isInitialized) producerScope.cancel()
-
         return callbackFlow {
-            producerScope = this
-
             WooLog.d(T.MEDIA, "MediaFilesRepository > Dispatching request to upload ${localMediaModel.filePath}")
+            val listener = OnMediaUploadListener(this)
+            dispatcher.register(listener)
             val payload = UploadMediaPayload(selectedSite.get(), localMediaModel, stripLocation)
             dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
 
             awaitClose {
+                dispatcher.unregister(listener)
                 // Cancel upload if the collection was cancelled before completion
-                if (!producerScope.isClosedForSend) {
+                if (!isClosedForSend) {
                     val payload = CancelMediaPayload(selectedSite.get(), localMediaModel, true)
                     dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload))
                 }
@@ -108,73 +96,74 @@ class MediaFilesRepository @Inject constructor(
         }
     }
 
-    @Suppress("LongMethod")
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    fun onMediaUploaded(event: OnMediaUploaded) {
-        if (!::producerScope.isInitialized) return
-        when {
-            event.isError -> {
-                WooLog.w(
-                    T.MEDIA,
-                    "MediaFilesRepository > error uploading media: ${event.error.type}, ${event.error.message}"
-                )
-                val exception = MediaUploadException(
-                    event.media,
-                    event.error.type,
-                    event.error.message
-                        ?: resourceProvider.getString(R.string.product_image_service_error_uploading)
-                )
-                producerScope.trySendBlocking(UploadFailure(exception))
-                    .onFailure {
+    private inner class OnMediaUploadListener(private val producerScope: ProducerScope<UploadResult>) {
+        @Suppress("LongMethod")
+        @SuppressWarnings("unused")
+        @Subscribe(threadMode = ThreadMode.BACKGROUND)
+        fun onMediaUploaded(event: OnMediaUploaded) {
+            when {
+                event.isError -> {
+                    WooLog.w(
+                        T.MEDIA,
+                        "MediaFilesRepository > error uploading media: ${event.error.type}, ${event.error.message}"
+                    )
+                    val exception = MediaUploadException(
+                        event.media,
+                        event.error.type,
+                        event.error.message
+                            ?: resourceProvider.getString(R.string.product_image_service_error_uploading)
+                    )
+                    producerScope.trySendBlocking(UploadFailure(exception))
+                        .onFailure {
+                            WooLog.w(
+                                T.MEDIA,
+                                "MediaFilesRepository > error delivering result, downstream collector may be cancelled"
+                            )
+                        }
+                    producerScope.close()
+                }
+                event.canceled -> {
+                    WooLog.d(T.MEDIA, "MediaFilesRepository > upload media cancelled")
+                }
+                event.completed -> {
+                    val channelResult = if (event.media?.url != null) {
+                        WooLog.i(T.MEDIA, "MediaFilesRepository > uploaded media ${event.media?.id}")
+                        producerScope.trySendBlocking(
+                            UploadSuccess(event.media)
+                        )
+                    } else {
+                        WooLog.w(
+                            T.MEDIA,
+                            "MediaFilesRepository > error uploading media ${event.media?.id}, null url"
+                        )
+
+                        producerScope.trySendBlocking(
+                            UploadFailure(
+                                error = MediaUploadException(
+                                    event.media,
+                                    GENERIC_ERROR,
+                                    resourceProvider.getString(R.string.product_image_service_error_uploading)
+                                )
+                            )
+                        )
+                    }
+                    channelResult.onFailure {
                         WooLog.w(
                             T.MEDIA,
                             "MediaFilesRepository > error delivering result, downstream collector may be cancelled"
                         )
                     }
-                producerScope.close()
-            }
-            event.canceled -> {
-                WooLog.d(T.MEDIA, "MediaFilesRepository > upload media cancelled")
-            }
-            event.completed -> {
-                val channelResult = if (event.media?.url != null) {
-                    WooLog.i(T.MEDIA, "MediaFilesRepository > uploaded media ${event.media?.id}")
-                    producerScope.trySendBlocking(
-                        UploadSuccess(event.media)
-                    )
-                } else {
-                    WooLog.w(
-                        T.MEDIA,
-                        "MediaFilesRepository > error uploading media ${event.media?.id}, null url"
-                    )
-
-                    producerScope.trySendBlocking(
-                        UploadFailure(
-                            error = MediaUploadException(
-                                event.media,
-                                GENERIC_ERROR,
-                                resourceProvider.getString(R.string.product_image_service_error_uploading)
-                            )
+                    producerScope.close()
+                }
+                else -> {
+                    producerScope.trySend(
+                        UploadResult.UploadProgress(event.progress)
+                    ).onFailure {
+                        WooLog.w(
+                            T.MEDIA,
+                            "MediaFilesRepository > error delivering result, downstream collector may be cancelled"
                         )
-                    )
-                }
-                channelResult.onFailure {
-                    WooLog.w(
-                        T.MEDIA,
-                        "MediaFilesRepository > error delivering result, downstream collector may be cancelled"
-                    )
-                }
-                producerScope.close()
-            }
-            else -> {
-                producerScope.trySend(
-                    UploadResult.UploadProgress(event.progress)
-                ).onFailure {
-                    WooLog.w(
-                        T.MEDIA,
-                        "MediaFilesRepository > error delivering result, downstream collector may be cancelled"
-                    )
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -928,7 +928,6 @@ class ProductDetailViewModel @Inject constructor(
         productRepository.onCleanup()
         productCategoriesRepository.onCleanup()
         productTagsRepository.onCleanup()
-        mediaFilesRepository.onCleanup()
         if (isProductUnderCreation) {
             // cancel uploads for the default ID, since we can't assign the uploads to it
             mediaFileUploadHandler.cancelUpload(DEFAULT_ADD_NEW_PRODUCT_ID)


### PR DESCRIPTION
### Description
Currently, MediaFilesRepository uses `callbackFlow` for exposing a `Flow<UploadResult>` to its clients, but as it follows the same approach we've been using in previous Repositories, it registers itself with EventBus on `init`, and has a cleanup function, and needs to keep track of the `ProducerScope`.
While discussing how this works with @hafizrahman, I just noticed that we don't need this necessarily, since we can use the `callbackFlow`'s lifecycle for registering a specific listener with `EventBus`, and use `awaitClose` to `unregister` it, this way we won't need any post-cleanup, and we won't need to keep track of the `ProducerScope`, and this is actually very similar to what the official [docs](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/callback-flow.html) sample.

### Testing instructions
Confirm that media upload works as expected, please test with a product image, and with a downloadable file.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
