### PR TITLE
Jetpack CP: Connect UI states with install states

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -2,14 +2,21 @@ package com.woocommerce.android.ui.jetpack
 
 import android.os.Bundle
 import android.view.View
+import android.widget.ImageView
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogJetpackInstallProgressBinding
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.show
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.ui.jetpack.JetpackInstallViewModel.InstallStatus
+import com.woocommerce.android.ui.jetpack.JetpackInstallViewModel.InstallStatus.*
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
@@ -21,7 +28,10 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         private const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.8f
     }
 
-    @Inject lateinit var selectedSite: SelectedSite
+    @Inject
+    lateinit var selectedSite: SelectedSite
+
+    private val viewModel: JetpackInstallViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,7 +52,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
             stringBuilder.append(context.getString(R.string.jetpack_install_start_default_name))
 
             selectedSite.get().name?.let {
-                stringBuilder.append(" <b>${selectedSite.get().name}</b> ",)
+                stringBuilder.append(" <b>${selectedSite.get().name}</b> ")
             }
 
             text = HtmlCompat.fromHtml(
@@ -59,6 +69,10 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
 
         // Temporary animation for testing the UI. Replace with actual animation when it's ready.
         WooAnimUtils.rotate(binding.secondStepIcon)
+
+        viewModel.installJetpackPlugin()
+
+        setupObservers(binding)
     }
 
     override fun onStart() {
@@ -70,6 +84,65 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
             )
         }
     }
+
+    private fun setupObservers(binding: DialogJetpackInstallProgressBinding) {
+        viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
+            new.installStatus?.takeIfNotEqualTo(old?.installStatus) {
+                updateInstallProgressUi(it, binding)
+            }
+        }
+    }
+
+    private fun updateInstallProgressUi(status: InstallStatus, binding: DialogJetpackInstallProgressBinding) {
+        val iconStart = R.drawable.ic_progress_circle_start
+        val iconComplete = R.drawable.ic_progress_circle_complete
+        when (status) {
+            is Installing -> {
+                binding.firstStepIcon.hide()
+                setImageViews(iconStart, binding.secondStepIcon, binding.thirdStepIcon, binding.fourthStepIcon)
+
+                // TODO Show loader on first step, hide all other loaders
+            }
+            is Activating -> {
+                binding.firstStepIcon.show()
+                binding.secondStepIcon.hide()
+                setImageViews(iconComplete, binding.firstStepIcon)
+                setImageViews(iconStart, binding.thirdStepIcon, binding.fourthStepIcon)
+
+                // TODO Show loader on second step, hide all other loaders
+            }
+            is Connecting -> {
+                binding.firstStepIcon.show()
+                binding.secondStepIcon.show()
+                binding.thirdStepIcon.hide()
+                setImageViews(iconComplete, binding.firstStepIcon, binding.secondStepIcon)
+                setImageViews(iconStart, binding.fourthStepIcon)
+
+                // TODO Show loader on third step, hide all other loaders
+            }
+            is Finished -> {
+                binding.firstStepIcon.show()
+                binding.secondStepIcon.show()
+                binding.thirdStepIcon.show()
+                setImageViews(
+                    iconComplete,
+                    binding.firstStepIcon,
+                    binding.secondStepIcon,
+                    binding.thirdStepIcon,
+                    binding.fourthStepIcon
+                )
+
+                // TODO Hide all loader
+
+                binding.jetpackProgressActionButton.isEnabled = true
+            }
+            is Failed -> {
+                // TODO Add error state
+            }
+        }
+    }
+
+    private fun setImageViews(resId: Int, vararg views: ImageView) = views.forEach { it.setImageResource(resId) }
 
     private fun isTabletLandscape() = (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) &&
         DisplayUtils.isLandscape(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -67,8 +67,6 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
             )
         }
 
-        viewModel.installJetpackPlugin()
-
         setupObservers(binding)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.ui.jetpack.JetpackInstallViewModel.InstallStatus
 import com.woocommerce.android.ui.jetpack.JetpackInstallViewModel.InstallStatus.*
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,8 +27,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         private const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.8f
     }
 
