### PR TITLE
Order Creation: reusable component for the form's sections

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreationSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreationSectionView.kt
@@ -1,0 +1,81 @@
+package com.woocommerce.android.ui.orders.creation.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.res.use
+import androidx.core.view.isVisible
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.OrderCreationSectionBinding
+
+class OrderCreationSectionView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.materialCardViewStyle
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    private val binding = OrderCreationSectionBinding.inflate(LayoutInflater.from(ctx), this, true)
+
+    var header: CharSequence
+        get() = binding.headerLabel.text
+        set(value) {
+            binding.headerLabel.text = value
+        }
+
+    var keepAddButtons: Boolean = false
+
+    init {
+        attrs?.let {
+            context.obtainStyledAttributes(attrs, R.styleable.OrderCreationSectionView, defStyleAttr, 0)
+                .use { a ->
+                    header = a.getString(R.styleable.OrderCreationSectionView_header).orEmpty()
+                    keepAddButtons = a.getBoolean(R.styleable.OrderCreationSectionView_keepAddButtons, false)
+                }
+        }
+    }
+
+    fun setAddButtons(buttons: List<AddButton>) {
+        binding.addButtonsLayout.removeAllViews()
+        buttons.forEach { buttonModel ->
+            val button = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
+            button.text = buttonModel.text
+            button.icon = AppCompatResources.getDrawable(context, R.drawable.ic_add)
+            button.gravity = Gravity.START or Gravity.CENTER_VERTICAL
+            button.setOnClickListener { buttonModel.onClickListener() }
+            binding.addButtonsLayout.addView(
+                button,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        }
+    }
+
+    fun updateContent(content: View?) {
+        binding.editButton.isVisible = content != null
+        binding.contentLayout.isVisible = content != null
+        binding.contentLayout.removeAllViews()
+        content?.let {
+            binding.contentLayout.addView(
+                content,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        }
+
+        binding.addButtonsLayout.isVisible = keepAddButtons || content == null
+    }
+
+    fun setOnEditButtonClicked(listener: () -> Unit) {
+        binding.editButton.setOnClickListener { listener() }
+    }
+
+    data class AddButton(
+        val text: CharSequence,
+        val onClickListener: () -> Unit
+    )
+}

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/header_label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_75"
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        app:layout_constraintEnd_toStartOf="@id/edit_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/edit_button"
+        style="@style/Woo.Button.TextButton.Secondary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/edit"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <FrameLayout
+        android:id="@+id/content_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/major_100"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/header_label" />
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/add_buttons_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/content_layout" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -24,6 +24,7 @@
         <attr name="settingsOptionValueStyle" format="reference" />
         <attr name="settingsCategoryHeaderStyle" format="reference" />
         <attr name="settingsButtonStyle" format="reference" />
+        <attr name="secondaryTextButtonStyle" format="reference" />
     </declare-styleable>
 
     <declare-styleable name="WCTextViewCompat">
@@ -180,6 +181,12 @@
         <attr name="circleProgressRestColor" format="color" />
         <attr name="circleProgressBorderColor" format="color" />
         <attr name="circleProgressBorderSize" format="dimension" />
+    </declare-styleable>
+
+
+    <declare-styleable name="OrderCreationSectionView">
+        <attr name="header" format="string" />
+        <attr name="keepAddButtons" format="boolean" />
     </declare-styleable>
 
 </resources>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -88,6 +88,7 @@
         <item name="autoCompleteTextViewStyle">@style/Woo.AutoCompleteTextView</item>
         <item name="bottomSheetDialogTheme">@style/Woo.Theme.BottomSheetDialog</item>
         <item name="actionOverflowButtonStyle">@style/Woo.ActionMode.OverflowButtonStyle</item>
+        <item name="secondaryTextButtonStyle">@style/Woo.Button.TextButton.Secondary</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>


### PR DESCRIPTION
### Description
Since the order note's subject wasn't decided today, I decided to spend some time checking if we can improve our workflow by having a reusable view for the form's sections, which resulted in this draft PR.
I tried to keep the component simple, so it won't be able to handle the payments' section, but it would allow handling all the other sections:

<img width="360" alt="Screen Shot 2021-12-03 at 16 56 02" src="https://user-images.githubusercontent.com/1657201/144632710-45444187-db3e-4bea-9c28-6f05048fd615.png">   <img width="360" alt="Screen Shot 2021-12-03 at 16 56 09" src="https://user-images.githubusercontent.com/1657201/144632682-f0045862-a5e7-4b17-b19b-f7498ce300b2.png">

The styling of the `edit` button might need some adjustments to be consistent (we need to either fix it for this component or for the status section)

If you think this kind of abstraction is not good for us, just let me know, we can drop this PR 🙂, and if you have remarks that can improve the Component's API, please share them 🙏 


If you want to play around with the component and to see how we can use it, please apply this patch:
```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt	(revision 96b0ed702ed2cd5411c097aae9678e5662637139)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt	(date 1638547390573)
@@ -20,4 +20,8 @@
     fun onOrderStatusChanged(status: Order.Status) {
         orderDraft = orderDraft.copy(status = status)
     }
+
+    fun onNoteAdded() {
+        orderDraft = orderDraft.copy(customerNote = "New Note")
+    }
 }
Index: WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml	(revision 96b0ed702ed2cd5411c097aae9678e5662637139)
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml	(date 1638547591046)
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -8,6 +9,20 @@
         android:id="@+id/order_status_view"
         style="@style/Woo.Card"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
 
+    <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
+        android:id="@+id/customer_section"
+        style="@style/Woo.Card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:header="Customer"/>
+
+    <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
+        android:id="@+id/note_section"
+        style="@style/Woo.Card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:header="Order Note" />
+
 </androidx.appcompat.widget.LinearLayoutCompat>
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt	(revision 96b0ed702ed2cd5411c097aae9678e5662637139)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt	(date 1638547563894)
@@ -5,17 +5,21 @@
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.textview.MaterialTextView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreationFormBinding
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.creation.OrderCreationFormViewModel.ShowStatusTag
+import com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog.Companion.KEY_ORDER_STATUS_RESULT
+import com.woocommerce.android.ui.orders.details.views.OrderDetailCustomerInfoView
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -41,11 +45,44 @@
                 formViewModel.onEditOrderStatusSelected(sharedViewModel.currentStatus)
             }
         )
+
+        noteSection.setAddButtons(listOf(
+            OrderCreationSectionView.AddButton(
+                text = "Add Note",
+                onClickListener = {
+                    sharedViewModel.onNoteAdded()
+                }
+            )
+        ))
+        noteSection.setOnEditButtonClicked {
+            // Handle edit button
+        }
+        customerSection.setAddButtons(listOf(
+            OrderCreationSectionView.AddButton(
+                text = "Add Customer",
+                onClickListener = {
+                    // An example of we can use another custom View for managing the section's content
+                    // Should be in [setupObserversWith]
+                    val content = OrderDetailCustomerInfoView(requireContext())
+                    val tempOrder = Order.EMPTY.copy(
+                        shippingAddress = Address.EMPTY.copy(
+                            firstName = "Jhon", lastName = "Doe", country = "United States"
+                        ),
+                        billingAddress = Address.EMPTY.copy(
+                            firstName = "Jhon", lastName = "Doe", country = "United States"
+                        )
+                    )
+                    content.updateCustomerInfo(tempOrder, false, true)
+                    customerSection.updateContent(content)
+                }
+            )
+        ))
     }
 
     private fun setupObserversWith(binding: FragmentOrderCreationFormBinding) {
         sharedViewModel.orderDraftData.observe(viewLifecycleOwner) { oldOrderData, newOrderData ->
             binding.orderStatusView.updateOrder(newOrderData)
+            bindOrderNote(binding.noteSection, newOrderData.customerNote)
             newOrderData.takeIfNotEqualTo(oldOrderData?.status) {
                 formViewModel.requestStatusTagData(newOrderData.status)
             }
@@ -56,6 +93,15 @@
         }
     }
 
+    private fun bindOrderNote(section: OrderCreationSectionView, note: String) {
+        note.takeIf { it.isNotBlank() }
+            ?.let {
+                MaterialTextView(requireContext()).apply { text = note }
+            }.let { view ->
+                section.updateContent(view)
+            }
+    }
+
     private fun setupHandleResults() {
         handleDialogResult<OrderStatusUpdateSource>(
             key = KEY_ORDER_STATUS_RESULT,
```
