### PR TITLE
Issue/5369 simple payment keyboard

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -37,7 +37,7 @@ import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.Companion.KEY_ORDER_CREATION_ACTION_RESULT
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.OrderCreationAction
-import com.woocommerce.android.ui.orders.simplepayments.SimplePaymentsDialog
+import com.woocommerce.android.ui.orders.simplepayments.SimplePaymentsDialog.Companion.KEY_SIMPLE_PAYMENTS_RESULT
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.FeatureFlag
@@ -308,15 +308,15 @@ class OrderListFragment :
     }
 
     private fun initializeResultHandlers() {
-        handleResult<Order>(SimplePaymentsDialog.KEY_SIMPLE_PAYMENTS_RESULT) { order ->
+        handleResult<String>(FILTER_CHANGE_NOTICE_KEY) {
+            viewModel.loadOrders()
+        }
+        handleDialogResult<Order>(KEY_SIMPLE_PAYMENTS_RESULT, R.id.orders) { order ->
             binding.orderListView.post {
                 openOrderDetail(order.localId.value, order.remoteId, order.status.value)
             }
         }
-        handleResult<String>(FILTER_CHANGE_NOTICE_KEY) {
-            viewModel.loadOrders()
-        }
-        handleResult<OrderCreationAction>(KEY_ORDER_CREATION_ACTION_RESULT) {
+        handleDialogResult<OrderCreationAction>(KEY_ORDER_CREATION_ACTION_RESULT, R.id.orders) {
             binding.orderListView.post {
                 when (it) {
                     OrderCreationAction.CREATE_ORDER -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
@@ -61,7 +61,7 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
                 {
                     ActivityUtils.showKeyboard(binding.editPrice)
                 },
-                100
+                KEYBOARD_DELAY
             )
         }
 
@@ -110,5 +110,6 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
         private const val WIDTH_RATIO = 0.9
         private const val HEIGHT_RATIO_LANDSCAPE = 0.9
         private const val WIDTH_RATIO_LANDSCAPE = 0.6
+        private const val KEYBOARD_DELAY = 100L
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
@@ -36,9 +36,13 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
 
         requireDialog().window?.let { window ->
             window.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
+            val isLandscape = DisplayUtils.isLandscape(requireContext())
+            val widthRatio = if (isLandscape) WIDTH_RATIO_LANDSCAPE else WIDTH_RATIO
+            val heightRatio = if (isLandscape) HEIGHT_RATIO_LANDSCAPE else HEIGHT_RATIO
+
             window.setLayout(
-                (DisplayUtils.getWindowPixelWidth(requireContext()) * WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * HEIGHT_RATIO).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * widthRatio).toInt(),
+                (DisplayUtils.getWindowPixelHeight(requireContext()) * heightRatio).toInt()
             )
         }
 
@@ -51,7 +55,6 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_CANCELED)
             findNavController().navigateUp()
         }
-        binding.captionText.isVisible = !DisplayUtils.isLandscape(requireContext())
 
         setupObservers(binding)
     }
@@ -96,5 +99,7 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
         const val KEY_SIMPLE_PAYMENTS_RESULT = "simple_payments_result"
         private const val HEIGHT_RATIO = 0.6
         private const val WIDTH_RATIO = 0.9
+        private const val HEIGHT_RATIO_LANDSCAPE = 0.9
+        private const val WIDTH_RATIO_LANDSCAPE = 0.6
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
@@ -34,9 +34,9 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val isLandscape = DisplayUtils.isLandscape(requireContext())
         requireDialog().window?.let { window ->
             window.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
-            val isLandscape = DisplayUtils.isLandscape(requireContext())
             val widthRatio = if (isLandscape) WIDTH_RATIO_LANDSCAPE else WIDTH_RATIO
             val heightRatio = if (isLandscape) HEIGHT_RATIO_LANDSCAPE else HEIGHT_RATIO
 
@@ -54,6 +54,15 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
         binding.imageClose.setOnClickListener {
             AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_CANCELED)
             findNavController().navigateUp()
+        }
+
+        if (!isLandscape && binding.editPrice.requestFocus()) {
+            binding.editPrice.postDelayed(
+                {
+                    ActivityUtils.showKeyboard(binding.editPrice)
+                },
+                100
+            )
         }
 
         setupObservers(binding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialog.kt
@@ -51,6 +51,7 @@ class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_CANCELED)
             findNavController().navigateUp()
         }
+        binding.captionText.isVisible = !DisplayUtils.isLandscape(requireContext())
 
         setupObservers(binding)
     }


### PR DESCRIPTION
Closes #5369 - this simple PR forces the keyboard to appear when entering the simple payment dialog. This is only done in portrait because in landscape the keyboard covers some of the views.