### PR TITLE
Track product image upload failures

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.media
 
 import android.os.Parcelable
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_IMAGE_UPLOAD_FAILED
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.media.ProductImagesNotificationHandler
 import com.woocommerce.android.media.ProductImagesUploadWorker
@@ -81,6 +83,14 @@ class MediaFileUploadHandler @Inject constructor(
             is Event.MediaUploadEvent.UploadFailed -> {
                 WooLog.e(WooLog.T.MEDIA, "MediaFileUploadHandler -> Upload failed", event.error)
                 statusList[index] = newStatus
+                AnalyticsTracker.track(
+                    PRODUCT_IMAGE_UPLOAD_FAILED,
+                    mapOf(
+                        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+                        AnalyticsTracker.KEY_ERROR_TYPE to event.error.errorType.toString(),
+                        AnalyticsTracker.KEY_ERROR_DESC to event.error.message
+                    )
+                )
                 showUploadFailureNotifIfNoObserver(event.productId, statusList)
             }
         }


### PR DESCRIPTION
### Description
During the implementation of background image upload, I accidentally removed the code responsible for tracking upload failures, this PR restores it.

I'm targeting 7.9 with the PR, but IMO it doesn't warrant a new beta build by itself, it can wait for any other beta build, or the final build, WDYT?

### Testing instructions
Simulate a product image upload failure, and confirm that the event is sent.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
