### PR TITLE
Media Upload: check filename before displaying upload error list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListAdapter.kt
@@ -51,7 +51,9 @@ class MediaUploadErrorListAdapter : RecyclerView.Adapter<MediaUploadErrorListIte
         RecyclerView.ViewHolder(viewBinding.root) {
         fun bind(model: ErrorUiModel) {
             with(model) {
-                viewBinding.mediaFileName.text = fileName
+                if (fileName.isNotBlank()) {
+                    viewBinding.mediaFileName.text = fileName
+                }
                 viewBinding.mediaFileErrorText.text = errorMessage
                 if (filePath.isNotBlank()) {
                     GlideApp.with(viewBinding.root.context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListAdapter.kt
@@ -51,9 +51,7 @@ class MediaUploadErrorListAdapter : RecyclerView.Adapter<MediaUploadErrorListIte
         RecyclerView.ViewHolder(viewBinding.root) {
         fun bind(model: ErrorUiModel) {
             with(model) {
-                if (fileName.isNotBlank()) {
-                    viewBinding.mediaFileName.text = fileName
-                }
+                viewBinding.mediaFileName.text = fileName
                 viewBinding.mediaFileErrorText.text = errorMessage
                 if (filePath.isNotBlank()) {
                     GlideApp.with(viewBinding.root.context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
@@ -75,7 +75,7 @@ class MediaUploadErrorListViewModel @Inject constructor(
         val filePath: String
     ) : Parcelable {
         constructor(state: UploadStatus.Failed) : this(
-            fileName = state.media.fileName,
+            fileName = state.media.fileName ?: "",
             errorMessage = state.mediaErrorMessage,
             filePath = state.media.filePath
         )


### PR DESCRIPTION
Closes: #5126 

### Description
I couldn't reproduce this issue but it is similar to the fix in #4828. There are cases when we might get a null url or fileName when the image upload process has failed. This used to happen in the downloadable files only but since v7.7 this has started occurring in the media upload error screen. We use the filename of the media for display purposes but since the filename is null, the app is crashing.

Since this has been happening for a while, I think we can target `develop` so that this issue will be fixed in the next beta.

### Testing
A small smoke test for image and downloadable file uploads should be enough.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.