### PR TITLE
Set Stripe Extension feature flag to false by default

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -24,8 +24,8 @@ enum class FeatureFlag {
             ORDER_CREATION,
             JETPACK_CP -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
+            PAYMENTS_STRIPE_EXTENSION -> false
             ORDER_FILTERS,
-            PAYMENTS_STRIPE_EXTENSION,
             ANALYTICS_HUB -> PackageUtils.isDebugBuild()
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcherTest.kt
@@ -81,9 +81,6 @@ class UserEligibilityFetcherTest : BaseUnitTest() {
 
     @Test
     fun `Do not update prefs when request failed`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        doReturn(
-            WooResult<WooError>(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.UNKNOWN))
-        ).whenever(userStore).fetchUserRole(any())
         doReturn(true).whenever(appPrefsWrapper).isUserEligible()
         doReturn(null).whenever(appPrefsWrapper).getUserEmail()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcherTest.kt
@@ -3,22 +3,23 @@ package com.woocommerce.android.ui.common
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.user.WCUserModel
-import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCUserStore
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class UserEligibilityFetcherTest : BaseUnitTest() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5428 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR sets the Stripe Extension feature flag to false by default so that the app won't crash because of TODO's added in some places for work in progress code.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Have both Stripe Extension and WCPay plugins installed on your site
2. Navigate to the Settings -> In-Person Payments screen
3. Notice there is no crash and the app works as previously.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
