### PR TITLE
Jetpack CP: handle fetching media for the Wordpress Media library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-4e694da297aa574ce1f9f8771f89ce2467566c24'
+    fluxCVersion = '2193-0f182a18824098deca26d607d34281ae3a2fa6c3'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2193-0f182a18824098deca26d607d34281ae3a2fa6c3'
+    fluxCVersion = 'develop-c8371d428208b6f3b8b39cbf78a5d90d04b9fd9b'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5305 

### Description
This PR just updates FluxC to point to the changes added by https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2193, to handle fetching media for Jetpack CP sites.

Please don't merge until a `develop` hash commit from FluxC is referenced.

### Testing instructions
1. Please use a Jetpack CP site (A site that has only WCPay without full Jetpack) for testing.
2. Open product details of one product.
2. Click on Add image, and select WordPress Media Library.
3. Confirm that the images have been fetched properly.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
