### PR TITLE
Add talk back support for software update

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -86,7 +86,7 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
         binding: CardReaderUpdateDialogBinding
     ) {
         val progress = UiHelpers.getTextOfUiString(requireActivity(), progressText)
-        binding.progressTextView.announceForAccessibility("$progress")
+        binding.progressTextView.announceForAccessibility(progress)
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.CardReaderUpdateDialogBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -63,6 +64,9 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
             viewLifecycleOwner,
             { state ->
                 with(binding) {
+                    state.progressText?.let { progressText ->
+                        announceSoftwareUpdateProgress(progressText, binding)
+                    }
                     UiHelpers.setTextOrHide(titleTextView, state.title)
                     UiHelpers.setTextOrHide(descriptionTextView, state.description)
                     UiHelpers.setTextOrHide(progressTextView, state.progressText)
@@ -76,6 +80,13 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
                 }
             }
         )
+    }
+
+    private fun announceSoftwareUpdateProgress(
+        progressText: UiString,
+        binding: CardReaderUpdateDialogBinding) {
+        val progress = UiHelpers.getTextOfUiString(requireActivity(), progressText)
+        binding.progressTextView.announceForAccessibility("$progress")
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -55,6 +55,8 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
                         KEY_READER_UPDATE_RESULT,
                         event.data as UpdateResult
                     )
+                    is CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateProgress ->
+                        announceSoftwareUpdateProgress(event.progress, binding)
                     else -> event.isHandled = false
                 }
             }
@@ -64,9 +66,6 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
             viewLifecycleOwner,
             { state ->
                 with(binding) {
-                    state.progressText?.let { progressText ->
-                        announceSoftwareUpdateProgress(progressText, binding)
-                    }
                     UiHelpers.setTextOrHide(titleTextView, state.title)
                     UiHelpers.setTextOrHide(descriptionTextView, state.description)
                     UiHelpers.setTextOrHide(progressTextView, state.progressText)
@@ -84,7 +83,8 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
 
     private fun announceSoftwareUpdateProgress(
         progressText: UiString,
-        binding: CardReaderUpdateDialogBinding) {
+        binding: CardReaderUpdateDialogBinding
+    ) {
         val progress = UiHelpers.getTextOfUiString(requireActivity(), progressText)
         binding.progressTextView.announceForAccessibility("$progress")
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.CardReaderUpdateDialogBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateAboutToStart
+import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateProgress
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -55,8 +57,10 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
                         KEY_READER_UPDATE_RESULT,
                         event.data as UpdateResult
                     )
-                    is CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateProgress ->
+                    is SoftwareUpdateProgress ->
                         announceSoftwareUpdateProgress(event.progress, binding)
+                    is SoftwareUpdateAboutToStart ->
+                        binding.root.announceForAccessibility(getString(event.accessibilityText))
                     else -> event.isHandled = false
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewMo
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.ViewState.UpdateAboutToStart
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.ViewState.UpdatingCancelingState
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.ViewState.UpdatingState
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -83,7 +84,16 @@ class CardReaderUpdateViewModel @Inject constructor(
                 is InstallationStarted -> viewState.value = UpdateAboutToStart(
                     buildProgressText(convertToPercentage(0f))
                 )
-                is Installing -> updateProgress(viewState.value, convertToPercentage(status.progress))
+                is Installing -> {
+                    triggerEvent(
+                        CardReaderUpdateEvent.SoftwareUpdateProgress(
+                            buildProgressText(
+                                convertToPercentage(status.progress)
+                            )
+                        )
+                    )
+                    updateProgress(viewState.value, convertToPercentage(status.progress))
+                }
                 Success -> onUpdateSucceeded()
                 Unknown -> onUpdateStatusUnknown()
             }.exhaustive
@@ -202,6 +212,10 @@ class CardReaderUpdateViewModel @Inject constructor(
             R.string.card_reader_software_update_progress_indicator,
             listOf(UiStringText(progress.toString()))
         )
+
+    sealed class CardReaderUpdateEvent : Event() {
+        data class SoftwareUpdateProgress(val progress: UiString) : Event()
+    }
 
     sealed class ViewState(
         val title: UiString? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs.cardreader.update
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -24,6 +25,7 @@ import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateAboutToStart
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.FAILED
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.SUCCESS
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.ViewState.ButtonState
@@ -81,9 +83,12 @@ class CardReaderUpdateViewModel @Inject constructor(
         cardReaderManager.softwareUpdateStatus.collect { status ->
             when (status) {
                 is Failed -> onUpdateFailed(status)
-                is InstallationStarted -> viewState.value = UpdateAboutToStart(
-                    buildProgressText(convertToPercentage(0f))
-                )
+                is InstallationStarted -> {
+                    triggerEvent(SoftwareUpdateAboutToStart(R.string.card_reader_software_update_description))
+                    viewState.value = UpdateAboutToStart(
+                        buildProgressText(convertToPercentage(0f))
+                    )
+                }
                 is Installing -> {
                     triggerEvent(
                         CardReaderUpdateEvent.SoftwareUpdateProgress(
@@ -215,6 +220,9 @@ class CardReaderUpdateViewModel @Inject constructor(
 
     sealed class CardReaderUpdateEvent : Event() {
         data class SoftwareUpdateProgress(val progress: UiString) : Event()
+        data class SoftwareUpdateAboutToStart(
+            @StringRes val accessibilityText: Int
+        ) : Event()
     }
 
     sealed class ViewState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatusE
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateAboutToStart
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateProgress
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.FAILED
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.SUCCESS
@@ -94,6 +95,25 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
             assertThat(state.progress).isEqualTo(0)
             assertThat(state.illustration).isEqualTo(R.drawable.img_card_reader_update_progress)
             assertThat(state.button?.text).isEqualTo(null)
+        }
+
+    @Test
+    fun `given installation about to start, when view model created, then announce for accessibility`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val status = InstallationStarted
+
+            // WHEN
+            val viewModel = createViewModel()
+            softwareStatus.value = status
+            viewModel.viewStateData.value as UpdateAboutToStart
+
+            // THEN
+            assertThat(viewModel.event.value).isEqualTo(
+                SoftwareUpdateAboutToStart(
+                    R.string.card_reader_software_update_description
+                )
+            )
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatusE
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateProgress
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.FAILED
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.SUCCESS
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.ViewState.UpdateAboutToStart
@@ -93,6 +94,27 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
             assertThat(state.progress).isEqualTo(0)
             assertThat(state.illustration).isEqualTo(R.drawable.img_card_reader_update_progress)
             assertThat(state.button?.text).isEqualTo(null)
+        }
+
+    @Test
+    fun `given installation 10 status, when view model created, then announce update progress for accessibility`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val status = Installing(.1f)
+
+            // WHEN
+            val viewModel = createViewModel()
+            softwareStatus.value = status
+
+            // THEN
+            val uiString = UiStringRes(
+                R.string.card_reader_software_update_progress_indicator,
+                params = listOf(
+                    UiString.UiStringText(text = "10", containsHtml = false)
+                ),
+                containsHtml = false
+            )
+            assertThat(viewModel.event.value).isEqualTo(SoftwareUpdateProgress(uiString))
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5172 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds TalkBack support for card reader software update flow.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Enable TalkBack by navigating to settings -> Accessibility -> TalkBack
2. Open the WooCommerce app and navigate to the settings screen
3. Open the In-Person Payments option
4. Tap the Connect to the reader button
5. Ensure TalkBack announces the text and the progress of software update as it progresses

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Release notes regarding Accessibility is added in this PR #5167

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
