### PR TITLE
 Implement search filter for country and state when editing an order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -76,7 +76,8 @@ class AddressViewModel @Inject constructor(
         if (countryCode != viewState.countryLocation.code) {
             viewState = viewState.copy(
                 countryLocation = getCountryLocationFromCode(countryCode),
-                stateLocation = Location("", "")
+                stateLocation = Location("", ""),
+                isStateSelectionEnabled = true
             )
         }
     }
@@ -103,7 +104,8 @@ class AddressViewModel @Inject constructor(
 
         viewState = this.copy(
             countryLocation = countryLocation,
-            stateLocation = getStateLocationFromCode(stateCode)
+            stateLocation = getStateLocationFromCode(stateCode),
+            isStateSelectionEnabled = countryCode.isNotEmpty()
         )
     }
 
@@ -111,6 +113,7 @@ class AddressViewModel @Inject constructor(
     data class ViewState(
         val countryLocation: Location = Location("", ""),
         val stateLocation: Location = Location("", ""),
-        val isLoading: Boolean = false
+        val isLoading: Boolean = false,
+        val isStateSelectionEnabled: Boolean = false
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.details.editing.BaseOrderEditingFragment
+import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 
@@ -134,25 +135,34 @@ abstract class BaseAddressEditingFragment :
 
     private fun showCountrySelectorDialog() {
         val countries = addressViewModel.countries
-        val action = OrderDetailFragmentDirections.actionGlobalItemSelectorDialog(
-            addressDraft.country,
-            countries.map { it.name }.toTypedArray(),
-            countries.map { it.code }.toTypedArray(),
-            SELECT_COUNTRY_REQUEST,
-            getString(R.string.shipping_label_edit_address_country)
+        val action = OrderDetailFragmentDirections.actionSearchFilterFragment(
+            selectedItem = addressDraft.country,
+            items = countries.map {
+                SearchFilterItem(
+                    name = it.name,
+                    value = it.code
+                )
+            }.toTypedArray(),
+            hint = getString(R.string.shipping_label_edit_address_country_search_hint),
+            requestKey = SELECT_COUNTRY_REQUEST,
+            title = getString(R.string.shipping_label_edit_address_country)
         )
         findNavController().navigateSafely(action)
     }
 
-    @Suppress("UnusedPrivateMember")
     private fun showStateSelectorDialog() {
         val states = addressViewModel.states
-        val action = OrderDetailFragmentDirections.actionGlobalItemSelectorDialog(
-            addressDraft.state,
-            states.map { it.name }.toTypedArray(),
-            states.map { it.code }.toTypedArray(),
-            SELECT_STATE_REQUEST,
-            getString(R.string.shipping_label_edit_address_state)
+        val action = OrderDetailFragmentDirections.actionSearchFilterFragment(
+            selectedItem = addressDraft.state,
+            items = states.map {
+                SearchFilterItem(
+                    name = it.name,
+                    value = it.code
+                )
+            }.toTypedArray(),
+            hint = getString(R.string.shipping_label_edit_address_state_search_hint),
+            requestKey = SELECT_STATE_REQUEST,
+            title = getString(R.string.shipping_label_edit_address_state)
         )
         findNavController().navigateSafely(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -136,7 +136,6 @@ abstract class BaseAddressEditingFragment :
     private fun showCountrySelectorDialog() {
         val countries = addressViewModel.countries
         val action = OrderDetailFragmentDirections.actionSearchFilterFragment(
-            selectedItem = addressDraft.country,
             items = countries.map {
                 SearchFilterItem(
                     name = it.name,
@@ -153,7 +152,6 @@ abstract class BaseAddressEditingFragment :
     private fun showStateSelectorDialog() {
         val states = addressViewModel.states
         val action = OrderDetailFragmentDirections.actionSearchFilterFragment(
-            selectedItem = addressDraft.state,
             items = states.map {
                 SearchFilterItem(
                     name = it.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -67,11 +67,11 @@ abstract class BaseAddressEditingFragment :
         )
 
         binding.countrySpinner.setClickListener {
-            showCountrySelectorDialog()
+            showCountrySearchScreen()
         }
 
         binding.stateSpinner.setClickListener {
-            showStateSelectorDialog()
+            showStateSearchScreen()
         }
 
         setupObservers()
@@ -133,7 +133,7 @@ abstract class BaseAddressEditingFragment :
         binding.stateEditText.isVisible = !shouldShowStateSpinner()
     }
 
-    private fun showCountrySelectorDialog() {
+    private fun showCountrySearchScreen() {
         val countries = addressViewModel.countries
         val action = OrderDetailFragmentDirections.actionSearchFilterFragment(
             items = countries.map {
@@ -149,7 +149,7 @@ abstract class BaseAddressEditingFragment :
         findNavController().navigateSafely(action)
     }
 
-    private fun showStateSelectorDialog() {
+    private fun showStateSearchScreen() {
         val states = addressViewModel.states
         val action = OrderDetailFragmentDirections.actionSearchFilterFragment(
             items = states.map {
@@ -182,6 +182,9 @@ abstract class BaseAddressEditingFragment :
                 if (old?.isLoading == true) {
                     updateStateViews()
                 }
+            }
+            new.isStateSelectionEnabled.takeIfNotEqualTo(old?.isStateSelectionEnabled) {
+                binding.stateSpinner.isEnabled = it
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -62,8 +62,8 @@ abstract class BaseAddressEditingFragment :
         bindTextWatchers()
 
         addressViewModel.start(
-            storedAddress = storedAddress,
-            addressDraft = addressDraft
+            countryCode = storedAddress.country,
+            stateCode = storedAddress.state
         )
 
         binding.countrySpinner.setClickListener {
@@ -88,6 +88,11 @@ abstract class BaseAddressEditingFragment :
         activity?.let {
             ActivityUtils.hideKeyboard(it)
         }
+    }
+
+    override fun onDetach() {
+        addressViewModel.onScreenDetached()
+        super.onDetach()
     }
 
     private fun Address.bindToView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -62,8 +62,8 @@ abstract class BaseAddressEditingFragment :
         bindTextWatchers()
 
         addressViewModel.start(
-            countryCode = storedAddress.country,
-            stateCode = storedAddress.state
+            storedAddress = storedAddress,
+            addressDraft = addressDraft
         )
 
         binding.countrySpinner.setClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -16,16 +16,27 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentEditShippingLabelAddressBinding
-import com.woocommerce.android.extensions.*
+import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.navigateBackWithNotice
+import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.show
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.InputField
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.*
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.DialPhoneNumber
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.OpenMapWithAddress
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel.Field
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
+import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -49,7 +60,8 @@ class EditShippingLabelAddressFragment :
         const val EDIT_ADDRESS_CLOSED = "key_edit_address_dialog_closed"
     }
 
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private var progressDialog: CustomProgressDialog? = null
 
@@ -228,25 +240,33 @@ class EditShippingLabelAddressFragment :
                     findNavController().navigateSafely(action)
                 }
                 is ShowCountrySelector -> {
-                    val action = EditShippingLabelAddressFragmentDirections
-                        .actionGlobalItemSelectorDialog(
-                            event.currentCountryCode,
-                            event.locations.map { it.name }.toTypedArray(),
-                            event.locations.map { it.code }.toTypedArray(),
-                            SELECT_COUNTRY_REQUEST,
-                            getString(R.string.shipping_label_edit_address_country)
-                        )
+                    val action = EditShippingLabelAddressFragmentDirections.actionSearchFilterFragment(
+                        selectedItem = event.currentCountryCode,
+                        items = event.locations.map {
+                            SearchFilterItem(
+                                name = it.name,
+                                value = it.code
+                            )
+                        }.toTypedArray(),
+                        hint = getString(R.string.shipping_label_edit_address_country_search_hint),
+                        requestKey = SELECT_COUNTRY_REQUEST,
+                        title = getString(R.string.shipping_label_edit_address_country)
+                    )
                     findNavController().navigateSafely(action)
                 }
                 is ShowStateSelector -> {
-                    val action = EditShippingLabelAddressFragmentDirections
-                        .actionGlobalItemSelectorDialog(
-                            event.currentStateCode,
-                            event.locations.map { it.name }.toTypedArray(),
-                            event.locations.map { it.code }.toTypedArray(),
-                            SELECT_STATE_REQUEST,
-                            getString(R.string.shipping_label_edit_address_state)
-                        )
+                    val action = EditShippingLabelAddressFragmentDirections.actionSearchFilterFragment(
+                        selectedItem = event.currentStateCode,
+                        items = event.locations.map {
+                            SearchFilterItem(
+                                name = it.name,
+                                value = it.code
+                            )
+                        }.toTypedArray(),
+                        hint = getString(R.string.shipping_label_edit_address_state_search_hint),
+                        requestKey = SELECT_STATE_REQUEST,
+                        title = getString(R.string.shipping_label_edit_address_state)
+                    )
                     findNavController().navigateSafely(action)
                 }
                 is OpenMapWithAddress -> launchMapsWithAddress(event.address)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -241,7 +241,6 @@ class EditShippingLabelAddressFragment :
                 }
                 is ShowCountrySelector -> {
                     val action = EditShippingLabelAddressFragmentDirections.actionSearchFilterFragment(
-                        selectedItem = event.currentCountryCode,
                         items = event.locations.map {
                             SearchFilterItem(
                                 name = it.name,
@@ -256,7 +255,6 @@ class EditShippingLabelAddressFragment :
                 }
                 is ShowStateSelector -> {
                     val action = EditShippingLabelAddressFragmentDirections.actionSearchFilterFragment(
-                        selectedItem = event.currentStateCode,
                         items = event.locations.map {
                             SearchFilterItem(
                                 name = it.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterAdapter.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.searchfilter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.FilterListItemBinding
 import com.woocommerce.android.extensions.hide
@@ -10,14 +11,7 @@ import com.woocommerce.android.ui.searchfilter.SearchFilterAdapter.SearchFilterV
 
 class SearchFilterAdapter(
     private val onItemSelectedListener: (SearchFilterItem) -> Unit
-) : RecyclerView.Adapter<SearchFilterViewHolder>() {
-
-    var items: List<SearchFilterItem> = emptyList()
-        set(value) {
-            val diffResult = DiffUtil.calculateDiff(SearchFilterDiffCallback(field, value))
-            field = value
-            diffResult.dispatchUpdatesTo(this)
-        }
+) : ListAdapter<SearchFilterItem, SearchFilterViewHolder>(SearchFilterDiffCallback) {
 
     init {
         setHasStableIds(true)
@@ -29,12 +23,10 @@ class SearchFilterAdapter(
         )
 
     override fun onBindViewHolder(holder: SearchFilterViewHolder, position: Int) {
-        holder.bind(items[position])
+        holder.bind(getItem(position))
     }
 
-    override fun getItemCount(): Int = items.size
-
-    override fun getItemId(position: Int): Long = items[position].hashCode().toLong()
+    override fun getItemId(position: Int): Long = getItem(position).hashCode().toLong()
 
     inner class SearchFilterViewHolder(val viewBinding: FilterListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
@@ -46,20 +38,16 @@ class SearchFilterAdapter(
         }
     }
 
-    private class SearchFilterDiffCallback(
-        private val oldList: List<SearchFilterItem>,
-        private val newList: List<SearchFilterItem>
-    ) : DiffUtil.Callback() {
-        override fun getOldListSize(): Int = oldList.size
+    object SearchFilterDiffCallback : DiffUtil.ItemCallback<SearchFilterItem>() {
 
-        override fun getNewListSize(): Int = newList.size
+        override fun areItemsTheSame(
+            oldSearchFilterItem: SearchFilterItem,
+            newSearchFilterItem: SearchFilterItem
+        ): Boolean = oldSearchFilterItem.value == newSearchFilterItem.value
 
-        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            return oldList[oldItemPosition].value == newList[newItemPosition].value
-        }
-
-        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            return oldList[oldItemPosition] == newList[newItemPosition]
-        }
+        override fun areContentsTheSame(
+            oldSearchFilterItem: SearchFilterItem,
+            newSearchFilterItem: SearchFilterItem
+        ): Boolean = oldSearchFilterItem == newSearchFilterItem
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterAdapter.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.searchfilter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.FilterListItemBinding
 import com.woocommerce.android.extensions.hide
@@ -11,7 +12,12 @@ class SearchFilterAdapter(
     private val onItemSelectedListener: (SearchFilterItem) -> Unit
 ) : RecyclerView.Adapter<SearchFilterViewHolder>() {
 
-    private var items: List<SearchFilterItem> = emptyList()
+    var items: List<SearchFilterItem> = emptyList()
+        set(value) {
+            val diffResult = DiffUtil.calculateDiff(SearchFilterDiffCallback(field, value))
+            field = value
+            diffResult.dispatchUpdatesTo(this)
+        }
 
     init {
         setHasStableIds(true)
@@ -30,11 +36,6 @@ class SearchFilterAdapter(
 
     override fun getItemId(position: Int): Long = items[position].hashCode().toLong()
 
-    fun setItems(items: List<SearchFilterItem>) {
-        this.items = items
-        notifyDataSetChanged()
-    }
-
     inner class SearchFilterViewHolder(val viewBinding: FilterListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
 
@@ -42,6 +43,23 @@ class SearchFilterAdapter(
             viewBinding.filterItemName.text = item.name
             viewBinding.filterItemSelection.hide()
             viewBinding.root.setOnClickListener { onItemSelectedListener(item) }
+        }
+    }
+
+    private class SearchFilterDiffCallback(
+        private val oldList: List<SearchFilterItem>,
+        private val newList: List<SearchFilterItem>
+    ) : DiffUtil.Callback() {
+        override fun getOldListSize(): Int = oldList.size
+
+        override fun getNewListSize(): Int = newList.size
+
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition].value == newList[newItemPosition].value
+        }
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition] == newList[newItemPosition]
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterAdapter.kt
@@ -8,9 +8,14 @@ import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.ui.searchfilter.SearchFilterAdapter.SearchFilterViewHolder
 
 class SearchFilterAdapter(
-    private val items: List<SearchFilterItem>,
     private val onItemSelectedListener: (SearchFilterItem) -> Unit
 ) : RecyclerView.Adapter<SearchFilterViewHolder>() {
+
+    private var items: List<SearchFilterItem> = emptyList()
+
+    init {
+        setHasStableIds(true)
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SearchFilterViewHolder =
         SearchFilterViewHolder(
@@ -22,6 +27,13 @@ class SearchFilterAdapter(
     }
 
     override fun getItemCount(): Int = items.size
+
+    override fun getItemId(position: Int): Long = items[position].hashCode().toLong()
+
+    fun setItems(items: List<SearchFilterItem>) {
+        this.items = items
+        notifyDataSetChanged()
+    }
 
     inner class SearchFilterViewHolder(val viewBinding: FilterListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterAdapter.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.ui.searchfilter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.databinding.FilterListItemBinding
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.ui.searchfilter.SearchFilterAdapter.SearchFilterViewHolder
+
+class SearchFilterAdapter(
+    private val items: List<SearchFilterItem>,
+    private val onItemSelectedListener: (SearchFilterItem) -> Unit
+) : RecyclerView.Adapter<SearchFilterViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SearchFilterViewHolder =
+        SearchFilterViewHolder(
+            FilterListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        )
+
+    override fun onBindViewHolder(holder: SearchFilterViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    inner class SearchFilterViewHolder(val viewBinding: FilterListItemBinding) :
+        RecyclerView.ViewHolder(viewBinding.root) {
+
+        fun bind(item: SearchFilterItem) {
+            viewBinding.filterItemName.text = item.name
+            viewBinding.filterItemSelection.hide()
+            viewBinding.root.setOnClickListener { onItemSelectedListener(item) }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterEvent.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.searchfilter
+
+sealed class SearchFilterEvent {
+
+    data class ItemSelected(val selectedItemValue: String, val requestKey: String) : SearchFilterEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.searchfilter
+
+import androidx.navigation.fragment.navArgs
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
+    companion object {
+        val TAG: String = SearchFilterFragment::class.java.simpleName
+    }
+
+    private val navArgs: SearchFilterFragmentArgs by navArgs()
+
+    private val selectedItem: String?
+        get() = navArgs.selectedItem
+
+    private val searchTitle: String
+        get() = navArgs.title
+
+    private val searchHint: String
+        get() = navArgs.hint
+
+    private val searchFilterItems: Array<SearchFilterItem>
+        get() = navArgs.items
+
+    private val requestKey: String
+        get() = navArgs.requestKey
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -7,6 +7,7 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentSearchFilterBinding
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -72,7 +73,7 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
             adapter = SearchFilterAdapter(
                 items = searchFilterItems.toList(),
                 onItemSelectedListener = { selectedItem ->
-                    //TODO
+                    navigateBackWithResult(requestKey, selectedItem.value)
                 }
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -35,17 +35,18 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         _binding = FragmentSearchFilterBinding.bind(view)
-
-        setHasOptionsMenu(true)
-        activity?.title = searchTitle
+        setupTitle()
         setupSearch()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun setupTitle() {
+        activity?.title = searchTitle
     }
 
     private fun setupSearch() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -10,7 +10,9 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentSearchFilterBinding
 import com.woocommerce.android.extensions.exhaustive
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.searchfilter.SearchFilterEvent.ItemSelected
 import com.woocommerce.android.ui.searchfilter.SearchFilterViewState.Empty
@@ -60,15 +62,18 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
         viewModel.viewStateLiveData.observe(viewLifecycleOwner, { viewState ->
             when (viewState) {
                 is Loaded -> {
+                    showSearchList()
                     updateSearchList(viewState.searchFilterItems)
                     setupTitle(viewState.title)
                     binding.searchEditText.hint = viewState.searchHint
                 }
                 is Search -> {
+                    showSearchList()
                     updateSearchList(viewState.searchFilterItems)
                     hideEmptyView()
                 }
                 is Empty -> {
+                    hideSearchList()
                     showEmptyView(viewState.searchQuery)
                 }
             }.exhaustive
@@ -114,6 +119,14 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
 
     private fun updateSearchList(searchFilterItems: List<SearchFilterItem>) {
         searchFilterAdapter.setItems(searchFilterItems.toList())
+    }
+
+    private fun showSearchList() {
+        binding.searchItemsList.show()
+    }
+
+    private fun hideSearchList() {
+        binding.searchItemsList.hide()
     }
 
     private fun setupTitle(title: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -4,11 +4,13 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentSearchFilterBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.WCEmptyView
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -99,6 +101,13 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
             )
             adapter = searchFilterAdapter
             searchFilterAdapter.setItems(searchFilterItems.toList())
+            addItemDecoration(
+                AlignedDividerDecoration(
+                    ctx = context,
+                    orientation = DividerItemDecoration.VERTICAL,
+                    alignStartToStartOf = R.id.filterItemName
+                )
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -17,9 +17,6 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
 
     private val navArgs: SearchFilterFragmentArgs by navArgs()
 
-    private val selectedItem: String?
-        get() = navArgs.selectedItem
-
     private val searchTitle: String
         get() = navArgs.title
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -42,7 +42,6 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentSearchFilterBinding.bind(view)
         viewModel.start(
-            title = navArgs.title,
             searchFilterItems = navArgs.items,
             searchHint = navArgs.hint,
             requestKey = navArgs.requestKey
@@ -58,6 +57,8 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
         _binding = null
     }
 
+    override fun getFragmentTitle(): String = navArgs.title
+
     private fun setupViewStateObserver() {
         viewModel.viewStateLiveData.observe(
             viewLifecycleOwner,
@@ -66,7 +67,6 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
                     is Loaded -> {
                         showSearchList()
                         updateSearchList(viewState.searchFilterItems)
-                        setupTitle(viewState.title)
                         binding.searchEditText.hint = viewState.searchHint
                     }
                     is Search -> {
@@ -133,10 +133,6 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
 
     private fun hideSearchList() {
         binding.searchItemsList.hide()
-    }
-
-    private fun setupTitle(title: String) {
-        activity?.title = title
     }
 
     private fun hideEmptyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -124,7 +124,7 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
     }
 
     private fun updateSearchList(searchFilterItems: List<SearchFilterItem>) {
-        searchFilterAdapter.items = searchFilterItems.toList()
+        searchFilterAdapter.submitList(searchFilterItems)
     }
 
     private fun showSearchList() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -59,35 +59,41 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
     }
 
     private fun setupViewStateObserver() {
-        viewModel.viewStateLiveData.observe(viewLifecycleOwner, { viewState ->
-            when (viewState) {
-                is Loaded -> {
-                    showSearchList()
-                    updateSearchList(viewState.searchFilterItems)
-                    setupTitle(viewState.title)
-                    binding.searchEditText.hint = viewState.searchHint
-                }
-                is Search -> {
-                    showSearchList()
-                    updateSearchList(viewState.searchFilterItems)
-                    hideEmptyView()
-                }
-                is Empty -> {
-                    hideSearchList()
-                    showEmptyView(viewState.searchQuery)
-                }
-            }.exhaustive
-        })
+        viewModel.viewStateLiveData.observe(
+            viewLifecycleOwner,
+            { viewState ->
+                when (viewState) {
+                    is Loaded -> {
+                        showSearchList()
+                        updateSearchList(viewState.searchFilterItems)
+                        setupTitle(viewState.title)
+                        binding.searchEditText.hint = viewState.searchHint
+                    }
+                    is Search -> {
+                        showSearchList()
+                        updateSearchList(viewState.searchFilterItems)
+                        hideEmptyView()
+                    }
+                    is Empty -> {
+                        hideSearchList()
+                        showEmptyView(viewState.searchQuery)
+                    }
+                }.exhaustive
+            }
+        )
     }
 
     private fun setupEventObserver() {
-        viewModel.eventLiveData.observe(viewLifecycleOwner, { event ->
-            when (event) {
-                is ItemSelected -> {
-                    navigateBackWithResult(event.requestKey, event.selectedItemValue)
-                }
-            }.exhaustive
-        })
+        viewModel.eventLiveData.observe(
+            viewLifecycleOwner,
+            { event ->
+                when (event) {
+                    is ItemSelected -> {
+                        navigateBackWithResult(event.requestKey, event.selectedItemValue)
+                    }
+                }.exhaustive
+            }
+        )
     }
 
     private fun setupSearchInput() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.searchfilter
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.widget.SearchView.OnQueryTextListener
+import androidx.core.widget.doAfterTextChanged
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -15,7 +15,7 @@ import com.woocommerce.android.widgets.WCEmptyView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQueryTextListener {
+class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
     companion object {
         val TAG: String = SearchFilterFragment::class.java.simpleName
     }
@@ -53,22 +53,6 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
         _binding = null
     }
 
-    override fun onQueryTextSubmit(query: String): Boolean {
-        return true
-    }
-
-    override fun onQueryTextChange(newText: String): Boolean {
-        val searchedItems = searchFilterItems.filter { it.name.contains(other = newText, ignoreCase = true) }
-        searchFilterAdapter.setItems(searchedItems)
-        //TODO move to VM
-        if (searchedItems.isEmpty()) {
-            showEmptyView(newText)
-        } else {
-            hideEmptyView()
-        }
-        return true
-    }
-
     private fun showEmptyView(searchQuery: String) {
         binding.emptyView.show(
             WCEmptyView.EmptyViewType.SEARCH_RESULTS,
@@ -85,9 +69,19 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
     }
 
     private fun setupSearch() {
-        binding.searchView.apply {
-            queryHint = searchHint
-            setOnQueryTextListener(this@SearchFilterFragment)
+        binding.searchEditText.apply {
+            hint = searchHint
+            doAfterTextChanged {
+                val text = it.toString()
+                val searchedItems = searchFilterItems.filter { it.name.contains(other = text, ignoreCase = true) }
+                searchFilterAdapter.setItems(searchedItems)
+                //TODO move to VM
+                if (searchedItems.isEmpty()) {
+                    showEmptyView(text)
+                } else {
+                    hideEmptyView()
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -124,7 +124,7 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
     }
 
     private fun updateSearchList(searchFilterItems: List<SearchFilterItem>) {
-        searchFilterAdapter.setItems(searchFilterItems.toList())
+        searchFilterAdapter.items = searchFilterItems.toList()
     }
 
     private fun showSearchList() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -1,8 +1,9 @@
 package com.woocommerce.android.ui.searchfilter
 
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.View
-import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -38,6 +39,20 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
 
     private lateinit var searchFilterAdapter: SearchFilterAdapter
 
+    private val searchTextWatcher = object : TextWatcher {
+        override fun afterTextChanged(editable: Editable?) {
+            // noop
+        }
+
+        override fun beforeTextChanged(charSequence: CharSequence?, start: Int, count: Int, after: Int) {
+            // noop
+        }
+
+        override fun onTextChanged(charSequence: CharSequence?, start: Int, before: Int, count: Int) {
+            viewModel.onSearch(charSequence.toString())
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentSearchFilterBinding.bind(view)
@@ -53,6 +68,7 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
     }
 
     override fun onDestroyView() {
+        binding.searchEditText.removeTextChangedListener(searchTextWatcher)
         super.onDestroyView()
         _binding = null
     }
@@ -98,9 +114,7 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
 
     private fun setupSearchInput() {
         binding.searchEditText.apply {
-            doAfterTextChanged {
-                viewModel.onSearch(it.toString())
-            }
+            addTextChangedListener(searchTextWatcher)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -35,6 +35,8 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
     private val binding: FragmentSearchFilterBinding
         get() = _binding!!
 
+    private lateinit var searchFilterAdapter: SearchFilterAdapter
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentSearchFilterBinding.bind(view)
@@ -49,11 +51,13 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
     }
 
     override fun onQueryTextSubmit(query: String): Boolean {
-        return false
+        return true
     }
 
     override fun onQueryTextChange(newText: String): Boolean {
-        return false
+        val searchedItems = searchFilterItems.filter { it.name.contains(other = newText, ignoreCase = true) }
+        searchFilterAdapter.setItems(searchedItems)
+        return true
     }
 
     private fun setupTitle() {
@@ -70,12 +74,13 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
     private fun setupSearchList() {
         binding.searchItemsList.apply {
             layoutManager = LinearLayoutManager(context)
-            adapter = SearchFilterAdapter(
-                items = searchFilterItems.toList(),
+            searchFilterAdapter = SearchFilterAdapter(
                 onItemSelectedListener = { selectedItem ->
                     navigateBackWithResult(requestKey, selectedItem.value)
                 }
             )
+            adapter = searchFilterAdapter
+            searchFilterAdapter.setItems(searchFilterItems.toList())
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentSearchFilterBinding
 import com.woocommerce.android.ui.base.BaseFragment
@@ -38,11 +39,20 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
         _binding = FragmentSearchFilterBinding.bind(view)
         setupTitle()
         setupSearch()
+        setupSearchList()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun onQueryTextSubmit(query: String): Boolean {
+        return false
+    }
+
+    override fun onQueryTextChange(newText: String): Boolean {
+        return false
     }
 
     private fun setupTitle() {
@@ -56,11 +66,15 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
         }
     }
 
-    override fun onQueryTextSubmit(query: String): Boolean {
-        return false
-    }
-
-    override fun onQueryTextChange(newText: String): Boolean {
-        return false
+    private fun setupSearchList() {
+        binding.searchItemsList.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = SearchFilterAdapter(
+                items = searchFilterItems.toList(),
+                onItemSelectedListener = { selectedItem ->
+                    //TODO
+                }
+            )
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentSearchFilterBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.widgets.WCEmptyView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -57,7 +58,24 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQu
     override fun onQueryTextChange(newText: String): Boolean {
         val searchedItems = searchFilterItems.filter { it.name.contains(other = newText, ignoreCase = true) }
         searchFilterAdapter.setItems(searchedItems)
+        //TODO move to VM
+        if (searchedItems.isEmpty()) {
+            showEmptyView(newText)
+        } else {
+            hideEmptyView()
+        }
         return true
+    }
+
+    private fun showEmptyView(searchQuery: String) {
+        binding.emptyView.show(
+            WCEmptyView.EmptyViewType.SEARCH_RESULTS,
+            searchQueryOrFilter = searchQuery
+        )
+    }
+
+    private fun hideEmptyView() {
+        binding.emptyView.hide()
     }
 
     private fun setupTitle() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -1,12 +1,16 @@
 package com.woocommerce.android.ui.searchfilter
 
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentSearchFilterBinding
 import com.woocommerce.android.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
+class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter), OnQueryTextListener {
     companion object {
         val TAG: String = SearchFilterFragment::class.java.simpleName
     }
@@ -27,4 +31,38 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
 
     private val requestKey: String
         get() = navArgs.requestKey
+
+    private var _binding: FragmentSearchFilterBinding? = null
+    private val binding: FragmentSearchFilterBinding
+        get() = _binding!!
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        _binding = FragmentSearchFilterBinding.bind(view)
+
+        setHasOptionsMenu(true)
+        activity?.title = searchTitle
+        setupSearch()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setupSearch() {
+        binding.searchView.apply {
+            queryHint = searchHint
+            setOnQueryTextListener(this@SearchFilterFragment)
+        }
+    }
+
+    override fun onQueryTextSubmit(query: String): Boolean {
+        return false
+    }
+
+    override fun onQueryTextChange(newText: String): Boolean {
+        return false
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterItem.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class SearchFilterItem(
+data class SearchFilterItem(
     val name: String,
     val value: String
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterItem.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.searchfilter
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+class SearchFilterItem(
+    val name: String,
+    val value: String
+) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModel.kt
@@ -25,11 +25,10 @@ class SearchFilterViewModel @Inject constructor() : ViewModel() {
 
     private lateinit var requestKey: String
 
-    fun start(title: String, searchFilterItems: Array<SearchFilterItem>, searchHint: String, requestKey: String) {
+    fun start(searchFilterItems: Array<SearchFilterItem>, searchHint: String, requestKey: String) {
         allSearchFilterItems = searchFilterItems.toList()
         this.requestKey = requestKey
         _viewStateLiveData.value = Loaded(
-            title = title,
             searchFilterItems = allSearchFilterItems,
             searchHint = searchHint
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModel.kt
@@ -1,0 +1,54 @@
+package com.woocommerce.android.ui.searchfilter
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.woocommerce.android.ui.searchfilter.SearchFilterEvent.ItemSelected
+import com.woocommerce.android.ui.searchfilter.SearchFilterViewState.Empty
+import com.woocommerce.android.ui.searchfilter.SearchFilterViewState.Loaded
+import com.woocommerce.android.ui.searchfilter.SearchFilterViewState.Search
+import com.woocommerce.android.viewmodel.SingleLiveEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchFilterViewModel @Inject constructor() : ViewModel() {
+
+    private val _viewStateLiveData = MutableLiveData<SearchFilterViewState>()
+    val viewStateLiveData: LiveData<SearchFilterViewState>
+        get() = _viewStateLiveData
+
+    private val _eventLiveData = SingleLiveEvent<SearchFilterEvent>()
+    val eventLiveData: LiveData<SearchFilterEvent> = _eventLiveData
+
+    private lateinit var allSearchFilterItems: List<SearchFilterItem>
+
+    private lateinit var requestKey: String
+
+    fun start(title: String, searchFilterItems: Array<SearchFilterItem>, searchHint: String, requestKey: String) {
+        allSearchFilterItems = searchFilterItems.toList()
+        this.requestKey = requestKey
+        _viewStateLiveData.value = Loaded(
+            title = title,
+            searchFilterItems = allSearchFilterItems,
+            searchHint = searchHint
+        )
+    }
+
+    fun onSearch(searchQuery: String) {
+        val searchedItems = allSearchFilterItems.filter { it.name.contains(searchQuery, true) }
+        val state = if (searchedItems.isNotEmpty()) {
+            Search(searchedItems)
+        } else {
+            Empty(searchQuery)
+        }
+        _viewStateLiveData.value = state
+    }
+
+    fun onItemSelected(selectedItem: SearchFilterItem) {
+        _eventLiveData.value = ItemSelected(
+            selectedItemValue = selectedItem.value,
+            requestKey = requestKey
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewState.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.searchfilter
 sealed class SearchFilterViewState {
 
     data class Loaded(
-        val title: String,
         val searchFilterItems: List<SearchFilterItem>,
         val searchHint: String
     ) : SearchFilterViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewState.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.ui.searchfilter
+
+sealed class SearchFilterViewState {
+
+    data class Loaded(
+        val title: String,
+        val searchFilterItems: List<SearchFilterItem>,
+        val searchHint: String
+    ) : SearchFilterViewState()
+
+    data class Search(
+        val searchFilterItems: List<SearchFilterItem>
+    ) : SearchFilterViewState()
+
+    data class Empty(
+        val searchQuery: String
+    ) : SearchFilterViewState()
+}

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -6,6 +6,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <ScrollView
+        android:id="@+id/edit_address_scroll"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -9,7 +9,7 @@
         android:id="@+id/searchView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_100"
+        android:background="@color/color_surface"
         app:iconifiedByDefault="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -18,9 +18,9 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/searchItemsList"
         android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="@dimen/major_100"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_height="wrap_content"
+        android:background="@color/color_surface"
+        android:paddingTop="@dimen/major_100"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/searchView" />

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -23,5 +24,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/searchView" />
+
+    <com.woocommerce.android.widgets.WCEmptyView
+        android:id="@+id/emptyView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/major_100"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/searchView"
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -5,25 +5,25 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.SearchView
-        android:id="@+id/searchView"
+    <FrameLayout
+        android:id="@+id/searchViewContainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="@color/color_surface"
-        app:iconifiedByDefault="false"
+        android:paddingBottom="@dimen/major_75"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/searchItemsList"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:background="@color/color_surface"
-        android:paddingTop="@dimen/major_100"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/searchView" />
+        <androidx.appcompat.widget.SearchView
+            android:id="@+id/searchView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingEnd="@dimen/major_250"
+            app:iconifiedByDefault="false"
+            app:searchIcon="@drawable/ic_search_24dp" />
+
+    </FrameLayout>
 
     <com.woocommerce.android.widgets.WCEmptyView
         android:id="@+id/emptyView"
@@ -34,7 +34,16 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/searchView"
+        app:layout_constraintTop_toBottomOf="@+id/searchViewContainer"
         tools:visibility="visible" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/searchItemsList"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/color_surface"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/searchViewContainer" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -10,18 +10,23 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="@color/color_surface"
-        android:paddingBottom="@dimen/major_75"
+        app:layout_constraintBottom_toTopOf="@+id/searchItemsList"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.appcompat.widget.SearchView
-            android:id="@+id/searchView"
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/searchEditText"
+            style="@style/Woo.EditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/major_250"
-            app:iconifiedByDefault="false"
-            app:searchIcon="@drawable/ic_search_24dp" />
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
+            android:drawableStart="@drawable/ic_search_24dp"
+            android:drawablePadding="@dimen/major_100"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </FrameLayout>
 

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -24,10 +24,7 @@
             android:layout_marginBottom="@dimen/major_100"
             android:drawableStart="@drawable/ic_search_24dp"
             android:drawablePadding="@dimen/major_100"
-            android:imeOptions="flagNoExtractUi"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:imeOptions="flagNoExtractUi" />
 
     </FrameLayout>
 

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -24,6 +24,7 @@
             android:layout_marginBottom="@dimen/major_100"
             android:drawableStart="@drawable/ic_search_24dp"
             android:drawablePadding="@dimen/major_100"
+            android:imeOptions="flagNoExtractUi"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -14,4 +14,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/searchItemsList"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/major_100"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/searchView" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/searchView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        app:iconifiedByDefault="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -657,7 +657,11 @@
         app:destination="@id/itemSelectorDialog" />
     <action
         android:id="@+id/action_search_filter_fragment"
-        app:destination="@id/searchFilterFragment" />
+        app:destination="@id/searchFilterFragment"
+        app:enterAnim="@anim/activity_slide_in_from_right"
+        app:exitAnim="@anim/activity_slide_out_to_left"
+        app:popEnterAnim="@anim/activity_slide_in_from_left"
+        app:popExitAnim="@anim/activity_slide_out_to_right" />
     <fragment
         android:id="@+id/searchFilterFragment"
         android:name="com.woocommerce.android.ui.searchfilter.SearchFilterFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -65,11 +65,11 @@
         <action
             android:id="@+id/action_printShippingLabelFragment_to_printShippingLabelCustomsFormFragment"
             app:destination="@id/printShippingLabelCustomsFormFragment"
-            app:popUpTo="@id/orderDetailFragment"
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right" />
+            app:popExitAnim="@anim/activity_slide_out_to_right"
+            app:popUpTo="@id/orderDetailFragment" />
     </fragment>
     <fragment
         android:id="@+id/printShippingLabelCustomsFormFragment"
@@ -508,7 +508,7 @@
     <dialog
         android:id="@+id/cardReaderWelcomeDialog"
         android:name="com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderWelcomeDialog"
-        android:label="CardReaderWelcomeDialog" >
+        android:label="CardReaderWelcomeDialog">
         <action
             android:id="@+id/action_cardReaderWelcomeFragment_to_cardReaderOnboardingFragment"
             app:destination="@id/cardReaderOnboardingFragment"
@@ -578,8 +578,7 @@
         android:id="@+id/printingInstructionsFragment"
         android:name="com.woocommerce.android.ui.orders.details.PrintingInstructionsFragment"
         android:label="PrintingInstructionsFragment"
-        tools:layout="@layout/fragment_printing_instructions">
-    </fragment>
+        tools:layout="@layout/fragment_printing_instructions"></fragment>
     <fragment
         android:id="@+id/shippingCustomsFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsFragment"
@@ -647,14 +646,15 @@
         android:id="@+id/shippingAddressEditingFragment"
         android:name="com.woocommerce.android.ui.orders.details.editing.address.ShippingAddressEditingFragment"
         android:label="ShippingAddressEditingFragment"
-        tools:layout="@layout/fragment_base_edit_address"/>
+        tools:layout="@layout/fragment_base_edit_address" />
     <fragment
         android:id="@+id/billingAddressEditingFragment"
         android:name="com.woocommerce.android.ui.orders.details.editing.address.BillingAddressEditingFragment"
         android:label="BillingAddressEditingFragment"
-        tools:layout="@layout/fragment_base_edit_address"/>
-    <action android:id="@+id/action_global_item_selector_dialog"
-        app:destination="@id/itemSelectorDialog"/>
+        tools:layout="@layout/fragment_base_edit_address" />
+    <action
+        android:id="@+id/action_global_item_selector_dialog"
+        app:destination="@id/itemSelectorDialog" />
     <action
         android:id="@+id/action_search_filter_fragment"
         app:destination="@id/searchFilterFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -578,7 +578,7 @@
         android:id="@+id/printingInstructionsFragment"
         android:name="com.woocommerce.android.ui.orders.details.PrintingInstructionsFragment"
         android:label="PrintingInstructionsFragment"
-        tools:layout="@layout/fragment_printing_instructions"></fragment>
+        tools:layout="@layout/fragment_printing_instructions" />
     <fragment
         android:id="@+id/shippingCustomsFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsFragment"
@@ -663,10 +663,6 @@
         android:name="com.woocommerce.android.ui.searchfilter.SearchFilterFragment"
         android:label="searchFilterFragment"
         tools:layout="@layout/fragment_search_filter">
-        <argument
-            android:name="selectedItem"
-            app:argType="string"
-            app:nullable="true" />
         <argument
             android:name="title"
             android:defaultValue='""'

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -655,4 +655,31 @@
         tools:layout="@layout/fragment_base_edit_address"/>
     <action android:id="@+id/action_global_item_selector_dialog"
         app:destination="@id/itemSelectorDialog"/>
+    <action
+        android:id="@+id/action_search_filter_fragment"
+        app:destination="@id/searchFilterFragment" />
+    <fragment
+        android:id="@+id/searchFilterFragment"
+        android:name="com.woocommerce.android.ui.searchfilter.SearchFilterFragment"
+        android:label="searchFilterFragment"
+        tools:layout="@layout/fragment_search_filter">
+        <argument
+            android:name="selectedItem"
+            app:argType="string"
+            app:nullable="true" />
+        <argument
+            android:name="title"
+            android:defaultValue='""'
+            app:argType="string" />
+        <argument
+            android:name="hint"
+            android:defaultValue='""'
+            app:argType="string" />
+        <argument
+            android:name="items"
+            app:argType="com.woocommerce.android.ui.searchfilter.SearchFilterItem[]" />
+        <argument
+            android:name="requestKey"
+            app:argType="string" />
+    </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -396,7 +396,7 @@
     <string name="order_detail_edit_address_line2">Address 2</string>
     <string name="order_detail_edit_address_city">City</string>
     <string name="order_detail_edit_address_zip">Postal Code</string>
-    <string name="order_detail_edit_address_state">State / County</string>
+    <string name="order_detail_edit_address_state">State</string>
     <string name="order_detail_edit_address_country">Country</string>
     <string name="order_detail_address_section">Address</string>
     <string name="order_detail_shipping_address_section">Shipping Address</string>
@@ -508,8 +508,8 @@
     <string name="shipping_label_edit_address_line1">Address line 1</string>
     <string name="shipping_label_edit_address_line2">Address line 2</string>
     <string name="shipping_label_edit_address_city">City</string>
-    <string name="shipping_label_edit_address_state">State / County</string>
-    <string name="shipping_label_edit_address_state_search_hint">Filter State / County</string>
+    <string name="shipping_label_edit_address_state">State</string>
+    <string name="shipping_label_edit_address_state_search_hint">Filter state</string>
     <string name="shipping_label_edit_address_zip">Zip / Postal Code</string>
     <string name="shipping_label_edit_address_country">Country</string>
     <string name="shipping_label_edit_address_country_search_hint">Filter countries</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -512,7 +512,7 @@
     <string name="shipping_label_edit_address_state_search_hint">Filter State / County</string>
     <string name="shipping_label_edit_address_zip">Zip / Postal Code</string>
     <string name="shipping_label_edit_address_country">Country</string>
-    <string name="shipping_label_edit_address_country_search_hint">Filter Countries</string>
+    <string name="shipping_label_edit_address_country_search_hint">Filter countries</string>
     <string name="shipping_label_edit_address_use_address_as_is">Use address as entered</string>
     <string name="shipping_label_edit_data_loading_error">Unable to load the address data</string>
     <string name="shipping_label_edit_address_validation_progress_title">Address validation in progress</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -509,8 +509,10 @@
     <string name="shipping_label_edit_address_line2">Address line 2</string>
     <string name="shipping_label_edit_address_city">City</string>
     <string name="shipping_label_edit_address_state">State / County</string>
+    <string name="shipping_label_edit_address_state_search_hint">Filter State / County</string>
     <string name="shipping_label_edit_address_zip">Zip / Postal Code</string>
     <string name="shipping_label_edit_address_country">Country</string>
+    <string name="shipping_label_edit_address_country_search_hint">Filter Countries</string>
     <string name="shipping_label_edit_address_use_address_as_is">Use address as entered</string>
     <string name="shipping_label_edit_data_loading_error">Unable to load the address data</string>
     <string name="shipping_label_edit_address_validation_progress_title">Address validation in progress</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -52,7 +52,7 @@ class AddressViewModelTest : BaseUnitTest() {
                 countryCode = "countryCode",
                 stateCode = "stateCode"
             )
-            verify(dataStore, times(1)).fetchCountriesAndStates(selectedSite.get())
+            verify(dataStore).fetchCountriesAndStates(selectedSite.get())
         }
     }
 
@@ -68,7 +68,7 @@ class AddressViewModelTest : BaseUnitTest() {
                 countryCode = "countryCode",
                 stateCode = "stateCode"
             )
-            verify(dataStore, times(1)).fetchCountriesAndStates(selectedSite.get())
+            verify(dataStore).fetchCountriesAndStates(selectedSite.get())
         }
     }
 
@@ -156,7 +156,7 @@ class AddressViewModelTest : BaseUnitTest() {
         whenever(dataStore.getCountries()).thenReturn(listOf(location))
         val countryCode = location.code
         addressViewModel.onCountrySelected(countryCode)
-        verify(viewStateObserver, times(1)).onChanged(
+        verify(viewStateObserver).onChanged(
             ViewState(
                 countryLocation = Location(countryCode, location.name),
                 stateLocation = Location("", ""),
@@ -170,7 +170,7 @@ class AddressViewModelTest : BaseUnitTest() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
         val countryCode = "countryCode"
         addressViewModel.onCountrySelected(countryCode)
-        verify(viewStateObserver, times(1)).onChanged(
+        verify(viewStateObserver).onChanged(
             ViewState(
                 countryLocation = Location(countryCode, countryCode),
                 stateLocation = Location("", ""),
@@ -184,7 +184,7 @@ class AddressViewModelTest : BaseUnitTest() {
         whenever(dataStore.getStates(any())).thenReturn(listOf(location))
         val stateCode = location.code
         addressViewModel.onStateSelected(stateCode)
-        verify(viewStateObserver, times(1)).onChanged(
+        verify(viewStateObserver).onChanged(
             ViewState(
                 stateLocation = Location(stateCode, location.name)
             )
@@ -196,7 +196,7 @@ class AddressViewModelTest : BaseUnitTest() {
         whenever(dataStore.getStates(any())).thenReturn(emptyList())
         val stateCode = "stateCode"
         addressViewModel.onStateSelected(stateCode)
-        verify(viewStateObserver, times(1)).onChanged(
+        verify(viewStateObserver).onChanged(
             ViewState(
                 stateLocation = Location(stateCode, stateCode)
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -64,14 +64,15 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should apply country and state changes to view state safely on start if countries list is empty`() {
-        whenever(dataStore.getCountries()).thenReturn(emptyList())
+        whenever(dataStore.getCountries()).thenReturn(listOf(location))
         val countryCode = "countryCode"
         val stateCode = "stateCode"
         addressViewModel.start(countryCode, stateCode)
         assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
             ViewState(
                 countryLocation = Location(countryCode, countryCode),
-                stateLocation = Location(stateCode, stateCode)
+                stateLocation = Location(stateCode, stateCode),
+                isStateSelectionEnabled = true
             )
         )
     }
@@ -101,14 +102,15 @@ class AddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should update viewState with selected country and reset selected state on onCountrySelected`() {
+    fun `Should update viewState with selected country, reset selected state and enable state selection on onCountrySelected`() {
         whenever(dataStore.getCountries()).thenReturn(listOf(location))
         val countryCode = location.code
         addressViewModel.onCountrySelected(countryCode)
         verify(viewStateObserver, times(1)).onChanged(
             ViewState(
                 countryLocation = Location(countryCode, location.name),
-                stateLocation = Location("", "")
+                stateLocation = Location("", ""),
+                isStateSelectionEnabled = true
             )
         )
     }
@@ -121,7 +123,8 @@ class AddressViewModelTest : BaseUnitTest() {
         verify(viewStateObserver, times(1)).onChanged(
             ViewState(
                 countryLocation = Location(countryCode, countryCode),
-                stateLocation = Location("", "")
+                stateLocation = Location("", ""),
+                isStateSelectionEnabled = true
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -1,0 +1,151 @@
+package com.woocommerce.android.ui.orders.details.editing.address
+
+import androidx.lifecycle.Observer
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.Location
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel.ViewState
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.data.WCLocationModel
+import org.wordpress.android.fluxc.store.WCDataStore
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class AddressViewModelTest : BaseUnitTest() {
+
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle()
+
+    private val selectedSite: SelectedSite = mock()
+
+    private val location = WCLocationModel().apply {
+        name = "Brazil"
+        code = "BR"
+    }
+
+    private val dataStore: WCDataStore = mock()
+
+    private val addressViewModel = AddressViewModel(savedStateHandle, selectedSite, dataStore)
+
+    private val viewStateObserver: Observer<ViewState> = mock()
+
+    @Before
+    fun setup() {
+        addressViewModel.viewStateData.liveData.observeForever(viewStateObserver)
+    }
+
+    @Test
+    fun `Should fetch countries and states on start if they've never been fetched`() {
+        whenever(dataStore.getCountries()).thenReturn(emptyList())
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            addressViewModel.start("country", "state")
+            verify(dataStore, times(1)).fetchCountriesAndStates(selectedSite.get())
+        }
+    }
+
+    @Test
+    fun `Should NOT fetch countries and states on start if countries have already been fetched`() {
+        whenever(dataStore.getCountries()).thenReturn(listOf(location))
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            addressViewModel.start("country", "state")
+            verify(dataStore, times(0)).fetchCountriesAndStates(selectedSite.get())
+        }
+    }
+
+    @Test
+    fun `Should return true on hasCountries if countries list is NOT empty`() {
+        whenever(dataStore.getCountries()).thenReturn(listOf(location))
+        assertTrue(addressViewModel.hasCountries())
+    }
+
+    @Test
+    fun `Should return false on hasCountries if countries list is empty`() {
+        whenever(dataStore.getCountries()).thenReturn(emptyList())
+        assertFalse(addressViewModel.hasCountries())
+    }
+
+    @Test
+    fun `Should return true on hasStates if states list is NOT empty`() {
+        whenever(dataStore.getStates(any())).thenReturn(listOf(location))
+        assertTrue(addressViewModel.hasStates())
+    }
+
+    @Test
+    fun `Should return false on hasStates if states list is empty`() {
+        whenever(dataStore.getStates(any())).thenReturn(emptyList())
+        assertFalse(addressViewModel.hasStates())
+    }
+
+    @Test
+    fun `Should update viewState with selected country and reset selected state on onCountrySelected`() {
+        whenever(dataStore.getCountries()).thenReturn(listOf(location))
+        val countryCode = location.code
+        addressViewModel.onCountrySelected(countryCode)
+        verify(viewStateObserver, times(1)).onChanged(
+            ViewState(
+                countryLocation = Location(countryCode, location.name),
+                stateLocation = Location("", "")
+            )
+        )
+    }
+
+    @Test
+    fun `Should update viewState with country code instead of name if country code is NOT on countries list`() {
+        whenever(dataStore.getCountries()).thenReturn(emptyList())
+        val countryCode = "countryCode"
+        addressViewModel.onCountrySelected(countryCode)
+        verify(viewStateObserver, times(1)).onChanged(
+            ViewState(
+                countryLocation = Location(countryCode, countryCode),
+                stateLocation = Location("", "")
+            )
+        )
+    }
+
+    @Test
+    fun `Should update viewState with selected state on onCountrySelected`() {
+        whenever(dataStore.getStates(any())).thenReturn(listOf(location))
+        val stateCode = location.code
+        addressViewModel.onStateSelected(stateCode)
+        verify(viewStateObserver, times(1)).onChanged(
+            ViewState(
+                stateLocation = Location(stateCode, location.name)
+            )
+        )
+    }
+
+    @Test
+    fun `Should update viewState with state code instead of name if state code is NOT on states list`() {
+        whenever(dataStore.getStates(any())).thenReturn(emptyList())
+        val stateCode = "stateCode"
+        addressViewModel.onStateSelected(stateCode)
+        verify(viewStateObserver, times(1)).onChanged(
+            ViewState(
+                stateLocation = Location(stateCode, stateCode)
+            )
+        )
+    }
+
+    @Test
+    fun `Should apply country and state changes to view state safely on start`() {
+        val countryCode = "countryCode"
+        val stateCode = "stateCode"
+        addressViewModel.start(countryCode, stateCode)
+        assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
+            ViewState(
+                countryLocation = Location(countryCode, countryCode),
+                stateLocation = Location(stateCode, stateCode)
+            )
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -63,6 +63,20 @@ class AddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `Should apply country and state changes to view state safely on start if countries list is empty`() {
+        whenever(dataStore.getCountries()).thenReturn(emptyList())
+        val countryCode = "countryCode"
+        val stateCode = "stateCode"
+        addressViewModel.start(countryCode, stateCode)
+        assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
+            ViewState(
+                countryLocation = Location(countryCode, countryCode),
+                stateLocation = Location(stateCode, stateCode)
+            )
+        )
+    }
+
+    @Test
     fun `Should return true on hasCountries if countries list is NOT empty`() {
         whenever(dataStore.getCountries()).thenReturn(listOf(location))
         assertTrue(addressViewModel.hasCountries())
@@ -131,19 +145,6 @@ class AddressViewModelTest : BaseUnitTest() {
         addressViewModel.onStateSelected(stateCode)
         verify(viewStateObserver, times(1)).onChanged(
             ViewState(
-                stateLocation = Location(stateCode, stateCode)
-            )
-        )
-    }
-
-    @Test
-    fun `Should apply country and state changes to view state safely on start`() {
-        val countryCode = "countryCode"
-        val stateCode = "stateCode"
-        addressViewModel.start(countryCode, stateCode)
-        assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
-            ViewState(
-                countryLocation = Location(countryCode, countryCode),
                 stateLocation = Location(stateCode, stateCode)
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -152,7 +152,7 @@ class AddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should update viewState with selected country, reset selected state and enable state selection on onCountrySelected`() {
+    fun `Should update viewState with selected country, reset state and enable state selection on onCountrySelected`() {
         whenever(dataStore.getCountries()).thenReturn(listOf(location))
         val countryCode = location.code
         addressViewModel.onCountrySelected(countryCode)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModelTest.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.ui.searchfilter
+
+import androidx.lifecycle.Observer
+import com.woocommerce.android.ui.searchfilter.SearchFilterEvent.ItemSelected
+import com.woocommerce.android.ui.searchfilter.SearchFilterViewState.Empty
+import com.woocommerce.android.ui.searchfilter.SearchFilterViewState.Loaded
+import com.woocommerce.android.ui.searchfilter.SearchFilterViewState.Search
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+
+class SearchFilterViewModelTest : BaseUnitTest() {
+
+    private val viewStateObserver: Observer<SearchFilterViewState> = mock()
+
+    private val eventObserver: Observer<SearchFilterEvent> = mock()
+
+    private val searchFilterViewModel = SearchFilterViewModel()
+
+    @Before
+    fun setup() {
+        searchFilterViewModel.viewStateLiveData.observeForever(viewStateObserver)
+        searchFilterViewModel.eventLiveData.observeForever(eventObserver)
+    }
+
+    @Test
+    fun `Should emit Loaded view state when start is called`() {
+        val title = "title"
+        val searchFilterItems = arrayOf(SearchFilterItem("name", "value"))
+        val searchHint = "hint"
+        searchFilterViewModel.start(title, searchFilterItems, searchHint, "requestKey")
+        verify(viewStateObserver, times(1)).onChanged(
+            Loaded(
+                title = title,
+                searchFilterItems = searchFilterItems.toList(),
+                searchHint = searchHint
+            )
+        )
+    }
+
+    @Test
+    fun `Should emit Search view state when onSearch is called and there are results for the query`() {
+        val resultSearchFilterItemName = "name1"
+        val resultSearchFilterItem = SearchFilterItem(resultSearchFilterItemName, "value1")
+        val searchFilterItems = arrayOf(
+            resultSearchFilterItem,
+            SearchFilterItem("name2", "value2"),
+            SearchFilterItem("name3", "value3")
+        )
+        searchFilterViewModel.start("title", searchFilterItems, "hint", "requestKey")
+        searchFilterViewModel.onSearch(resultSearchFilterItemName)
+        verify(viewStateObserver, times(1)).onChanged(
+            Search(
+                searchFilterItems = listOf(resultSearchFilterItem)
+            )
+        )
+    }
+
+    @Test
+    fun `Should emit Empty view state when onSearch is called and there are NO results for the query`() {
+        val query = "query"
+        searchFilterViewModel.start("title", emptyArray(), "hint", "requestKey")
+        searchFilterViewModel.onSearch(query)
+        verify(viewStateObserver, times(1)).onChanged(Empty(query))
+    }
+
+    @Test
+    fun `Should emit ItemSelected event when onItemSelected is called`() {
+        val selectedItem = SearchFilterItem("name", "value")
+        val requestKey = "requestKey"
+        searchFilterViewModel.start("title", emptyArray(), "hint", requestKey)
+        searchFilterViewModel.onItemSelected(selectedItem)
+        verify(eventObserver, times(1)).onChanged(ItemSelected(selectedItem.value, requestKey))
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModelTest.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 class SearchFilterViewModelTest : BaseUnitTest() {
@@ -31,7 +30,7 @@ class SearchFilterViewModelTest : BaseUnitTest() {
         val searchFilterItems = arrayOf(SearchFilterItem("name", "value"))
         val searchHint = "hint"
         searchFilterViewModel.start(searchFilterItems, searchHint, "requestKey")
-        verify(viewStateObserver, times(1)).onChanged(
+        verify(viewStateObserver).onChanged(
             Loaded(
                 searchFilterItems = searchFilterItems.toList(),
                 searchHint = searchHint
@@ -50,7 +49,7 @@ class SearchFilterViewModelTest : BaseUnitTest() {
         )
         searchFilterViewModel.start(searchFilterItems, "hint", "requestKey")
         searchFilterViewModel.onSearch(resultSearchFilterItemName)
-        verify(viewStateObserver, times(1)).onChanged(
+        verify(viewStateObserver).onChanged(
             Search(
                 searchFilterItems = listOf(resultSearchFilterItem)
             )
@@ -62,7 +61,7 @@ class SearchFilterViewModelTest : BaseUnitTest() {
         val query = "query"
         searchFilterViewModel.start(emptyArray(), "hint", "requestKey")
         searchFilterViewModel.onSearch(query)
-        verify(viewStateObserver, times(1)).onChanged(Empty(query))
+        verify(viewStateObserver).onChanged(Empty(query))
     }
 
     @Test
@@ -71,6 +70,6 @@ class SearchFilterViewModelTest : BaseUnitTest() {
         val requestKey = "requestKey"
         searchFilterViewModel.start(emptyArray(), "hint", requestKey)
         searchFilterViewModel.onItemSelected(selectedItem)
-        verify(eventObserver, times(1)).onChanged(ItemSelected(selectedItem.value, requestKey))
+        verify(eventObserver).onChanged(ItemSelected(selectedItem.value, requestKey))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModelTest.kt
@@ -28,13 +28,11 @@ class SearchFilterViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should emit Loaded view state when start is called`() {
-        val title = "title"
         val searchFilterItems = arrayOf(SearchFilterItem("name", "value"))
         val searchHint = "hint"
-        searchFilterViewModel.start(title, searchFilterItems, searchHint, "requestKey")
+        searchFilterViewModel.start(searchFilterItems, searchHint, "requestKey")
         verify(viewStateObserver, times(1)).onChanged(
             Loaded(
-                title = title,
                 searchFilterItems = searchFilterItems.toList(),
                 searchHint = searchHint
             )
@@ -50,7 +48,7 @@ class SearchFilterViewModelTest : BaseUnitTest() {
             SearchFilterItem("name2", "value2"),
             SearchFilterItem("name3", "value3")
         )
-        searchFilterViewModel.start("title", searchFilterItems, "hint", "requestKey")
+        searchFilterViewModel.start(searchFilterItems, "hint", "requestKey")
         searchFilterViewModel.onSearch(resultSearchFilterItemName)
         verify(viewStateObserver, times(1)).onChanged(
             Search(
@@ -62,7 +60,7 @@ class SearchFilterViewModelTest : BaseUnitTest() {
     @Test
     fun `Should emit Empty view state when onSearch is called and there are NO results for the query`() {
         val query = "query"
-        searchFilterViewModel.start("title", emptyArray(), "hint", "requestKey")
+        searchFilterViewModel.start(emptyArray(), "hint", "requestKey")
         searchFilterViewModel.onSearch(query)
         verify(viewStateObserver, times(1)).onChanged(Empty(query))
     }
@@ -71,7 +69,7 @@ class SearchFilterViewModelTest : BaseUnitTest() {
     fun `Should emit ItemSelected event when onItemSelected is called`() {
         val selectedItem = SearchFilterItem("name", "value")
         val requestKey = "requestKey"
-        searchFilterViewModel.start("title", emptyArray(), "hint", requestKey)
+        searchFilterViewModel.start(emptyArray(), "hint", requestKey)
         searchFilterViewModel.onItemSelected(selectedItem)
         verify(eventObserver, times(1)).onChanged(ItemSelected(selectedItem.value, requestKey))
     }


### PR DESCRIPTION
This is a raw clone of https://github.com/RenanLukas/woocommerce-android/pull/1. Please see it for related discussions and code reviews.

cc: @RenanLukas @nbradbury 

 # Implement search for country/state on address editing screen
 Closes: [woocommerce#4956](https://github.com/woocommerce/woocommerce-android/issues/4956)
 
 ### Description
 Implements a search feature for country and state selection on the address editing screen. Currently we have a Dialog for this selection, and user has to scroll to find the desired option. With the search filtering the items it is possible to find an option faster than scrolling.
 
 It seems that we were allowing user to tap on the state selection even if country was empty. I've disabled the option to select state until country is fulfilled, but if this was on purpose I'll revert the commit ([e3cbcbd](https://github.com/RenanLukas/woocommerce-android/commit/e3cbcbd6fca61bda11e9f1ee2eccbb3ace117bae)).
 
 ### Testing instructions
 1 - Login with an user that has at least one order of a physical product in any status (the order must contain a physical product in order to test all the scenarios); 
 2 - Navigate to "Orders" screen and tap on any order to open details;
 
 **To test billing address** 
 3 - Tap on "Add Billing Address" or the edit button if the address is already filled. 
 4 - Tap on "Country" to open search filter for country. Select a country; 
 5 - Tap on "State" to open search filter for state. Select a state; 
 6 - Tap on "Done" to update the address with the selected options.
 
 **To test shipping address** 
 3 - Tap on "Add Shipping Address" or the edit button if the address is already filled. 
 4 - Tap on "Country" to open search filter for country. Select a country; 
 5 - Tap on "State" to open search filter for state. Select a state; 
 6 - Tap on "Done" to update the address with the selected options.
 
 ### Images/gif
 #### State disabled
<img alt="State disabled" width="250" src="https://user-images.githubusercontent.com/14964993/140660246-e1a5b2d4-a6ee-4bbd-b734-ed45c7ae6a36.png"> <img alt="State disabled (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661178-cbfecca0-c40f-484c-b102-3bffcc6b54c3.png">
 
#### Searching for country
<img alt="Searching for country" width="250" src="https://user-images.githubusercontent.com/14964993/140660250-0d1574a5-a414-491b-878f-3a07274f635d.png"> <img alt="Searching for country" width="250" src="https://user-images.githubusercontent.com/14964993/140661235-66100ea3-10a5-49f5-b9a7-10665373f593.png">
 
 #### Search country with 3 results
 <img alt="Search country with 3 results" width="250" src="https://user-images.githubusercontent.com/14964993/140660257-7c4fef1d-ca3a-4dbd-9c98-b18acfce0aed.png"> <img alt="Search country with 3 results (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661251-3b066034-d320-4c56-9e1d-dcc6d23cc37d.png">
 
 #### Search country with 1 result
 <img alt="Search country with 1 result" width="250" src="https://user-images.githubusercontent.com/14964993/140660627-cf894448-fd77-4604-aacf-7c7f48fe1a8c.png"> <img alt="Search country with 1 result (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661266-ba389875-49fb-44fa-8990-3ba4c6c524ce.png">
 
 #### Search empty state
<img alt="Search empty state" width="250" src="https://user-images.githubusercontent.com/14964993/140660278-0a4b8187-7597-45e1-ad63-d741208a7e91.png"> <img alt="Search empty state (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661274-4cd3441d-0bc3-4779-b35f-0d8ffbf3b679.png">
 
 #### Country selected
 <img alt="Country selected" width="250" src="https://user-images.githubusercontent.com/14964993/140660299-5c99668a-3e4e-41ab-8352-6d7553faa5c3.png"> <img alt="Country selected (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661293-e9af0017-941e-4cae-ba0b-c234220fdf15.png">
 
 #### State enabled
 <img alt="State enabled" width="250" src="https://user-images.githubusercontent.com/14964993/140660309-c4c271be-7019-496b-94d0-5ec42c7443c4.png"> <img alt="State enabled (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661310-bb03a78d-b92b-4a2c-88cf-1ae3e456a5e3.png">
 
 #### Search state
 <img alt="Search state" width="250" src="https://user-images.githubusercontent.com/14964993/140660316-00d1eca6-bd90-4341-95bb-b83f5bce38d0.png"> <img alt="Search state (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661389-80f47874-ba79-481d-9a0f-63a8148a9642.png">
 
 #### Search state with 1 result
 <img alt="Search state with 1 result" width="250" src="https://user-images.githubusercontent.com/14964993/140660656-d1b6d844-0496-4918-8b01-04c17752480f.png"> <img alt="Search state with 1 result (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661402-e4959219-04c9-4e92-8598-b653211e0c8f.png">
 
 #### Country and state selected
 <img alt="Country and state selected" width="250" src="https://user-images.githubusercontent.com/14964993/140660330-d600925e-e06c-4861-ba1b-8a56e6a51e69.png"> <img alt="Country and state selected (dark)" width="250" src="https://user-images.githubusercontent.com/14964993/140661424-fd12d148-7fc8-4afd-8c19-58a65375a2f3.png">
 
 * [ ]  I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
