### PR TITLE
Navigation: fix crash when restoring state that has custom Parcelable arrays

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
@@ -10,18 +10,23 @@ import java.util.Locale
 object PackageUtils {
     const val PACKAGE_VERSION_CODE_DEFAULT = -1
 
+    private var isTesting: Boolean? = null
+
     /**
      * Return true if Debug build. false otherwise.
      */
     fun isDebugBuild() = BuildConfig.DEBUG
 
     fun isTesting(): Boolean {
-        return try {
-            Class.forName("com.woocommerce.android.viewmodel.BaseUnitTest")
-            true
-        } catch (e: ClassNotFoundException) {
-            false
+        if (isTesting == null) {
+            isTesting = try {
+                Class.forName("com.woocommerce.android.viewmodel.BaseUnitTest")
+                true
+            } catch (e: ClassNotFoundException) {
+                false
+            }
         }
+        return isTesting!!
     }
 
     fun isBetaBuild(context: Context): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
@@ -38,7 +38,6 @@ inline fun <reified Args : NavArgs> SavedStateHandle.navArgs(): Lazy<Args> {
     }
 }
 
-
 /** cache the methods for [NavArgsLazy] to avoid depending on reflection for all invocations **/
 private val methodMap = ArrayMap<KClass<out NavArgs>, Method>()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
@@ -1,28 +1,76 @@
 package com.woocommerce.android.viewmodel
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.annotation.MainThread
+import androidx.collection.ArrayMap
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavArgs
-import androidx.navigation.NavArgsLazy
+import com.woocommerce.android.util.PackageUtils
 import java.io.Serializable
+import java.lang.reflect.Method
+import kotlin.reflect.KClass
+import androidx.navigation.NavArgsLazy as CompatNavArgsLazy
 
 /**
  * The current implementation of `fromSavedStateHandle` can't restore Parcelable[] properly
- * So we'll keep using the old implementation temporarily.
+ * So we'll keep using the old implementation temporarily when not running tests.
  * TODO go back to using `fromSavedStateHandle` when the issue is fixed https://issuetracker.google.com/issues/207315994
  */
 @MainThread
-inline fun <reified Args : NavArgs> SavedStateHandle.navArgs() = NavArgsLazy(Args::class) {
-    val bundle = Bundle()
-    keys().forEach {
-        val value = get<Any>(it)
-        if (value is Serializable?) {
-            bundle.putSerializable(it, value)
-        } else if (value is Parcelable?) {
-            bundle.putParcelable(it, value)
+inline fun <reified Args : NavArgs> SavedStateHandle.navArgs(): Lazy<Args> {
+    return if (PackageUtils.isTesting()) {
+        NavArgsLazy(Args::class, this)
+    } else {
+        CompatNavArgsLazy(Args::class) {
+            val bundle = Bundle()
+            keys().forEach {
+                val value = get<Any>(it)
+                if (value is Serializable?) {
+                    bundle.putSerializable(it, value)
+                } else if (value is Parcelable?) {
+                    bundle.putParcelable(it, value)
+                }
+            }
+            bundle
         }
     }
-    bundle
+}
+
+
+/** cache the methods for [NavArgsLazy] to avoid depending on reflection for all invocations **/
+private val methodMap = ArrayMap<KClass<out NavArgs>, Method>()
+
+/**
+ * An implementation of [Lazy] to retrieve [NavArgs] from the provided [savedStateHandle]
+ *
+ * The implementation is copied from [androidx.navigation.NavArgsLazy]
+ */
+class NavArgsLazy<Args : NavArgs>(
+    private val navArgsClass: KClass<Args>,
+    private val savedStateHandle: SavedStateHandle
+) : Lazy<Args> {
+    private var cached: Args? = null
+
+    override val value: Args
+        get() {
+            var args = cached
+            if (args == null) {
+                val method: Method = methodMap[navArgsClass]
+                    ?: navArgsClass.java.getMethod("fromSavedStateHandle", SavedStateHandle::class.java)
+                        .also { method ->
+                            // Save a reference to the method
+                            methodMap[navArgsClass] = method
+                        }
+
+                @SuppressLint("BanUncheckedReflection") // needed for method.invoke
+                @Suppress("UNCHECKED_CAST")
+                args = method.invoke(null, savedStateHandle) as Args
+                cached = args
+            }
+            return args
+        }
+
+    override fun isInitialized(): Boolean = cached != null
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
@@ -1,48 +1,28 @@
 package com.woocommerce.android.viewmodel
 
-import android.annotation.SuppressLint
+import android.os.Bundle
+import android.os.Parcelable
 import androidx.annotation.MainThread
-import androidx.collection.ArrayMap
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavArgs
-import java.lang.reflect.Method
-import kotlin.reflect.KClass
-
-@MainThread
-inline fun <reified Args : NavArgs> SavedStateHandle.navArgs() = NavArgsLazy(Args::class, this)
-
-/** cache the methods for [NavArgsLazy] to avoid depending on reflection for all invocations **/
-private val methodMap = ArrayMap<KClass<out NavArgs>, Method>()
+import androidx.navigation.NavArgsLazy
+import java.io.Serializable
 
 /**
- * An implementation of [Lazy] to retrieve [NavArgs] from the provided [savedStateHandle]
- *
- * The implementation is copied from [androidx.navigation.NavArgsLazy]
+ * The current implementation of `fromSavedStateHandle` can't restore Parcelable[] properly
+ * So we'll keep using the old implementation temporarily.
+ * TODO go back to using `fromSavedStateHandle` when the issue is fixed https://issuetracker.google.com/issues/207315994
  */
-class NavArgsLazy<Args : NavArgs>(
-    private val navArgsClass: KClass<Args>,
-    private val savedStateHandle: SavedStateHandle
-) : Lazy<Args> {
-    private var cached: Args? = null
-
-    override val value: Args
-        get() {
-            var args = cached
-            if (args == null) {
-                val method: Method = methodMap[navArgsClass]
-                    ?: navArgsClass.java.getMethod("fromSavedStateHandle", SavedStateHandle::class.java)
-                        .also { method ->
-                            // Save a reference to the method
-                            methodMap[navArgsClass] = method
-                        }
-
-                @SuppressLint("BanUncheckedReflection") // needed for method.invoke
-                @Suppress("UNCHECKED_CAST")
-                args = method.invoke(null, savedStateHandle) as Args
-                cached = args
-            }
-            return args
+@MainThread
+inline fun <reified Args : NavArgs> SavedStateHandle.navArgs() = NavArgsLazy(Args::class) {
+    val bundle = Bundle()
+    keys().forEach {
+        val value = get<Any>(it)
+        if (value is Serializable?) {
+            bundle.putSerializable(it, value)
+        } else if (value is Parcelable?) {
+            bundle.putParcelable(it, value)
         }
-
-    override fun isInitialized(): Boolean = cached != null
+    }
+    bundle
 }


### PR DESCRIPTION
### Description
The current version of navigation library generates a function `fromSavedStateHandle` for the generated NavArgs, but it doesn't handle restoration after a process-death properly if one of the arguments is a custom `Parcelable[]`.
To fix the crash, this PR reverts to using `fromBundle` temporarily, and I filed the following issue to have Google fix this https://issuetracker.google.com/issues/207315994 

### Testing instructions
1. Enable "Don't keep activities" from the developer options.
2. Open Product Images screen of on the products.
3. Navigate to another app, then re-open the app.
4. Confirm that the app doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
