### PR TITLE
Fix swipe to refresh in analytics hub section

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -36,6 +36,10 @@ class AnalyticsFragment :
         setupResultHandlers(viewModel)
         lifecycleScope.launchWhenStarted { viewModel.state.collect { newState -> handleStateChange(newState) } }
         viewModel.event.observe(viewLifecycleOwner, { event -> handleEvent(event) })
+        binding.analyticsRefreshLayout.setOnRefreshListener {
+            binding.analyticsRefreshLayout.scrollUpChild = binding.scrollView
+            viewModel.onRefreshRequested()
+        }
     }
 
     override fun onDestroyView() {
@@ -85,6 +89,7 @@ class AnalyticsFragment :
         binding.analyticsDateSelectorCard.updateFromText(viewState.analyticsDateRangeSelectorState.fromDatePeriod)
         binding.analyticsDateSelectorCard.updateToText(viewState.analyticsDateRangeSelectorState.toDatePeriod)
         binding.analyticsRevenueCard.updateInformation(viewState.revenueState)
+        binding.analyticsRefreshLayout.isRefreshing = false
     }
 
     private fun getDateRangeSelectorViewState() = viewModel.state.value.analyticsDateRangeSelectorState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -76,7 +76,7 @@ class AnalyticsFragment :
         handleDialogResult<String>(
             key = KEY_DATE_RANGE_SELECTOR_RESULT,
             entryId = R.id.analytics
-        ) { dateRange -> viewModel.onSelectedDateRangeChanged(dateRange) }
+        ) { dateRange -> viewModel.onSelectedTimePeriodChanged(dateRange) }
     }
 
     private fun bind(view: View) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentAnalyticsBinding
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.analytics.RefreshIndicator.*
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -89,7 +90,7 @@ class AnalyticsFragment :
         binding.analyticsDateSelectorCard.updateFromText(viewState.analyticsDateRangeSelectorState.fromDatePeriod)
         binding.analyticsDateSelectorCard.updateToText(viewState.analyticsDateRangeSelectorState.toDatePeriod)
         binding.analyticsRevenueCard.updateInformation(viewState.revenueState)
-        binding.analyticsRefreshLayout.isRefreshing = false
+        binding.analyticsRefreshLayout.isRefreshing = viewState.refreshIndicator == ShowIndicator
     }
 
     private fun getDateRangeSelectorViewState() = viewModel.state.value.analyticsDateRangeSelectorState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -43,10 +43,10 @@ class AnalyticsFragment :
         _binding = null
     }
 
