### PR TITLE
Change the target SDK version to 30

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -60,7 +60,7 @@ android {
         versionCode 260
 
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 30
 
         vectorDrawables.useSupportLibrary = true
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ ext {
     jUnitExtVersion = '1.1.3'
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = "develop-eebc5d8e91a1d90190919f900f924b39c861a528"
-    mediapickerVersion = 'trunk-e70c6df699fbfad8bd907a6b8c0862c69bafb04f'
+    mediapickerVersion = 'trunk-4da42c711820c4b2e83b7735fbb39dbcf8c9176c'
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
This PR changes the `targetSdkVersion` to 30, because version 31 is causing issues for the IPP project and the change can potentially introduce breaking changes in other parts of the app. The app needs to be thoroughly tested with version 31 before releasing it publicly.

The reason why the version was changed to 31 in the first place was that the Media picker library was assumed to require it. However, it turned out that it's sufficient to only change the `compileSdkVersion`.

**To test:**
A quick smoke-test should be sufficient.