### PR TITLE
Track selected filters when show orders button is clicked

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -704,6 +704,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_ADDONS = "addons"
         const val KEY_SOFTWARE_UPDATE_TYPE = "software_update_type"
         const val KEY_SUBJECT = "subject"
+        const val KEY_DATE_RANGE = "date_range"
 
         const val KEY_SORT_ORDER = "order"
         const val VALUE_SORT_NAME_ASC = "name,ascending"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetTrackingForFilterSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetTrackingForFilterSelection.kt
@@ -19,7 +19,7 @@ class GetTrackingForFilterSelection @Inject constructor(
             trackingData[AnalyticsTracker.KEY_STATUS] = orderStatusOptions.joinToString(separator = ",")
         }
         if (dateRangeOptions.isNotEmpty()) {
-            trackingData[AnalyticsTracker.KEY_DATE_RANGE] = orderStatusOptions.first()
+            trackingData[AnalyticsTracker.KEY_DATE_RANGE] = dateRangeOptions.first()
         }
         return trackingData
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetTrackingForFilterSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetTrackingForFilterSelection.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.orders.filters.domain
+
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.ui.orders.filters.data.OrderFiltersRepository
+import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory.DATE_RANGE
+import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory.ORDER_STATUS
+import javax.inject.Inject
+
+class GetTrackingForFilterSelection @Inject constructor(
+    private val orderFiltersRepository: OrderFiltersRepository
+) {
+    operator fun invoke(): Map<String, String> {
+        val orderStatusOptions = orderFiltersRepository
+            .getCurrentFilterSelection(ORDER_STATUS)
+        val dateRangeOptions = orderFiltersRepository.getCurrentFilterSelection(DATE_RANGE)
+
+        val trackingData = mutableMapOf<String, String>()
+        if (orderStatusOptions.isNotEmpty()) {
+            trackingData[AnalyticsTracker.KEY_STATUS] = orderStatusOptions.joinToString(separator = ",")
+        }
+        if (dateRangeOptions.isNotEmpty()) {
+            trackingData[AnalyticsTracker.KEY_DATE_RANGE] = orderStatusOptions.first()
+        }
+        return trackingData
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModelTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory
 import com.woocommerce.android.ui.orders.filters.data.OrderStatusOption
 import com.woocommerce.android.ui.orders.filters.domain.GetDateRangeFilterOptions
 import com.woocommerce.android.ui.orders.filters.domain.GetOrderStatusFilterOptions
+import com.woocommerce.android.ui.orders.filters.domain.GetTrackingForFilterSelection
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterCategoryListViewState
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterCategoryUiModel
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.OnShowOrders
@@ -38,6 +39,7 @@ class OrderFilterCategoriesViewModelTest : BaseUnitTest() {
     private val getOrderStatusFilterOptions: GetOrderStatusFilterOptions = mock()
     private val getDateRangeFilterOptions: GetDateRangeFilterOptions = mock()
     private val orderFilterRepository: OrderFiltersRepository = mock()
+    private val getTrackingForFilterSelection: GetTrackingForFilterSelection = mock()
 
     private lateinit var viewModel: OrderFilterCategoriesViewModel
 
@@ -135,7 +137,8 @@ class OrderFilterCategoriesViewModelTest : BaseUnitTest() {
             resourceProvider,
             getOrderStatusFilterOptions,
             getDateRangeFilterOptions,
-            orderFilterRepository
+            orderFilterRepository,
+            getTrackingForFilterSelection
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Work in progress for: #4934 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Add tracking for new filtering options. For this, we are going to reuse the existing tracking but we are adding a new `date_range` property to provide the date range filters that are selected, if any. Every time "Show Orders" button is clicked from the filters flow we will track an event and send the selected filters. 
