### PR TITLE
Bump compileSdkVersion to 31

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -46,7 +46,7 @@ allOpen {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.woocommerce.android"

--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 21


### PR DESCRIPTION
### Description
All the upcoming Jetpack versions use the API 31 as `compileSdkVersion`, the following PRs are blocked by using 30 in our repo: #4621 (Important to be able to incorporate the last changes from `navigation` 2.4, and drop Robolectric from our tests), https://github.com/woocommerce/woocommerce-android/pull/5166 and https://github.com/woocommerce/woocommerce-android/pull/5130

After the internal discussion: p1636018166194000-slack-C70PAM3RA, we decided to increase our compile SDK version, this shouldn't cause any behavioral changes 🤞 

### Testing instructions
Smoke test the app, preferably against multiple Android versions.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
