### PR TITLE
Order Creation: add repository for handling the creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooException.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooException.kt
@@ -2,4 +2,4 @@ package com.woocommerce.android
 
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 
-class WooException(val error: WooError): Exception()
+class WooException(val error: WooError) : Exception()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooException.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooException.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+
+class WooException(val error: WooError): Exception()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCOrderModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCOrderModelExt.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.extensions
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
+import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.store.WCProductStore
 
 internal const val CASH_ON_DELIVERY_PAYMENT_TYPE = "cod"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.CreateOrderRequest
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.store.WCOrderStore

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -16,9 +16,7 @@ class OrderCreationRepository @Inject constructor(
 ) {
     suspend fun createOrder(order: Order): Result<Order> {
         val status = orderStore.getOrderStatusForSiteAndKey(selectedSite.get(), order.status.value)
-            ?: WCOrderStatusModel().apply {
-                statusKey = order.status.value
-            }
+            ?: error("Couldn't find the a status with key ${order.status.value}")
         val request = CreateOrderRequest(
             status = status,
             lineItems = order.items.map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -20,7 +20,7 @@ class OrderCreationRepository @Inject constructor(
         val status = withContext(dispatchers.io) {
             // Currently this query will run on the current thread, so forcing the usage of IO dispatcher
             orderStore.getOrderStatusForSiteAndKey(selectedSite.get(), order.status.value)
-                ?: error("Couldn't find the a status with key ${order.status.value}")
+                ?: error("Couldn't find a status with key ${order.status.value}")
         }
         val request = CreateOrderRequest(
             status = status,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.WooException
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.model.order.CreateOrderRequest
+import org.wordpress.android.fluxc.model.order.LineItem
+import org.wordpress.android.fluxc.store.WCOrderStore
+import javax.inject.Inject
+
+class OrderCreationRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val orderStore: WCOrderStore
+) {
+    suspend fun createOrder(order: Order): Result<Order> {
+        val status = orderStore.getOrderStatusForSiteAndKey(selectedSite.get(), order.status.value)
+            ?: WCOrderStatusModel().apply {
+                statusKey = order.status.value
+            }
+        val request = CreateOrderRequest(
+            status = status,
+            lineItems = order.items.map {
+                LineItem(
+                    name = it.name,
+                    productId = it.productId,
+                    variationId = it.variationId,
+                    quantity = it.quantity
+                )
+            },
+            shippingAddress = order.shippingAddress.toShippingAddressModel(),
+            billingAddress = order.billingAddress.toBillingAddressModel()
+        )
+        val result = orderStore.createOrder(selectedSite.get(), request)
+
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            else -> Result.success(result.model!!.toAppModel())
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -103,7 +103,7 @@ class OrderDetailRepository @Inject constructor(
     ): Flow<UpdateOrderResult> {
         val status = withContext(dispatchers.io) {
             orderStore.getOrderStatusForSiteAndKey(selectedSite.get(), newStatus)
-                ?: error("Couldn't find the a status with key $newStatus")
+                ?: error("Couldn't find a status with key $newStatus")
         }
         return orderStore.updateOrderStatus(
             orderLocalId,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonTestFixtures.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonTestFixtures.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.util.UnitTestUtils.jsonFileToString
 import org.wordpress.android.fluxc.domain.Addon
 import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjusted.*
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
+import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.mappers.RemoteAddonMapper
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2202-2d036cca34a8c57cf70430f2a9bca2697818c9bb'
+    fluxCVersion = 'develop-9f2b7cd0f56946748a39e3d525ecd81cc9a5575d'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-fa819801570505a0e9b4f7f226bb704b88ccc1d2'
+    fluxCVersion = '2202-2d036cca34a8c57cf70430f2a9bca2697818c9bb'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
Closes: #5275 

Please don't merge until https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2202 is merged and the commit has is updated.

### Description
This PR brings the changes from FluxC's PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2202, and adds a new Repository class to handle the order creation.

### Testing instructions
There is nothing to test yet, just code review.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
