### PR TITLE
Set FCMMessageService as non-exported

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -102,7 +102,7 @@
 
         <service
             android:name=".push.FCMMessageService"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5270 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The initial goal of the PR was to add the `exported` attribute where it's missing to align with Android 12 changes, but thanks to @0nko's work with media library, this was already done in the [commit](https://github.com/woocommerce/woocommerce-android/commit/274a29949a506fd4356d2689f3223def07b1865b).
So I'm just adjusting the attribute value for `FCMMessageService` to false, as it doesn't need to be.

### Testing instructions
1. Make sure push notifications are still working.
2. Change `targetSdkVersion` to 31, and make sure the app builds fine.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
