### PR TITLE
Preserve the variation model in SavedStateHandle

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -60,11 +60,12 @@ class VariationDetailViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_VARIATION_PARAMETERS = "key_variation_parameters"
+        private const val KEY_ORIGINAL_VARIATION = "key_original_variation"
     }
 
     private val navArgs: VariationDetailFragmentArgs by savedState.navArgs()
 
-    private var originalVariation: ProductVariation? = null
+    private var originalVariation: ProductVariation? = savedState.get<ProductVariation>(KEY_ORIGINAL_VARIATION)
         get() {
             if (field == null) {
                 loadVariation(navArgs.remoteProductId, navArgs.remoteVariationId)
@@ -75,6 +76,7 @@ class VariationDetailViewModel @Inject constructor(
             // Update the cards (and the original SKU, so that that the "SKU error taken" is not shown unnecessarily
             if (field != value && value != null) {
                 field = value
+                savedState[KEY_ORIGINAL_VARIATION] = value
                 updateCards(value)
             }
         }


### PR DESCRIPTION
Fixes #5221.

**To test:**
1. Enable `Don't keep activities` in Developer options
2. Go to Products -> Select a variable product -> Variations -> Select a variation
3. Tap on the image
4. Replace the image
5. Tap on the back button
6. Verify the new image is shown