### PR TITLE
Issue/5245 quick order onboarding check

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -414,11 +414,18 @@ object AppPrefs {
             false
         )
 
-    fun setCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, value: Boolean) =
+    fun setCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
         PreferenceUtils.setBoolean(
             getPreferences(),
             getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
-            value
+            true
+        )
+
+    fun resetCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
+        PreferenceUtils.setBoolean(
+            getPreferences(),
+            getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
+            false
         )
 
     fun getJetpackBenefitsDismissalDate(): Long {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -414,11 +414,11 @@ object AppPrefs {
             false
         )
 
-    fun setCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
+    fun setCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, value: Boolean) =
         PreferenceUtils.setBoolean(
             getPreferences(),
             getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
-            true
+            value
         )
 
     fun getJetpackBenefitsDismissalDate(): Long {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -20,8 +20,9 @@ class AppPrefsWrapper @Inject constructor() {
     fun setCardReaderOnboardingCompleted(
         localSiteId: Int,
         remoteSiteId: Long,
-        selfHostedSiteId: Long
-    ) = AppPrefs.setCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId)
+        selfHostedSiteId: Long,
+        value: Boolean
+    ) = AppPrefs.setCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId, value)
 
     fun setLastConnectedCardReaderId(readerId: String) = AppPrefs.setLastConnectedCardReaderId(readerId)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -20,9 +20,14 @@ class AppPrefsWrapper @Inject constructor() {
     fun setCardReaderOnboardingCompleted(
         localSiteId: Int,
         remoteSiteId: Long,
-        selfHostedSiteId: Long,
-        value: Boolean
-    ) = AppPrefs.setCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId, value)
+        selfHostedSiteId: Long
+    ) = AppPrefs.setCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId)
+
+    fun resetCardReaderOnboardingCompleted(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = AppPrefs.resetCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId)
 
     fun setLastConnectedCardReaderId(readerId: String) = AppPrefs.setLastConnectedCardReaderId(readerId)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -275,7 +275,11 @@ class OrderListFragment :
         _binding = null
     }
 
