### PR TITLE
Enable build time reporting on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ commands:
       - run:
           name: Setup gradle.properties
           command: cp gradle.properties-example gradle.properties
+      - run:
+          name: Enable build time reporting
+          command: sed -i "s/tracksEnabled = false/tracksEnabled = true/" gradle.properties
   update-gradle-memory:
       parameters:
         jvmargs:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Relates to: #5212
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates CI configuration to enable build time measurements for those workflows, where sample `gradle.properties` file is used (where build time measurements are disabled by default).

![image](https://user-images.githubusercontent.com/5845095/144120694-5d10aa19-b61f-41d3-a441-c189ad067acc.png)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
