### PR TITLE
Issue/4991 memory leaks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -65,7 +65,9 @@ class ProductListFragment :
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    private lateinit var productAdapter: ProductListAdapter
+    private var _productAdapter: ProductListAdapter? = null
+    private val productAdapter: ProductListAdapter
+        get() = _productAdapter!!
 
     private val viewModel: ProductListViewModel by viewModels()
 
@@ -95,7 +97,7 @@ class ProductListFragment :
         setupObservers(viewModel)
         setupResultHandlers()
 
-        productAdapter = ProductListAdapter(this, this)
+        _productAdapter = ProductListAdapter(this, this)
         binding.productsRecycler.layoutManager = LinearLayoutManager(requireActivity())
         binding.productsRecycler.adapter = productAdapter
 
@@ -137,6 +139,7 @@ class ProductListFragment :
         skeletonView.hide()
         disableSearchListeners()
         searchView = null
+        _productAdapter = null
         super.onDestroyView()
         _binding = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -60,7 +60,7 @@ class ProductReviewsFragment :
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        _reviewsAdapter = ReviewListAdapter( this)
+        _reviewsAdapter = ReviewListAdapter(this)
 
         binding.reviewsList.apply {
             layoutManager = LinearLayoutManager(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -33,7 +33,9 @@ class ProductReviewsFragment :
 
     val viewModel: ProductReviewsViewModel by viewModels()
 
-    private lateinit var reviewsAdapter: ReviewListAdapter
+    private var _reviewsAdapter: ReviewListAdapter? = null
+    private val reviewsAdapter: ReviewListAdapter
+        get() = _reviewsAdapter!!
 
     private val skeletonView = SkeletonView()
 
@@ -50,6 +52,7 @@ class ProductReviewsFragment :
 
     override fun onDestroyView() {
         skeletonView.hide()
+        _reviewsAdapter = null
         super.onDestroyView()
         _binding = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -57,8 +57,7 @@ class ProductReviewsFragment :
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        val activity = requireActivity()
-        reviewsAdapter = ReviewListAdapter(activity, this)
+        _reviewsAdapter = ReviewListAdapter( this)
 
         binding.reviewsList.apply {
             layoutManager = LinearLayoutManager(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.reviews
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -24,10 +23,7 @@ import com.woocommerce.android.widgets.sectionedrecyclerview.SectionParameters
 import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerViewAdapter
 import com.woocommerce.android.widgets.sectionedrecyclerview.StatelessSection
 
-class ReviewListAdapter(
-    private val context: Context,
-    private val clickListener: OnReviewClickListener
-) : SectionedRecyclerViewAdapter() {
+class ReviewListAdapter(private val clickListener: OnReviewClickListener) : SectionedRecyclerViewAdapter() {
     private val reviewList = mutableListOf<ProductReview>()
 
     // Copy of current review manually removed from the list so the action may be undone.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -57,7 +57,9 @@ class ReviewListFragment :
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var notificationMessageHandler: NotificationMessageHandler
 
-    private lateinit var reviewsAdapter: ReviewListAdapter
+    private var _reviewsAdapter: ReviewListAdapter? = null
+    private val reviewsAdapter: ReviewListAdapter
+        get() = _reviewsAdapter!!
 
     private val viewModel: ReviewListViewModel by viewModels()
 
@@ -86,7 +88,7 @@ class ReviewListFragment :
 
         val activity = requireActivity()
 
-        reviewsAdapter = ReviewListAdapter(activity, this)
+        _reviewsAdapter = ReviewListAdapter( this)
         val unreadDecoration = UnreadItemDecoration(activity as Context, this)
         binding.reviewsList.apply {
             layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
@@ -165,6 +167,7 @@ class ReviewListFragment :
 
     override fun onDestroyView() {
         skeletonView.hide()
+        _reviewsAdapter = null
         super.onDestroyView()
         _binding = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -88,7 +88,7 @@ class ReviewListFragment :
 
         val activity = requireActivity()
 
-        _reviewsAdapter = ReviewListAdapter( this)
+        _reviewsAdapter = ReviewListAdapter(this)
         val unreadDecoration = UnreadItemDecoration(activity as Context, this)
         binding.reviewsList.apply {
             layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/SkeletonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/SkeletonView.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.widgets
 
 import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,12 +15,18 @@ import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 
 class SkeletonView {
-    private lateinit var parentView: ViewGroup
-    private lateinit var actualView: ViewGroup
+    private var _parentView: ViewGroup? = null
+    private val parentView: ViewGroup
+        get() = _parentView!!
+
+    private var _actualView: ViewGroup? = null
+    private val actualView: ViewGroup
+        get() = _actualView!!
+
     private lateinit var skeletonView: View
     private lateinit var shimmerView: ShimmerFrameLayout
 
-    private val handler = Handler()
+    private val handler = Handler(Looper.getMainLooper())
 
     private var isShowing = false
 
@@ -37,8 +44,8 @@ class SkeletonView {
 
         val viewParent = viewActual.parent ?: throw IllegalStateException("Source view isn't attached")
 
-        parentView = viewParent as ViewGroup
-        actualView = viewActual
+        _parentView = viewParent as ViewGroup
+        _actualView = viewActual
 
         // create the shimmer view
         shimmerView = ShimmerFrameLayout(parentView.context)
@@ -99,6 +106,8 @@ class SkeletonView {
         WooAnimUtils.fadeIn(actualView, Duration.MEDIUM)
 
         isShowing = false
+        _actualView = null
+        _parentView = null
     }
 
     fun findViewById(@IdRes id: Int): View? = parentView.findViewById(id)


### PR DESCRIPTION
Fix memory leaks in Reviews and Product Reviews views

Closes: #4991  #4992 

### Description
This PR fixes some memory leaks in Reviews and Product Reviews views.
In SkeletonView, references to parentView and actualView were not released after the  fragment onDestroyView() was called. This was leaking ReviewListFragment and ProductReviewsFragment. The same was happening with reviewsAdapter and productAdapter in ReviewListFragment, ProductReviewsFragment, and ProductListFragment, not releasing these references in onDestroyView() was leaking the views.
The solution to these issues was to release the references in the Fragment's onDestroyView() and let the GC do his magic.

### Testing instructions
To test the issues navigate to the view you want to check and return to back to MyStore. Wait a few seconds until LeakCanary displays a notification indicating a retained object. Next, let LeakCanary finishes the heap processing and, you should be able to see the leak trace to the references that prevent that retained object from being garbage collected.

#### Test scenarios:

- **reviewsAdapter memory leak**
   MyStore --> Reviews --> MyStore 
   MyStore --> Products --> Product Details -->  Product Reviews --> MyStore

- **parentView and actualView memory leak**
   MyStore --> Reviews --> MyStore (go back to MyStore when the SkeletonView is still displayed)

- **productAdapter memory leak**
   MyStore --> Products --> MyStore 

Further information:
https://square.github.io/leakcanary/fundamentals/
https://stackoverflow.com/questions/59503689/could-navigation-arch-component-create-a-false-positive-memory-leak/59504797#59504797

### Images/gif
#### Before

| reviewsAdapter memory leak | productAdapter memory leak | parentView memory leak |
| --- | --- | --- |
| ![reviewsAdapter](https://user-images.githubusercontent.com/18119390/142443709-1b787b92-a01e-4546-a86a-fce0e42fcc7e.gif) |  ![productAdapter](https://user-images.githubusercontent.com/18119390/142443686-4c21ce42-977d-40cc-ba54-2a357ad17042.gif) | ![parentView](https://user-images.githubusercontent.com/18119390/142443663-b61d8f87-4462-41e1-8b89-a805681a3739.gif) |

#### Result
![resultOk](https://user-images.githubusercontent.com/18119390/142446707-25d476f7-90b2-4310-86eb-24929bbf4bac.gif)