-    @Inject
-    lateinit var selectedSite: SelectedSite
+    @Inject lateinit var selectedSite: SelectedSite
 
     private val viewModel: JetpackInstallViewModel by viewModels()
 
@@ -67,9 +65,6 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
             )
         }
 
-        // Temporary animation for testing the UI. Replace with actual animation when it's ready.
-        WooAnimUtils.rotate(binding.secondStepIcon)
-
         viewModel.installJetpackPlugin()
 
         setupObservers(binding)
@@ -94,47 +89,46 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
     }
 
     private fun updateInstallProgressUi(status: InstallStatus, binding: DialogJetpackInstallProgressBinding) {
-        val iconStart = R.drawable.ic_progress_circle_start
-        val iconComplete = R.drawable.ic_progress_circle_complete
+        val iconNotDone = R.drawable.ic_progress_circle_start
+        val iconDone = R.drawable.ic_progress_circle_complete
+        val iconStep1 = binding.firstStepIcon
+        val iconStep2 = binding.secondStepIcon
+        val iconStep3 = binding.thirdStepIcon
+        val iconStep4 = binding.fourthStepIcon
+        val progressStep1 = binding.firstStepProgressBar
+        val progressStep2 = binding.secondStepProgressBar
+        val progressStep3 = binding.thirdStepProgressBar
+
         when (status) {
             is Installing -> {
-                binding.firstStepIcon.hide()
-                setImageViews(iconStart, binding.secondStepIcon, binding.thirdStepIcon, binding.fourthStepIcon)
+                setViewsVisibility(View.INVISIBLE, iconStep1, progressStep2, progressStep3)
+                setViewsVisibility(View.VISIBLE, iconStep2, iconStep3, iconStep4, progressStep1)
+                setImageViews(iconNotDone, iconStep2, iconStep3, iconStep4)
 
-                // TODO Show loader on first step, hide all other loaders
+                binding.jetpackProgressActionButton.hide()
             }
             is Activating -> {
-                binding.firstStepIcon.show()
-                binding.secondStepIcon.hide()
-                setImageViews(iconComplete, binding.firstStepIcon)
-                setImageViews(iconStart, binding.thirdStepIcon, binding.fourthStepIcon)
+                setViewsVisibility(View.INVISIBLE, iconStep2, progressStep1, progressStep3)
+                setViewsVisibility(View.VISIBLE, iconStep1, iconStep3, iconStep4, progressStep2)
+                setImageViews(iconNotDone, iconStep3, iconStep4)
+                setImageViews(iconDone, iconStep1)
 
-                // TODO Show loader on second step, hide all other loaders
+                binding.jetpackProgressActionButton.hide()
             }
             is Connecting -> {
-                binding.firstStepIcon.show()
-                binding.secondStepIcon.show()
-                binding.thirdStepIcon.hide()
-                setImageViews(iconComplete, binding.firstStepIcon, binding.secondStepIcon)
-                setImageViews(iconStart, binding.fourthStepIcon)
+                setViewsVisibility(View.INVISIBLE, iconStep3, progressStep1, progressStep2)
+                setViewsVisibility(View.VISIBLE, iconStep1, iconStep2, iconStep4, progressStep3)
+                setImageViews(iconNotDone, iconStep4)
+                setImageViews(iconDone, iconStep1, iconStep2)
 
-                // TODO Show loader on third step, hide all other loaders
+                binding.jetpackProgressActionButton.hide()
             }
             is Finished -> {
-                binding.firstStepIcon.show()
-                binding.secondStepIcon.show()
-                binding.thirdStepIcon.show()
-                setImageViews(
-                    iconComplete,
-                    binding.firstStepIcon,
-                    binding.secondStepIcon,
-                    binding.thirdStepIcon,
-                    binding.fourthStepIcon
-                )
+                setViewsVisibility(View.INVISIBLE, progressStep1, progressStep2, progressStep3)
+                setViewsVisibility(View.VISIBLE, iconStep1, iconStep2, iconStep3, iconStep4)
+                setImageViews(iconDone, iconStep1, iconStep2, iconStep3, iconStep4)
 
-                // TODO Hide all loader
-
-                binding.jetpackProgressActionButton.isEnabled = true
+                binding.jetpackProgressActionButton.show()
             }
             is Failed -> {
                 // TODO Add error state
@@ -142,6 +136,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         }
     }
 
+    private fun setViewsVisibility(visibility: Int, vararg views: View) = views.forEach { it.visibility = visibility }
     private fun setImageViews(resId: Int, vararg views: ImageView) = views.forEach { it.setImageResource(resId) }
 
     private fun isTabletLandscape() = (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -107,38 +107,38 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
 
         when (status) {
             is Installing -> {
-                setViewsVisibility(View.INVISIBLE, iconStep1, progressStep2, progressStep3)
-                setViewsVisibility(View.VISIBLE, iconStep2, iconStep3, iconStep4, progressStep1)
-                setImageViews(iconNotDone, iconStep2, iconStep3, iconStep4)
+                setViewVisibility(View.INVISIBLE, iconStep1, progressStep2, progressStep3)
+                setViewVisibility(View.VISIBLE, iconStep2, iconStep3, iconStep4, progressStep1)
+                setViewImage(iconNotDone, iconStep2, iconStep3, iconStep4)
                 setTextWeight(Typeface.BOLD, messageStep1)
                 setTextWeight(Typeface.NORMAL, messageStep2, messageStep3, messageStep4)
 
                 binding.jetpackProgressActionButton.hide()
             }
             is Activating -> {
-                setViewsVisibility(View.INVISIBLE, iconStep2, progressStep1, progressStep3)
-                setViewsVisibility(View.VISIBLE, iconStep1, iconStep3, iconStep4, progressStep2)
-                setImageViews(iconNotDone, iconStep3, iconStep4)
-                setImageViews(iconDone, iconStep1)
+                setViewVisibility(View.INVISIBLE, iconStep2, progressStep1, progressStep3)
+                setViewVisibility(View.VISIBLE, iconStep1, iconStep3, iconStep4, progressStep2)
+                setViewImage(iconNotDone, iconStep3, iconStep4)
+                setViewImage(iconDone, iconStep1)
                 setTextWeight(Typeface.BOLD, messageStep1, messageStep2)
                 setTextWeight(Typeface.NORMAL, messageStep3, messageStep4)
 
                 binding.jetpackProgressActionButton.hide()
             }
             is Connecting -> {
-                setViewsVisibility(View.INVISIBLE, iconStep3, progressStep1, progressStep2)
-                setViewsVisibility(View.VISIBLE, iconStep1, iconStep2, iconStep4, progressStep3)
-                setImageViews(iconNotDone, iconStep4)
-                setImageViews(iconDone, iconStep1, iconStep2)
+                setViewVisibility(View.INVISIBLE, iconStep3, progressStep1, progressStep2)
+                setViewVisibility(View.VISIBLE, iconStep1, iconStep2, iconStep4, progressStep3)
+                setViewImage(iconNotDone, iconStep4)
+                setViewImage(iconDone, iconStep1, iconStep2)
                 setTextWeight(Typeface.BOLD, messageStep1, messageStep2, messageStep3)
                 setTextWeight(Typeface.NORMAL, messageStep4)
 
                 binding.jetpackProgressActionButton.hide()
             }
             is Finished -> {
-                setViewsVisibility(View.INVISIBLE, progressStep1, progressStep2, progressStep3)
-                setViewsVisibility(View.VISIBLE, iconStep1, iconStep2, iconStep3, iconStep4)
-                setImageViews(iconDone, iconStep1, iconStep2, iconStep3, iconStep4)
+                setViewVisibility(View.INVISIBLE, progressStep1, progressStep2, progressStep3)
+                setViewVisibility(View.VISIBLE, iconStep1, iconStep2, iconStep3, iconStep4)
+                setViewImage(iconDone, iconStep1, iconStep2, iconStep3, iconStep4)
                 setTextWeight(Typeface.BOLD, messageStep1, messageStep2, messageStep3, messageStep4)
 
                 binding.jetpackProgressActionButton.show()
@@ -149,8 +149,8 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         }
     }
 
-    private fun setViewsVisibility(visibility: Int, vararg views: View) = views.forEach { it.visibility = visibility }
-    private fun setImageViews(resId: Int, vararg views: ImageView) = views.forEach { it.setImageResource(resId) }
+    private fun setViewVisibility(visibility: Int, vararg views: View) = views.forEach { it.visibility = visibility }
+    private fun setViewImage(resId: Int, vararg views: ImageView) = views.forEach { it.setImageResource(resId) }
     private fun setTextWeight(weight: Int, vararg views: TextView) = views.forEach { it.setTypeface(null, weight) }
 
     private fun isTabletLandscape() = (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.jetpack
 
+import android.graphics.Typeface
 import android.os.Bundle
 import android.view.View
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -98,12 +100,18 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         val progressStep1 = binding.firstStepProgressBar
         val progressStep2 = binding.secondStepProgressBar
         val progressStep3 = binding.thirdStepProgressBar
+        val messageStep1 = binding.firstStepMessage
+        val messageStep2 = binding.secondStepMessage
+        val messageStep3 = binding.thirdStepMessage
+        val messageStep4 = binding.fourthStepMessage
 
         when (status) {
             is Installing -> {
                 setViewsVisibility(View.INVISIBLE, iconStep1, progressStep2, progressStep3)
                 setViewsVisibility(View.VISIBLE, iconStep2, iconStep3, iconStep4, progressStep1)
                 setImageViews(iconNotDone, iconStep2, iconStep3, iconStep4)
+                setTextWeight(Typeface.BOLD, messageStep1)
+                setTextWeight(Typeface.NORMAL, messageStep2, messageStep3, messageStep4)
 
                 binding.jetpackProgressActionButton.hide()
             }
@@ -112,6 +120,8 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 setViewsVisibility(View.VISIBLE, iconStep1, iconStep3, iconStep4, progressStep2)
                 setImageViews(iconNotDone, iconStep3, iconStep4)
                 setImageViews(iconDone, iconStep1)
+                setTextWeight(Typeface.BOLD, messageStep1, messageStep2)
+                setTextWeight(Typeface.NORMAL, messageStep3, messageStep4)
 
                 binding.jetpackProgressActionButton.hide()
             }
@@ -120,6 +130,8 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 setViewsVisibility(View.VISIBLE, iconStep1, iconStep2, iconStep4, progressStep3)
                 setImageViews(iconNotDone, iconStep4)
                 setImageViews(iconDone, iconStep1, iconStep2)
+                setTextWeight(Typeface.BOLD, messageStep1, messageStep2, messageStep3)
+                setTextWeight(Typeface.NORMAL, messageStep4)
 
                 binding.jetpackProgressActionButton.hide()
             }
@@ -127,6 +139,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 setViewsVisibility(View.INVISIBLE, progressStep1, progressStep2, progressStep3)
                 setViewsVisibility(View.VISIBLE, iconStep1, iconStep2, iconStep3, iconStep4)
                 setImageViews(iconDone, iconStep1, iconStep2, iconStep3, iconStep4)
+                setTextWeight(Typeface.BOLD, messageStep1, messageStep2, messageStep3, messageStep4)
 
                 binding.jetpackProgressActionButton.show()
             }
@@ -138,6 +151,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
 
     private fun setViewsVisibility(visibility: Int, vararg views: View) = views.forEach { it.visibility = visibility }
     private fun setImageViews(resId: Int, vararg views: ImageView) = views.forEach { it.setImageResource(resId) }
+    private fun setTextWeight(weight: Int, vararg views: TextView) = views.forEach { it.setTypeface(null, weight) }
 
     private fun isTabletLandscape() = (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) &&
         DisplayUtils.isLandscape(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallViewModel.kt
@@ -30,6 +30,8 @@ class JetpackInstallViewModel @Inject constructor(
         viewState = viewState.copy(
             installStatus = Installing
         )
+
+        installJetpackPlugin()
     }
 
     override fun onCleared() {
@@ -37,7 +39,7 @@ class JetpackInstallViewModel @Inject constructor(
         repository.onCleanup()
     }
 
-    fun installJetpackPlugin() {
+    private fun installJetpackPlugin() {
         launch {
             repository.installPlugin(JETPACK_SLUG).collect {
                 when (it) {

--- a/WooCommerce/src/main/res/layout/dialog_jetpack_install_progress.xml
+++ b/WooCommerce/src/main/res/layout/dialog_jetpack_install_progress.xml
@@ -91,7 +91,7 @@
 
             <ProgressBar
                 android:id="@+id/first_step_progress_bar"
-                style="@style/Woo.ProgressBar"
+                style="@style/Woo.JetpackProgressBar"
                 android:layout_width="@dimen/image_minor_60"
                 android:layout_height="@dimen/image_minor_60"
                 android:layout_marginTop="@dimen/major_200"
@@ -125,7 +125,7 @@
 
             <ProgressBar
                 android:id="@+id/second_step_progress_bar"
-                style="@style/Woo.ProgressBar"
+                style="@style/Woo.JetpackProgressBar"
                 android:layout_width="@dimen/image_minor_60"
                 android:layout_height="@dimen/image_minor_60"
                 android:layout_marginTop="@dimen/major_125"
@@ -158,7 +158,7 @@
 
             <ProgressBar
                 android:id="@+id/third_step_progress_bar"
-                style="@style/Woo.ProgressBar"
+                style="@style/Woo.JetpackProgressBar"
                 android:layout_width="@dimen/image_minor_60"
                 android:layout_height="@dimen/image_minor_60"
                 android:layout_marginTop="@dimen/major_125"

--- a/WooCommerce/src/main/res/layout/dialog_jetpack_install_progress.xml
+++ b/WooCommerce/src/main/res/layout/dialog_jetpack_install_progress.xml
@@ -86,7 +86,18 @@
                 android:src="@drawable/ic_progress_circle_complete"
                 android:layout_marginTop="@dimen/major_200"
                 app:layout_constraintStart_toStartOf="@id/jetpack_progress_guideline_start"
-                app:layout_constraintTop_toBottomOf="@id/subtitle" />
+                app:layout_constraintTop_toBottomOf="@id/subtitle"
+                android:visibility="visible" />
+
+            <ProgressBar
+                android:id="@+id/first_step_progress_bar"
+                style="@style/Woo.ProgressBar"
+                android:layout_width="@dimen/image_minor_60"
+                android:layout_height="@dimen/image_minor_60"
+                android:layout_marginTop="@dimen/major_200"
+                app:layout_constraintStart_toStartOf="@id/jetpack_progress_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/subtitle"
+                android:visibility="invisible"/>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/first_step_message"
@@ -109,7 +120,18 @@
                 android:src="@drawable/ic_progress_circle_loading"
                 android:layout_marginTop="@dimen/major_125"
                 app:layout_constraintStart_toStartOf="@id/jetpack_progress_guideline_start"
-                app:layout_constraintTop_toBottomOf="@id/first_step_icon" />
+                app:layout_constraintTop_toBottomOf="@id/first_step_icon"
+                android:visibility="invisible"/>
+
+            <ProgressBar
+                android:id="@+id/second_step_progress_bar"
+                style="@style/Woo.ProgressBar"
+                android:layout_width="@dimen/image_minor_60"
+                android:layout_height="@dimen/image_minor_60"
+                android:layout_marginTop="@dimen/major_125"
+                app:layout_constraintStart_toStartOf="@id/jetpack_progress_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/first_step_icon"
+                android:visibility="visible"/>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/second_step_message"
@@ -133,6 +155,16 @@
                 android:layout_marginTop="@dimen/major_125"
                 app:layout_constraintStart_toStartOf="@id/jetpack_progress_guideline_start"
                 app:layout_constraintTop_toBottomOf="@id/second_step_icon" />
+
+            <ProgressBar
+                android:id="@+id/third_step_progress_bar"
+                style="@style/Woo.ProgressBar"
+                android:layout_width="@dimen/image_minor_60"
+                android:layout_height="@dimen/image_minor_60"
+                android:layout_marginTop="@dimen/major_125"
+                app:layout_constraintStart_toStartOf="@id/jetpack_progress_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/second_step_icon"
+                android:visibility="invisible"/>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/third_step_message"

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -121,6 +121,7 @@
     Jetpack plugin installation dialog
     -->
     <color name="jetpack_button_color">@color/woo_white</color>
+    <color name="jetpack_install_progressbar">@color/woo_white</color>
 
     <color name="reader_update_progress_color">@color/woo_purple_40</color>
     <color name="reader_update_rest_color">@color/woo_purple_20</color>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -173,6 +173,7 @@
     Jetpack plugin installation dialog
     -->
     <color name="jetpack_button_color">@color/color_secondary</color>
+    <color name="jetpack_install_progressbar">@color/jetpack_green_40</color>
 
     <color name="reader_update_progress_color">@color/woo_purple_50</color>
     <color name="reader_update_rest_color">@color/woo_purple_30</color>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -625,6 +625,12 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:indeterminateTintMode">src_in</item>
     </style>
 
+    <style name="Woo.JetpackProgressBar" parent="Widget.AppCompat.ProgressBar">
+        <item name="android:indeterminateTint">@color/jetpack_install_progressbar</item>
+        <item name="android:indeterminateTintMode">src_in</item>
+    </style>
+
+
     <!--
         TagView Style
     -->

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -57,5 +57,6 @@
     <color name="woo_black_900">#272727</color>
     <color name="woo_black_80">#363636</color>
 
+    <color name="jetpack_green_40">#069e08</color>
     <color name="jetpack_black">#0B2621</color>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallViewModelTest.kt
@@ -1,25 +1,28 @@
 package com.woocommerce.android.ui.jetpack
 
 import androidx.lifecycle.SavedStateHandle
-import org.mockito.kotlin.any
-import org.mockito.kotlin.whenever
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.jetpack.JetpackInstallViewModel.InstallStatus.*
+import com.woocommerce.android.ui.jetpack.PluginRepository.PluginStatus
 import com.woocommerce.android.ui.jetpack.PluginRepository.PluginStatus.*
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.model.SiteModel
 
 @ExperimentalCoroutinesApi
 class JetpackInstallViewModelTest : BaseUnitTest() {
     private val savedState: SavedStateHandle = SavedStateHandle()
-    private val pluginRepository: PluginRepository = mock()
+    private val installationStateFlow = MutableSharedFlow<PluginStatus>(extraBufferCapacity = Int.MAX_VALUE)
+    private val pluginRepository: PluginRepository = mock {
+        on { installPlugin(any()) } doReturn installationStateFlow
+    }
     private val siteModel: SiteModel = mock()
     private lateinit var viewModel: JetpackInstallViewModel
 
@@ -27,7 +30,6 @@ class JetpackInstallViewModelTest : BaseUnitTest() {
         const val EXAMPLE_SLUG = "plugin-slug"
         const val EXAMPLE_NAME = "plugin-name"
         const val EXAMPLE_ERROR = "error-message"
-        const val CONNECTION_DELAY = 1000L
     }
 
     @Before
@@ -40,22 +42,14 @@ class JetpackInstallViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when installation is successful, then set proper install states`() = testBlocking {
-        whenever(pluginRepository.installPlugin(any()))
-            .thenReturn(
-                flow {
-                    emit(PluginInstalled(EXAMPLE_SLUG, siteModel))
-                    emit(PluginActivated(EXAMPLE_NAME, siteModel))
-                }
-            )
         val installStates = mutableListOf<JetpackInstallViewModel.InstallStatus>()
         viewModel.viewStateLiveData.observeForever { old, new ->
             new.installStatus?.takeIfNotEqualTo(old?.installStatus) { installStates.add(it) }
         }
 
-        viewModel.installJetpackPlugin()
-
-        // delay needed because between Connecting -> Finished steps there's an introduced delay.
-        delay(CONNECTION_DELAY)
+        installationStateFlow.tryEmit(PluginInstalled(EXAMPLE_SLUG, siteModel))
+        installationStateFlow.tryEmit(PluginActivated(EXAMPLE_NAME, siteModel))
+        advanceUntilIdle()
 
         Assertions.assertThat(installStates).containsExactly(
             Installing,
@@ -67,18 +61,13 @@ class JetpackInstallViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when installation is failed, then set failed state`() = testBlocking {
-        whenever(pluginRepository.installPlugin(any()))
-            .thenReturn(
-                flow {
-                    emit(PluginInstallFailed(EXAMPLE_ERROR))
-                }
-            )
         val installStates = mutableListOf<JetpackInstallViewModel.InstallStatus>()
         viewModel.viewStateLiveData.observeForever { old, new ->
             new.installStatus?.takeIfNotEqualTo(old?.installStatus) { installStates.add(it) }
         }
 
-        viewModel.installJetpackPlugin()
+        installationStateFlow.tryEmit(PluginInstallFailed(EXAMPLE_ERROR))
+        advanceUntilIdle()
 
         Assertions.assertThat(installStates).contains(
             Failed(EXAMPLE_ERROR)
@@ -87,19 +76,13 @@ class JetpackInstallViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when activation is failed, then set failed state`() = testBlocking {
-        whenever(pluginRepository.installPlugin(any()))
-            .thenReturn(
-                flow {
-                    emit(PluginInstalled(EXAMPLE_SLUG, siteModel))
-                    emit(PluginActivationFailed(EXAMPLE_ERROR))
-                }
-            )
         val installStates = mutableListOf<JetpackInstallViewModel.InstallStatus>()
         viewModel.viewStateLiveData.observeForever { old, new ->
             new.installStatus?.takeIfNotEqualTo(old?.installStatus) { installStates.add(it) }
         }
 
-        viewModel.installJetpackPlugin()
+        installationStateFlow.tryEmit(PluginActivationFailed(EXAMPLE_ERROR))
+        advanceUntilIdle()
 
         Assertions.assertThat(installStates).contains(
             Failed(EXAMPLE_ERROR)


### PR DESCRIPTION
# Description
This is the third part for the "Jetpack CP: Install Jetpack from app" feature: #4865. 

This PR connects [the previous repo/vm work](https://github.com/woocommerce/woocommerce-android/pull/5287) to the UI so that it reflects the state of actual installation progress.

# Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Two possible ways to test:

**A. To test UI without doing actual install**
Apply [the patch here](https://gist.github.com/hafizrahman/ea844bc3259245fd7d24c93d7a91eea5). The patch simulates the various states of a successful install. Then continue below:

1. Start with a JCP site (install WooCommerce and Woo Payment only on a site, then active Woo Payment and connect it to a WordPress.com account),
2. Tap the bottom Jetpack banner on the "My Store" screen,
3. Tap "Install Jetpack" on the dialog that appears,
4. Tap "Install Jetpack" on the next dialog,
5. This will show the whole install progress. See that each steps start with loading/progress bar, then ends with check icon, and continues to the next steps.
6. Ensure that "Done" button is shown after all steps are done.
7. You can go back and then tap "Install Jetpack" again to test again (check in light/dark mode, different orientations, etc.).

**B. To test UI with actual plugin install**
Optional but highly recommended: go to `JetpackInstallViewModel` and replace `const val JETPACK_SLUG = "jetpack"` with `const val JETPACK_SLUG = "SOMETHING_ELSE"`, where `SOMETHING_ELSE` is the slug of any random plugin [in the repository](https://wordpress.org/plugins/). If you install Jetpack to your test site, you can't use it again for JCP site testing, so might be better to test with different plugins instead.
1. Start with a JCP site (install WooCommerce and Woo Payment only on a site, then active Woo Payment and connect it to a WordPress.com account),
2. Tap the bottom Jetpack banner on the "My Store" screen,
3. Tap "Install Jetpack" on the dialog that appears,
4. Tap "Install Jetpack" on the next dialog,
5. This will show the whole install progress. See that each steps start with loading/progress bar, then ends with check icon, and continues to the next steps.
6. Ensure that "Done" button is shown after all steps are done.
7. Check the store's wp-admin and confirm that the plugin you added is installed and activated.
8. To test again, you'll have to modify `JETPACK_SLUG` with a different plugin slug, rebuild, and start over.

# Not included in this PR
Things that happen after successful or failure attempt is not added yet. So, tapping "Done" button will not do anything yet, and if actual plugin install fails, no error will show up. This will be handled in a future PR.

# Demo video

https://user-images.githubusercontent.com/266376/143177542-bb961d75-2d86-4f7a-a0a1-bd6b4482e4a8.mp4


