### PR TITLE
Remove PR list generation at code freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,9 +68,6 @@ platform :android do
     android_bump_version_release()
     new_version = android_get_app_version()
 
-    # Get PRs list before the frozen tag is set
-    get_prs_list(repository: GHHELPER_REPO, milestone:"#{new_version}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list_#{old_version}_#{new_version}.txt")
-
     extract_release_notes_for_version(version: new_version,
       release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt",
       extracted_notes_file_path:release_notes_path)
@@ -459,11 +456,6 @@ platform :android do
   ########################################################################
   # Helper Lanes
   ########################################################################
-  desc "Get a list of pull requests from the `milestone`"
-  lane :get_pullrequests_list do | options |
-    get_prs_list(repository:GHHELPER_REPO, milestone:"#{options[:milestone]}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list.txt")
-  end
-
   private_lane :commit_strings do | options |
     if (options[:auto_commit]) then
        sh("cd .. && git add #{main_strings_path}")


### PR DESCRIPTION
This PR removes the step in Fastlane's `code_freeze` lane that generates a text file with a list of the PRs that made it to the new version. With the current process to generate the release notes and the new tooling we built to generate the draft of the release announcement, this file is not used anymore.

This is also removing the `get_pullrequests_list` lane.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
