### PR TITLE
Update OnboardingChecker and add unit test

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -421,19 +421,16 @@ object AppPrefs {
             false
         )
 
-    fun setCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
-        PreferenceUtils.setBoolean(
-            getPreferences(),
-            getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
-            true
-        )
-
-    fun resetCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
-        PreferenceUtils.setBoolean(
-            getPreferences(),
-            getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
-            false
-        )
+    fun setCardReaderOnboardingCompleted(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long,
+        isCompleted: Boolean
+    ) = PreferenceUtils.setBoolean(
+        getPreferences(),
+        getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
+        isCompleted
+    )
 
     fun getJetpackBenefitsDismissalDate(): Long {
         return getLong(DeletableSitePrefKey.JETPACK_BENEFITS_BANNER_DISMISSAL_DATE, 0L)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -20,14 +20,9 @@ class AppPrefsWrapper @Inject constructor() {
     fun setCardReaderOnboardingCompleted(
         localSiteId: Int,
         remoteSiteId: Long,
-        selfHostedSiteId: Long
-    ) = AppPrefs.setCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId)
-
-    fun resetCardReaderOnboardingCompleted(
-        localSiteId: Int,
-        remoteSiteId: Long,
-        selfHostedSiteId: Long
-    ) = AppPrefs.resetCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId)
+        selfHostedSiteId: Long,
+        isCompleted: Boolean
+    ) = AppPrefs.setCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId, isCompleted)
 
     fun setLastConnectedCardReaderId(readerId: String) = AppPrefs.setLastConnectedCardReaderId(readerId)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -29,7 +29,6 @@ class CardReaderOnboardingChecker @Inject constructor(
     private val dispatchers: CoroutineDispatchers,
     private val networkStatus: NetworkStatus,
 ) {
-    @Suppress("ReturnCount", "ComplexMethod")
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         if (!networkStatus.isConnected()) return NoConnectionError
 
@@ -39,6 +38,7 @@ class CardReaderOnboardingChecker @Inject constructor(
             }
     }
 
+    @Suppress("ReturnCount", "ComplexMethod")
     private suspend fun fetchOnboardingState(): CardReaderOnboardingState {
         val countryCode = getStoreCountryCode()
         if (!isCountrySupported(countryCode)) return StoreCountryNotSupported(countryCode)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -33,10 +33,13 @@ class CardReaderOnboardingChecker @Inject constructor(
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         if (!networkStatus.isConnected()) return NoConnectionError
 
-        with(selectedSite.get()) {
-            appPrefsWrapper.resetCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId)
-        }
+        return fetchOnboardingState()
+            .also {
+                updateOnboardingCompletedFlag(isCompleted = it is OnboardingCompleted)
+            }
+    }
 
+    private suspend fun fetchOnboardingState(): CardReaderOnboardingState {
         val countryCode = getStoreCountryCode()
         if (!isCountrySupported(countryCode)) return StoreCountryNotSupported(countryCode)
 
@@ -60,10 +63,6 @@ class CardReaderOnboardingChecker @Inject constructor(
         )
         if (isStripeAccountRejected(paymentAccount)) return StripeAccountRejected
         if (isInUndefinedState(paymentAccount)) return GenericError
-
-        with(selectedSite.get()) {
-            appPrefsWrapper.setCardReaderOnboardingCompleted(this.id, this.siteId, this.selfHostedSiteId)
-        }
 
         return OnboardingCompleted
     }
@@ -113,10 +112,20 @@ class CardReaderOnboardingChecker @Inject constructor(
             paymentAccount.status == REJECTED_LISTED ||
             paymentAccount.status == REJECTED_TERMS_OF_SERVICE ||
             paymentAccount.status == REJECTED_OTHER
-}
 
-private fun isInUndefinedState(paymentAccount: WCPaymentAccountResult): Boolean =
-    paymentAccount.status != COMPLETE
+    private fun isInUndefinedState(paymentAccount: WCPaymentAccountResult): Boolean =
+        paymentAccount.status != COMPLETE
+
+    private fun updateOnboardingCompletedFlag(isCompleted: Boolean) {
+        val site = selectedSite.get()
+        appPrefsWrapper.setCardReaderOnboardingCompleted(
+            localSiteId = site.id,
+            remoteSiteId = site.siteId,
+            selfHostedSiteId = site.selfHostedSiteId,
+            isCompleted = isCompleted
+        )
+    }
+}
 
 sealed class CardReaderOnboardingState {
     object OnboardingCompleted : CardReaderOnboardingState()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -404,7 +404,11 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     fun `when onboarding completed, then onboarding completed flag saved`() = testBlocking {
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong())
+        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            isCompleted = eq(true))
     }
 
     @Test
@@ -416,7 +420,29 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         )
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper, never()).setCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong())
+        verify(appPrefsWrapper, never()).setCardReaderOnboardingCompleted(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            isCompleted = eq(true)
+        )
+    }
+
+    @Test
+    fun `when onboarding NOT completed, then onboarding completed flag cleared`() = testBlocking {
+        whenever(wcPayStore.loadAccount(site)).thenReturn(
+            buildPaymentAccountResult(
+                WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_TERMS_OF_SERVICE,
+            )
+        )
+        checker.getOnboardingState()
+
+        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            isCompleted = eq(false)
+        )
     }
 
     private fun buildPaymentAccountResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -408,7 +408,8 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             anyInt(),
             anyLong(),
             anyLong(),
-            isCompleted = eq(true))
+            isCompleted = eq(true)
+        )
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR:
-  Fixes an issue where "onboarding completed" flag was reset before the app knew if the onboarding was completed or not. This didn't cause any known issues, however, the `onboardingCompleted` flag was always `false` while the app was checking the state.
- Adds a missing unit tests which checks if the flag gets reset.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The unit tests should verify the expected behavior. If you want to make sure, go to app settings -> In-Person Payments section and make sure the onboarding works as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No UI changes

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