-    override fun shouldExpandToolbar(): Boolean = true
+    override fun shouldExpandToolbar(): Boolean = binding.scrollView.scrollY == 0
 
     override fun scrollToTop() {
-        return
+        binding.scrollView.smoothScrollTo(0, 0)
     }
 
     private fun handleEvent(event: MultiLiveEvent.Event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -23,7 +23,6 @@ class AnalyticsRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore
 ) {
-
     suspend fun fetchRevenueData(
         dateRange: AnalyticsDateRange,
         selectedRange: AnalyticTimePeriod
@@ -31,7 +30,6 @@ class AnalyticsRepository @Inject constructor(
         getGranularity(selectedRange).let {
             return getCurrentPeriodRevenue(dateRange, it)
                 .combine(getPreviousPeriodRevenue(dateRange, it)) { currentPeriodRevenue, previousPeriodRevenue ->
-
                     if (currentPeriodRevenue.isFailure || currentPeriodRevenue.getOrNull() == null) {
                         return@combine RevenueError
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -5,8 +5,8 @@ import com.woocommerce.android.model.RevenueStat
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueData
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueError
-import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRanges
-import com.woocommerce.android.ui.analytics.daterangeselector.DateRange
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange
 import com.woocommerce.android.ui.mystore.data.StatsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
@@ -23,13 +23,18 @@ class AnalyticsRepository @Inject constructor(
     private val wooCommerceStore: WooCommerceStore
 ) {
 
-    suspend fun fetchRevenueData(dateRange: DateRange, selectedRange: AnalyticsDateRanges): Flow<RevenueResult> =
+    suspend fun fetchRevenueData(
+        dateRange: AnalyticsDateRange,
+        selectedRange: AnalyticTimePeriod
+    ): Flow<RevenueResult> =
         getGranularity(selectedRange).let {
             return getCurrentPeriodRevenue(dateRange, it)
                 .combine(getPreviousPeriodRevenue(dateRange, it)) { currentPeriodRevenue, previousPeriodRevenue ->
 
-                    if (currentPeriodRevenue.isFailure || currentPeriodRevenue.getOrNull() == null ||
-                        previousPeriodRevenue.isFailure || previousPeriodRevenue.getOrNull() == null) {
+                    if (currentPeriodRevenue.isFailure || currentPeriodRevenue.getOrNull() == null) {
+                        return@combine RevenueError
+                    }
+                    if (previousPeriodRevenue.isFailure || previousPeriodRevenue.getOrNull() == null) {
                         return@combine RevenueError
                     }
 
@@ -52,35 +57,35 @@ class AnalyticsRepository @Inject constructor(
 
     fun getRevenueAdminPanelUrl() = getAdminPanelUrl() + ANALYTICS_REVENUE_PATH
 
-    private suspend fun getCurrentPeriodRevenue(dateRange: DateRange, granularity: StatsGranularity) =
+    private suspend fun getCurrentPeriodRevenue(dateRange: AnalyticsDateRange, granularity: StatsGranularity) =
         when (dateRange) {
-            is DateRange.SimpleDateRange ->
+            is AnalyticsDateRange.SimpleDateRange ->
                 fetchRevenueStats(dateRange.to.formatToYYYYmmDD(), dateRange.to.formatToYYYYmmDD(), granularity)
-            is DateRange.MultipleDateRange ->
+            is AnalyticsDateRange.MultipleDateRange ->
                 fetchRevenueStats(
                     dateRange.to.from.formatToYYYYmmDD(), dateRange.to.to.formatToYYYYmmDD(),
                     granularity
                 )
         }
 
-    private suspend fun getPreviousPeriodRevenue(dateRange: DateRange, granularity: StatsGranularity) =
+    private suspend fun getPreviousPeriodRevenue(dateRange: AnalyticsDateRange, granularity: StatsGranularity) =
         when (dateRange) {
-            is DateRange.SimpleDateRange ->
+            is AnalyticsDateRange.SimpleDateRange ->
                 fetchRevenueStats(dateRange.from.formatToYYYYmmDD(), dateRange.from.formatToYYYYmmDD(), granularity)
-            is DateRange.MultipleDateRange ->
+            is AnalyticsDateRange.MultipleDateRange ->
                 fetchRevenueStats(
                     dateRange.from.from.formatToYYYYmmDD(), dateRange.from.to.formatToYYYYmmDD(),
                     granularity
                 )
         }
 
-    private fun getGranularity(selectedRange: AnalyticsDateRanges) =
+    private fun getGranularity(selectedRange: AnalyticTimePeriod) =
         when (selectedRange) {
-            AnalyticsDateRanges.TODAY, AnalyticsDateRanges.YESTERDAY -> DAYS
-            AnalyticsDateRanges.LAST_WEEK, AnalyticsDateRanges.WEEK_TO_DATE -> WEEKS
-            AnalyticsDateRanges.LAST_MONTH, AnalyticsDateRanges.MONTH_TO_DATE -> MONTHS
-            AnalyticsDateRanges.LAST_QUARTER, AnalyticsDateRanges.QUARTER_TO_DATE -> MONTHS
-            AnalyticsDateRanges.LAST_YEAR, AnalyticsDateRanges.YEAR_TO_DATE -> YEARS
+            AnalyticTimePeriod.TODAY, AnalyticTimePeriod.YESTERDAY -> DAYS
+            AnalyticTimePeriod.LAST_WEEK, AnalyticTimePeriod.WEEK_TO_DATE -> WEEKS
+            AnalyticTimePeriod.LAST_MONTH, AnalyticTimePeriod.MONTH_TO_DATE -> MONTHS
+            AnalyticTimePeriod.LAST_QUARTER, AnalyticTimePeriod.QUARTER_TO_DATE -> MONTHS
+            AnalyticTimePeriod.LAST_YEAR, AnalyticTimePeriod.YEAR_TO_DATE -> YEARS
         }
 
     private fun calculateDeltaPercentage(previousVal: Double, currentVal: Double) = when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -36,7 +36,6 @@ class AnalyticsViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-
     private val mutableState =
         MutableStateFlow(
             AnalyticsViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -189,10 +189,10 @@ class AnalyticsViewModel @Inject constructor(
         ?: value
 
     private fun buildAnalyticsDateRangeSelectorViewState() = AnalyticsDateRangeSelectorViewState(
-        fromDatePeriod = calculateFromDatePeriod(getDefaultDateRange()),
-        toDatePeriod = calculateToDatePeriod(AnalyticTimePeriod.TODAY, getDefaultDateRange()),
+        fromDatePeriod = calculateFromDatePeriod(getSavedDateRange()),
+        toDatePeriod = calculateToDatePeriod(getSavedTimePeriod(), getSavedDateRange()),
         availableRangeDates = getAvailableDateRanges(),
-        selectedPeriod = getTimePeriodDescription(getDefaultTimePeriod())
+        selectedPeriod = getTimePeriodDescription(getSavedTimePeriod())
     )
 
     private fun buildRevenueDataViewState(totalValue: String, totalDelta: Int, netValue: String, netDelta: Int) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -221,7 +221,7 @@ class AnalyticsViewModel @Inject constructor(
         ?: getDefaultTimePeriod()
 
     companion object {
-        const val TIME_PERIOD_SELECTED_KEY = "range_selection_key"
-        const val DATE_RANGE_SELECTED_KEY = "date_range_selection_key"
+        const val TIME_PERIOD_SELECTED_KEY = "time_period_selected_key"
+        const val DATE_RANGE_SELECTED_KEY = "date_range_selected_key"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -44,9 +44,15 @@ class AnalyticsViewModel @Inject constructor(
         updateRevenue()
     }
 
+    fun onRefreshRequested() {
+        updateRevenue(getCurrentRange(), getCurrentDateRange())
+    }
+
     fun onSelectedDateRangeChanged(newSelection: String) {
         val selectedRange: AnalyticsDateRanges = AnalyticsDateRanges.from(newSelection)
         val newDateRange = analyticsDateRange.getAnalyticsDateRangeFrom(selectedRange)
+        saveCurrentRange(selectedRange)
+        saveCurrentDateRange(newDateRange)
         updateDateRangeCalendarView(selectedRange, newDateRange)
         updateRevenue(selectedRange, newDateRange)
     }
@@ -181,4 +187,22 @@ class AnalyticsViewModel @Inject constructor(
                 netValue, netDelta
             )
         )
+
+    private fun saveCurrentRange(range: AnalyticsDateRanges) {
+        savedState[RANGE_SELECTION_KEY] = range
+    }
+
+    private fun saveCurrentDateRange(dateRange: DateRange) {
+        savedState[DATE_RANGE_SELECTION_KEY] = dateRange
+    }
+
+    private fun getCurrentDateRange(): DateRange = savedState[DATE_RANGE_SELECTION_KEY] ?: getDefaultDateRange()
+    private fun getCurrentRange(): AnalyticsDateRanges = savedState[RANGE_SELECTION_KEY]
+        ?: AnalyticsDateRanges.from(getDefaultSelectedPeriod())
+
+    companion object {
+        const val RANGE_SELECTION_KEY = "range_selection_key"
+        const val DATE_RANGE_SELECTION_KEY = "date_range_selection_key"
+    }
+
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -5,7 +5,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueData
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueError
-import com.woocommerce.android.ui.analytics.AnalyticsViewEvent.*
+import com.woocommerce.android.ui.analytics.AnalyticsViewEvent.OpenUrl
+import com.woocommerce.android.ui.analytics.AnalyticsViewEvent.OpenWPComWebView
 import com.woocommerce.android.ui.analytics.RefreshIndicator.NotShowIndicator
 import com.woocommerce.android.ui.analytics.daterangeselector.*
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange.MultipleDateRange
@@ -163,7 +164,7 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     private fun getAvailableDateRanges() = resourceProvider.getStringArray(R.array.date_range_selectors).asList()
-    private fun getDefaultTimePeriod() = getTimePeriodDescription(AnalyticTimePeriod.TODAY)
+    private fun getDefaultTimePeriod() = AnalyticTimePeriod.TODAY
     private fun getDefaultDateRange() = SimpleDateRange(
         Date(dateUtils.getCurrentDateTimeMinusDays(1)),
         dateUtils.getCurrentDate()
@@ -191,7 +192,7 @@ class AnalyticsViewModel @Inject constructor(
         fromDatePeriod = calculateFromDatePeriod(getDefaultDateRange()),
         toDatePeriod = calculateToDatePeriod(AnalyticTimePeriod.TODAY, getDefaultDateRange()),
         availableRangeDates = getAvailableDateRanges(),
-        selectedPeriod = getDefaultTimePeriod()
+        selectedPeriod = getTimePeriodDescription(getDefaultTimePeriod())
     )
 
     private fun buildRevenueDataViewState(totalValue: String, totalDelta: Int, netValue: String, netDelta: Int) =
@@ -217,7 +218,7 @@ class AnalyticsViewModel @Inject constructor(
 
     private fun getSavedDateRange(): AnalyticsDateRange = savedState[DATE_RANGE_SELECTED_KEY] ?: getDefaultDateRange()
     private fun getSavedTimePeriod(): AnalyticTimePeriod = savedState[TIME_PERIOD_SELECTED_KEY]
-        ?: AnalyticTimePeriod.from(getDefaultTimePeriod())
+        ?: getDefaultTimePeriod()
 
     companion object {
         const val TIME_PERIOD_SELECTED_KEY = "range_selection_key"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewState.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformation
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 
 data class AnalyticsViewState(
+    val refreshIndicator: RefreshIndicator,
     val analyticsDateRangeSelectorState: AnalyticsDateRangeSelectorViewState,
     val revenueState: AnalyticsInformationViewState
 )
@@ -12,4 +13,9 @@ data class AnalyticsViewState(
 sealed class AnalyticsViewEvent : MultiLiveEvent.Event() {
     data class OpenUrl(val url: String) : AnalyticsViewEvent()
     data class OpenWPComWebView(val url: String) : AnalyticsViewEvent()
+}
+
+sealed class RefreshIndicator {
+    object ShowIndicator : RefreshIndicator()
+    object NotShowIndicator : RefreshIndicator()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
@@ -1,36 +1,43 @@
 package com.woocommerce.android.ui.analytics.daterangeselector
 
 import android.os.Parcelable
-import com.woocommerce.android.ui.analytics.daterangeselector.DateRange.MultipleDateRange
-import com.woocommerce.android.ui.analytics.daterangeselector.DateRange.SimpleDateRange
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange.MultipleDateRange
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange.SimpleDateRange
 import com.woocommerce.android.util.DateUtils
 import kotlinx.parcelize.Parcelize
 import java.util.*
 import javax.inject.Inject
 
-sealed class DateRange {
+sealed class AnalyticsDateRange {
     @Parcelize
-    data class SimpleDateRange(val from: Date, val to: Date) : DateRange(), Parcelable
+    data class SimpleDateRange(
+        val from: Date,
+        val to: Date
+    ) : AnalyticsDateRange(), Parcelable
 
     @Parcelize
-    data class MultipleDateRange(val from: SimpleDateRange, val to: SimpleDateRange) : DateRange(), Parcelable
+    data class MultipleDateRange(
+        val from: SimpleDateRange,
+        val to: SimpleDateRange
+    ) : AnalyticsDateRange(), Parcelable
 }
 
 class AnalyticsDateRangeCalculator @Inject constructor(
     val dateUtils: DateUtils
 ) {
-    fun getAnalyticsDateRangeFrom(selectionRange: AnalyticsDateRanges): DateRange = when (selectionRange) {
-        AnalyticsDateRanges.TODAY -> getTodayRange()
-        AnalyticsDateRanges.YESTERDAY -> getYesterdayRange()
-        AnalyticsDateRanges.LAST_WEEK -> getLastWeekRange()
-        AnalyticsDateRanges.LAST_MONTH -> getLastMonthRange()
-        AnalyticsDateRanges.LAST_QUARTER -> getLastQuarterRange()
-        AnalyticsDateRanges.LAST_YEAR -> getLastYearRange()
-        AnalyticsDateRanges.WEEK_TO_DATE -> getWeekToDateRange()
-        AnalyticsDateRanges.MONTH_TO_DATE -> getMonthToDateRange()
-        AnalyticsDateRanges.QUARTER_TO_DATE -> getQuarterToRangeDate()
-        AnalyticsDateRanges.YEAR_TO_DATE -> getYearToDateRange()
-    }
+    fun getAnalyticsDateRangeFrom(selectionRange: AnalyticTimePeriod): AnalyticsDateRange =
+        when (selectionRange) {
+            AnalyticTimePeriod.TODAY -> getTodayRange()
+            AnalyticTimePeriod.YESTERDAY -> getYesterdayRange()
+            AnalyticTimePeriod.LAST_WEEK -> getLastWeekRange()
+            AnalyticTimePeriod.LAST_MONTH -> getLastMonthRange()
+            AnalyticTimePeriod.LAST_QUARTER -> getLastQuarterRange()
+            AnalyticTimePeriod.LAST_YEAR -> getLastYearRange()
+            AnalyticTimePeriod.WEEK_TO_DATE -> getWeekToDateRange()
+            AnalyticTimePeriod.MONTH_TO_DATE -> getMonthToDateRange()
+            AnalyticTimePeriod.QUARTER_TO_DATE -> getQuarterToRangeDate()
+            AnalyticTimePeriod.YEAR_TO_DATE -> getYearToDateRange()
+        }
 
     private fun getYearToDateRange() = MultipleDateRange(
         SimpleDateRange(dateUtils.getDateForFirstDayOfPreviousYear(), getMinusOneYearDate()),
@@ -128,7 +135,7 @@ class AnalyticsDateRangeCalculator @Inject constructor(
     }
 }
 
-enum class AnalyticsDateRanges(val description: String) {
+enum class AnalyticTimePeriod(val description: String) {
     TODAY("Today"),
     YESTERDAY("Yesterday"),
     LAST_WEEK("Last Week"),
@@ -141,8 +148,8 @@ enum class AnalyticsDateRanges(val description: String) {
     YEAR_TO_DATE("Year to Date");
 
     companion object {
-        fun from(dateRangeDescription: String): AnalyticsDateRanges = values()
-            .find { it.description == dateRangeDescription } ?: TODAY
+        fun from(datePeriod: String): AnalyticTimePeriod = values()
+            .find { it.description == datePeriod } ?: TODAY
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
@@ -1,14 +1,19 @@
 package com.woocommerce.android.ui.analytics.daterangeselector
 
+import android.os.Parcelable
 import com.woocommerce.android.ui.analytics.daterangeselector.DateRange.MultipleDateRange
 import com.woocommerce.android.ui.analytics.daterangeselector.DateRange.SimpleDateRange
 import com.woocommerce.android.util.DateUtils
+import kotlinx.parcelize.Parcelize
 import java.util.*
 import javax.inject.Inject
 
 sealed class DateRange {
-    data class SimpleDateRange(val from: Date, val to: Date) : DateRange()
-    data class MultipleDateRange(val from: SimpleDateRange, val to: SimpleDateRange) : DateRange()
+    @Parcelize
+    data class SimpleDateRange(val from: Date, val to: Date) : DateRange(), Parcelable
+
+    @Parcelize
+    data class MultipleDateRange(val from: SimpleDateRange, val to: SimpleDateRange) : DateRange(), Parcelable
 }
 
 class AnalyticsDateRangeCalculator @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationCardView.kt
@@ -15,7 +15,6 @@ class AnalyticsInformationCardView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : MaterialCardView(ctx, attrs, defStyleAttr) {
-
     val binding = AnalyticsInformationCardViewBinding.inflate(LayoutInflater.from(ctx), this)
     private var skeletonView = SkeletonView()
 

--- a/WooCommerce/src/main/res/layout/fragment_analytics.xml
+++ b/WooCommerce/src/main/res/layout/fragment_analytics.xml
@@ -7,27 +7,33 @@
     android:layout_height="match_parent"
     tools:context=".ui.analytics.AnalyticsFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/analyticsViewRoot"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeCardView
-            android:id="@+id/analyticsDateSelectorCard"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/minor_10"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/analyticsViewRoot"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationCardView
-            android:id="@+id/analyticsRevenueCard"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/analyticsDateSelectorCard" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeCardView
+                android:id="@+id/analyticsDateSelectorCard"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_10"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationCardView
+                android:id="@+id/analyticsRevenueCard"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/analyticsDateSelectorCard" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -131,7 +131,6 @@
     Analytics
     -->
     <color name="analytics_background">@color/woo_black_90</color>
-    <color name="analytics_divider">@color/woo_black_900</color>
     <color name="analytics_delta_positive_color">#B8E6BF</color>
     <color name="analytics_delta_text_color">@color/woo_black_90</color>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepositoryTest.kt
@@ -4,8 +4,9 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.Companion.ANALYTICS_REVENUE_PATH
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueData
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueError
-import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRanges
-import com.woocommerce.android.ui.analytics.daterangeselector.DateRange
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange.MultipleDateRange
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange.SimpleDateRange
 import com.woocommerce.android.ui.mystore.data.StatsRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -46,7 +47,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
             .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
         // When
-        val result = sut.fetchRevenueData(DateRange.SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
+        val result = sut.fetchRevenueData(SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
 
         // Then
         with(result.first()) {
@@ -65,7 +66,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
             .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
         // When
-        val result = sut.fetchRevenueData(DateRange.SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
+        val result = sut.fetchRevenueData(SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
 
         // Then
         with(result.first()) {
@@ -85,7 +86,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 .thenReturn(listOf(Result.success(revenue)).asFlow())
 
             // When
-            val result = sut.fetchRevenueData(DateRange.SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
+            val result = sut.fetchRevenueData(
+                SimpleDateRange(previousDate!!, currentDate!!),
+                ANY_RANGE
+            )
 
             // Then
             with(result.single()) {
@@ -111,7 +115,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
-            val result = sut.fetchRevenueData(DateRange.SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
+            val result = sut.fetchRevenueData(SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
 
             // Then
             with(result.single()) {
@@ -137,7 +141,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
-            val result = sut.fetchRevenueData(DateRange.SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
+            val result = sut.fetchRevenueData(SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
 
             // Then
             with(result.single()) {
@@ -163,7 +167,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
-            val result = sut.fetchRevenueData(DateRange.SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
+            val result = sut.fetchRevenueData(SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
 
             // Then
             with(result.single()) {
@@ -189,7 +193,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
-            val result = sut.fetchRevenueData(DateRange.SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
+            val result = sut.fetchRevenueData(SimpleDateRange(previousDate!!, currentDate!!), ANY_RANGE)
 
             // Then
             with(result.single()) {
@@ -216,9 +220,9 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
 
             // When
             val result = sut.fetchRevenueData(
-                DateRange.MultipleDateRange(
-                    DateRange.SimpleDateRange(previousDate!!, previousDate),
-                    DateRange.SimpleDateRange(currentDate!!, currentDate)
+                MultipleDateRange(
+                    SimpleDateRange(previousDate!!, previousDate),
+                    SimpleDateRange(currentDate!!, currentDate)
                 ),
                 ANY_RANGE
             )
@@ -266,7 +270,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
 
         const val ANY_URL = "https://a8c.com"
 
-        val ANY_RANGE = AnalyticsDateRanges.LAST_YEAR
+        val ANY_RANGE = AnalyticTimePeriod.LAST_YEAR
         private val sdf = SimpleDateFormat("yyyy-MM-dd")
         val previousDate: Date? = sdf.parse(PREVIOUS_DATE)
         val currentDate: Date? = sdf.parse(CURRENT_DATE)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
@@ -4,11 +4,11 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.RevenueStat
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueData
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.LAST_YEAR
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.WEEK_TO_DATE
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange.MultipleDateRange
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange.SimpleDateRange
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeCalculator
-import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRanges.LAST_YEAR
-import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRanges.WEEK_TO_DATE
-import com.woocommerce.android.ui.analytics.daterangeselector.DateRange
-import com.woocommerce.android.ui.analytics.daterangeselector.DateRange.MultipleDateRange
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.LoadingViewState
 import com.woocommerce.android.util.CurrencyFormatter
@@ -38,8 +38,8 @@ class AnalyticsViewModelTest : BaseUnitTest() {
 
     private val calculator: AnalyticsDateRangeCalculator = mock {
         on { getAnalyticsDateRangeFrom(LAST_YEAR) } doReturn MultipleDateRange(
-            DateRange.SimpleDateRange(ANY_OTHER_DATE, ANY_OTHER_DATE),
-            DateRange.SimpleDateRange(ANY_OTHER_DATE, ANY_OTHER_DATE),
+            SimpleDateRange(ANY_OTHER_DATE, ANY_OTHER_DATE),
+            SimpleDateRange(ANY_OTHER_DATE, ANY_OTHER_DATE),
         )
     }
 
@@ -98,7 +98,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             }
 
             sut = givenAViewModel(resourceProvider)
-            sut.onSelectedDateRangeChanged(LAST_YEAR.description)
+            sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
 
             with(sut.state.value.analyticsDateRangeSelectorState) {
                 assertNotNull(this)
@@ -117,7 +117,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
 
             sut = givenAViewModel()
 
-            sut.onSelectedDateRangeChanged(LAST_YEAR.description)
+            sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
 
             with(sut.state.value.revenueState) {
 
@@ -167,8 +167,8 @@ class AnalyticsViewModelTest : BaseUnitTest() {
     fun `given a week to date selected, when refresh is requested, then revenue is the expected`() = testBlocking {
 
         val weekToDateRange = MultipleDateRange(
-            DateRange.SimpleDateRange(ANY_WEEK_DATE, ANY_WEEK_DATE),
-            DateRange.SimpleDateRange(ANY_WEEK_DATE, ANY_WEEK_DATE),
+            SimpleDateRange(ANY_WEEK_DATE, ANY_WEEK_DATE),
+            SimpleDateRange(ANY_WEEK_DATE, ANY_WEEK_DATE),
         )
 
         val weekRevenueStats = getRevenueStats(
@@ -184,7 +184,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             .thenReturn(listOf(weekRevenueStats, weekRevenueStats).asFlow())
 
         sut = givenAViewModel()
-        sut.onSelectedDateRangeChanged(WEEK_TO_DATE.description)
+        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE.description)
         sut.onRefreshRequested()
 
         with(sut.state.value.revenueState) {
@@ -194,7 +194,6 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             assertEquals(OTHER_NET_CURRENCY_VALUE, rightSection.value)
             assertEquals(OTHER_NET_DELTA, rightSection.delta)
         }
-
     }
 
     private fun givenAResourceProvider(): ResourceProvider = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
@@ -98,7 +98,6 @@ class AnalyticsViewModelTest : BaseUnitTest() {
     @Test
     fun `when ViewModel is with savedState is created, then has the expected values`() =
         testBlocking {
-
             val resourceProvider: ResourceProvider = mock {
                 on { getString(any()) } doReturn ANY_SAVED_VALUE
                 on { getString(any(), anyVararg()) } doReturn ANY_SAVED_RANGE_EXPECTED_DATE_MESSAGE
@@ -158,7 +157,6 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
 
             with(sut.state.value.revenueState) {
-
                 assertTrue(this is AnalyticsInformationViewState.DataViewState)
                 assertEquals(TOTAL_CURRENCY_VALUE, leftSection.value)
                 assertEquals(TOTAL_DELTA, leftSection.delta)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
@@ -189,13 +189,10 @@ class AnalyticsViewModelTest : BaseUnitTest() {
 
         with(sut.state.value.revenueState) {
             assertTrue(this is AnalyticsInformationViewState.DataViewState)
-            assertTrue(leftSection is SectionDataViewState)
-            assertEquals(OTHER_TOTAL_CURRENCY_VALUE, (leftSection as SectionDataViewState).value)
-            assertEquals(OTHER_TOTAL_DELTA, (leftSection as SectionDataViewState).delta)
-
-            assertTrue(rightSection is SectionDataViewState)
-            assertEquals(OTHER_NET_CURRENCY_VALUE, (rightSection as SectionDataViewState).value)
-            assertEquals(OTHER_NET_DELTA, (rightSection as SectionDataViewState).delta)
+            assertEquals(OTHER_TOTAL_CURRENCY_VALUE, leftSection.value)
+            assertEquals(OTHER_TOTAL_DELTA, leftSection.delta)
+            assertEquals(OTHER_NET_CURRENCY_VALUE, rightSection.value)
+            assertEquals(OTHER_NET_DELTA, rightSection.delta)
         }
 
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.analytics.daterangeselector
 
-import com.woocommerce.android.ui.analytics.daterangeselector.DateRange.SimpleDateRange
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange.SimpleDateRange
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import org.junit.Test
@@ -38,7 +38,7 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getCurrentDate()).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.TODAY)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.TODAY)
 
         // Then
         assertTrue(result is SimpleDateRange)
@@ -52,7 +52,7 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getCurrentDateTimeMinusDays(any())).thenReturn(DATE_ZERO)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.YESTERDAY)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.YESTERDAY)
 
         // Then
         assertTrue(result is SimpleDateRange)
@@ -67,10 +67,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getDateForLastDayOfPreviousWeek(any(), any())).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.LAST_WEEK)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.LAST_WEEK)
 
         // Then
-        assertTrue(result is DateRange.MultipleDateRange)
+        assertTrue(result is AnalyticsDateRange.MultipleDateRange)
         assertEquals(date, result.from.from)
         assertEquals(date, result.from.to)
         assertEquals(date, result.to.from)
@@ -84,10 +84,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getDateForLastDayOfPreviousMonth(any(), any())).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.LAST_MONTH)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.LAST_MONTH)
 
         // Then
-        assertTrue(result is DateRange.MultipleDateRange)
+        assertTrue(result is AnalyticsDateRange.MultipleDateRange)
         assertEquals(date, result.from.from)
         assertEquals(date, result.from.to)
         assertEquals(date, result.to.from)
@@ -101,10 +101,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getDateForLastDayOfPreviousQuarter(any(), any())).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.LAST_QUARTER)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.LAST_QUARTER)
 
         // Then
-        assertTrue(result is DateRange.MultipleDateRange)
+        assertTrue(result is AnalyticsDateRange.MultipleDateRange)
         assertEquals(date, result.from.from)
         assertEquals(date, result.from.to)
         assertEquals(date, result.to.from)
@@ -118,10 +118,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getDateForLastDayOfPreviousYear(any(), any())).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.LAST_YEAR)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.LAST_YEAR)
 
         // Then
-        assertTrue(result is DateRange.MultipleDateRange)
+        assertTrue(result is AnalyticsDateRange.MultipleDateRange)
         assertEquals(date, result.from.from)
         assertEquals(date, result.from.to)
         assertEquals(date, result.to.from)
@@ -137,10 +137,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getDateForFirstDayOfWeek(any())).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.WEEK_TO_DATE)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.WEEK_TO_DATE)
 
         // Then
-        assertTrue(result is DateRange.MultipleDateRange)
+        assertTrue(result is AnalyticsDateRange.MultipleDateRange)
         assertEquals(date, result.from.from)
         assertEquals(date, result.from.to)
         assertEquals(date, result.to.from)
@@ -156,10 +156,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getDateForFirstDayOfMonth(any())).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.MONTH_TO_DATE)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.MONTH_TO_DATE)
 
         // Then
-        assertTrue(result is DateRange.MultipleDateRange)
+        assertTrue(result is AnalyticsDateRange.MultipleDateRange)
         assertEquals(date, result.from.from)
         assertEquals(date, result.from.to)
         assertEquals(date, result.to.from)
@@ -175,10 +175,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getDateForFirstDayOfQuarter(any())).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.QUARTER_TO_DATE)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.QUARTER_TO_DATE)
 
         // Then
-        assertTrue(result is DateRange.MultipleDateRange)
+        assertTrue(result is AnalyticsDateRange.MultipleDateRange)
         assertEquals(date, result.from.from)
         assertEquals(date, result.from.to)
         assertEquals(date, result.to.from)
@@ -194,10 +194,10 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         whenever(dateUtils.getDateForFirstDayOfYear(any())).thenReturn(date)
 
         // When
-        val result = sut.getAnalyticsDateRangeFrom(AnalyticsDateRanges.YEAR_TO_DATE)
+        val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.YEAR_TO_DATE)
 
         // Then
-        assertTrue(result is DateRange.MultipleDateRange)
+        assertTrue(result is AnalyticsDateRange.MultipleDateRange)
         assertEquals(date, result.from.from)
         assertEquals(date, result.from.to)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
@@ -20,20 +20,20 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
         private const val THREE_JAN_1970_TIME = 234083000L
         private const val THREE_FEB_1970_TIME = 2912483000L
         private const val TWTY_FOUR_NOV_2021 = 1637776266465L
-        private const val TWTY8_NOV_2021 = 1638054000000L
-        private const val ONE_DEC_2021 = 1638313200000L
+        private const val TWTY8_NOV_2021 = 1638087612000L
+        private const val TWO_DEC_2021 = 1638433212000L
 
         val date = Date().apply { time = DATE_ZERO }
         val threeJan1970 = Date().apply { time = THREE_JAN_1970_TIME }
         val threeFeb1970 = Date().apply { time = THREE_FEB_1970_TIME }
         val twtyFourNov2021 = Date().apply { time = TWTY_FOUR_NOV_2021 }
         val twtyEightNov2021 = Date().apply { time = TWTY8_NOV_2021 }
-        val oneDec2021 = Date().apply { time = ONE_DEC_2021 }
+        val oneDec2021 = Date().apply { time = TWO_DEC_2021 }
 
         const val SAME_YEAR_SAME_MONTH_EXPECTED = "Jan 1 - 3, 1970"
         const val SAME_YEAR_DIFFERENT_MONTH_EXPECTED = "Jan 3 - Feb 3, 1970"
         const val DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED = "Jan 3, 1970 - Nov 24, 2021"
-        const val DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED_TWO = "Nov 28 - Dec 1, 2021"
+        const val DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED_TWO = "Nov 28 - Dec 2, 2021"
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
@@ -213,19 +213,19 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
     @Test
     fun `get the friendly period date range is the expected`() {
         val sameYearAndMonthFriendlyFormattedDate = SimpleDateRange(date, threeJan1970)
-            .formatDatesToFriendlyPeriod()
+            .formatDatesToFriendlyPeriod(Locale.UK)
         assertEquals(SAME_YEAR_SAME_MONTH_EXPECTED, sameYearAndMonthFriendlyFormattedDate)
 
         val sameYearAndDifferentMonthFriendlyFormattedDate = SimpleDateRange(threeJan1970, threeFeb1970)
-            .formatDatesToFriendlyPeriod()
+            .formatDatesToFriendlyPeriod(Locale.UK)
         assertEquals(SAME_YEAR_DIFFERENT_MONTH_EXPECTED, sameYearAndDifferentMonthFriendlyFormattedDate)
 
         val differentYearAndDifferentMonthFriendlyFormattedDate = SimpleDateRange(threeJan1970, twtyFourNov2021)
-            .formatDatesToFriendlyPeriod()
+            .formatDatesToFriendlyPeriod(Locale.UK)
         assertEquals(DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED, differentYearAndDifferentMonthFriendlyFormattedDate)
 
         val differentYearAndDifferentMonthFriendlyFormattedDateTwo =
-            SimpleDateRange(twtyEightNov2021, oneDec2021).formatDatesToFriendlyPeriod()
+            SimpleDateRange(twtyEightNov2021, oneDec2021).formatDatesToFriendlyPeriod(Locale.UK)
         assertEquals(
             DIFFERENT_YEAR_DIFFERENT_MONTH_EXPECTED_TWO,
             differentYearAndDifferentMonthFriendlyFormattedDateTwo

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,11 @@
 import io.github.wzieba.tracks.plugin.TracksExtension
 
+buildscript {
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.2.2'
+    }
+}
+
 plugins {
     id 'com.automattic.android.fetchstyle'
     id 'io.gitlab.arturbosch.detekt'

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,5 @@
 import io.github.wzieba.tracks.plugin.TracksExtension
 
-buildscript {
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
-    }
-}
-
 plugins {
     id 'com.automattic.android.fetchstyle'
     id 'io.gitlab.arturbosch.detekt'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes:  [5426](https://github.com/woocommerce/woocommerce-android/issues/5426)

### Description
This pull request adds scrollable view to analytics fragment and implements pull to refresh action

### Testing instructions

1. Open the application compiled in debug mode
2. Click on the analytics section in the bottom bar navigation
3. Do a swipe to refresh action in the section
4. Data should be reloaded

### Images/gif
<img src="https://user-images.githubusercontent.com/572601/145399015-25ded608-7811-438c-93ac-62202b375f41.gif" width="280" height="600">

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

