### PR TITLE
Android 12: backup configuration

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
 
     <application
         android:allowBackup="true"
-        android:fullBackupContent="@xml/backup_scheme"
+        android:fullBackupContent="@xml/legacy_backup_scheme"
+        android:dataExtractionRules="@xml/backup_scheme"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/WooCommerce/src/main/res/xml/backup_scheme.xml
+++ b/WooCommerce/src/main/res/xml/backup_scheme.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<full-backup-content>
-  <!--
-   The default sharedPreferences file is com.woocommerce.android_preferences and
-   this file is backed up by default by the system, unless specified otherwise
-   Reference: https://developer.android.com/guide/topics/data/autobackup#define-device-conditions
-   -->
-  <exclude domain="sharedpref" path="com.woocommerce.android_deletable_preferences.xml"/>
-</full-backup-content>
+<data-extraction-rules>
+    <cloud-backup>
+        <!--
+           The default sharedPreferences file is com.woocommerce.android_preferences and
+           this file is backed up by default by the system, unless specified otherwise
+           Reference: https://developer.android.com/guide/topics/data/autobackup#define-device-conditions
+        -->
+        <exclude
+            domain="sharedpref"
+            path="com.woocommerce.android_deletable_preferences.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude
+            domain="sharedpref"
+            path="com.woocommerce.android_deletable_preferences.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/WooCommerce/src/main/res/xml/legacy_backup_scheme.xml
+++ b/WooCommerce/src/main/res/xml/legacy_backup_scheme.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+  <!--
+   The default sharedPreferences file is com.woocommerce.android_preferences and
+   this file is backed up by default by the system, unless specified otherwise
+   Reference: https://developer.android.com/guide/topics/data/autobackup#define-device-conditions
+   -->
+  <exclude domain="sharedpref" path="com.woocommerce.android_deletable_preferences.xml"/>
+</full-backup-content>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5301 

### Description
Apps targetting Android 12 need to follow a new format for configuring backup feature: https://developer.android.com/about/versions/12/behavior-changes-12#new-format, this PR handles this.

### Testing instructions
1. Update targetSdkVersion to 31
2. Switch to the flavor `vanillaDebug`
3. Run the app on an Android 12 device.
4. Check the contents of the directory `/data/data/com.woocommerce.android/shared_prefs` and confirm the existence of the file `com.woocommerce.android_deletable_preferences.xml` (you can use the tab "Device File Explorer" from Android Studio for this)
5. Run the command: `adb shell bmgr backupnow com.woocommerce.android`
6. Run the command `adb shell dumpsys backup` and grab the token of the `Current` section.
7. Run the command `adb shell bmgr restore {token} com.woocommerce.android` where the token is from the last step.
8. Make sure you don't run the app after this last step.
9. Check the contents of the directory `/data/data/com.woocommerce.android/shared_prefs`  and confirm that the file `com.woocommerce.android_deletable_preferences.xml` is not restored.

For more details on the testing steps, check the official guide: https://developer.android.com/guide/topics/data/testingbackup

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
