### PR TITLE
issue/5343-simple-payment-device-rotation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -37,7 +37,7 @@ import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.Companion.KEY_ORDER_CREATION_ACTION_RESULT
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.OrderCreationAction
-import com.woocommerce.android.ui.orders.simplepayments.SimplePaymentsDialog
+import com.woocommerce.android.ui.orders.simplepayments.SimplePaymentsDialog.Companion.KEY_SIMPLE_PAYMENTS_RESULT
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.FeatureFlag
@@ -308,15 +308,15 @@ class OrderListFragment :
     }
 
     private fun initializeResultHandlers() {
-        handleResult<Order>(SimplePaymentsDialog.KEY_SIMPLE_PAYMENTS_RESULT) { order ->
+        handleResult<String>(FILTER_CHANGE_NOTICE_KEY) {
+            viewModel.loadOrders()
+        }
+        handleDialogResult<Order>(KEY_SIMPLE_PAYMENTS_RESULT, R.id.orders) { order ->
             binding.orderListView.post {
                 openOrderDetail(order.localId.value, order.remoteId, order.status.value)
             }
         }
-        handleResult<String>(FILTER_CHANGE_NOTICE_KEY) {
-            viewModel.loadOrders()
-        }
-        handleResult<OrderCreationAction>(KEY_ORDER_CREATION_ACTION_RESULT) {
+        handleDialogResult<OrderCreationAction>(KEY_ORDER_CREATION_ACTION_RESULT, R.id.orders) {
             binding.orderListView.post {
                 when (it) {
                     OrderCreationAction.CREATE_ORDER -> {


### PR DESCRIPTION
Fixes #5343 - prior to this PR, the result from the simple payments dialog would be lost if you rotated the device while the dialog was showing. This PR resolves that by using `handleDialogResult` with the order list entry ID, and it also resolves a similar bug when rotating the device while the order list bottom sheet is showing.

To test:

* Tap to create a simple payment
* Enter an amount
* Rotate the device
* Tap Done
* Confirm that the result is received by the order list and the order detail of the new order is shown