### PR TITLE
Products List: improve handling of the FAB

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -805,13 +805,6 @@ class MainActivity :
         navController.navigateSafely(action)
     }
 
-    override fun showProductAddBottomSheet() {
-        val action = ProductListFragmentDirections.actionProductListFragmentToProductTypesBottomSheet(
-            isAddProduct = true
-        )
-        navController.navigateSafely(action)
-    }
-
     override fun showOrderDetail(
         localSiteId: Int,
         localOrderId: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -32,6 +32,5 @@ interface MainNavigationRouter {
     )
 
     fun showFeedbackSurvey()
-    fun showProductAddBottomSheet()
     fun showSettingsScreen()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -11,8 +11,10 @@ import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.FeedbackPrefs
@@ -25,11 +27,10 @@ import com.woocommerce.android.databinding.FragmentProductListBinding
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.extensions.verticalOffsetChanges
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
+import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.*
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -37,16 +38,16 @@ import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.products.ProductListAdapter.OnProductClickListener
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowAddProductBottomSheet
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductFilterScreen
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductSortingBottomSheet
+import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.*
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
+import kotlin.math.abs
 
 @AndroidEntryPoint
 class ProductListFragment :
@@ -110,9 +111,26 @@ class ProductListFragment :
             }
         }
 
+        initAddProductFab(binding.addProductButton)
+
         if (!viewModel.isSearching()) {
             viewModel.reloadProductsFromDb(excludeProductId = pendingTrashProductId)
         }
+    }
+
+    private fun initAddProductFab(fabButton: FloatingActionButton) {
+        fabButton.setOnClickListener {
+            viewModel.onAddProductButtonClicked()
+        }
+
+        // Adjust translationY to keep the FAB always above the bottom nav
+        val appBarLayout = (requireActivity().findViewById<View>(R.id.app_bar_layout) as AppBarLayout)
+        appBarLayout.verticalOffsetChanges()
+            .onEach { verticalOffset ->
+                fabButton.translationY =
+                    (abs(verticalOffset) - appBarLayout.totalScrollRange).toFloat()
+            }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     override fun onDestroyView() {
@@ -423,32 +441,9 @@ class ProductListFragment :
     }
 
     private fun showAddProductButton(show: Boolean) {
-        // note that the FAB is part of the main activity so it can be direct child of the CoordinatorLayout
-        val addProductButton = requireActivity().findViewById<FloatingActionButton>(R.id.addProductButton)
-
-        fun showButton() = run {
-            if (!addProductButton.isVisible) {
-                addProductButton.show()
-            }
-        }
-
-        fun hideButton() = run {
-            if (addProductButton.isVisible) {
-                addProductButton.hide()
-            }
-        }
-
         when (show) {
-            true -> {
-                showButton()
-                addProductButton.setOnClickListener {
-                    viewModel.onAddProductButtonClicked()
-                }
-            }
-            else -> {
-                hideButton()
-                addProductButton.setOnClickListener(null)
-            }
+            true -> binding.addProductButton.show()
+            else -> binding.addProductButton.hide()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -137,7 +137,6 @@ class ProductListFragment :
         skeletonView.hide()
         disableSearchListeners()
         searchView = null
-        showAddProductButton(false)
         super.onDestroyView()
         _binding = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -453,7 +453,12 @@ class ProductListFragment :
         (activity as? MainNavigationRouter)?.showProductDetail(remoteProductId, enableTrash = true)
     }
 
-    private fun showAddProductBottomSheet() = (activity as? MainNavigationRouter)?.showProductAddBottomSheet()
+    private fun showAddProductBottomSheet() {
+        val action = ProductListFragmentDirections.actionProductListFragmentToProductTypesBottomSheet(
+            isAddProduct = true
+        )
+        findNavController().navigateSafely(action)
+    }
 
     override fun onRequestLoadMore() {
         viewModel.onLoadMoreRequested()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -10,32 +10,22 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowAddProductBottomSheet
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductFilterScreen
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductSortingBottomSheet
+import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.*
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.*
 import javax.inject.Inject
 
 @HiltViewModel
@@ -170,22 +160,9 @@ class ProductListViewModel @Inject constructor(
 
     fun onAddProductButtonClicked() {
         launch {
-            cancelSearch()
-
             AnalyticsTracker.track(Stat.PRODUCT_LIST_ADD_PRODUCT_BUTTON_TAPPED)
             triggerEvent(ShowAddProductBottomSheet)
         }
-    }
-
-    private suspend fun cancelSearch() {
-        searchJob?.cancelAndJoin()
-        viewState = viewState.copy(
-            query = null,
-            isSearchActive = false,
-            isAddProductButtonVisible = false,
-            isEmptyViewVisible = false
-        )
-        _productList.value = productRepository.getProductList()
     }
 
     fun onSearchOpened() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -426,6 +427,7 @@ class ProductListViewModel @Inject constructor(
         val displaySortAndFilterCard: Boolean? = null,
         val isAddProductButtonVisible: Boolean? = null,
     ) : Parcelable {
+        @IgnoredOnParcel
         val isBottomNavBarVisible = isSearchActive != true
     }
 

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -59,20 +59,6 @@
                 app:defaultNavHost="true"
                 tools:layout="@layout/fragment_my_store" />
         </FrameLayout>
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/addProductButton"
-            style="@style/Woo.AddButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
-            android:layout_margin="@dimen/major_100"
-            android:animateLayoutChanges="true"
-            android:contentDescription="@string/add_products_button"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            tools:visibility="visible" />
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <com.woocommerce.android.ui.network.OfflineStatusBarView

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -74,5 +74,17 @@
             app:layout_constraintStart_toStartOf="parent"
             tools:visibility="gone" />
 
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/addProductButton"
+            style="@style/Woo.AddButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/major_100"
+            android:contentDescription="@string/add_products_button"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:visibility="visible" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>


### PR DESCRIPTION
### Description
To deal with the expandable behavior of the toolbar, we had to move the add product FAB to the activity layout, and proxy all requests of showing/hiding it to the activity, and while this works well, it will create some issues when we need to show the FAB button in other screens, since the lifecycle of the fragments will complicate things (check @kidinov's trial [PR](https://github.com/woocommerce/woocommerce-android/pull/3613) especially this [comment](https://github.com/woocommerce/woocommerce-android/pull/3613))

This PR tries to make things simpler, but putting the FAB back to the fragment's layout, and to make sure it doesn't get hidden by the bottom nav, we adjust its `translationY` to accommodate for the `appBarLayout`'s offset.
With this change, the FAB will always be destroyed when we navigate to another Fragment, and we won't need any fancy solution to keep it in sync.

The PR also fixes bug #5230, check the comments for the cause.

### Testing instructions
This shouldn't cause any change to the behavior, except the bug fix, so just a small smoke testing for the FAB state, and confirming that the bug is fixed, by following the steps below should be enough:
1. Open products list.
2. Click on the add product FAB.
3. Dismiss the product type sheet.
4. Confirm that the FAB is visible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
