### PR TITLE
Hide m2 reader manual row

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
@@ -35,11 +35,6 @@ class CardReaderHubViewModel @Inject constructor(
                 label = UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader),
                 onItemClicked = ::onBbposManualCardReaderClicked
             ),
-            CardReaderHubListItemViewState(
-                icon = R.drawable.ic_card_reader_manual,
-                label = UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader),
-                onItemClicked = ::onM2ManualCardReaderClicked
-            ),
         )
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
@@ -52,6 +52,7 @@ class CardReaderHubViewModel @Inject constructor(
         triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.BBPOS_MANUAL_CARD_READER))
     }
 
+    @Suppress("unused")
     private fun onM2ManualCardReaderClicked() {
         triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.M2_MANUAL_CARD_READER))
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
 class CardReaderHubViewModelTest : BaseUnitTest() {
@@ -145,6 +146,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    @Ignore("Row with M2 reader is temporarily hidden")
     fun `when user clicks on m2 manual card reader, then app opens external webview with m2 link`() {
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
             .find {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -91,6 +91,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    @Ignore("Row with M2 reader is temporarily hidden")
     fun `when screen shown, then m2 manual card reader row present at fourth last`() {
         val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
         assertThat(rows[3].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -67,6 +67,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    @Ignore
     fun `when screen shown, then m2 manual card reader row present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {


### PR DESCRIPTION
One review is enough.
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR hides "M2 Card Reader Manual" row on the Hub fragment. We are not officially supporting M2 readers just yet.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open App Settings
2. Tap on In-person payments
3. Notice only BBPOS manual row is visible

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->


cc @jkmassel We'll need to release a new beta version. Sorry for the inconvenience :(. Thanks!