### PR TITLE
Drop jetifier

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "woocommerce-android",
   "branch": "trunk",
-  "pinned_hash": "00dcdd5394cd26d918852323c3af5295efaedb9d",
+  "pinned_hash": "a458c6ca852c7e3bf5cece0f72c51976fa014693",
   "files_to_copy": [
     {
       "file": "android/WCAndroid/gradle.properties",

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -209,7 +209,6 @@ dependencies {
     implementation project(":libs:cardreader")
 
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
-    implementation 'com.github.vihtarb:tooltip:0.2.0'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
     // Dagger

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -272,7 +272,9 @@ dependencies {
     // Resolve conflicts between main and test APK
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
 
-    implementation "com.zendesk:support:5.0.3"
+    implementation ("com.zendesk:support:5.0.3") {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
 
     // ViewModel and LiveData
     // TODO Try to re-enable NullSafeMutableLiveData lint check when we move to fragment-ktx v1.4.0+

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -306,7 +306,6 @@ theme across the entire app. Overridden versions should be added to the styles.x
     -->
     <!-- Set at the theme level so no need to set it in the layout -->
     <style name="Woo.CheckedTextView">
-        <item name="textAppearance">@style/TextAppearance.Woo.Subtitle1</item>
         <item name="android:textAppearance">@style/TextAppearance.Woo.Subtitle1</item>
         <item name="android:checkMark">?android:attr/listChoiceIndicatorSingle</item>
         <item name="android:background">?attr/selectableItemBackground</item>

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ ext {
     mockitoVersion = '4.0.0'
     constraintLayoutVersion = '1.2.0'
     libaddressinputVersion = '0.0.2'
-    eventBusVersion = '3.2.0'
+    eventBusVersion = '3.3.0'
     googlePlayCoreVersion = '1.10.2'
     coroutinesVersion = '1.5.2'
     lifecycleVersion = '2.4.0'

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx1536m
 # WooCommerce for Android properties.
 
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 
 
 # For more details on what these properties do visit


### PR DESCRIPTION
Merge instructions:
1. Review this PR
2. Approve this PR
3. Merge `disable-jetifier` branch in the secrets repo into trunk
4. ~Update hash in .configure file~
5. Remove "do not merge" label and merge this PR

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR disabled jetifier. Jetifier has always been meant as a temporary tool to help with migration from the support library to AndroidX. It was slowing down build times since the tasks were not cacheable. I hoped this PR would improve the builds times, but "unfortunately" [this issue was fixed in AGP 4.1](https://issuetracker.google.com/issues/149241380). I run several benchmarks and the build times haven't changed at all.

This PR:
1. Updates example gradle properties
2. Updates CI gradle properties
3. Excludes `support-annotations` from Zendesk dependency - annotations are used only for static analysis so this should not affect run time
4. Removes `com.github.vihtarb:tooltip:0.2.0` since it is not used at all
5. Removes `textAppearance` from `Woo.CheckedTextView` style - I believe that `textAppearance` without `android:` prefix was never actually needed, wdyt?
6. Updates event bus to v 3.3.0 which doesn't use the support library anymore - funny thing is that this update has been released yesterday, after I tested all the different scenarios to make sure the previous version works as expected even without the support library ... 

The last thing that is dependant on the support library is LeakCanary. However, since it's not breaking the build, seems to work as expected, and is used only in debug builds I think we are fine.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


Smoke test the app - if you are building the app locally, don't forgot to disable jetifier in gradle.properties

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No user facing changes

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
