### PR TITLE
Simple Payments: Decrease font size to major_100

### DIFF
--- a/WooCommerce/src/main/res/layout/dialog_simple_payments.xml
+++ b/WooCommerce/src/main/res/layout/dialog_simple_payments.xml
@@ -58,7 +58,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:imeOptions="flagNoExtractUi"
-        android:textSize="@dimen/text_major_150"
+        android:textSize="@dimen/text_major_100"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Closes #5394 

As suggested by @malinajirka in https://github.com/woocommerce/woocommerce-android/issues/5394#issuecomment-988569362, we can decrease the font size to `_major_100` to fit a few more characters. This can especially help those with currencies that are more elaborate like this default WooCommerce symbol for the Canadian Dollar: 

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/145311579-80bd8d10-7f92-4d9b-9b5b-0755eac35caf.png" width="300">|<img src="https://user-images.githubusercontent.com/198826/145311578-3578cc3d-41d3-48fe-bfab-5740dd25ab24.png" width="300">

What do you think @nbradbury? 

## Testing

1. Tap on FAB
2. Confirm that Simple Payments still works normally. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

