### PR TITLE
Tracks for What's New

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -815,7 +815,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_ANNOUNCEMENT_SOURCE_UPGRADE = "app_upgrade"
         const val VALUE_ANNOUNCEMENT_SOURCE_SETTINGS = "app_settings"
 
-
         var sendUsageStats: Boolean = true
             set(value) {
                 if (value != field) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -537,6 +537,9 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ENCRYPTED_LOGGING_UPLOAD_SUCCESSFUL,
         ENCRYPTED_LOGGING_UPLOAD_FAILED,
 
+        // -- What's new / feature announcements
+        FEATURE_ANNOUNCEMENT_SHOWN,
+
         // -- Other
         UNFULFILLED_ORDERS_LOADED,
         TOP_EARNER_PRODUCT_TAPPED
@@ -806,6 +809,12 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_AMOUNT = "amount"
 
         private const val PREFKEY_SEND_USAGE_STATS = "wc_pref_send_usage_stats"
+
+        // -- Feature Announcement / What's New
+        const val KEY_ANNOUNCEMENT_VIEW_SOURCE = "source"
+        const val VALUE_ANNOUNCEMENT_SOURCE_UPGRADE = "app_upgrade"
+        const val VALUE_ANNOUNCEMENT_SOURCE_SETTINGS = "app_settings"
+
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.main
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.push.NotificationChannelType
@@ -116,6 +117,13 @@ class MainActivityViewModel @Inject constructor(
                     cachedAnnouncement.canBeDisplayedOnAppUpgrade(buildConfigWrapper.versionName)
                 ) {
                     WooLog.i(T.DEVICE, "Displaying Feature Announcement on main activity")
+                    AnalyticsTracker.track(
+                        AnalyticsTracker.Stat.FEATURE_ANNOUNCEMENT_SHOWN,
+                        mapOf(
+                            AnalyticsTracker.KEY_ANNOUNCEMENT_VIEW_SOURCE to
+                                AnalyticsTracker.VALUE_ANNOUNCEMENT_SOURCE_UPGRADE
+                        )
+                    )
                     triggerEvent(ShowFeatureAnnouncement(it))
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -244,6 +244,13 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         binding.optionWhatsNew.show()
         binding.optionWhatsNew.setOnClickListener {
             WooLog.i(T.DEVICE, "Displaying Feature Announcement from Settings menu.")
+            AnalyticsTracker.track(
+                Stat.FEATURE_ANNOUNCEMENT_SHOWN,
+                mapOf(
+                    AnalyticsTracker.KEY_ANNOUNCEMENT_VIEW_SOURCE to
+                        AnalyticsTracker.VALUE_ANNOUNCEMENT_SOURCE_SETTINGS
+                )
+            )
             findNavController()
                 .navigateSafely(
                     MainSettingsFragmentDirections.actionMainSettingsFragmentToFeatureAnnouncementDialogFragment(


### PR DESCRIPTION
Closes #5238 

## Description:

This adds tracking for when a feature announcement is shown. There are two possible paths where it is tracked:
- When it is shown after app upgrade (`source` is `app_upgrade`),
- When merchants go to app settings and viewed it from the menu there (`source` is `app_settings`).

## To test:
1. Go to `build.gradle` and edit `versionName` to be: `998.1` (this is to simulate an app upgrade situation to a version where the example announcement will show up on),
2. Start app and make sure you're logged in with your Automattician account,
3. The announcement is meant to show on main activity's `onResume`, so it might show right away or not. 
 a. If it does, check Logcat and make sure `Tracked: feature_announcement_shown, Properties: {"source":"app_upgrade" ` is shown.
b. If it does not, switch to a different app, then come back to Woo mobile. Make sure the announcement is now shown, and in logcat `Tracked: feature_announcement_shown, Properties: {"source":"app_upgrade" ` is shown.
4. Go to settings and tap "What's New in WooCommerce". Make sure `Tracked: feature_announcement_shown, Properties: {"source":"app_settings",` is shown. 