### PR TITLE
Android 12: update targetSdkVersion to 31

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -63,7 +63,7 @@ android {
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)
         // and thoroughly testing the app. Consider publishing a p2 post to inform the team about the upcoming change.
         // P.S. Update the targetSdkVersion in all the modules, otherwise static analysis tools won't give you a heads-up about potential issues.
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         vectorDrawables.useSupportLibrary = true
 

--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Closes: #5327 

### Description
This PR updates `targetSdkVersion` to 31, this is the last step of https://github.com/woocommerce/woocommerce-android/issues/4113.

### Testing instructions
Smoke test the app, and confirm everything works as expected.
And pay more attention to the following scenarios:
1. Bluetooth and location permission's handling.
2. Push notifications.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
