### PR TITLE
Release Experimental Simple Payments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -29,8 +29,7 @@ object AppUrls {
     const val CROWDSIGNAL_SHIPPING_LABELS_SURVEY =
         "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
 
-    // TODO nbradbury - change to https://automattic.survey.fm/woo-app-quick-order-production when feature is released
-    const val SIMPLE_PAYMENTS_SURVEY = "https://automattic.survey.fm/woo-app-quick-order-testing"
+    const val SIMPLE_PAYMENTS_SURVEY = "https://automattic.survey.fm/woo-app-quick-order-production"
 
     const val WOOCOMMERCE_USER_ROLES =
         "https://woocommerce.com/posts/a-guide-to-woocommerce-user-roles-permissions-and-security/"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -796,8 +796,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_SHIPPING_LABELS_M4_FEEDBACK = "shipping_labels_m4"
         const val VALUE_PRODUCT_ADDONS_FEEDBACK = "product_addons"
 
-        // TODO nbradbury change to production when feature is released
-        const val VALUE_SIMPLE_PAYMENTS_FEEDBACK = "simple_payments_prototype"
+        const val VALUE_SIMPLE_PAYMENTS_FEEDBACK = "simple_payments"
 
         // -- Downloadable Files
         const val KEY_DOWNLOADABLE_FILE_ACTION = "action"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -145,9 +145,7 @@ class OrderListFragment :
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
-        if (FeatureFlag.SIMPLE_PAYMENTS.isEnabled()) {
-            displaySimplePaymentsWIPCard(true)
-        }
+        displaySimplePaymentsWIPCard(true)
     }
 
     override fun onResume() {
@@ -172,8 +170,7 @@ class OrderListFragment :
     }
 
     private fun isSimplePaymentsAvailable(): Boolean {
-        return FeatureFlag.SIMPLE_PAYMENTS.isEnabled() &&
-            AppPrefs.isSimplePaymentsEnabled &&
+        return AppPrefs.isSimplePaymentsEnabled &&
             viewModel.isCardReaderOnboardingCompleted()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -57,7 +57,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     }
 
     private fun FragmentSettingsBetaBinding.bindSimplePaymentToggle() {
-        if (FeatureFlag.SIMPLE_PAYMENTS.isEnabled() && navArgs.isCardReaderOnboardingCompleted) {
+        if (navArgs.isCardReaderOnboardingCompleted) {
             switchSimplePaymentsToggle.show()
             switchSimplePaymentsToggle.isChecked = AppPrefs.isSimplePaymentsEnabled
             switchSimplePaymentsToggle.setOnCheckedChangeListener { switch, isChecked ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,7 +8,6 @@ import android.content.Context
 enum class FeatureFlag {
     DB_DOWNGRADE,
     ORDER_CREATION,
-    SIMPLE_PAYMENTS,
     CARD_READER,
     JETPACK_CP,
     ORDER_FILTERS,
@@ -20,7 +19,6 @@ enum class FeatureFlag {
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
-            SIMPLE_PAYMENTS,
             ORDER_CREATION,
             JETPACK_CP -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -63,6 +63,20 @@ class CurrencyEditText : AppCompatEditText {
         if (isInitialized && !isChangingText) {
             isChangingText = true
 
+            val cleanValue = clean(text = text, decimals = decimals, lengthBefore = lengthBefore, lengthAfter = lengthAfter)
+
+            _value.value = cleanValue
+            setText(formatCurrency(cleanValue))
+
+            isChangingText = false
+        }
+    }
+
+    companion object TextCleaner {
+        /**
+         * Cleans the [text] so that it only has numerical characters and has the correct number of fractional digits.
+         */
+        fun clean(text: CharSequence?, decimals: Int, lengthBefore: Int, lengthAfter: Int): BigDecimal {
             val regex = Regex("[^\\d]")
             var cleanValue = text.toString().replace(regex, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
 
@@ -74,10 +88,8 @@ class CurrencyEditText : AppCompatEditText {
                 cleanValue = cleanValue.divide(BigDecimal(10f.pow(lengthBefore - lengthAfter).toInt()), DOWN)
             }
 
-            _value.value = cleanValue
-            setText(formatCurrency(cleanValue))
-
-            isChangingText = false
+            return cleanValue
         }
+
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.woocommerce.android.util.CurrencyFormatter
 import java.math.BigDecimal
-import java.math.RoundingMode.DOWN
 import java.math.RoundingMode.HALF_UP
 import kotlin.math.pow
 
@@ -63,7 +62,7 @@ class CurrencyEditText : AppCompatEditText {
         if (isInitialized && !isChangingText) {
             isChangingText = true
 
-            val cleanValue = clean(text = text, decimals = decimals, lengthBefore = lengthBefore, lengthAfter = lengthAfter)
+            val cleanValue = clean(text = text, decimals = decimals)
 
             _value.value = cleanValue
             setText(formatCurrency(cleanValue))
@@ -76,7 +75,7 @@ class CurrencyEditText : AppCompatEditText {
         /**
          * Cleans the [text] so that it only has numerical characters and has the correct number of fractional digits.
          */
-        fun clean(text: CharSequence?, decimals: Int, lengthBefore: Int, lengthAfter: Int): BigDecimal {
+        fun clean(text: CharSequence?, decimals: Int): BigDecimal {
             val regex = Regex("[^\\d]")
             var cleanValue = text.toString().replace(regex, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -85,6 +85,5 @@ class CurrencyEditText : AppCompatEditText {
 
             return cleanValue
         }
-
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -84,10 +84,6 @@ class CurrencyEditText : AppCompatEditText {
                 cleanValue = cleanValue.divide(BigDecimal(10f.pow(decimals).toInt()), decimals, HALF_UP)
             }
 
-            if (lengthBefore > lengthAfter) {
-                cleanValue = cleanValue.divide(BigDecimal(10f.pow(lengthBefore - lengthAfter).toInt()), DOWN)
-            }
-
             return cleanValue
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.widgets
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CurrencyEditTextTest {
+    @Test
+    fun `clean() returns the value without the non-numeric characters`() {
+        val text = "US$1345 nope"
+
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 0, lengthBefore = 0, lengthAfter = 0)
+
+        assertEquals(1345.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `clean() returns the value with the expected number of fractional digits`() {
+        val text = "US$1345 nope"
+
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+
+        assertEquals(13.45.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `clean() returns the expected number of fractional digits after pressing backspace`() {
+        val text = "12.3"
+
+        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+
+        assertEquals(1.23.toBigDecimal(), cleaned)
+    }
+
+    @Test
+    fun `clean() moves the decimal separator if the fractional digits are greater than the decimals argument`() {
+        val text = "12.345"
+
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+
+        assertEquals(123.45.toBigDecimal(), cleaned)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/CurrencyEditTextTest.kt
@@ -8,7 +8,7 @@ class CurrencyEditTextTest {
     fun `clean() returns the value without the non-numeric characters`() {
         val text = "US$1345 nope"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 0, lengthBefore = 0, lengthAfter = 0)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 0)
 
         assertEquals(1345.toBigDecimal(), cleaned)
     }
@@ -17,17 +17,16 @@ class CurrencyEditTextTest {
     fun `clean() returns the value with the expected number of fractional digits`() {
         val text = "US$1345 nope"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
 
         assertEquals(13.45.toBigDecimal(), cleaned)
     }
 
     @Test
-    fun `clean() returns the expected number of fractional digits after pressing backspace`() {
-        val text = "12.3"
+    fun `clean() returns the same value if it is a valid number with the expected number of fractional digits`() {
+        val text = "1.23"
 
-        // We're only emulating a backspace by specifying that the [lengthBefore] is larger than the [lengthAfter].
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = text.length + 1, lengthAfter = text.length)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
 
         assertEquals(1.23.toBigDecimal(), cleaned)
     }
@@ -36,7 +35,7 @@ class CurrencyEditTextTest {
     fun `clean() moves the decimal separator if the fractional digits are greater than the decimals argument`() {
         val text = "12.345"
 
-        val cleaned = CurrencyEditText.clean(text = text, decimals = 2, lengthBefore = 0, lengthAfter = 0)
+        val cleaned = CurrencyEditText.clean(text = text, decimals = 2)
 
         assertEquals(123.45.toBigDecimal(), cleaned)
     }


### PR DESCRIPTION
Closes #5116 

⚠️  Please make sure that https://github.com/woocommerce/woocommerce-android/pull/5412 is reviewed and merged first. 

This removes the feature flag for Simple Payments so it's immediately available for:

- Those who are eligible for In-Person Payments 
- Have turned on the Simple Payments flag in the Beta features setting

## Testing

0. You might want to set the `FeatureFlag.PAYMENTS_STRIPE_EXTENSION` to `false` first. It seems to be causing a crash at the moment. 
1. Make sure that you've been onboarded to In-Person Payments and have connected a reader. 
2. Turn on Simple Payments in Settings → Beta features. 
3. Navigate to Orders. 
4. Tap on FAB. 
5. Enter an amount. 
6. Tap Done. 
7. Confirm that the Order Details screen is shown with the Fees amount set to the amount that you previously entered. 
8. Tap on Collect Payment. 
9. Confirm that you can go through the whole In-Person Payments flow. 

## Reviewing

Only 1 reviewer is needed but anyone can review.

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

