### PR TITLE
Added a mock for a recently introduced endpoint.

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/rest_api_locale_POST.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/rest_api_locale_POST.json
@@ -1,7 +1,11 @@
 {
   "request": {
     "method": "POST",
-    "urlPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/\\?locale=(.*)"
+    "urlPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/\\?locale=(.*)",
+    "queryParameters" : {
+      "json" : {
+        "absent" : true
+      }
   },
   "response": {
     "status": 200,

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/rest_api_locale_POST.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/rest_api_locale_POST.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/\\?locale=(.*)"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "data": null
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive"
+    }
+  }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/rest_api_locale_POST.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/rest_api_locale_POST.json
@@ -6,6 +6,7 @@
       "json" : {
         "absent" : true
       }
+    }
   },
   "response": {
     "status": 200,


### PR DESCRIPTION
### Description
The available UI tests started failing because of this WireMock warning, which most probably is a result of a recently introduced endpoint, for which a mock was not created:

<img width="1281" alt="Screenshot 2021-12-06 at 18 55 07" src="https://user-images.githubusercontent.com/73365754/144890634-30989448-b4c8-4783-842e-45072a96fda5.png">

This PR adds a missing mock file.

### Testing instructions
- Run `ProductsUITest` and `ReviewsUITest` -> they should pass

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.