### PR TITLE
Issue/5332 use stripe extension account endpoint

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils.WCPluginModel
+import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType
 
 private val SUPPORTED_COUNTRIES = listOf("US")
 
@@ -73,7 +74,10 @@ class CardReaderOnboardingChecker @Inject constructor(
             STRIPE_TERMINAL_GATEWAY -> throw IllegalStateException("Developer error: `preferredPlugin` should be WCPay")
         }
 
-        val paymentAccount = inPersonPaymentsStore.loadAccount(selectedSite.get()).model ?: return GenericError
+        val fluxCPluginType = preferredPlugin.type.toInPersonPaymentsPluginType()
+
+        val paymentAccount =
+            inPersonPaymentsStore.loadAccount(fluxCPluginType, selectedSite.get()).model ?: return GenericError
 
         if (!isCountrySupported(paymentAccount.country)) return StripeAccountCountryNotSupported(paymentAccount.country)
         if (!isPluginSetupCompleted(paymentAccount)) return SetupNotCompleted(preferredPlugin.type)
@@ -167,6 +171,11 @@ class CardReaderOnboardingChecker @Inject constructor(
             pluginType
         )
     }
+}
+
+private fun PluginType.toInPersonPaymentsPluginType(): InPersonPaymentsPluginType = when (this) {
+    WOOCOMMERCE_PAYMENTS -> InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+    STRIPE_TERMINAL_GATEWAY -> InPersonPaymentsPluginType.STRIPE
 }
 
 private data class PluginWrapper(val type: PluginType, val info: WCPluginModel?)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -734,7 +734,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding failed due to error, then onboarding completed plugin type is reset`() = testBlocking {
-        whenever(wcInPersonPaymentsStore.loadAccount(site)).thenReturn(
+        whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
             buildPaymentAccountResult(
                 WCPaymentAccountResult.WCPaymentAccountStatus.REJECTED_OTHER,
             )

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2204-a4eebe979b82ac4f87a1b25ca17fc042b859a41b'
+    fluxCVersion = '2204-26487513163e1a39c347cb7b60b5a2eb929acf71'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2201-914dba641739910dc6b516a37750ab186d9589c1'
+    fluxCVersion = '2204-a4eebe979b82ac4f87a1b25ca17fc042b859a41b'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge instructions:
1. Review this PR
2. Make sure https://github.com/woocommerce/woocommerce-android/pull/5375 is merged
3. Merge https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2204
4. Update fluxc hash in this PR
5. Remove "Do not merge" label
5. Merge this PR

Closes: #5332 (fluxc part)
Closes: #5334 (wcandroid part)
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates WCAndroid so it's compatible with fluxC after introduction of /wc_stripe/account/summary endpoint - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2204

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Install the newest version of Stripe Extension plugin to your store (the version hasn't be released yet, you'll need to build it locally)
2. Make sure WCPay is not active on your store
3. Open the App
4. Open app settings
5. Tap on "In-Person Payments"
6. Notice the account state is loaded - my site for example shows "Your WooCommerce Payments account has pending requirements" (I created [an issue](https://github.com/woocommerce/woocommerce-android/issues/5400) since it should not mention "WooCommerce Payments") )... you can also simply check what endpoint was invoked using flipper or similar tool

P.S. I haven't tested all the different states of the account yet, since we'll test that when the whole feature is ready.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No changes

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
