### PR TITLE
Fix date selector display for different weeks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -28,8 +28,11 @@ class AnalyticsRepository @Inject constructor(
             return getCurrentPeriodRevenue(dateRange, it)
                 .combine(getPreviousPeriodRevenue(dateRange, it)) { currentPeriodRevenue, previousPeriodRevenue ->
 
-                    if (currentPeriodRevenue.isFailure || currentPeriodRevenue.getOrNull() == null ||
-                        previousPeriodRevenue.isFailure || previousPeriodRevenue.getOrNull() == null) {
+                    if (currentPeriodRevenue.isFailure || currentPeriodRevenue.getOrNull() == null) {
+                        return@combine RevenueError
+                    }
+
+                    if (previousPeriodRevenue.isFailure || previousPeriodRevenue.getOrNull() == null) {
                         return@combine RevenueError
                     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -103,7 +103,7 @@ class AnalyticsViewModel @Inject constructor(
                 ).orEmpty()
             )
             is MultipleDateRange ->
-                if (isSameDay(dateRange.to.from, dateRange.to.to))
+                if (isSameDay(dateRange.to.from, dateRange.to.to)) {
                     resourceProvider.getString(
                         R.string.analytics_date_range_to_date,
                         getDateSelectedMessage(analyticsDateRange),
@@ -111,11 +111,13 @@ class AnalyticsViewModel @Inject constructor(
                             dateUtils.getYearMonthDayStringFromDate(dateRange.to.from)
                         ).orEmpty()
                     )
-                else resourceProvider.getString(
-                    R.string.analytics_date_range_to_date,
-                    getDateSelectedMessage(analyticsDateRange),
-                    dateRange.to.formatDatesToFriendlyPeriod()
-                )
+                } else {
+                    resourceProvider.getString(
+                        R.string.analytics_date_range_to_date,
+                        getDateSelectedMessage(analyticsDateRange),
+                        dateRange.to.formatDatesToFriendlyPeriod()
+                    )
+                }
         }
 
     private fun calculateFromDatePeriod(dateRange: DateRange) = when (dateRange) {
@@ -124,17 +126,19 @@ class AnalyticsViewModel @Inject constructor(
             dateUtils.getShortMonthDayAndYearString(dateUtils.getYearMonthDayStringFromDate(dateRange.from)).orEmpty()
         )
         is MultipleDateRange ->
-            if (isSameDay(dateRange.from.from, dateRange.from.to))
+            if (isSameDay(dateRange.from.from, dateRange.from.to)) {
                 resourceProvider.getString(
                     R.string.analytics_date_range_from_date,
                     dateUtils.getShortMonthDayAndYearString(
                         dateUtils.getYearMonthDayStringFromDate(dateRange.from.from)
                     ).orEmpty()
                 )
-            else resourceProvider.getString(
-                R.string.analytics_date_range_from_date,
-                dateRange.from.formatDatesToFriendlyPeriod()
-            )
+            } else {
+                resourceProvider.getString(
+                    R.string.analytics_date_range_from_date,
+                    dateRange.from.formatDatesToFriendlyPeriod()
+                )
+            }
     }
 
     private fun getAvailableDateRanges() = resourceProvider.getStringArray(R.array.date_range_selectors).asList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -102,20 +102,20 @@ class AnalyticsViewModel @Inject constructor(
                     dateUtils.getYearMonthDayStringFromDate(dateRange.to)
                 ).orEmpty()
             )
-            is MultipleDateRange -> when {
-                isSameDay(dateRange.to.from, dateRange.to.to) -> resourceProvider.getString(
-                    R.string.analytics_date_range_to_date,
-                    getDateSelectedMessage(analyticsDateRange),
-                    dateUtils.getShortMonthDayAndYearString(
-                        dateUtils.getYearMonthDayStringFromDate(dateRange.to.from)
-                    ).orEmpty()
-                )
-                else -> resourceProvider.getString(
+            is MultipleDateRange ->
+                if (isSameDay(dateRange.to.from, dateRange.to.to))
+                    resourceProvider.getString(
+                        R.string.analytics_date_range_to_date,
+                        getDateSelectedMessage(analyticsDateRange),
+                        dateUtils.getShortMonthDayAndYearString(
+                            dateUtils.getYearMonthDayStringFromDate(dateRange.to.from)
+                        ).orEmpty()
+                    )
+                else resourceProvider.getString(
                     R.string.analytics_date_range_to_date,
                     getDateSelectedMessage(analyticsDateRange),
                     dateRange.to.formatDatesToFriendlyPeriod()
                 )
-            }
         }
 
     private fun calculateFromDatePeriod(dateRange: DateRange) = when (dateRange) {
@@ -123,18 +123,18 @@ class AnalyticsViewModel @Inject constructor(
             R.string.analytics_date_range_from_date,
             dateUtils.getShortMonthDayAndYearString(dateUtils.getYearMonthDayStringFromDate(dateRange.from)).orEmpty()
         )
-        is MultipleDateRange -> when {
-            isSameDay(dateRange.from.from, dateRange.from.to) -> resourceProvider.getString(
-                R.string.analytics_date_range_from_date,
-                dateUtils.getShortMonthDayAndYearString(
-                    dateUtils.getYearMonthDayStringFromDate(dateRange.from.from)
-                ).orEmpty()
-            )
-            else -> resourceProvider.getString(
+        is MultipleDateRange ->
+            if (isSameDay(dateRange.from.from, dateRange.from.to))
+                resourceProvider.getString(
+                    R.string.analytics_date_range_from_date,
+                    dateUtils.getShortMonthDayAndYearString(
+                        dateUtils.getYearMonthDayStringFromDate(dateRange.from.from)
+                    ).orEmpty()
+                )
+            else resourceProvider.getString(
                 R.string.analytics_date_range_from_date,
                 dateRange.from.formatDatesToFriendlyPeriod()
             )
-        }
     }
 
     private fun getAvailableDateRanges() = resourceProvider.getStringArray(R.array.date_range_selectors).asList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
@@ -147,38 +147,42 @@ enum class AnalyticsDateRanges(val description: String) {
  */
 @Throws(IllegalArgumentException::class)
 fun SimpleDateRange.formatDatesToFriendlyPeriod(locale: Locale = Locale.getDefault()): String {
-    val calendar: Calendar = let {
+    val firstCalendar: Calendar = let {
         Calendar.getInstance().apply {
             time = it.from
         }
     }
 
-    val anotherCalendar: Calendar = let {
+    val secondCalendar: Calendar = let {
         Calendar.getInstance().apply {
             time = it.to
         }
     }
 
-    val isSameYearAndMonth =
-        calendar.get(Calendar.YEAR) == anotherCalendar.get(Calendar.YEAR) &&
-            calendar.get(Calendar.MONTH) == anotherCalendar.get(Calendar.MONTH)
+    val sortedDates = listOf(firstCalendar, secondCalendar).sorted()
+    val firstDate = sortedDates.first()
+    val secondDate = sortedDates[1]
 
-    val minDay = kotlin.math.min(calendar.get(Calendar.DAY_OF_MONTH), anotherCalendar.get(Calendar.DAY_OF_MONTH))
-    val maxDay = kotlin.math.max(calendar.get(Calendar.DAY_OF_MONTH), anotherCalendar.get(Calendar.DAY_OF_MONTH))
-    val month = calendar.getDisplayName(Calendar.MONTH, Calendar.SHORT, locale)
-    val year = calendar.get(Calendar.YEAR)
+    val isSameYearAndMonth =
+        firstCalendar.get(Calendar.YEAR) == secondCalendar.get(Calendar.YEAR) &&
+            firstCalendar.get(Calendar.MONTH) == secondCalendar.get(Calendar.MONTH)
+
+    val firstCalendarDay = firstDate.get(Calendar.DAY_OF_MONTH)
+    val secondCalendarDay = secondDate.get(Calendar.DAY_OF_MONTH)
+
+    val firstDisplayMonth = firstCalendar.getDisplayName(Calendar.MONTH, Calendar.SHORT, locale)
+    val firstYear = firstCalendar.get(Calendar.YEAR)
 
     return if (isSameYearAndMonth) {
-        "$month $minDay - $maxDay, $year"
+        "$firstDisplayMonth $firstCalendarDay - $secondCalendarDay, $firstYear"
     } else {
-        val isSameYear = calendar.get(Calendar.YEAR) == anotherCalendar.get(Calendar.YEAR)
-        val anotherMonth = anotherCalendar.getDisplayName(Calendar.MONTH, Calendar.SHORT, locale)
-
+        val isSameYear = firstCalendar.get(Calendar.YEAR) == secondCalendar.get(Calendar.YEAR)
+        val secondDisplayMonth = secondDate.getDisplayName(Calendar.MONTH, Calendar.SHORT, locale)
         if (isSameYear) {
-            "$month $minDay - $anotherMonth $maxDay, $year"
+            "$firstDisplayMonth $firstCalendarDay - $secondDisplayMonth $secondCalendarDay, $firstYear"
         } else {
-            val anotherYear = anotherCalendar.get(Calendar.YEAR)
-            "$month $minDay, $year - $anotherMonth $maxDay, $anotherYear"
+            val secondYear = secondCalendar.get(Calendar.YEAR)
+            "$firstDisplayMonth $firstCalendarDay, $firstYear - $secondDisplayMonth $secondCalendarDay, $secondYear"
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
@@ -30,12 +30,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         val twtyEightNov2021 = Date().apply { time = TWTY8_NOV_2021 }
         val oneDec2021 = Date().apply { time = ONE_DEC_2021 }
 
-
         const val SAME_YEAR_SAME_MONTH_EXPECTED = "Jan 1 - 3, 1970"
         const val SAME_YEAR_DIFFERENT_MONTH_EXPECTED = "Jan 3 - Feb 3, 1970"
         const val DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED = "Jan 3, 1970 - Nov 24, 2021"
         const val DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED_TWO = "Nov 28 - Dec 1, 2021"
-
     }
 
     @Test
@@ -228,8 +226,9 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
 
         val differentYearAndDifferentMonthFriendlyFormattedDateTwo =
             SimpleDateRange(twtyEightNov2021, oneDec2021).formatDatesToFriendlyPeriod()
-        assertEquals(DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED_TWO, differentYearAndDifferentMonthFriendlyFormattedDateTwo)
+        assertEquals(
+            DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED_TWO,
+            differentYearAndDifferentMonthFriendlyFormattedDateTwo
+        )
     }
 }
-
-

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
@@ -20,15 +20,22 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         private const val THREE_JAN_1970_TIME = 234083000L
         private const val THREE_FEB_1970_TIME = 2912483000L
         private const val TWTY_FOUR_NOV_2021 = 1637776266465L
+        private const val TWTY8_NOV_2021 = 1638054000000L
+        private const val ONE_DEC_2021 = 1638313200000L
 
         val date = Date().apply { time = DATE_ZERO }
         val threeJan1970 = Date().apply { time = THREE_JAN_1970_TIME }
         val threeFeb1970 = Date().apply { time = THREE_FEB_1970_TIME }
         val twtyFourNov2021 = Date().apply { time = TWTY_FOUR_NOV_2021 }
+        val twtyEightNov2021 = Date().apply { time = TWTY8_NOV_2021 }
+        val oneDec2021 = Date().apply { time = ONE_DEC_2021 }
+
 
         const val SAME_YEAR_SAME_MONTH_EXPECTED = "Jan 1 - 3, 1970"
         const val SAME_YEAR_DIFFERENT_MONTH_EXPECTED = "Jan 3 - Feb 3, 1970"
         const val DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED = "Jan 3, 1970 - Nov 24, 2021"
+        const val DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED_TWO = "Nov 28 - Dec 1, 2021"
+
     }
 
     @Test
@@ -218,5 +225,11 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         val differentYearAndDifferentMonthFriendlyFormattedDate = SimpleDateRange(threeJan1970, twtyFourNov2021)
             .formatDatesToFriendlyPeriod()
         assertEquals(DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED, differentYearAndDifferentMonthFriendlyFormattedDate)
+
+        val differentYearAndDifferentMonthFriendlyFormattedDateTwo =
+            SimpleDateRange(twtyEightNov2021, oneDec2021).formatDatesToFriendlyPeriod()
+        assertEquals(DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED_TWO, differentYearAndDifferentMonthFriendlyFormattedDateTwo)
     }
 }
+
+


### PR DESCRIPTION
Closes: #5424

### Description
There were some cases where the analytics date range selector displays some wrong dates, for example, with date ranges like a week to date, being two different months and weeks.

This pull request fixes it

### Testing instructions

1. Open the application compiled in debug mode
2. Click on analytics section tab in bottom navigation bar
3. Check the date displayed
4. Click on the calendar icon
5. Select any other range
6. Check the date displayed

### Images/gif

Before:

![image](https://user-images.githubusercontent.com/572601/145394858-e8f8e295-5ace-4e68-9b95-089b19ac1e9e.png)
![image](https://user-images.githubusercontent.com/572601/145394877-0184fe05-51ea-408c-b692-f10a60bc207e.png)

After:
<img width="376" alt="Screenshot 2021-12-09 at 13 17 58" src="https://user-images.githubusercontent.com/572601/145395047-6d56a16e-db12-4287-b18d-6c18573d125b.png">
<img width="383" alt="Screenshot 2021-12-09 at 13 18 09" src="https://user-images.githubusercontent.com/572601/145395050-5f53dc30-c54d-458d-ad1d-582d992777eb.png">



- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.