### PR TITLE
Issue/4363 improve navigation transition

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.extensions
 import androidx.annotation.IdRes
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
+import androidx.navigation.fragment.FragmentNavigator
 
 /**
  * Prevents crashes caused by rapidly double-clicking views which navigate to the same
@@ -20,12 +21,22 @@ object CallThrottler {
     }
 }
 
-fun NavController.navigateSafely(directions: NavDirections, skipThrottling: Boolean = false) {
+fun NavController.navigateSafely(
+    directions: NavDirections,
+    skipThrottling: Boolean = false,
+    extras: FragmentNavigator.Extras? = null
+) {
     if (skipThrottling) {
         currentDestination?.getAction(directions.actionId)?.let { navigate(directions) }
     } else {
         CallThrottler.throttle {
-            currentDestination?.getAction(directions.actionId)?.let { navigate(directions) }
+            currentDestination?.getAction(directions.actionId)?.let {
+                if (extras != null) {
+                    navigate(directions, extras)
+                } else {
+                    navigate(directions)
+                }
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
@@ -26,7 +26,7 @@ fun View.hide() {
     this.visibility = View.GONE
 }
 
-fun View.expand() {
+fun View.expand(duration: Long = 300L) {
     if (!this.isVisible) {
         this.visibility = View.VISIBLE
         this.measure(
@@ -52,12 +52,12 @@ fun View.expand() {
             }
         }
 
-        a.duration = 300
+        a.duration = duration
         this.startAnimation(a)
     }
 }
 
-fun View.collapse() {
+fun View.collapse(duration: Long = 300L) {
     if (this.isVisible) {
         val initialHeight = this.measuredHeight
         val view = this
@@ -77,7 +77,7 @@ fun View.collapse() {
             }
         }
 
-        a.duration = 300
+        a.duration = duration
         this.startAnimation(a)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
+import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.appbar.AppBarLayout
 import com.woocommerce.android.*
@@ -818,6 +819,21 @@ class MainActivity :
         val orderId = OrderIdentifier(localOrderId, localSiteId, remoteOrderId)
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderDetailFragment(orderId, remoteNoteId)
         navController.navigateSafely(action)
+    }
+
+    override fun showOrderDetailWithSharedTransition(
+        localSiteId: Int,
+        localOrderId: Int,
+        remoteOrderId: Long,
+        remoteNoteId: Long,
+        sharedView: View
+    ) {
+        val orderCardDetailTransitionName = getString(R.string.order_card_detail_transition_name)
+        val extras = FragmentNavigatorExtras(sharedView to orderCardDetailTransitionName)
+
+        val orderId = OrderIdentifier(localOrderId, localSiteId, remoteOrderId)
+        val action = OrderListFragmentDirections.actionOrderListFragmentToOrderDetailFragment(orderId, remoteNoteId)
+        navController.navigateSafely(directions = action, extras = extras)
     }
 
     override fun showFeedbackSurvey() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -826,6 +826,24 @@ class MainActivity :
         navController.navigateSafely(action)
     }
 
+    override fun showReviewDetailWithSharedTransition(
+        remoteReviewId: Long,
+        launchedFromNotification: Boolean,
+        enableModeration: Boolean,
+        sharedView: View,
+        tempStatus: String?
+    ) {
+        val reviewCardDetailTransitionName = getString(R.string.review_card_detail_transition_name)
+        val extras = FragmentNavigatorExtras(sharedView to reviewCardDetailTransitionName)
+        val action = ReviewListFragmentDirections.actionReviewListFragmentToReviewDetailFragment(
+            remoteReviewId = remoteReviewId,
+            tempStatus = tempStatus,
+            launchedFromNotification = launchedFromNotification,
+            enableModeration = enableModeration
+        )
+        navController.navigateSafely(directions = action, extras = extras)
+    }
+
     override fun showProductFilters(
         stockStatus: String?,
         productType: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -61,6 +61,7 @@ import javax.inject.Inject
 import kotlin.math.abs
 
 // TODO Extract logic out of MainActivity to reduce size
+@Suppress("LargeClass")
 @AndroidEntryPoint
 class MainActivity :
     AppUpgradeActivity(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -779,6 +779,17 @@ class MainActivity :
         navController.navigateSafely(action)
     }
 
+    override fun showProductDetailWithSharedTransition(remoteProductId: Long, sharedView: View, enableTrash: Boolean) {
+        val productCardDetailTransitionName = getString(R.string.product_card_detail_transition_name)
+        val extras = FragmentNavigatorExtras(sharedView to productCardDetailTransitionName)
+
+        val action = NavGraphMainDirections.actionGlobalProductDetailFragment(
+            remoteProductId = remoteProductId,
+            isTrashEnabled = enableTrash
+        )
+        navController.navigateSafely(directions = action, extras = extras)
+    }
+
     override fun showProductVariationDetail(remoteProductId: Long, remoteVariationId: Long) {
         // variation detail is part of the products navigation graph, and product detail is the starting destination
         // for that graph, so we have to use a deep link to navigate to variation detail

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -37,6 +37,13 @@ interface MainNavigationRouter {
         enableModeration: Boolean,
         tempStatus: String? = null
     )
+    fun showReviewDetailWithSharedTransition(
+        remoteReviewId: Long,
+        launchedFromNotification: Boolean,
+        enableModeration: Boolean,
+        sharedView: View,
+        tempStatus: String? = null
+    )
 
     fun showProductFilters(
         stockStatus: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -7,6 +7,11 @@ interface MainNavigationRouter {
     fun isChildFragmentShowing(): Boolean
 
     fun showProductDetail(remoteProductId: Long, enableTrash: Boolean = false)
+    fun showProductDetailWithSharedTransition(
+        remoteProductId: Long,
+        sharedView: View,
+        enableTrash: Boolean = false
+    )
     fun showProductVariationDetail(remoteProductId: Long, remoteVariationId: Long)
 
     fun showOrderDetail(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.main
 
+import android.view.View
+
 interface MainNavigationRouter {
     fun isAtNavigationRoot(): Boolean
     fun isChildFragmentShowing(): Boolean
@@ -13,6 +15,14 @@ interface MainNavigationRouter {
         remoteOrderId: Long,
         remoteNoteId: Long = 0,
         launchedFromNotification: Boolean = false
+    )
+
+    fun showOrderDetailWithSharedTransition(
+        localSiteId: Int,
+        localOrderId: Int = 0,
+        remoteOrderId: Long,
+        remoteNoteId: Long = 0,
+        sharedView: View
     )
 
     fun showAddProduct()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -1,13 +1,17 @@
 package com.woocommerce.android.ui.orders.details
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.transition.MaterialContainerTransform
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
@@ -106,6 +110,19 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         super.onStop()
     }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        val backgroundColor = ContextCompat.getColor(requireContext(), R.color.default_window_background)
+        sharedElementEnterTransition = MaterialContainerTransform().apply {
+            drawingViewId = R.id.snack_root
+            duration = transitionDuration
+            scrimColor = Color.TRANSPARENT
+            startContainerColor = backgroundColor
+            endContainerColor = backgroundColor
+        }
+    }
+
     override fun getFragmentTitle() = screenTitle
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -122,6 +139,11 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             scrollUpChild = binding.scrollView
             setOnRefreshListener { viewModel.onRefreshRequested() }
         }
+
+        ViewCompat.setTransitionName(
+            binding.scrollView,
+            getString(R.string.order_card_detail_transition_name)
+        )
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -5,6 +5,7 @@ import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -145,11 +146,20 @@ class OrderListAdapter(
             viewBinding.orderTags.removeAllViews()
             processTagView(orderItemUI.status, this)
 
+            ViewCompat.setTransitionName(
+                viewBinding.root,
+                String.format(
+                    ctx.getString(R.string.order_card_transition_name),
+                    orderItemUI.localOrderId
+                )
+            )
+
             this.itemView.setOnClickListener {
                 listener.openOrderDetail(
                     orderItemUI.localOrderId.value,
                     orderItemUI.remoteOrderId.value,
-                    orderItemUI.status
+                    orderItemUI.status,
+                    viewBinding.root
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.extensions.pinFabAboveBottomNavigationBar

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.extensions.pinFabAboveBottomNavigationBar
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListListener.kt
@@ -1,5 +1,12 @@
 package com.woocommerce.android.ui.orders.list
 
+import android.view.View
+
 interface OrderListListener {
-    fun openOrderDetail(localOrderId: Int, remoteOrderId: Long, orderStatus: String)
+    fun openOrderDetail(
+        localOrderId: Int,
+        remoteOrderId: Long,
+        orderStatus: String,
+        sharedView: View? = null
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import android.annotation.SuppressLint
+import android.graphics.Color
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.SpannableString
@@ -11,6 +12,7 @@ import android.view.MenuItem
 import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.forEach
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
@@ -19,6 +21,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.transition.MaterialContainerTransform
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -84,12 +87,29 @@ class ProductDetailFragment :
 
     @Inject lateinit var crashLogging: CrashLogging
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        val backgroundColor = ContextCompat.getColor(requireContext(), R.color.default_window_background)
+        sharedElementEnterTransition = MaterialContainerTransform().apply {
+            drawingViewId = R.id.snack_root
+            duration = transitionDuration
+            scrimColor = Color.TRANSPARENT
+            startContainerColor = backgroundColor
+            endContainerColor = backgroundColor
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentProductDetailBinding.bind(view)
         setHasOptionsMenu(true)
 
+        ViewCompat.setTransitionName(
+            binding.root,
+            getString(R.string.product_card_detail_transition_name)
+        )
         initializeViews(savedInstanceState)
         initializeViewModel()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -5,6 +5,7 @@ import android.view.MotionEvent
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.selection.ItemDetailsLookup
 import androidx.recyclerview.widget.RecyclerView
@@ -83,6 +84,14 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
             height = size
             width = size
         }
+
+        ViewCompat.setTransitionName(
+            viewBinding.root,
+            String.format(
+                context.getString(R.string.order_card_transition_name),
+                product.remoteId
+            )
+        )
     }
 
     fun setOnDeleteClickListener(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.selection.SelectionTracker
 import androidx.recyclerview.widget.DiffUtil
@@ -20,7 +21,7 @@ class ProductListAdapter(
     var tracker: SelectionTracker<Long>? = null
 
     interface OnProductClickListener {
-        fun onProductClick(remoteProductId: Long)
+        fun onProductClick(remoteProductId: Long, sharedView: View? = null)
     }
 
     init {
@@ -48,7 +49,7 @@ class ProductListAdapter(
 
         holder.itemView.setOnClickListener {
             AnalyticsTracker.track(PRODUCT_LIST_PRODUCT_TAPPED)
-            clickListener?.onProductClick(product.remoteId)
+            clickListener?.onProductClick(product.remoteId, holder.itemView)
         }
 
         if (position == itemCount - 1) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem.OnActionExpandListener
 import android.view.View
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
+import androidx.core.view.ViewGroupCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -15,6 +16,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.transition.MaterialFadeThrough
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
@@ -88,7 +90,7 @@ class ProductListFragment :
         _binding = FragmentProductListBinding.bind(view)
         setupObservers(viewModel)
         setupResultHandlers()
-
+        ViewGroupCompat.setTransitionGroup(binding.productsRefreshLayout, true)
         _productAdapter = ProductListAdapter(this, this)
         binding.productsRecycler.layoutManager = LinearLayoutManager(requireActivity())
         binding.productsRecycler.adapter = productAdapter
@@ -137,6 +139,15 @@ class ProductListFragment :
     override fun onStop() {
         super.onStop()
         trashProductUndoSnack?.dismiss()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        val fadeThroughTransition = MaterialFadeThrough().apply { duration = transitionDuration }
+        enterTransition = fadeThroughTransition
+        exitTransition = fadeThroughTransition
+        reenterTransition = fadeThroughTransition
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -144,7 +144,7 @@ class ProductReviewsFragment :
         }
     }
 
-    override fun onReviewClick(review: ProductReview) {
+    override fun onReviewClick(review: ProductReview, sharedView: View?) {
         (activity as? MainNavigationRouter)?.showReviewDetail(
             review.remoteId,
             launchedFromNotification = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.reviews
 
 import android.content.Context
+import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.drawable.LayerDrawable
 import android.os.Build
@@ -10,10 +11,12 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.google.android.material.transition.MaterialContainerTransform
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -85,7 +88,25 @@ class ReviewDetailFragment : BaseFragment(R.layout.fragment_review_detail) {
 
         _binding = FragmentReviewDetailBinding.bind(view)
 
+        ViewCompat.setTransitionName(
+            binding.scrollView,
+            getString(R.string.review_card_detail_transition_name)
+        )
+
         initializeViewModel()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        val backgroundColor = ContextCompat.getColor(requireContext(), R.color.default_window_background)
+        sharedElementEnterTransition = MaterialContainerTransform().apply {
+            drawingViewId = R.id.snack_root
+            duration = transitionDuration
+            scrimColor = Color.TRANSPARENT
+            startContainerColor = backgroundColor
+            endContainerColor = backgroundColor
+        }
     }
 
     override fun onStart() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
+import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.woocommerce.android.R
@@ -33,7 +34,7 @@ class ReviewListAdapter(private val clickListener: OnReviewClickListener) : Sect
     private val removedRemoteIds = HashSet<Long>()
 
     interface OnReviewClickListener {
-        fun onReviewClick(review: ProductReview) {}
+        fun onReviewClick(review: ProductReview, sharedView: View? = null) {}
     }
 
     fun setReviews(reviews: List<ProductReview>) {
@@ -355,7 +356,7 @@ class ReviewListAdapter(private val clickListener: OnReviewClickListener) : Sect
                 reviewStatus = ProductReviewStatus.fromString(review.status)
             )
             itemHolder.itemView.setOnClickListener {
-                clickListener.onReviewClick(review)
+                clickListener.onReviewClick(review, itemHolder.itemView)
             }
         }
 
@@ -395,6 +396,14 @@ class ReviewListAdapter(private val clickListener: OnReviewClickListener) : Sect
             viewBinding.notifRating.visibility = View.GONE
             viewBinding.notifIcon.setImageResource(R.drawable.ic_comment)
             viewBinding.notifDesc.maxLines = 2
+
+            ViewCompat.setTransitionName(
+                viewBinding.root,
+                String.format(
+                    context.getString(R.string.review_card_transition_name),
+                    review.remoteId
+                )
+            )
 
             if (review.rating > 0) {
                 viewBinding.notifRating.numStars = review.rating

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -7,11 +7,13 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.View.OnClickListener
+import androidx.core.view.ViewGroupCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.transition.MaterialFadeThrough
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -77,6 +79,11 @@ class ReviewListFragment :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
+        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        val fadeThroughTransition = MaterialFadeThrough().apply { duration = transitionDuration }
+        enterTransition = fadeThroughTransition
+        exitTransition = fadeThroughTransition
+        reenterTransition = fadeThroughTransition
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -87,7 +94,7 @@ class ReviewListFragment :
         _binding = FragmentReviewsListBinding.bind(view)
 
         val activity = requireActivity()
-
+        ViewGroupCompat.setTransitionGroup(binding.notifsRefreshLayout, true)
         _reviewsAdapter = ReviewListAdapter(this)
         val unreadDecoration = UnreadItemDecoration(activity as Context, this)
         binding.reviewsList.apply {

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -36,6 +36,7 @@
                     android:layout_height="wrap_content"
                     android:importantForAccessibility="yes"
                     app:layout_collapseMode="parallax"
+                    android:visibility="gone"
                     tools:text="Subtitle shop name"
                     tools:visibility="visible" />
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -104,9 +104,7 @@
         tools:layout="@layout/fragment_reviews_list">
         <action
             android:id="@+id/action_reviewListFragment_to_reviewDetailFragment"
-            app:destination="@id/reviewDetailFragment"
-            app:enterAnim="@anim/activity_slide_in_from_right"
-            app:popExitAnim="@anim/activity_slide_out_to_right" />
+            app:destination="@id/reviewDetailFragment"/>
     </fragment>
     <fragment
         android:id="@+id/analytics"
@@ -180,9 +178,7 @@
 
     <action
         android:id="@+id/action_global_productDetailFragment"
-        app:destination="@id/nav_graph_products"
-        app:enterAnim="@anim/activity_slide_in_from_right"
-        app:popExitAnim="@anim/activity_slide_out_to_right">
+        app:destination="@id/nav_graph_products">
         <argument
             android:name="remoteProductId"
             android:defaultValue="0L"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -24,9 +24,7 @@
         tools:layout="@layout/fragment_order_list">
         <action
             android:id="@+id/action_orderListFragment_to_orderDetailFragment"
-            app:destination="@id/nav_graph_orders"
-            app:enterAnim="@anim/activity_slide_in_from_right"
-            app:popExitAnim="@anim/activity_slide_out_to_right">
+            app:destination="@id/nav_graph_orders">
             <argument
                 android:name="orderId"
                 android:defaultValue='""'

--- a/WooCommerce/src/main/res/values/integers.xml
+++ b/WooCommerce/src/main/res/values/integers.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="anim_slide_transition">150</integer>
+    <integer name="default_fragment_transition">300</integer>
     <integer name="max_length_tracking_number">255</integer>
     <integer name="stats_label_count_days">6</integer>
     <integer name="stats_label_count_weeks">6</integer>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1309,7 +1309,8 @@
     <string name="upsell_product_count_one">%d upsell product</string>
     <string name="upsell_product_count_many">%d upsell products</string>
     <string name="product_detail_background_image_upload">Image uploading will continue in the background</string>
-
+    <string name="product_card_transition_name">product_card_%1$s</string>
+    <string name="product_card_detail_transition_name">product_card_detail</string>
     <!--
         Product Add more details Bottom sheet
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -297,6 +297,8 @@
     <string name="orderlist_simple_payments_wip_message_enabled">We are working on making it easier for you to take payments from your device! For now, tap the "+" button and you\'ll be able to create an order with the amount you want to collect.</string>
     <string name="orderlist_simple_payments_wip_message_disabled">We are working on making it easier for you to take payments from your device! Enable it in Settings &gt; Beta features.</string>
     <string name="orderlist_simple_payments_menu">Simple payment</string>
+    <string name="order_card_transition_name">order_card_%1$s</string>
+    <string name="order_card_detail_transition_name">order_card_detail</string>
     <!--
          Simple Payments
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1074,6 +1074,8 @@
     <string name="wc_load_review_error">Error loading product review detail</string>
     <string name="wc_moderate_review_error">Error updating product review status</string>
     <string name="wc_review_title">Review</string>
+    <string name="review_card_transition_name">review_card_%1$s</string>
+    <string name="review_card_detail_transition_name">review_card_detail</string>
     <!--
         Product Reviews List
     -->


### PR DESCRIPTION
## Improve  Orders -> order details navigation transition

Closes: #4363

### Description
This PR attempts to improve the transition navigating from orders list to order details by implementing a shared element transition. These animations were implemented using the [material motion system](https://material.io/develop/android/theming/motion). 
A fade-through transition was also necessary for the orders lists view to keep the orders list visible even after being replaced.
For consistency, the fade-through transition was also added to the reviews list and products list views.

### Testing instructions
#### Fade through transition
My Store --> Orders
My Store --> Products 
My Store --> Reviews
#### Container transform transition (shared element transition)
Orders --> Order details

### Images/gif

Starting idea 

https://user-images.githubusercontent.com/18119390/143918872-2d160e30-255d-48d1-93de-d85e2689154b.mp4 

Current behavior

https://user-images.githubusercontent.com/18119390/143923013-a5ab657b-c957-43f6-9b18-dcd0652396fc.mp4  

Result 

https://user-images.githubusercontent.com/18119390/143920125-a9a083b4-ccaa-4e51-986b-e154c7f81038.mp4
