### PR TITLE
Display IssueRefund button for Simple Payments orders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -50,6 +50,7 @@ data class Order(
     val shippingMethods: List<ShippingMethod>,
     val items: List<Item>,
     val shippingLines: List<ShippingLine>,
+    val feesLines: List<FeeLine>,
     val metaData: List<MetaData<String>>
 ) : Parcelable {
     val localId
@@ -60,7 +61,7 @@ data class Order(
 
     // Allow refunding only integer quantities
     @IgnoredOnParcel
-    val availableRefundQuantity = items.sumByFloat { it.quantity }.toInt()
+    val availableRefundQuantity = items.sumByFloat { it.quantity }.toInt() + feesLines.count()
 
     @IgnoredOnParcel
     val isRefundAvailable = refundTotal < total && availableRefundQuantity > 0
@@ -158,6 +159,12 @@ data class Order(
         val methodId: String,
         val methodTitle: String,
         val totalTax: BigDecimal,
+        val total: BigDecimal
+    ) : Parcelable
+
+    @Parcelize
+    data class FeeLine(
+        val name: String,
         val total: BigDecimal
     ) : Parcelable
 
@@ -270,7 +277,8 @@ data class Order(
                 shippingMethods = emptyList(),
                 items = emptyList(),
                 shippingLines = emptyList(),
-                metaData = emptyList()
+                metaData = emptyList(),
+                feesLines = emptyList()
             )
         }
     }
@@ -366,6 +374,12 @@ fun WCOrderModel.toAppModel(): Order {
                 it.methodId ?: StringUtils.EMPTY,
                 it.methodTitle ?: StringUtils.EMPTY,
                 it.totalTax?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+                it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO
+            )
+        },
+        feesLines = this.getFeeLineList().map {
+            FeeLine(
+                it.name ?: StringUtils.EMPTY,
                 it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO
             )
         },


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5415 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR displays "Issue Refund" button even on orders which don't contain anything else but `fees` - eg. Simple Payments Orders. The app still doesn't support refunding fees, the goal of this PR is to let the user enter Refund Detail screen where they can see "You can refund fees in your store admin" hint. We plan to add full support for refunding fees in the upcoming release.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Enable Simple Payments in App Settings -> Beta features
2. Open Orders List
3. Tap on "+" FAB
4. Enter an amount > $0.5
5. Notice "Issue refund" button is visible
6. Tap on "Issue refund" button
7. Notice the "Next" button is disabled, but the "You can refund feees in your store admin" hint is visible
---------------------
- Test anything else you can think of related to refunds

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After | After |
| --- | --- | --- |
| ![Screenshot_20211207-133711_WooCommerce (Pre-Alpha)](https://user-images.githubusercontent.com/2261188/145031995-2de53c86-c15e-4be3-b385-e7ba591975ee.jpg) | ![Screenshot_20211207-133722_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/145032035-7ddf9c60-61e2-49c5-b815-80c5c6333616.jpg) | ![Screenshot_20211207-133619_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/145032049-a8487b6d-be3f-44fe-ae74-9edced721017.jpg) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @shiki @Ecarrion 
