### PR TITLE
Bump Stripe terminal Android SDK to v2.5.1

### DIFF
--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 
-    implementation "com.stripe:stripeterminal:2.4.1"
+    implementation "com.stripe:stripeterminal:2.5.1"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5261 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Bump Stripe Android terminal SDK to the latest version i.e v2.5.1

### Changelog
2.5.1 - 2021-11-16
Fix: Pre-dipping following a canceled transaction now works as expected. See issue 179 for details.

2.5.0 - 2021-11-15
Fix: Pre-dipping now works as expected with Chippers. See issue 173 for details.
Fix: Failure to issue a card-present refund will now invoke error callbacks properly.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Check whether CI is ✅
2. Check out locally, build and run. Ensure the flow around payments works as expected



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
