### PR TITLE
Order Creation: adding customer note

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
@@ -53,6 +53,8 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
         }
     }
 
+    override fun getFragmentTitle() = getString(R.string.order_creation_customer_note)
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.widget.doAfterTextChanged
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
@@ -18,6 +19,8 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
     val binding
         get() = _binding!!
 
+    private lateinit var doneMenuItem: MenuItem
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
@@ -26,12 +29,17 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
         if (savedInstanceState == null) {
             binding.customerOrderNoteEditor.setText(sharedViewModel.currentDraft.customerNote)
         }
+        binding.customerOrderNoteEditor.doAfterTextChanged {
+            doneMenuItem.isVisible = hasChanges()
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
+        doneMenuItem = menu.findItem(R.id.menu_done)
+        doneMenuItem.isVisible = hasChanges()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -49,4 +57,7 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
         super.onDestroyView()
         _binding = null
     }
+
+    private fun hasChanges() =
+        binding.customerOrderNoteEditor.text.toString() != sharedViewModel.currentDraft.customerNote
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
@@ -6,6 +6,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditCustomerOrderNoteBinding
 import com.woocommerce.android.ui.base.BaseFragment
@@ -19,8 +20,12 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setHasOptionsMenu(true)
+
         _binding = FragmentEditCustomerOrderNoteBinding.bind(view)
