### PR TITLE
Fix backspace deleting 2 characters at a time

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -63,6 +63,20 @@ class CurrencyEditText : AppCompatEditText {
         if (isInitialized && !isChangingText) {
             isChangingText = true
 
+            val cleanValue = clean(text = text, decimals = decimals, lengthBefore = lengthBefore, lengthAfter = lengthAfter)
+
+            _value.value = cleanValue
+            setText(formatCurrency(cleanValue))
+
+            isChangingText = false
+        }
+    }
+
+    companion object TextCleaner {
+        /**
+         * Cleans the [text] so that it only has numerical characters and has the correct number of fractional digits.
+         */
+        fun clean(text: CharSequence?, decimals: Int, lengthBefore: Int, lengthAfter: Int): BigDecimal {
             val regex = Regex("[^\\d]")
             var cleanValue = text.toString().replace(regex, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
 
@@ -74,10 +88,8 @@ class CurrencyEditText : AppCompatEditText {
                 cleanValue = cleanValue.divide(BigDecimal(10f.pow(lengthBefore - lengthAfter).toInt()), DOWN)
             }
 
-            _value.value = cleanValue
-            setText(formatCurrency(cleanValue))
-
-            isChangingText = false
+            return cleanValue
         }
+
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.woocommerce.android.util.CurrencyFormatter
 import java.math.BigDecimal
-import java.math.RoundingMode.DOWN
 import java.math.RoundingMode.HALF_UP
 import kotlin.math.pow
 
@@ -63,7 +62,7 @@ class CurrencyEditText : AppCompatEditText {
         if (isInitialized && !isChangingText) {
             isChangingText = true
 
-            val cleanValue = clean(text = text, decimals = decimals, lengthBefore = lengthBefore, lengthAfter = lengthAfter)
+            val cleanValue = clean(text = text, decimals = decimals)
 
             _value.value = cleanValue
             setText(formatCurrency(cleanValue))
@@ -76,7 +75,7 @@ class CurrencyEditText : AppCompatEditText {
         /**
          * Cleans the [text] so that it only has numerical characters and has the correct number of fractional digits.
          */
-        fun clean(text: CharSequence?, decimals: Int, lengthBefore: Int, lengthAfter: Int): BigDecimal {
+        fun clean(text: CharSequence?, decimals: Int): BigDecimal {
             val regex = Regex("[^\\d]")
             var cleanValue = text.toString().replace(regex, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -85,6 +85,5 @@ class CurrencyEditText : AppCompatEditText {
 
             return cleanValue
         }
-
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -77,8 +77,8 @@ class CurrencyEditText : AppCompatEditText {
          * Cleans the [text] so that it only has numerical characters and has the correct number of fractional digits.
          */
         fun clean(text: CharSequence?, decimals: Int, lengthBefore: Int, lengthAfter: Int): BigDecimal {
-            val regex = Regex("[^\\d]")
-            var cleanValue = text.toString().replace(regex, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
+            val nonNumericMatchPattern = Regex("[^\\d]")
+            var cleanValue = text.toString().replace(nonNumericMatchPattern, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
 
             if (decimals > 0) {
                 cleanValue = cleanValue.divide(BigDecimal(10f.pow(decimals).toInt()), decimals, HALF_UP)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -63,7 +63,12 @@ class CurrencyEditText : AppCompatEditText {
         if (isInitialized && !isChangingText) {
             isChangingText = true
 
-            val cleanValue = clean(text = text, decimals = decimals, lengthBefore = lengthBefore, lengthAfter = lengthAfter)
+            val cleanValue = clean(
+                text = text,
+                decimals = decimals,
+                lengthBefore = lengthBefore,
+                lengthAfter = lengthAfter
+            )
 
             _value.value = cleanValue
             setText(formatCurrency(cleanValue))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.woocommerce.android.util.CurrencyFormatter
 import java.math.BigDecimal
+import java.math.RoundingMode.DOWN
 import java.math.RoundingMode.HALF_UP
 import kotlin.math.pow
 
@@ -62,7 +63,7 @@ class CurrencyEditText : AppCompatEditText {
         if (isInitialized && !isChangingText) {
             isChangingText = true
 
-            val cleanValue = clean(text = text, decimals = decimals)
+            val cleanValue = clean(text = text, decimals = decimals, lengthBefore = lengthBefore, lengthAfter = lengthAfter)
 
             _value.value = cleanValue
             setText(formatCurrency(cleanValue))
@@ -75,7 +76,7 @@ class CurrencyEditText : AppCompatEditText {
         /**
          * Cleans the [text] so that it only has numerical characters and has the correct number of fractional digits.
          */
-        fun clean(text: CharSequence?, decimals: Int): BigDecimal {
+        fun clean(text: CharSequence?, decimals: Int, lengthBefore: Int, lengthAfter: Int): BigDecimal {
             val regex = Regex("[^\\d]")
             var cleanValue = text.toString().replace(regex, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -77,15 +77,19 @@ class CurrencyEditText : AppCompatEditText {
          * Cleans the [text] so that it only has numerical characters and has the correct number of fractional digits.
          */
         fun clean(text: CharSequence?, decimals: Int, lengthBefore: Int, lengthAfter: Int): BigDecimal {
-            val nonNumericMatchPattern = Regex("[^\\d]")
-            var cleanValue = text.toString().replace(nonNumericMatchPattern, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
+            val nonNumericPattern = Regex("[^\\d]")
+            var cleanValue = text.toString().replace(nonNumericPattern, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
 
             if (decimals > 0) {
                 cleanValue = cleanValue.divide(BigDecimal(10f.pow(decimals).toInt()), decimals, HALF_UP)
             }
 
             if (lengthBefore > lengthAfter) {
-                cleanValue = cleanValue.divide(BigDecimal(10f.pow(lengthBefore - lengthAfter).toInt()), DOWN)
+                // https://regexr.com/6b5tk
+                val startsWithDigitPattern = Regex("^\\d.*")
+                if (text.toString().matches(startsWithDigitPattern)) {
+                    cleanValue = cleanValue.divide(BigDecimal(10f.pow(lengthBefore - lengthAfter).toInt()), DOWN)
+                }
             }
 
             return cleanValue

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -84,6 +84,10 @@ class CurrencyEditText : AppCompatEditText {
                 cleanValue = cleanValue.divide(BigDecimal(10f.pow(decimals).toInt()), decimals, HALF_UP)
             }
 
+            if (lengthBefore > lengthAfter) {
+                cleanValue = cleanValue.divide(BigDecimal(10f.pow(lengthBefore - lengthAfter).toInt()), DOWN)
+            }
+
             return cleanValue
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -84,7 +84,23 @@ class CurrencyEditText : AppCompatEditText {
                 cleanValue = cleanValue.divide(BigDecimal(10f.pow(decimals).toInt()), decimals, HALF_UP)
             }
 
+            // Check if a backspace was pressed.
             if (lengthBefore > lengthAfter) {
+                // If backspace was pressed, we want the last digit to be removed if there is a non-numeric character
+                // (i.e. the currency symbol) on the right. Or if there is no non-numeric character at all. This means
+                // that the backspace only deleted the currency symbol character and not the digit.
+                //
+                // If we don't handle this manually, it will look like the user _did not delete anything_.
+                //
+                // Example scenario:
+                //
+                // 1. If the current text is "123.79CA$" (French Canada places the dollar symbol on the right)
+                // 2. The user presses backspace
+                // 3. The [CurrencyEditText.onTextChanged] will be called with [text] equal to "123.79CA"
+                //
+                // If keep this as is and reformat again, we'll end up with same text, "123.79CA$". So it'll look like
+                // the backspace was ignored.
+
                 // https://regexr.com/6b5tk
                 val startsWithDigitPattern = Regex("^\\d.*")
                 if (text.toString().matches(startsWithDigitPattern)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -84,10 +84,6 @@ class CurrencyEditText : AppCompatEditText {
                 cleanValue = cleanValue.divide(BigDecimal(10f.pow(decimals).toInt()), decimals, HALF_UP)
             }
 
-            if (lengthBefore > lengthAfter) {
-                cleanValue = cleanValue.divide(BigDecimal(10f.pow(lengthBefore - lengthAfter).toInt()), DOWN)
-            }
-
             return cleanValue
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.widgets
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CurrencyEditTextTest {
+    @Test
+    fun `clean() returns the value without the non-numeric characters`() {
+        val text = "US$1345 nope"
+
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 0, lengthBefore = 0, lengthAfter = 0)
+
+        assertEquals(1345.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `clean() returns the value with the expected number of fractional digits`() {
+        val text = "US$1345 nope"
+
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+
+        assertEquals(13.45.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `clean() returns the expected number of fractional digits after pressing backspace`() {
+        val text = "12.3"
+
+        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+
+        assertEquals(1.23.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `clean() moves the decimal separator if the fractional digits are greater than the decimals argument`() {
+        val text = "12.345"
+
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+
+        assertEquals(123.45.toBigDecimal(), cleaned)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -8,7 +8,7 @@ class CurrencyEditTextTest {
     fun `clean() returns the value without the non-numeric characters`() {
         val text = "US$1345 nope"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 0)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 0, lengthBefore = 0, lengthAfter = 0)
 
         assertEquals(1345.toBigDecimal(), cleaned)
     }
@@ -17,16 +17,17 @@ class CurrencyEditTextTest {
     fun `clean() returns the value with the expected number of fractional digits`() {
         val text = "US$1345 nope"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
 
         assertEquals(13.45.toBigDecimal(), cleaned)
     }
 
     @Test
-    fun `clean() returns the same value if it is a valid number with the expected number of fractional digits`() {
-        val text = "1.23"
+    fun `clean() returns the expected number of fractional digits after pressing backspace`() {
+        val text = "12.3"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
+        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
 
         assertEquals(1.23.toBigDecimal(), cleaned)
     }
@@ -35,7 +36,7 @@ class CurrencyEditTextTest {
     fun `clean() moves the decimal separator if the fractional digits are greater than the decimals argument`() {
         val text = "12.345"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
 
         assertEquals(123.45.toBigDecimal(), cleaned)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -8,7 +8,7 @@ class CurrencyEditTextTest {
     fun `clean() returns the value without the non-numeric characters`() {
         val text = "US$1345 nope"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 0, lengthBefore = 0, lengthAfter = 0)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 0)
 
         assertEquals(1345.toBigDecimal(), cleaned)
     }
@@ -17,17 +17,16 @@ class CurrencyEditTextTest {
     fun `clean() returns the value with the expected number of fractional digits`() {
         val text = "US$1345 nope"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
 
         assertEquals(13.45.toBigDecimal(), cleaned)
     }
 
     @Test
-    fun `clean() returns the expected number of fractional digits after pressing backspace`() {
-        val text = "12.3"
+    fun `clean() returns the same value if it is a valid number with the expected number of fractional digits`() {
+        val text = "1.23"
 
-        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
 
         assertEquals(1.23.toBigDecimal(), cleaned)
     }
@@ -36,7 +35,7 @@ class CurrencyEditTextTest {
     fun `clean() moves the decimal separator if the fractional digits are greater than the decimals argument`() {
         val text = "12.345"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
 
         assertEquals(123.45.toBigDecimal(), cleaned)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -29,18 +29,41 @@ class CurrencyEditTextTest {
      *
      * Example scenario:
      *
-     * 1. If the current text is "123.79$" (French Canada places the dollar symbol on the right)
+     * 1. If the current text is "123.79CA$" (French Canada places the dollar symbol on the right)
      * 2. The user presses backspace
-     * 3. The [CurrencyEditText.onTextChanged] will be called with [text] equal to "123.79"
+     * 3. The [CurrencyEditText.onTextChanged] will be called with [text] equal to "123.79CA"
      *
-     * If keep this as is and reformat again, we'll end up with same text, "123.79$". So it'll look like the backspace
+     * If keep this as is and reformat again, we'll end up with same text, "123.79CA$". So it'll look like the backspace
      * was ignored.
      */
     @Test
     fun `given a currency symbol on the right, when pressing backspace, clean() removes the last digit`() {
-        val text = "123.79$"
+        val text = "123.79CA"
 
         // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+
+        assertEquals(12.37.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `given a currency symbol with space on the right, when pressing backspace, clean() removes the last digit`() {
+        val text = "123.79 $"
+
+        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+
+        assertEquals(12.37.toBigDecimal(), cleaned)
+    }
+
+    /**
+     * In this case, we assume that there was previously a symbol on the right but the backspace deleted it. To emulate
+     * proper backspace behavior, the last digit should be removed.
+     */
+    @Test
+    fun `given no currency symbol, when pressing backspace, clean() removes the last digit`() {
+        val text = "123.79"
+
         val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
 
         assertEquals(12.37.toBigDecimal(), cleaned)
@@ -59,23 +82,21 @@ class CurrencyEditTextTest {
      * If we manually remove the last digit, we'd end up with "123", which means we've incorrectly deleted 2 characters!
      */
     @Test
-    fun `given no currency symbol, when pressing backspace, clean() removes the last digit`() {
-        val text = "123.79"
-
-        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
-
-        assertEquals(123.79.toBigDecimal(), cleaned)
-    }
-
-    @Test
     fun `given a currency symbol on the left, when pressing backspace, clean() does not remove the last digit`() {
         val text = "$1,237,87.39"
 
-        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
         val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
 
         assertEquals(1_237_87.39.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `given a currency symbol with space on the left, when pressing backspace, clean() does not remove the last digit`() {
+        val text = "$ 123.89"
+
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+
+        assertEquals(123.89.toBigDecimal(), cleaned)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -111,7 +111,7 @@ class CurrencyEditTextTest {
     }
 
     @Test
-    fun `given a currency symbol with space on the left, when pressing backspace, clean() does not remove the last digit`() {
+    fun `given a spaced currency symbol on left, when pressing backspace, clean() does not remove the last digit`() {
         val text = "$ 123.89"
 
         val cleaned = CurrencyEditText.clean(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -23,7 +23,7 @@ class CurrencyEditTextTest {
     }
 
     /**
-     * We want the last digit to be removed if there is a currency symbol on the right. That's because the [text]
+     * We want the last digit to be removed if there is a currency symbol on the right. That's because the `text`
      * argument in [CurrencyEditText.onTextChanged] will have the symbol removed but not the last digit. If we don't
      * handle this manually, it will look like the user _did not delete anything_.
      *
@@ -31,7 +31,7 @@ class CurrencyEditTextTest {
      *
      * 1. If the current text is "123.79CA$" (French Canada places the dollar symbol on the right)
      * 2. The user presses backspace
-     * 3. The [CurrencyEditText.onTextChanged] will be called with [text] equal to "123.79CA"
+     * 3. The [CurrencyEditText.onTextChanged] will be called with `text` equal to "123.79CA"
      *
      * If keep this as is and reformat again, we'll end up with same text, "123.79CA$". So it'll look like the backspace
      * was ignored.
@@ -41,7 +41,12 @@ class CurrencyEditTextTest {
         val text = "123.79CA"
 
         // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+        val cleaned = CurrencyEditText.clean(
+            text = text,
+            decimals = 2,
+            lengthBefore = text.length + 1,
+            lengthAfter = text.length
+        )
 
         assertEquals(12.37.toBigDecimal(), cleaned)
     }
@@ -51,7 +56,12 @@ class CurrencyEditTextTest {
         val text = "123.79 $"
 
         // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+        val cleaned = CurrencyEditText.clean(
+            text = text,
+            decimals = 2,
+            lengthBefore = text.length + 1,
+            lengthAfter = text.length
+        )
 
         assertEquals(12.37.toBigDecimal(), cleaned)
     }
@@ -64,20 +74,25 @@ class CurrencyEditTextTest {
     fun `given no currency symbol, when pressing backspace, clean() removes the last digit`() {
         val text = "123.79"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+        val cleaned = CurrencyEditText.clean(
+            text = text,
+            decimals = 2,
+            lengthBefore = text.length + 1,
+            lengthAfter = text.length
+        )
 
         assertEquals(12.37.toBigDecimal(), cleaned)
     }
 
     /**
-     * We don't want the last digit to be removed in this case because the given [text] argument in
+     * We don't want the last digit to be removed in this case because the given `text` argument in
      * [CurrencyEditText.onTextChanged] will already have the last digit removed.
      *
      * Example scenario:
      *
      * 1. If the current text is "123.79"
      * 2. The user presses backspace
-     * 3. The [CurrencyEditText.onTextChanged] will be called with [text] equal to "123.7"
+     * 3. The [CurrencyEditText.onTextChanged] will be called with `text` equal to "123.7"
      *
      * If we manually remove the last digit, we'd end up with "123", which means we've incorrectly deleted 2 characters!
      */
@@ -85,7 +100,12 @@ class CurrencyEditTextTest {
     fun `given a currency symbol on the left, when pressing backspace, clean() does not remove the last digit`() {
         val text = "$1,237,87.39"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+        val cleaned = CurrencyEditText.clean(
+            text = text,
+            decimals = 2,
+            lengthBefore = text.length + 1,
+            lengthAfter = text.length
+        )
 
         assertEquals(1_237_87.39.toBigDecimal(), cleaned)
     }
@@ -94,7 +114,12 @@ class CurrencyEditTextTest {
     fun `given a currency symbol with space on the left, when pressing backspace, clean() does not remove the last digit`() {
         val text = "$ 123.89"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+        val cleaned = CurrencyEditText.clean(
+            text = text,
+            decimals = 2,
+            lengthBefore = text.length + 1,
+            lengthAfter = text.length
+        )
 
         assertEquals(123.89.toBigDecimal(), cleaned)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -22,14 +22,60 @@ class CurrencyEditTextTest {
         assertEquals(13.45.toBigDecimal(), cleaned)
     }
 
+    /**
+     * We want the last digit to be removed if there is a currency symbol on the right. That's because the [text]
+     * argument in [CurrencyEditText.onTextChanged] will have the symbol removed but not the last digit. If we don't
+     * handle this manually, it will look like the user _did not delete anything_.
+     *
+     * Example scenario:
+     *
+     * 1. If the current text is "123.79$" (French Canada places the dollar symbol on the right)
+     * 2. The user presses backspace
+     * 3. The [CurrencyEditText.onTextChanged] will be called with [text] equal to "123.79"
+     *
+     * If keep this as is and reformat again, we'll end up with same text, "123.79$". So it'll look like the backspace
+     * was ignored.
+     */
     @Test
-    fun `clean() returns the expected number of fractional digits after pressing backspace`() {
-        val text = "12.3"
+    fun `given a currency symbol on the right, when pressing backspace, clean() removes the last digit`() {
+        val text = "123.79$"
 
         // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
         val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
 
-        assertEquals(1.23.toBigDecimal(), cleaned)
+        assertEquals(12.37.toBigDecimal(), cleaned)
+    }
+
+    /**
+     * We don't want the last digit to be removed in this case because the given [text] argument in
+     * [CurrencyEditText.onTextChanged] will already have the last digit removed.
+     *
+     * Example scenario:
+     *
+     * 1. If the current text is "123.79"
+     * 2. The user presses backspace
+     * 3. The [CurrencyEditText.onTextChanged] will be called with [text] equal to "123.7"
+     *
+     * If we manually remove the last digit, we'd end up with "123", which means we've incorrectly deleted 2 characters!
+     */
+    @Test
+    fun `given no currency symbol, when pressing backspace, clean() removes the last digit`() {
+        val text = "123.79"
+
+        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+
+        assertEquals(123.79.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `given a currency symbol on the left, when pressing backspace, clean() does not remove the last digit`() {
+        val text = "$1,237,87.39"
+
+        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+
+        assertEquals(1_237_87.39.toBigDecimal(), cleaned)
     }
 
     @Test
@@ -39,5 +85,14 @@ class CurrencyEditTextTest {
         val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
 
         assertEquals(123.45.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `clean() returns the same value if it is a valid number with the expected number of fractional digits`() {
+        val text = "1.23"
+
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+
+        assertEquals(1.23.toBigDecimal(), cleaned)
     }
 }


### PR DESCRIPTION
Closes #5393 

## Findings

The Simple Payments numerical entry uses [`CurrencyEditText`](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt). This custom text field uses [regex filtering](https://github.com/woocommerce/woocommerce-android/blob/38223050ae60c8404e6eed90ae4497a5fd3ed144/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt#L62) to prevent the user from entering non-numeric characters. 

Based on my understanding, the backspace deleting 2 characters seem to be caused by these lines:

https://github.com/woocommerce/woocommerce-android/blob/38223050ae60c8404e6eed90ae4497a5fd3ed144/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt#L73-L75

And these lines were added in 2f71c15f586cfe4b602916f31a12d38f72ec459a which has a message "Fix the backspace edit in CurrencyEditText". But there doesn't seem to be enough context on what the problem is. (cc @0nko). 

## Solution

I removed the lines above and it seems to be working fine. 🤷 

I also added some unit tests for that function: [`CurrencyEditTestTest`](https://github.com/woocommerce/woocommerce-android/blob/issue/5393-fix-backspace/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt). 

## Testing

1. Open the Simple Payments UI. 
2. Type 4 numbers. 
3. Press backspace. 
4. Confirm that only 1 number was deleted. 

### Regression

If I'm understanding Android Studio correctly, the `CurrencyEditText` is only used in Simple Payments and in Refund by Amount. The Refund by Amount has been disabled for a long time. IIRC, we're still waiting for an API change for that to be feasible. 

## Reviewing

Only 1 reviewer is needed but anyone can review.

Please feel free to nitpick me to the death. 🤪 It's been a while since I've written Kotlin. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

---

cc @nbradbury 