### PR TITLE
Android 12: migrate to WindowMetrics API

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -297,9 +297,7 @@ dependencies {
     implementation("${gradle.ext.mediaPickerBinaryPath}:$mediapickerVersion") {
         exclude group: "org.wordpress", module: "utils"
     }
-    implementation("${gradle.ext.mediaPickerSourceDeviceBinaryPath}:$mediapickerVersion") {
-        exclude group: "org.wordpress", module: "utils"
-    }
+    implementation("${gradle.ext.mediaPickerSourceDeviceBinaryPath}:$mediapickerVersion")
 }
 
 task copyGoogleServicesExampleFile(type: Copy) {

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -294,8 +294,12 @@ dependencies {
 
     implementation "com.tinder.statemachine:statemachine:$stateMachineVersion"
 
-    implementation("${gradle.ext.mediaPickerBinaryPath}:$mediapickerVersion")
-    implementation("${gradle.ext.mediaPickerSourceDeviceBinaryPath}:$mediapickerVersion")
+    implementation("${gradle.ext.mediaPickerBinaryPath}:$mediapickerVersion") {
+        exclude group: "org.wordpress", module: "utils"
+    }
+    implementation("${gradle.ext.mediaPickerSourceDeviceBinaryPath}:$mediapickerVersion") {
+        exclude group: "org.wordpress", module: "utils"
+    }
 }
 
 task copyGoogleServicesExampleFile(type: Copy) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackBenefitsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackBenefitsDialog.kt
@@ -44,8 +44,8 @@ class JetpackBenefitsDialog : DialogFragment(R.layout.dialog_jetpack_benefits) {
         super.onStart()
         if (isTabletLandscape()) {
             requireDialog().window!!.setLayout(
-                (DisplayUtils.getDisplayPixelWidth() * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getDisplayPixelHeight(context) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
+                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -65,8 +65,8 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         super.onStart()
         if (isTabletLandscape()) {
             requireDialog().window!!.setLayout(
-                (DisplayUtils.getDisplayPixelWidth() * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getDisplayPixelHeight(context) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
+                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallStartDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallStartDialog.kt
@@ -59,8 +59,8 @@ class JetpackInstallStartDialog : DialogFragment(R.layout.dialog_jetpack_install
         super.onStart()
         if (isTabletLandscape()) {
             requireDialog().window!!.setLayout(
-                (DisplayUtils.getDisplayPixelWidth() * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getDisplayPixelHeight(context) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
+                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueViewPagerItemFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueViewPagerItemFragment.kt
@@ -54,9 +54,9 @@ class LoginPrologueViewPagerItemFragment : Fragment(R.layout.fragment_login_prol
 
             // adjust the view sizes based on orientation
             val ratio = if (isLandscape) {
-                (DisplayUtils.getDisplayPixelWidth() * RATIO_LANDSCAPE).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * RATIO_LANDSCAPE).toInt()
             } else {
-                (DisplayUtils.getDisplayPixelWidth() * RATIO_PORTRAIT).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * RATIO_PORTRAIT).toInt()
             }
             binding.textView.layoutParams.width = ratio
             binding.imageView.layoutParams.width = ratio

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
@@ -37,8 +37,8 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
         requireDialog().window?.let { window ->
             window.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
             window.setLayout(
-                (DisplayUtils.getDisplayPixelWidth() * WIDTH_RATIO).toInt(),
-                (DisplayUtils.getDisplayPixelHeight(context) * HEIGHT_RATIO).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * WIDTH_RATIO).toInt(),
+                (DisplayUtils.getWindowPixelHeight(requireContext()) * HEIGHT_RATIO).toInt()
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -54,8 +54,8 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
         super.onStart()
         if (isTabletLandscape()) {
             dialog?.window?.setLayout(
-                (DisplayUtils.getDisplayPixelWidth() * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getDisplayPixelHeight(context) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
+                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -94,10 +94,10 @@ class WPMediaGalleryView @JvmOverloads constructor(
         val borderRadius = context.resources.getDimensionPixelSize(R.dimen.corner_radius_small)
         glideTransform = RequestOptions.bitmapTransform(RoundedCorners(borderRadius))
 
-        // base the image size on the screen width divided by columns, taking margin into account
-        val screenWidth = DisplayUtils.getWindowPixelWidth(context)
+        // base the image size on the app's window width divided by columns, taking margin into account
+        val windowWidth = DisplayUtils.getWindowPixelWidth(context)
         val margin = context.resources.getDimensionPixelSize(R.dimen.minor_25)
-        imageSize = (screenWidth / NUM_COLUMNS) - (margin * NUM_COLUMNS)
+        imageSize = (windowWidth / NUM_COLUMNS) - (margin * NUM_COLUMNS)
     }
 
     fun showImages(images: List<Product.Image>, listener: WPMediaGalleryListener, isMultiSelectionAllowed: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -95,7 +95,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
         glideTransform = RequestOptions.bitmapTransform(RoundedCorners(borderRadius))
 
         // base the image size on the screen width divided by columns, taking margin into account
-        val screenWidth = DisplayUtils.getDisplayPixelWidth(context)
+        val screenWidth = DisplayUtils.getWindowPixelWidth(context)
         val margin = context.resources.getDimensionPixelSize(R.dimen.minor_25)
         imageSize = (screenWidth / NUM_COLUMNS) - (margin * NUM_COLUMNS)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -132,10 +132,10 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         glideTransform = RequestOptions.bitmapTransform(RoundedCorners(borderRadius))
 
         imageSize = if (isGridView) {
-            val screenWidth = DisplayUtils.getWindowPixelWidth(context)
+            val windowWidth = DisplayUtils.getWindowPixelWidth(context)
             val margin = context.resources.getDimensionPixelSize(R.dimen.margin_extra_large)
             val deleteIconsSpace = context.resources.getDimensionPixelSize(R.dimen.margin_extra_large)
-            ((screenWidth - margin * NUM_GRID_MARGINS) / 2) - deleteIconsSpace
+            ((windowWidth - margin * NUM_GRID_MARGINS) / 2) - deleteIconsSpace
         } else {
             context.resources.getDimensionPixelSize(R.dimen.image_major_120)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -132,7 +132,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         glideTransform = RequestOptions.bitmapTransform(RoundedCorners(borderRadius))
 
         imageSize = if (isGridView) {
-            val screenWidth = DisplayUtils.getDisplayPixelWidth(context)
+            val screenWidth = DisplayUtils.getWindowPixelWidth(context)
             val margin = context.resources.getDimensionPixelSize(R.dimen.margin_extra_large)
             val deleteIconsSpace = context.resources.getDimensionPixelSize(R.dimen.margin_extra_large)
             ((screenWidth - margin * NUM_GRID_MARGINS) / 2) - deleteIconsSpace

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ ext {
     jUnitVersion = '4.13.2'
     jUnitExtVersion = '1.1.3'
     hiltJetpackVersion = '1.0.0'
-    wordPressUtilsVersion = "99-c96c6f8969edfaa734f896d65927c7e88cf520d0"
+    wordPressUtilsVersion = "develop-358e582786c11d6d5ae5a351c2ad5475a3376ece"
     mediapickerVersion = 'trunk-4da42c711820c4b2e83b7735fbb39dbcf8c9176c'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ ext {
     jUnitVersion = '4.13.2'
     jUnitExtVersion = '1.1.3'
     hiltJetpackVersion = '1.0.0'
-    wordPressUtilsVersion = "develop-eebc5d8e91a1d90190919f900f924b39c861a528"
+    wordPressUtilsVersion = "99-c96c6f8969edfaa734f896d65927c7e88cf520d0"
     mediapickerVersion = 'trunk-4da42c711820c4b2e83b7735fbb39dbcf8c9176c'
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5342 

Please don't merge until a `develop` commit from WordPress-Utils is used.

### Description
This PR updates the WordPress-Utils library to make sure we use the updated API WindowMetrics for calculating the window sizes, and update the method calls to use the ones with clearer names (refer to https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/99 for more details).

Just as an example of what those changes will fix, is for Dialogs where we need a fixed size related to the Window size, we've been wrongly using `DisplayUtils#getDisplayPixelWidth` without passing a context, which resulted in the following issues:

| Before | After |
| ---- | ---- |
| ![Screenshot_20211125_111031](https://user-images.githubusercontent.com/1657201/143424119-e1decf53-620b-41d2-a66f-12d0bfd238e8.png) | ![Screenshot_20211125_111904](https://user-images.githubusercontent.com/1657201/143424179-5fa84aaf-8d6b-4d93-9984-23fa85c5256c.png) |


### Testing instructions
The APIs are used in multiple places, but just to confirm there is no regression, go to the Product images gallery, and check that the images have the right size, with fullscreen, and with split-screen.
And for the PR review, check if I didn't use a wrong version of any method.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
