### PR TITLE
Supply the necessary mutability flags for PendingIntents

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationsProcessingService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationsProcessingService.kt
@@ -5,6 +5,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
+import androidx.core.os.BuildCompat
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,7 +23,12 @@ class NotificationsProcessingService : Service() {
             intent.putExtra(ARG_ACTION_TYPE, ARG_ACTION_NOTIFICATION_DISMISS)
             intent.putExtra(ARG_PUSH_ID, pushId)
             intent.addCategory(ARG_ACTION_NOTIFICATION_DISMISS)
-            return PendingIntent.getService(context, pushId, intent, PendingIntent.FLAG_CANCEL_CURRENT)
+            val flags = if (BuildCompat.isAtLeastS()) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+            return PendingIntent.getService(context, pushId, intent, flags)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
@@ -15,6 +15,7 @@ import android.os.RemoteException
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import androidx.core.os.BuildCompat
 import com.bumptech.glide.Glide
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Notification
@@ -150,9 +151,14 @@ class WooNotificationBuilder @Inject constructor(private val context: Context) {
             )
             builder.setDeleteIntent(pendingDeleteIntent)
 
+            val flags = if (BuildCompat.isAtLeastS()) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
             val pendingIntent = PendingIntent.getActivity(
                 context, pushId, getResultIntent(pushId, notification),
-                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_UPDATE_CURRENT
+                flags
             )
             builder.setContentIntent(pendingIntent)
             NotificationManagerCompat.from(context).notify(pushId, builder.build())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5272 

### Description
This simply adds the Immutable flag to our push notifications PendingIntents.

I took it also as a chance to add a utility class for handling the android versions checks, it's similar to [`BuildCompat`](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/os/BuildCompat.java;l=33?q=BuildCompat&sq=) that the androidx libraries use.

### Testing instructions
1. Test push notifications and confirm that opening and dismissing a push notification works as expected.
2. Change targetSdkVersion to 31, then repeat the first test, and confirm that the app doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