-        binding.customerOrderNoteEditor.setText(sharedViewModel.currentDraft.customerNote)
+        if (savedInstanceState == null) {
+            binding.customerOrderNoteEditor.setText(sharedViewModel.currentDraft.customerNote)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -33,6 +38,7 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
         return when (item.itemId) {
             R.id.menu_done -> {
                 sharedViewModel.onCustomerNoteEdited(binding.customerOrderNoteEditor.text.toString())
+                findNavController().navigateUp()
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.orders.creation
+
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentEditCustomerOrderNoteBinding
+import com.woocommerce.android.ui.base.BaseFragment
+
+class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_customer_order_note) {
+    private val sharedViewModel by hiltNavGraphViewModels<OrderCreationViewModel>(R.id.nav_graph_order_creations)
+
+    private var _binding: FragmentEditCustomerOrderNoteBinding? = null
+    val binding
+        get() = _binding!!
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentEditCustomerOrderNoteBinding.bind(view)
+        binding.customerOrderNoteEditor.setText(sharedViewModel.currentDraft.customerNote)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        menu.clear()
+        inflater.inflate(R.menu.menu_done, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_done -> {
+                sharedViewModel.onCustomerNoteEdited(binding.customerOrderNoteEditor.text.toString())
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerNoteFragment.kt
@@ -30,7 +30,9 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
             binding.customerOrderNoteEditor.setText(sharedViewModel.currentDraft.customerNote)
         }
         binding.customerOrderNoteEditor.doAfterTextChanged {
-            doneMenuItem.isVisible = hasChanges()
+            if (::doneMenuItem.isInitialized) {
+                doneMenuItem.isVisible = hasChanges()
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -20,14 +20,11 @@ import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderStatu
 import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog.Companion.KEY_ORDER_STATUS_RESULT
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_form) {
     private val sharedViewModel by hiltNavGraphViewModels<OrderCreationViewModel>(R.id.nav_graph_order_creations)
     private val formViewModel by viewModels<OrderCreationFormViewModel>()
-
-    @Inject lateinit var navigator: OrderCreationNavigator
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -98,7 +95,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
 
     private fun handleViewModelEvents(event: Event) {
         when (event) {
-            is OrderCreationNavigationTarget -> navigator.navigate(this, event)
+            is OrderCreationNavigationTarget -> OrderCreationNavigator.navigate(this, event)
             is ViewOrderStatusSelector ->
                 OrderCreationFormFragmentDirections
                     .actionOrderCreationFragmentToOrderStatusSelectorDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -54,7 +54,8 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                     text = getString(R.string.order_creation_add_customer_note),
                     onClickListener = {
                         formViewModel.onCustomerNoteClicked()
-                    })
+                    }
+                )
             )
         )
         notesSection.setOnEditButtonClicked {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormViewModel.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.extensions.runWithContext
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.creation.OrderCreationNavigationTarget.EditCustomerNote
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -41,6 +42,10 @@ class OrderCreationFormViewModel @Inject constructor(
             ShowStatusTag(orderDetailRepository.getOrderStatus(status.value))
                 .runWithContext(dispatchers.main) { triggerEvent(it) }
         }
+    }
+
+    fun onCustomerNoteClicked() {
+        triggerEvent(EditCustomerNote)
     }
 
     data class ShowStatusTag(val orderStatus: OrderStatus) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigationTarget.kt
@@ -3,5 +3,5 @@ package com.woocommerce.android.ui.orders.creation
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
 sealed class OrderCreationNavigationTarget : Event() {
-    data class EditCustomerNote(val currentNote: String): OrderCreationNavigationTarget()
+    object EditCustomerNote: OrderCreationNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigationTarget.kt
@@ -3,5 +3,5 @@ package com.woocommerce.android.ui.orders.creation
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
 sealed class OrderCreationNavigationTarget : Event() {
-    object EditCustomerNote: OrderCreationNavigationTarget()
+    object EditCustomerNote : OrderCreationNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigationTarget.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+
+sealed class OrderCreationNavigationTarget : Event() {
+    data class EditCustomerNote(val currentNote: String): OrderCreationNavigationTarget()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
@@ -3,9 +3,8 @@ package com.woocommerce.android.ui.orders.creation
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.orders.creation.OrderCreationNavigationTarget.EditCustomerNote
-import javax.inject.Inject
 
-class OrderCreationNavigator @Inject constructor() {
+object OrderCreationNavigator {
     fun navigate(fragment: Fragment, target: OrderCreationNavigationTarget) {
         val navController = fragment.findNavController()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
@@ -10,8 +10,8 @@ class OrderCreationNavigator @Inject constructor() {
         val navController = fragment.findNavController()
 
         val action = when (target) {
-            is EditCustomerNote -> OrderCreationFormFragmentDirections
-                .actionOrderCreationFragmentToOrderCreationCustomerNoteFragment()
+            is EditCustomerNote ->
+                OrderCreationFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCustomerNoteFragment()
         }
 
         navController.navigate(action)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.orders.creation
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.ui.orders.creation.OrderCreationNavigationTarget.EditCustomerNote
+import javax.inject.Inject
+
+class OrderCreationNavigator @Inject constructor() {
+    fun navigate(fragment: Fragment, target: OrderCreationNavigationTarget) {
+        val navController = fragment.findNavController()
+
+        val action = when (target) {
+            is EditCustomerNote -> OrderCreationFormFragmentDirections
+                .actionOrderCreationFragmentToOrderCreationCustomerNoteFragment()
+        }
+
+        navController.navigate(action)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -22,6 +22,9 @@ class OrderCreationRepository @Inject constructor(
             orderStore.getOrderStatusForSiteAndKey(selectedSite.get(), order.status.value)
                 ?: error("Couldn't find a status with key ${order.status.value}")
         }
+
+        // TODO pass the customer note to the request
+
         val request = CreateOrderRequest(
             status = status,
             lineItems = order.items.map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -14,10 +14,14 @@ class OrderCreationViewModel @Inject constructor(
     val orderDraftData = LiveDataDelegate(savedState, Order.EMPTY)
     private var orderDraft by orderDraftData
 
-    val currentStatus
-        get() = orderDraft.status
+    val currentDraft
+        get() = orderDraft
 
     fun onOrderStatusChanged(status: Order.Status) {
         orderDraft = orderDraft.copy(status = status)
+    }
+
+    fun onCustomerNoteEdited(newNote: String) {
+        orderDraft = orderDraft.copy(customerNote = newNote)
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -8,6 +9,13 @@
         android:id="@+id/order_status_view"
         style="@style/Woo.Card"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
+
+    <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
+        android:id="@+id/notes_section"
+        style="@style/Woo.Card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:header="@string/order_creation_customer_note" />
 
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -14,6 +14,9 @@
             app:destination="@id/orderStatusSelectorDialog"
             app:enterAnim="@anim/activity_fade_in"
             app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_orderCreationFragment_to_orderCreationCustomerNoteFragment"
+            app:destination="@id/orderCreationCustomerNoteFragment" />
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"
@@ -26,4 +29,9 @@
             android:name="orderStatusList"
             app:argType="com.woocommerce.android.model.Order$OrderStatus[]" />
     </dialog>
+    <fragment
+        android:id="@+id/orderCreationCustomerNoteFragment"
+        android:name="com.woocommerce.android.ui.orders.creation.OrderCreationCustomerNoteFragment"
+        android:label="OrderCreationCustomerNoteFragment" />
+
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2096,4 +2096,6 @@
     <string name="product_downloadable_files_download_settings">Download Settings</string>
     <string name="shipping_label_payments_cant_edit_warning">Only the site owner can manage the shipping label payment methods. Please contact Store Owner %1$s (%2$s) to manage payment methods.</string>
     <string name="magic_link_not_meaning_to_create_account">Didn\'t mean to create a new account? Go back to re-enter your email address.</string>
+    <string name="order_creation_customer_note">Customer Note</string>
+    <string name="order_creation_add_customer_note">Add note</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5227 
Closes: #5228 

### Description
This PR handles the customer note section, it's based on the work done on #5405, but if the team decides against this component, the migration won't be hard.

I took liberty to add classes for managing the navigation: `OrderCreationNavigationTarget` and `OrderCreationNavigator`

### Testing instructions
1. Make sure the Order Creation experimental flag is activated
2. Go to the Order List and hit the FAB, select the Order Creation option if asked
3. Click on Add note button.
4. Make changes and make sure the "done" button appears as expected.
5. Click on Done and confirm the changes are saved.
6. Click on Edit and confirm it works. 

### Images/gif
| | | |
|- | - | -|
| <img width="400" alt="Screen Shot 2021-12-03 at 18 00 14" src="https://user-images.githubusercontent.com/1657201/144642602-d17cd603-d87f-41ee-bb97-4ebe01b126e5.png"> | <img width="400" alt="Screen Shot 2021-12-03 at 18 03 24" src="https://user-images.githubusercontent.com/1657201/144642945-8f4e9b9a-1ce8-4474-87f8-ef0176d001ad.png"> | <img width="400" alt="Screen Shot 2021-12-03 at 18 00 30" src="https://user-images.githubusercontent.com/1657201/144642596-50c924a0-037c-4526-b920-81f6f42dc315.png"> |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
