### PR TITLE
Improve WooLog entry list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
@@ -26,8 +26,7 @@ import com.woocommerce.android.util.copyToClipboard
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import org.wordpress.android.util.ToastUtils
 import java.lang.String.format
-import java.util.ArrayList
-import java.util.Locale
+import java.util.*
 
 class WooLogViewerActivity : AppCompatActivity() {
     companion object {
@@ -127,7 +126,7 @@ class WooLogViewerActivity : AppCompatActivity() {
     }
 
     private inner class LogAdapter constructor(context: Context) : RecyclerView.Adapter<LogViewHolder>() {
-        private val entries: ArrayList<String> =
+        private val entries: List<String> =
             WooLog.toHtmlList(AppThemeUtils.isDarkThemeActive(this@WooLogViewerActivity))
         private val inflater: LayoutInflater = LayoutInflater.from(context)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/LogEntryList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/LogEntryList.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.util.LogEntryList.LogEntry
+import com.woocommerce.android.util.WooLog.LogLevel
+import com.woocommerce.android.util.WooLog.LogLevel.d
+import com.woocommerce.android.util.WooLog.LogLevel.e
+import com.woocommerce.android.util.WooLog.LogLevel.i
+import com.woocommerce.android.util.WooLog.LogLevel.v
+import com.woocommerce.android.util.WooLog.LogLevel.w
+import com.woocommerce.android.util.WooLog.T
+import org.wordpress.android.util.DateTimeUtils
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * Fix-sized list of log entries
+ */
+class LogEntryList(private val maxEntries: Int) : LinkedList<LogEntry>() {
+    @Synchronized
+    override fun add(element: LogEntry): Boolean {
+        if (size == maxEntries) {
+            removeFirst()
+        }
+        return super.add(element)
+    }
+
+    /**
+     * Returns the log entries as an array of html-formatted strings - this enables us to display
+     * a formatted log in [com.woocommerce.android.support.WooLogViewerActivity]
+     */
+    fun toHtmlList(isDarkTheme: Boolean): List<String> {
+        fun LogEntry.getColor(): String {
+            return if (isDarkTheme) {
+                "white"
+            } else when (level) {
+                v -> "grey"
+                d -> "teal"
+                i -> "black"
+                w -> "purple"
+                e -> "red"
+            }
+        }
+
+        // work with a copy of the log entries in case they're modified while traversing them
+        return toList().map { entry ->
+            "<font color='${entry.getColor()}'>$entry</font>"
+        }
+    }
+
+    /**
+     * Returns the log entries as a single string with each entry on a new line. Works with a copy of the log
+     * entries in case they're modified while traversing them.
+     */
+    override fun toString() = toList().joinToString("\n")
+
+    /**
+     * Individual log entry
+     */
+    class LogEntry(
+        val tag: T,
+        val level: LogLevel,
+        val text: String?
+    ) {
+        private val logDate: Date = DateTimeUtils.nowUTC()
+
+        override fun toString(): String {
+            val logText = if (text.isNullOrEmpty()) "null" else text
+            val logDateStr = SimpleDateFormat("MMM-dd kk:mm", Locale.US).format(logDate)
+            return "[$logDateStr ${tag.name} ${level.name}] $logText"
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RollingLogEntries.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RollingLogEntries.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.util
 
-import com.woocommerce.android.util.LogEntryList.LogEntry
+import com.woocommerce.android.util.RollingLogEntries.LogEntry
 import com.woocommerce.android.util.WooLog.LogLevel
 import com.woocommerce.android.util.WooLog.LogLevel.d
 import com.woocommerce.android.util.WooLog.LogLevel.e
@@ -9,16 +9,21 @@ import com.woocommerce.android.util.WooLog.LogLevel.v
 import com.woocommerce.android.util.WooLog.LogLevel.w
 import com.woocommerce.android.util.WooLog.T
 import org.wordpress.android.util.DateTimeUtils
+import java.security.InvalidParameterException
 import java.text.SimpleDateFormat
 import java.util.*
 
 /**
  * Fix-sized list of log entries
  */
-class LogEntryList(private val maxEntries: Int) : LinkedList<LogEntry>() {
+class RollingLogEntries(private val limit: Int) : LinkedList<LogEntry>() {
+    init {
+        if (limit <= 0) throw InvalidParameterException("The limit must be greater than 0")
+    }
+
     @Synchronized
     override fun add(element: LogEntry): Boolean {
-        if (size == maxEntries) {
+        if (size == limit) {
             removeFirst()
         }
         return super.add(element)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -1,12 +1,8 @@
 package com.woocommerce.android.util
 
 import android.util.Log
-import org.wordpress.android.util.DateTimeUtils
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.text.SimpleDateFormat
-import java.util.*
-import kotlin.collections.MutableMap.MutableEntry
 import org.wordpress.android.util.AppLog as WordPressAppLog
 
 /**
@@ -38,7 +34,7 @@ object WooLog {
 
     const val TAG = "WooCommerce"
     private const val MAX_ENTRIES = 99
-    private val logEntries = LogEntryList()
+    private val logEntries = LogEntryList(MAX_ENTRIES)
 
     init {
         // add listener for WP app log so we can capture login & FluxC logs
@@ -182,63 +178,4 @@ object WooLog {
 
     override fun toString() = logEntries.toString()
 
-    /**
-     * Individual log entry
-     */
-    private class LogEntry(
-        val tag: T,
-        val level: LogLevel,
-        val text: String?
-    ) {
-        val logDate: Date = DateTimeUtils.nowUTC()
-
-        override fun toString(): String {
-            val logText = if (text.isNullOrEmpty()) "null" else text
-            val logDateStr = SimpleDateFormat("MMM-dd kk:mm", Locale.US).format(logDate)
-            return "[$logDateStr ${tag.name} ${level.name}] $logText"
-        }
-    }
-
-    /**
-     * Fix-sized list of log entries
-     */
-    private class LogEntryList : LinkedHashMap<Int, LogEntry>() {
-        override fun removeEldestEntry(eldest: MutableEntry<Int, LogEntry>?): Boolean {
-            return size > MAX_ENTRIES
-        }
-
-        @Synchronized
-        fun add(element: LogEntry) {
-            put(size, element)
-        }
-
-        /**
-         * Returns the log entries as an array of html-formatted strings - this enables us to display
-         * a formatted log in [com.woocommerce.android.support.WooLogViewerActivity]
-         */
-        fun toHtmlList(isDarkTheme: Boolean): List<String> {
-            fun LogEntry.getColor(): String {
-                return if (isDarkTheme) {
-                    "white"
-                } else when (level) {
-                    LogLevel.v -> "grey"
-                    LogLevel.d -> "teal"
-                    LogLevel.i -> "black"
-                    LogLevel.w -> "purple"
-                    LogLevel.e -> "red"
-                }
-            }
-
-            // work with a copy of the log entries in case they're modified while traversing them
-            return values.toList().map { entry ->
-                "<font color='${entry.getColor()}'>$entry</font>"
-            }
-        }
-
-        /**
-         * Returns the log entries as a single string with each entry on a new line. Works with a copy of the log
-         * entries in case they're modified while traversing them.
-         */
-        override fun toString() = values.toList().joinToString("\n")
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -178,5 +178,4 @@ object WooLog {
     fun toHtmlList(isDarkTheme: Boolean) = logEntries.toHtmlList(isDarkTheme)
 
     override fun toString() = logEntries.toString()
-
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -7,9 +7,8 @@ import org.wordpress.android.util.DateTimeUtils
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.text.SimpleDateFormat
-import java.util.ArrayList
-import java.util.Locale
-import java.util.NoSuchElementException
+import java.util.*
+import kotlin.collections.MutableMap.MutableEntry
 import org.wordpress.android.util.AppLog as WordPressAppLog
 
 typealias LogListener = (T, LogLevel, String) -> Unit
@@ -44,7 +43,7 @@ object WooLog {
     const val TAG = "WooCommerce"
     private const val MAX_ENTRIES = 99
     private val logEntries = LogEntryList()
-    private val listeners = ArrayList<LogListener>(0)
+    private val listeners = mutableListOf<LogListener>()
 
     init {
         // add listener for WP app log so we can capture login & FluxC logs
@@ -173,7 +172,7 @@ object WooLog {
     private fun addEntry(tag: T, level: LogLevel, text: String) {
         // add to list of entries
         val entry = LogEntry(tag, level, text)
-        logEntries.addEntry(entry)
+        logEntries.add(entry)
 
         // Call our listeners if any
         for (listener in listeners) {
@@ -200,12 +199,12 @@ object WooLog {
     /**
      * Individual log entry
      */
-    private class LogEntry internal constructor(
-        internal val tag: T,
-        internal val level: LogLevel,
-        internal val text: String?
+    private class LogEntry(
+        val tag: T,
+        val level: LogLevel,
+        val text: String?
     ) {
-        internal val logDate: java.util.Date = DateTimeUtils.nowUTC()
+        val logDate: Date = DateTimeUtils.nowUTC()
 
         override fun toString(): String {
             val logText = if (text.isNullOrEmpty()) "null" else text
@@ -217,60 +216,43 @@ object WooLog {
     /**
      * Fix-sized list of log entries
      */
-    private class LogEntryList : ArrayList<LogEntry>() {
-        @Synchronized
-        fun addEntry(entry: LogEntry): Boolean {
-            if (size >= MAX_ENTRIES) {
-                removeFirstEntry()
-            }
-            return add(entry)
+    private class LogEntryList : LinkedHashMap<Int, LogEntry>() {
+        override fun removeEldestEntry(eldest: MutableEntry<Int, LogEntry>?): Boolean {
+            return size > MAX_ENTRIES
         }
 
-        private fun removeFirstEntry() {
-            val it = iterator()
-            if (it.hasNext()) {
-                try {
-                    remove(it.next())
-                } catch (e: NoSuchElementException) {
-                    // ignore
-                }
-            }
+        @Synchronized
+        fun add(element: LogEntry) {
+            put(size, element)
         }
 
         /**
          * Returns the log entries as an array of html-formatted strings - this enables us to display
          * a formatted log in [com.woocommerce.android.support.WooLogViewerActivity]
          */
-        fun toHtmlList(isDarkTheme: Boolean): ArrayList<String> {
-            val list = ArrayList<String>()
-            // work with a copy of the log entries in case they're modified while traversing them
-            val entries = mutableListOf<LogEntry>().also { it.addAll(this) }
-            for (entry in entries) {
-                // same colors as WPAndroid
-                val color = if (isDarkTheme) {
+        fun toHtmlList(isDarkTheme: Boolean): List<String> {
+            fun LogEntry.getColor(): String {
+                return if (isDarkTheme) {
                     "white"
-                } else when (entry.level) {
+                } else when (level) {
                     LogLevel.v -> "grey"
                     LogLevel.d -> "teal"
                     LogLevel.i -> "black"
                     LogLevel.w -> "purple"
                     LogLevel.e -> "red"
                 }
-                list.add("<font color='$color'>$entry</font>")
             }
-            return list
+
+            // work with a copy of the log entries in case they're modified while traversing them
+            return values.toList().map { entry ->
+                "<font color='${entry.getColor()}'>$entry</font>"
+            }
         }
 
         /**
-         * Returns the log entries as a single string with each entry on a new line
+         * Returns the log entries as a single string with each entry on a new line. Works with a copy of the log
+         * entries in case they're modified while traversing them.
          */
-        override fun toString(): String {
-            val sb = StringBuilder()
-            val entries = mutableListOf<LogEntry>().also { it.addAll(this) }
-            for (entry in entries) {
-                sb.append("${entry}\n")
-            }
-            return sb.toString()
-        }
+        override fun toString() = values.toList().joinToString("\n")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import android.util.Log
+import com.woocommerce.android.util.LogEntryList.LogEntry
 import java.io.PrintWriter
 import java.io.StringWriter
 import org.wordpress.android.util.AppLog as WordPressAppLog

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.util
 
 import android.util.Log
-import com.woocommerce.android.util.WooLog.LogLevel
-import com.woocommerce.android.util.WooLog.T
 import org.wordpress.android.util.DateTimeUtils
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -10,8 +8,6 @@ import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.collections.MutableMap.MutableEntry
 import org.wordpress.android.util.AppLog as WordPressAppLog
-
-typealias LogListener = (T, LogLevel, String) -> Unit
 
 /**
  * Simple wrapper for Android log calls, enables registering listeners for log events.
@@ -43,7 +39,6 @@ object WooLog {
     const val TAG = "WooCommerce"
     private const val MAX_ENTRIES = 99
     private val logEntries = LogEntryList()
-    private val listeners = mutableListOf<LogListener>()
 
     init {
         // add listener for WP app log so we can capture login & FluxC logs
@@ -62,10 +57,6 @@ object WooLog {
         }
 
         addEntry(T.WP, wooLogLevel, wpTag.name + " " + wpMessage)
-    }
-
-    fun addListener(listener: LogListener) {
-        listeners.add(listener)
     }
 
     /**
@@ -173,11 +164,6 @@ object WooLog {
         // add to list of entries
         val entry = LogEntry(tag, level, text)
         logEntries.add(entry)
-
-        // Call our listeners if any
-        for (listener in listeners) {
-            listener(tag, level, text)
-        }
     }
 
     fun addDeviceInfoEntry(tag: T, level: LogLevel = LogLevel.i) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.util
 
 import android.util.Log
-import com.woocommerce.android.util.LogEntryList.LogEntry
+import com.woocommerce.android.util.RollingLogEntries.LogEntry
 import java.io.PrintWriter
 import java.io.StringWriter
 import org.wordpress.android.util.AppLog as WordPressAppLog
@@ -35,7 +35,7 @@ object WooLog {
 
     const val TAG = "WooCommerce"
     private const val MAX_ENTRIES = 99
-    private val logEntries = LogEntryList(MAX_ENTRIES)
+    private val logEntries = RollingLogEntries(MAX_ENTRIES)
 
     init {
         // add listener for WP app log so we can capture login & FluxC logs

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/RollingLogEntriesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/RollingLogEntriesTest.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.util
 
 import com.woocommerce.android.util.RollingLogEntries.LogEntry
 import com.woocommerce.android.util.WooLog.LogLevel.d
-import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLog.T.UTILS
 import org.junit.Assert.assertThrows
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/RollingLogEntriesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/RollingLogEntriesTest.kt
@@ -23,7 +23,6 @@ class RollingLogEntriesTest {
         for (i in 0 until entries) {
             assertEquals(log[i].text, "$i")
         }
-
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/RollingLogEntriesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/RollingLogEntriesTest.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.util.RollingLogEntries.LogEntry
+import com.woocommerce.android.util.WooLog.LogLevel.d
+import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.util.WooLog.T.UTILS
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.security.InvalidParameterException
+import kotlin.test.assertEquals
+
+class RollingLogEntriesTest {
+    @Test
+    fun `Verify all entries are present if limit not reached`() {
+        val maxEntries = 20
+        val entries = 15
+        val log = RollingLogEntries(maxEntries)
+        for (i in 0 until entries) {
+            log.add(LogEntry(UTILS, d, "$i"))
+        }
+
+        assertEquals(log.size, entries)
+        for (i in 0 until entries) {
+            assertEquals(log[i].text, "$i")
+        }
+
+    }
+
+    @Test
+    fun `Verify oldest entries are discarded if limit reached`() {
+        val maxEntries = 10
+        val entries = 15
+        val logs = RollingLogEntries(maxEntries)
+
+        for (i in 0 until entries) {
+            logs.add(LogEntry(T.UTILS, d, "$i"))
+        }
+
+        assertEquals(logs.size, maxEntries)
+        logs.forEachIndexed { i, log ->
+            val expectedValue = i + entries - maxEntries
+            assertEquals(log.text, "$expectedValue")
+        }
+    }
+
+    @Test
+    fun `Verify an exception is thrown if the limit is less than or equal to 0`() {
+        assertThrows(InvalidParameterException::class.java) {
+            RollingLogEntries(0)
+        }
+
+        assertThrows(InvalidParameterException::class.java) {
+            RollingLogEntries(-1)
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/RollingLogEntriesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/RollingLogEntriesTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 
 class RollingLogEntriesTest {
     @Test
-    fun `Verify all entries are present if limit not reached`() {
+    fun `Given there are fewer entries than the limit, no entries are removed`() {
         val maxEntries = 20
         val entries = 15
         val log = RollingLogEntries(maxEntries)
@@ -26,13 +26,13 @@ class RollingLogEntriesTest {
     }
 
     @Test
-    fun `Verify oldest entries are discarded if limit reached`() {
+    fun `Given there are more entries than the limit, the oldest entries are removed, keeping the size to the max`() {
         val maxEntries = 10
         val entries = 15
         val logs = RollingLogEntries(maxEntries)
 
         for (i in 0 until entries) {
-            logs.add(LogEntry(T.UTILS, d, "$i"))
+            logs.add(LogEntry(UTILS, d, "$i"))
         }
 
         assertEquals(logs.size, maxEntries)
@@ -43,7 +43,7 @@ class RollingLogEntriesTest {
     }
 
     @Test
-    fun `Verify an exception is thrown if the limit is less than or equal to 0`() {
+    fun `When the RollingLogEntries is initialized with non-positive number as the limit, an exception is thrown`() {
         assertThrows(InvalidParameterException::class.java) {
             RollingLogEntries(0)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -1,12 +1,7 @@
 package com.woocommerce.android.util
 
-import com.woocommerce.android.util.WooLog.LogLevel
-import com.woocommerce.android.util.WooLog.T
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.ArrayList
-
-typealias LogListener = (T, LogLevel, String) -> Unit
 
 /**
  * Simple wrapper for Android log calls, enables registering listeners for log events.
@@ -37,11 +32,6 @@ object WooLog {
     enum class LogLevel { v, d, i, w, e }
 
     const val TAG = "WooCommerce"
-    private val listeners = ArrayList<LogListener>(0)
-
-    fun addListener(listener: LogListener) {
-        listeners.add(listener)
-    }
 
     /**
      * Sends a VERBOSE log message
@@ -145,10 +135,6 @@ object WooLog {
     }
 
     private fun addEntry(tag: T, level: LogLevel, text: String) {
-        // Call our listeners if any
-        for (listener in listeners) {
-            listener(tag, level, text)
-        }
     }
 
     private fun getStringStackTrace(throwable: Throwable): String {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -40,7 +40,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun v(tag: T, message: String) {
-        System.out.println("v - $TAG-$tag - $message")
+        println("v - $TAG-$tag - $message")
         addEntry(tag, LogLevel.v, message)
     }
 
@@ -51,7 +51,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun d(tag: T, message: String) {
-        System.out.println("d - $TAG-$tag - $message")
+        println("d - $TAG-$tag - $message")
         addEntry(tag, LogLevel.d, message)
     }
 
@@ -62,7 +62,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun i(tag: T, message: String) {
-        System.out.println("i - $TAG-$tag - $message")
+        println("i - $TAG-$tag - $message")
         addEntry(tag, LogLevel.i, message)
     }
 
@@ -73,7 +73,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun w(tag: T, message: String) {
-        System.out.println("w - $TAG-$tag - $message")
+        println("w - $TAG-$tag - $message")
         addEntry(tag, LogLevel.w, message)
     }
 
@@ -84,7 +84,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun e(tag: T, message: String) {
-        System.out.println("e - $TAG-$tag - $message")
+        println("e - $TAG-$tag - $message")
         addEntry(tag, LogLevel.e, message)
     }
 
@@ -96,8 +96,8 @@ object WooLog {
      * @param tr An exception to log
      */
     fun e(tag: T, message: String, tr: Throwable) {
-        System.out.println("e - $TAG-$tag - $message")
-        System.out.println(tr)
+        println("e - $TAG-$tag - $message")
+        println(tr)
         addEntry(tag, LogLevel.e, message + " - exception: " + tr.message)
         addEntry(tag, LogLevel.e, "StackTrace: " + getStringStackTrace(tr))
     }
@@ -109,8 +109,8 @@ object WooLog {
      * @param tr An exception to log to get StackTrace
      */
     fun e(tag: T, tr: Throwable) {
-        System.out.println("e - " + TAG + "-" + tag.toString() + " - " + tr.message)
-        System.out.println(tr)
+        println("e - " + TAG + "-" + tag.toString() + " - " + tr.message)
+        println(tr)
         addEntry(tag, LogLevel.e, tr.message ?: "")
         addEntry(tag, LogLevel.e, "StackTrace: " + getStringStackTrace(tr))
     }
@@ -130,7 +130,7 @@ object WooLog {
         } else {
             "$volleyErrorMsg, status $statusCode"
         }
-        System.out.println("e - $TAG-$tag - $logText")
+        println("e - $TAG-$tag - $logText")
         addEntry(tag, LogLevel.w, logText)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -1,8 +1,5 @@
 package com.woocommerce.android.util
 
-import java.io.PrintWriter
-import java.io.StringWriter
-
 /**
  * Simple wrapper for Android log calls, enables registering listeners for log events.
  *
@@ -41,7 +38,6 @@ object WooLog {
      */
     fun v(tag: T, message: String) {
         println("v - $TAG-$tag - $message")
-        addEntry(tag, LogLevel.v, message)
     }
 
     /**
@@ -52,7 +48,6 @@ object WooLog {
      */
     fun d(tag: T, message: String) {
         println("d - $TAG-$tag - $message")
-        addEntry(tag, LogLevel.d, message)
     }
 
     /**
@@ -63,7 +58,6 @@ object WooLog {
      */
     fun i(tag: T, message: String) {
         println("i - $TAG-$tag - $message")
-        addEntry(tag, LogLevel.i, message)
     }
 
     /**
@@ -74,7 +68,6 @@ object WooLog {
      */
     fun w(tag: T, message: String) {
         println("w - $TAG-$tag - $message")
-        addEntry(tag, LogLevel.w, message)
     }
 
     /**
@@ -85,7 +78,6 @@ object WooLog {
      */
     fun e(tag: T, message: String) {
         println("e - $TAG-$tag - $message")
-        addEntry(tag, LogLevel.e, message)
     }
 
     /**
@@ -98,8 +90,6 @@ object WooLog {
     fun e(tag: T, message: String, tr: Throwable) {
         println("e - $TAG-$tag - $message")
         println(tr)
-        addEntry(tag, LogLevel.e, message + " - exception: " + tr.message)
-        addEntry(tag, LogLevel.e, "StackTrace: " + getStringStackTrace(tr))
     }
 
     /**
@@ -111,8 +101,6 @@ object WooLog {
     fun e(tag: T, tr: Throwable) {
         println("e - " + TAG + "-" + tag.toString() + " - " + tr.message)
         println(tr)
-        addEntry(tag, LogLevel.e, tr.message ?: "")
-        addEntry(tag, LogLevel.e, "StackTrace: " + getStringStackTrace(tr))
     }
 
     /**
@@ -131,15 +119,5 @@ object WooLog {
             "$volleyErrorMsg, status $statusCode"
         }
         println("e - $TAG-$tag - $logText")
-        addEntry(tag, LogLevel.w, logText)
-    }
-
-    private fun addEntry(tag: T, level: LogLevel, text: String) {
-    }
-
-    private fun getStringStackTrace(throwable: Throwable): String {
-        val errors = StringWriter()
-        throwable.printStackTrace(PrintWriter(errors))
-        return errors.toString()
     }
 }


### PR DESCRIPTION
This PR improves the `WooLog` rolling entry list by using a more efficient data structure, namely ~~`LinkedHashMap`~~`LinkedList`. 

The `WooLog` limits the number of entries to a certain number of elements (99). Previously the last entry was manually removed. ~~With the new approach, this is done automattically using the `LinkedHashMap.removeEldestEntry()` function.~~

The main reason for this PR is to avoid using an `ArrayList` as a base class to implement `LogEntryList` because it's causing a crash due to a bug in Jetpack Compose:

```
 No virtual method getSize()I in class Lcom/woocommerce/android/util/WooLog$LogEntryList; or its super classes (declaration of ‘com.woocommerce.android.util.WooLog$LogEntryList’)
```