### PR TITLE
Refresh order status list whenever we load order list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -166,6 +166,7 @@ class OrderListViewModel @Inject constructor(
         if (networkStatus.isConnected()) {
             launch(dispatchers.main) {
                 activePagedListWrapper?.fetchFirstPage()
+                orderListRepository.fetchOrderStatusOptionsFromApi()
                 fetchPaymentGateways()
             }
         } else {
@@ -173,7 +174,6 @@ class OrderListViewModel @Inject constructor(
             showOfflineSnack()
         }
     }
-
     /**
      * Fetch payment gateways so they are available for order refunds later
      */

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -141,6 +141,16 @@ class OrderListViewModelTest : BaseUnitTest() {
         assertTrue(isRefreshPending)
     }
 
+    @Test
+    fun `Given network is connected, when fetching orders and dependencies, then load order status list from api`() =
+        testBlocking {
+            doReturn(true).whenever(networkStatus).isConnected()
+
+            viewModel.fetchOrdersAndOrderDependencies()
+
+            verify(orderListRepository).fetchOrderStatusOptionsFromApi()
+        }
+
     /**
      * Test the logic that generates the "No orders yet" empty view for the ALL tab
      * is successful and verify the view is emitted via [OrderListViewModel.emptyViewType].


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5389
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Order status are not prefilled when we open the app for the first time. Only if we open order filters first, then the order status list will be saved and prefilled.

With this changes order status list is refreshed every time we load orders. This also fixes other corner cases related to order status list not been in sync with server whenever the user adds/removes custom order statuses. 

### Testing instructions

1. Login into the app
2. Right after login, pen order detail
3. Try to update the order detail status. The prefilled order status dialog is empty.

### Images/gif
**Before:**

https://user-images.githubusercontent.com/2663464/144432000-c06dd5b6-339e-4ecb-934e-682ea8ee3562.mp4

**After:** 

https://user-images.githubusercontent.com/2663464/144432025-1aa79351-8434-4cf0-b9e1-5f6cd348c149.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