-    private fun isQuickOrderAvailable() = FeatureFlag.QUICK_ORDER.isEnabled() && AppPrefs.isQuickOrderEnabled
+    private fun isQuickOrderAvailable(): Boolean {
+        return FeatureFlag.QUICK_ORDER.isEnabled() &&
+            AppPrefs.isQuickOrderEnabled &&
+            viewModel.isCardReaderOnboardingCompleted()
+    }
 
     /**
      * This is a replacement for activity?.invalidateOptionsMenu() since that causes the
@@ -821,7 +825,10 @@ class OrderListFragment :
     }
 
     private fun displayQuickOrderWIPCard(show: Boolean) {
-        if (!show || feedbackState == FeatureFeedbackSettings.FeedbackState.DISMISSED) {
+        if (!show ||
+            feedbackState == FeatureFeedbackSettings.FeedbackState.DISMISSED ||
+            !viewModel.isCardReaderOnboardingCompleted()
+        ) {
             binding.quickOrderWIPcard.isVisible = false
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import androidx.paging.PagedList
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATUS
@@ -75,6 +76,7 @@ class OrderListViewModel @Inject constructor(
     private val fetcher: WCOrderFetcher,
     private val resourceProvider: ResourceProvider,
     private val wooCommerceStore: WooCommerceStore,
+    private val appPrefsWrapper: AppPrefsWrapper,
     private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters,
     private val getSelectedOrderFiltersCount: GetSelectedOrderFiltersCount,
 ) : ScopedViewModel(savedState), LifecycleOwner {
@@ -482,6 +484,16 @@ class OrderListViewModel @Inject constructor(
     private fun refreshOrders() {
         val pagedListWrapper = listStore.getList(getWCOrderListDescriptorWithFilters(), dataSource, lifecycle)
         activatePagedListWrapper(pagedListWrapper)
+    }
+
+    fun isCardReaderOnboardingCompleted(): Boolean {
+        return selectedSite.getIfExists()?.let {
+            appPrefsWrapper.isCardReaderOnboardingCompleted(
+                localSiteId = it.id,
+                remoteSiteId = it.siteId,
+                selfHostedSiteId = it.selfHostedSiteId
+            )
+        } ?: false
     }
 
     sealed class OrderListEvent : Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -4,12 +4,13 @@ import android.os.Bundle
 import android.view.View
 import android.widget.CompoundButton
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_ADDONS_BETA_FEATURES_SWITCH_TOGGLED
 import com.woocommerce.android.databinding.FragmentSettingsBetaBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
@@ -21,6 +22,8 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     companion object {
         const val TAG = "beta-features"
     }
+
+    private val navArgs: BetaFeaturesFragmentArgs by navArgs()
 
     private val settingsListener by lazy {
         activity as? AppSettingsListener
@@ -45,7 +48,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
                 ?: binding.handleToggleChangeFailure(switch, isChecked)
         }
 
-        if (FeatureFlag.QUICK_ORDER.isEnabled()) {
+        if (FeatureFlag.QUICK_ORDER.isEnabled() && navArgs.isCardReaderOnboardingCompleted) {
             binding.switchQuickOrderToggle.show()
             binding.switchQuickOrderToggle.isChecked = AppPrefs.isQuickOrderEnabled
             binding.switchQuickOrderToggle.setOnCheckedChangeListener { switch, isChecked ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -9,6 +9,7 @@ interface MainSettingsContract {
         fun getUserDisplayName(): String
         fun getStoreDomainName(): String
         fun hasMultipleStores(): Boolean
+        fun isCardReaderOnboardingCompleted(): Boolean
         fun setupAnnouncementOption()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -164,16 +164,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             }
         }
 
-        val isOnboarded = presenter.isCardReaderOnboardingCompleted()
-        binding.optionBetaFeatures.optionValue = if (isOnboarded) {
-            getString(R.string.beta_features_add_ons_and_quick_order)
-        } else {
-            getString(R.string.beta_features_add_ons)
-        }
         binding.optionBetaFeatures.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_BETA_FEATURES_BUTTON_TAPPED)
             val action = MainSettingsFragmentDirections.actionMainSettingsFragmentToBetaFeaturesFragment(
-                isCardReaderOnboardingCompleted = isOnboarded
+                isCardReaderOnboardingCompleted = presenter.isCardReaderOnboardingCompleted()
             )
             findNavController().navigateSafely(action)
         }
@@ -283,6 +277,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     private fun updateStoreSettings() {
         binding.storeSettingsContainer.visibility =
             if (CARD_READER.isEnabled()) View.VISIBLE else View.GONE
+        binding.optionBetaFeatures.optionValue = if (presenter.isCardReaderOnboardingCompleted()) {
+            getString(R.string.beta_features_add_ons_and_quick_order)
+        } else {
+            getString(R.string.beta_features_add_ons)
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -36,13 +36,18 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
-import com.woocommerce.android.util.*
+import com.woocommerce.android.util.AnalyticsUtils
+import com.woocommerce.android.util.AppThemeUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.FeatureFlag.CARD_READER
+import com.woocommerce.android.util.ThemeOption
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import com.woocommerce.android.util.WooLog.T
 
 @AndroidEntryPoint
 class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSettingsContract.View {
@@ -54,6 +59,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     }
 
     @Inject lateinit var presenter: MainSettingsContract.Presenter
+    @Inject lateinit var selectedSite: SelectedSite
 
     private var _binding: FragmentSettingsMainBinding? = null
     private val binding get() = _binding!!
@@ -158,9 +164,18 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             }
         }
 
+        val isOnboarded = presenter.isCardReaderOnboardingCompleted()
+        binding.optionBetaFeatures.optionValue = if (isOnboarded) {
+            getString(R.string.beta_features_add_ons_and_quick_order)
+        } else {
+            getString(R.string.beta_features_add_ons)
+        }
         binding.optionBetaFeatures.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_BETA_FEATURES_BUTTON_TAPPED)
-            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
+            val action = MainSettingsFragmentDirections.actionMainSettingsFragmentToBetaFeaturesFragment(
+                isCardReaderOnboardingCompleted = isOnboarded
+            )
+            findNavController().navigateSafely(action)
         }
 
         binding.optionPrivacy.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -36,7 +36,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
@@ -59,7 +58,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     }
 
     @Inject lateinit var presenter: MainSettingsContract.Presenter
-    @Inject lateinit var selectedSite: SelectedSite
 
     private var _binding: FragmentSettingsMainBinding? = null
     private val binding get() = _binding!!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.prefs
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
@@ -46,5 +47,15 @@ class MainSettingsPresenter @Inject constructor(
                 }
             }
         }
+    }
+
+    override fun isCardReaderOnboardingCompleted(): Boolean {
+        return selectedSite.getIfExists()?.let {
+            AppPrefs.isCardReaderOnboardingCompleted(
+                localSiteId = it.id,
+                remoteSiteId = it.siteId,
+                selfHostedSiteId = it.selfHostedSiteId
+            )
+        } ?: false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -34,7 +34,7 @@ class CardReaderOnboardingChecker @Inject constructor(
         if (!networkStatus.isConnected()) return NoConnectionError
 
         with(selectedSite.get()) {
-            appPrefsWrapper.setCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId, false)
+            appPrefsWrapper.resetCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId)
         }
 
         val countryCode = getStoreCountryCode()
@@ -62,7 +62,7 @@ class CardReaderOnboardingChecker @Inject constructor(
         if (isInUndefinedState(paymentAccount)) return GenericError
 
         with(selectedSite.get()) {
-            appPrefsWrapper.setCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId, true)
+            appPrefsWrapper.setCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId)
         }
 
         return OnboardingCompleted

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -32,6 +32,11 @@ class CardReaderOnboardingChecker @Inject constructor(
     @Suppress("ReturnCount", "ComplexMethod")
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         if (!networkStatus.isConnected()) return NoConnectionError
+
+        with(selectedSite.get()) {
+            appPrefsWrapper.setCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId, false)
+        }
+
         val countryCode = getStoreCountryCode()
         if (!isCountrySupported(countryCode)) return StoreCountryNotSupported(countryCode)
 
@@ -57,7 +62,7 @@ class CardReaderOnboardingChecker @Inject constructor(
         if (isInUndefinedState(paymentAccount)) return GenericError
 
         with(selectedSite.get()) {
-            appPrefsWrapper.setCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId)
+            appPrefsWrapper.setCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId, true)
         }
 
         return OnboardingCompleted

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -169,7 +169,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:optionTitle="@string/beta_features"
-        app:optionValue="@string/beta_features_message" />
+        app:optionValue="@string/beta_features_add_ons" />
 
     <!--
         Send Feedback

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -144,7 +144,11 @@
     <fragment
         android:id="@+id/betaFeaturesFragment"
         android:name="com.woocommerce.android.ui.prefs.BetaFeaturesFragment"
-        android:label="BetaFeaturesFragment" />
+        android:label="BetaFeaturesFragment">
+        <argument
+            android:name="isCardReaderOnboardingCompleted"
+            app:argType="boolean" />
+    </fragment>
     <fragment
         android:id="@+id/feedbackSurveyFragment"
         android:name="com.woocommerce.android.ui.feedback.FeedbackSurveyFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1322,7 +1322,8 @@
     <string name="privacy_settings">Privacy settings</string>
     <string name="send_feedback">Send feedback</string>
     <string name="beta_features">Beta features</string>
-    <string name="beta_features_message">View Add-ons, quick order</string>
+    <string name="beta_features_add_ons">View Add-ons</string>
+    <string name="beta_features_add_ons_and_quick_order">View Add-ons, Quick order</string>
     <string name="settings_signout">Log out</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.NotificationReceivedEvent
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -57,6 +58,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val wooCommerceStore: WooCommerceStore = mock()
     private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters = mock()
     private val getSelectedOrderFiltersCount: GetSelectedOrderFiltersCount = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
 
     @Before
     fun setup() = coroutinesTestRule.testDispatcher.runBlockingTest {
@@ -88,6 +90,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             fetcher = orderFetcher,
             resourceProvider = resourceProvider,
             wooCommerceStore = wooCommerceStore,
+            appPrefsWrapper = appPrefsWrapper,
             getWCOrderListDescriptorWithFilters = getWCOrderListDescriptorWithFilters,
             getSelectedOrderFiltersCount = getSelectedOrderFiltersCount
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -404,7 +404,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     fun `when onboarding completed, then onboarding completed flag saved`() = testBlocking {
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong(), true)
+        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong())
     }
 
     @Test
@@ -416,7 +416,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         )
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper, never()).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong(), true)
+        verify(appPrefsWrapper, never()).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong())
     }
 
     private fun buildPaymentAccountResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -404,7 +404,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     fun `when onboarding completed, then onboarding completed flag saved`() = testBlocking {
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong())
+        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong(), true)
     }
 
     @Test
@@ -416,7 +416,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         )
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper, never()).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong())
+        verify(appPrefsWrapper, never()).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong(), true)
     }
 
     private fun buildPaymentAccountResult(


### PR DESCRIPTION
Closes: #5245 - this PR ensures that quick order features are only shown if the user has completed the card reader onboarding flow. To test:

* Switch to a store that you've never onboarded
* Verify that the WIP banner and plus button on the order list don't appear
* Verify that "Quick order" no longer appears in beta settings
* Switch to a store that you have onboarded
* Verify those three items now appear

Note that at some point we'll want to regularly re-check whether the site is eligible for IPP instead of relying on `AppPrefs`, but for now this should suffice.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
