### PR TITLE
Navigation: fix navigation to my store after receiving push notifications

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -39,7 +39,9 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
     var currentPosition: BottomNavigationPosition
         get() = findNavigationPositionById(selectedItemId)
-        set(value) = navController.navigate(value.id)
+        set(value) {
+            selectedItemId = value.id
+        }
 
     fun init(navController: NavController, listener: MainNavigationListener) {
         this.listener = listener


### PR DESCRIPTION
### Description
This is a minor bug that I faced today, when we receive a push notification, we update the `MainBottomNavigationView#currentPosition` to the tab we want, this setter was using `navController` directly, and while this was OK previously, it doesn't work well with multiple back stacks, since it's lacking a boolean to let the navController that we are migrating to a different back stack.
The fix is quite simple, I just updated the setter to change the `selectedItemId` of the `MainBottomNavigationView`, so that it mimics exactly what happens when the user navigates manually -> calling `NavigationUI#onNavDestinationSelected`

### Testing instructions
1. Use a build from develop branch.
2. Make sure the app is closed.
3. Trigger an order push notification.
4. Click on it to open the app.
5. Click on back.
6. Click on "MyStore" tab.
7. Notice that it doesn't do anything.
8. Checkout this branch, and repeat steps 2-6
9. Confirm that you can navigate now.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
