### PR TITLE
issue/5218-move-collect-payment-button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -189,7 +189,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         }
 
         // TODO: Once the refund by amount is supported again, this condition will need to be updated
-        binding.paymentInfoIssueRefundButtonSection.isVisible = availableRefundQuantity > 0 && order.isRefundAvailable
+        binding.paymentInfoIssueRefundButton.isVisible = availableRefundQuantity > 0 && order.isRefundAvailable
     }
 
     fun showRefundTotal(
@@ -200,6 +200,6 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         binding.paymentInfoRefundTotal.text = formatCurrencyForDisplay(refundTotal)
         binding.paymentInfoRefunds.hide()
         binding.paymentInfoRefundTotalSection.show()
-        binding.paymentInfoIssueRefundButtonSection.isVisible = show
+        binding.paymentInfoIssueRefundButton.isVisible = show
     }
 }

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -333,7 +333,6 @@
 
         <!-- Refund button & In-Person Payments section -->
         <LinearLayout
-            android:id="@+id/paymentInfo_issueRefundButtonSection"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -336,9 +336,7 @@
             android:id="@+id/paymentInfo_issueRefundButtonSection"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:orientation="vertical">
 
             <!-- See Receipt button -->
             <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -188,6 +188,18 @@
                     tools:text="$49.00"/>
             </LinearLayout>
 
+            <!-- Accept Card Present Payment button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/paymentInfo_collectCardPresentPaymentButton"
+                style="@style/Woo.Button.Colored"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_100"
+                android:layout_gravity="end|center_vertical"
+                android:text="@string/orderdetail_collect_payment_button"/>
+
             <LinearLayout
                 android:id="@+id/paymentInfo_paidSection"
                 android:layout_width="match_parent"
@@ -353,18 +365,6 @@
                 android:paddingEnd="@dimen/major_100"
                 android:text="@string/orderdetail_see_receipt_button"
                 android:textAllCaps="false" />
-
-            <!-- Accept Card Present Payment button -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/paymentInfo_collectCardPresentPaymentButton"
-                style="@style/Woo.Button.Colored"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100"
-                android:layout_gravity="end|center_vertical"
-                android:text="@string/orderdetail_collect_payment_button"/>
 
             <!-- Refund button -->
             <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -331,7 +331,7 @@
             </LinearLayout>
         </LinearLayout>
 
-        <!-- Refund button section -->
+        <!-- Refund button & In-Person Payments section -->
         <LinearLayout
             android:id="@+id/paymentInfo_issueRefundButtonSection"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -188,18 +188,6 @@
                     tools:text="$49.00"/>
             </LinearLayout>
 
-            <!-- Accept Card Present Payment button -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/paymentInfo_collectCardPresentPaymentButton"
-                style="@style/Woo.Button.Colored"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100"
-                android:layout_gravity="end|center_vertical"
-                android:text="@string/orderdetail_collect_payment_button"/>
-
             <LinearLayout
                 android:id="@+id/paymentInfo_paidSection"
                 android:layout_width="match_parent"
@@ -365,6 +353,18 @@
                 android:paddingEnd="@dimen/major_100"
                 android:text="@string/orderdetail_see_receipt_button"
                 android:textAllCaps="false" />
+
+            <!-- Accept Card Present Payment button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/paymentInfo_collectCardPresentPaymentButton"
+                style="@style/Woo.Button.Colored"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_100"
+                android:layout_gravity="end|center_vertical"
+                android:text="@string/orderdetail_collect_payment_button"/>
 
             <!-- Refund button -->
             <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
Closes: #5218

This simple PR moves the "Collect payment" button from the refund section to below the order total. To test, verify that the collect payment button appears as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.