### PR TITLE
Issue/5148 Missing unit tests for start async update method

### DIFF
--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/firmware/SoftwareUpdateManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/firmware/SoftwareUpdateManagerTest.kt
@@ -1,9 +1,15 @@
 package com.woocommerce.android.cardreader.internal.firmware
 
 import com.stripe.stripeterminal.external.callable.Cancelable
-import com.woocommerce.android.cardreader.internal.connection.BluetoothReaderListenerImpl
 import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
+import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatusErrorType
+import com.woocommerce.android.cardreader.internal.connection.BluetoothReaderListenerImpl
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -19,6 +25,106 @@ class SoftwareUpdateManagerTest {
         bluetoothReaderListener,
         logWrapper,
     )
+
+    @Test
+    fun `given update status changes to started, when start update, then function resumes`() = runBlockingTest {
+        // GIVEN
+        val availabilityEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.Unknown)
+        whenever(bluetoothReaderListener.updateStatusEvents).thenReturn(availabilityEvents)
+
+        // WHEN
+        val asyncJob = launch {
+            softwareUpdateManager.startAsyncSoftwareUpdate()
+        }
+
+        // THEN
+        assertThat(asyncJob.isActive).isTrue()
+        availabilityEvents.emit(SoftwareUpdateStatus.InstallationStarted)
+        assertThat(asyncJob.isActive).isFalse()
+    }
+
+    @Test
+    fun `given update status changes to installing, when start update, then function resumes`() = runBlockingTest {
+        // GIVEN
+        val availabilityEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.Unknown)
+        whenever(bluetoothReaderListener.updateStatusEvents).thenReturn(availabilityEvents)
+
+        // WHEN
+        val asyncJob = launch {
+            softwareUpdateManager.startAsyncSoftwareUpdate()
+        }
+
+        // THEN
+        assertThat(asyncJob.isActive).isTrue()
+        availabilityEvents.emit(SoftwareUpdateStatus.Installing(1f))
+        assertThat(asyncJob.isActive).isFalse()
+    }
+
+    @Test
+    fun `given update status changes to success, when start update, then function resumes`() = runBlockingTest {
+        // GIVEN
+        val availabilityEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.Unknown)
+        whenever(bluetoothReaderListener.updateStatusEvents).thenReturn(availabilityEvents)
+
+        // WHEN
+        val asyncJob = launch {
+            softwareUpdateManager.startAsyncSoftwareUpdate()
+        }
+
+        // THEN
+        assertThat(asyncJob.isActive).isTrue()
+        availabilityEvents.emit(SoftwareUpdateStatus.Success)
+        assertThat(asyncJob.isActive).isFalse()
+    }
+
+    @Test
+    fun `given update status changes to failed, when start update, then function resumes`() = runBlockingTest {
+        // GIVEN
+        val availabilityEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.Unknown)
+        whenever(bluetoothReaderListener.updateStatusEvents).thenReturn(availabilityEvents)
+
+        // WHEN
+        val asyncJob = launch {
+            softwareUpdateManager.startAsyncSoftwareUpdate()
+        }
+
+        // THEN
+        assertThat(asyncJob.isActive).isTrue()
+        availabilityEvents.emit(SoftwareUpdateStatus.Failed(SoftwareUpdateStatusErrorType.ServerError, null))
+        assertThat(asyncJob.isActive).isFalse()
+    }
+
+    @Test
+    fun `given update status is install started, when start update, then function resumes`() = runBlockingTest {
+        // GIVEN
+        val availabilityEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.InstallationStarted)
+        whenever(bluetoothReaderListener.updateStatusEvents).thenReturn(availabilityEvents)
+
+        // WHEN
+        val asyncJob = launch {
+            softwareUpdateManager.startAsyncSoftwareUpdate()
+        }
+
+        // THEN
+        assertThat(asyncJob.isActive).isFalse()
+    }
+
+    @Test
+    fun `given unknown status and timeout, when start update, then function resumes`() = runBlockingTest {
+        // GIVEN
+        val availabilityEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.Unknown)
+        whenever(bluetoothReaderListener.updateStatusEvents).thenReturn(availabilityEvents)
+
+        // WHEN
+        val asyncJob = launch {
+            softwareUpdateManager.startAsyncSoftwareUpdate()
+        }
+
+        // THEN
+        assertThat(asyncJob.isActive).isTrue()
+        advanceTimeBy(TIMEOUT_LONGER_THAN_UPDATE_STARTED_MS)
+        assertThat(asyncJob.isActive).isFalse()
+    }
 
     @Test
     fun `given non null cancel update action, when cancel ongoing update, then action invoked`() {
@@ -44,5 +150,9 @@ class SoftwareUpdateManagerTest {
 
         // THEN
         verify(bluetoothReaderListener).cancelUpdateAction = null
+    }
+
+    companion object {
+        private const val TIMEOUT_LONGER_THAN_UPDATE_STARTED_MS = 30_100L
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5148
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds missing unit tests for start async update method

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Nothing to test here

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
