### PR TITLE
UI Tests: fix crash when running multiple tests

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceTest.kt
@@ -21,8 +21,6 @@ open class BaseWooCommerce : Application(), HasAndroidInjector {
         fun injector(): DispatchingAndroidInjector<Any>
     }
 
-    private lateinit var injector: AndroidInjector<Any>
-
     override fun onCreate() {
         super.onCreate()
         val wellSqlConfig = WooWellSqlConfig(this)
@@ -30,12 +28,9 @@ open class BaseWooCommerce : Application(), HasAndroidInjector {
     }
 
     override fun androidInjector(): AndroidInjector<Any> {
-        if (!this::injector.isInitialized) {
-            injector = EntryPoints.get(
-                applicationContext,
-                AndroidInjectorEntryPoint::class.java
-            ).injector()
-        }
-        return injector
+        return EntryPoints.get(
+            applicationContext,
+            AndroidInjectorEntryPoint::class.java
+        ).injector()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/InitializationRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/InitializationRule.kt
@@ -10,7 +10,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
-import org.greenrobot.eventbus.EventBus
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/InitializationRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/InitializationRule.kt
@@ -3,10 +3,14 @@ package com.woocommerce.android.helpers
 import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
 import com.woocommerce.android.AppInitializer
+import com.woocommerce.android.di.AppCoroutineScope
 import dagger.hilt.EntryPoint
 import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import org.greenrobot.eventbus.EventBus
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -14,8 +18,9 @@ import org.junit.runners.model.Statement
 class InitializationRule : TestRule {
     @EntryPoint
     @InstallIn(SingletonComponent::class)
-    interface AppInitializerEntryPoint {
-        fun inject(): AppInitializer
+    interface AppEntryPoint {
+        fun initializer(): AppInitializer
+        @AppCoroutineScope fun appCoroutineScope(): CoroutineScope
     }
 
     private val instrumentation
@@ -24,16 +29,16 @@ class InitializationRule : TestRule {
     override fun apply(base: Statement?, description: Description?): Statement {
         return object : Statement() {
             override fun evaluate() {
+                val application = instrumentation.targetContext.applicationContext as Application
+                val entryPoint = EntryPoints.get(
+                    application,
+                    AppEntryPoint::class.java
+                )
                 instrumentation.runOnMainSync {
-                    val application = instrumentation.targetContext.applicationContext as Application
-                    val appInitializer = EntryPoints.get(
-                        application,
-                        AppInitializerEntryPoint::class.java
-                    ).inject()
-
-                    appInitializer.init(application)
+                    entryPoint.initializer().init(application)
                 }
                 base?.evaluate()
+                entryPoint.appCoroutineScope().cancel()
             }
         }
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/push/FCMMessageService.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/push/FCMMessageService.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.push
+
+import com.google.firebase.messaging.FirebaseMessagingService
+
+/**
+ * A dummy implementation of the FCMMessageService.
+ * This is needed to avoid a race condition between Hilt's test initialization, and the injection
+ * done by @AndroidEntryPoint in the service when receiving a new token.
+ */
+class FCMMessageService : FirebaseMessagingService()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -6,10 +6,12 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import com.woocommerce.android.datastore.DataStoreType.TRACKER
+import com.woocommerce.android.di.AppCoroutineScope
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 @Module
@@ -18,9 +20,13 @@ class DataStoreModule {
     @Provides
     @Singleton
     @DataStoreQualifier(TRACKER)
-    fun provideTrackerDataStore(appContext: Context): DataStore<Preferences> = PreferenceDataStoreFactory.create(
+    fun provideTrackerDataStore(
+        appContext: Context,
+        @AppCoroutineScope appCoroutineScope: CoroutineScope
+    ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("tracker")
-        }
+        },
+        scope = appCoroutineScope
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -12,6 +12,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import javax.inject.Singleton
 
 @Module
@@ -27,6 +28,6 @@ class DataStoreModule {
         produceFile = {
             appContext.preferencesDataStoreFile("tracker")
         },
-        scope = appCoroutineScope
+        scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ApplicationModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ApplicationModule.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import org.wordpress.android.login.di.LoginServiceModule
 import javax.inject.Qualifier
+import javax.inject.Singleton
 import kotlin.annotation.AnnotationRetention.RUNTIME
 
 @InstallIn(SingletonComponent::class)
@@ -39,6 +40,7 @@ abstract class ApplicationModule {
     companion object {
         @Provides
         @AppCoroutineScope
+        @Singleton
         fun provideAppCoroutineScope(dispatcher: CoroutineDispatcher): CoroutineScope =
             CoroutineScope(SupervisorJob() + dispatcher)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -98,8 +98,9 @@ class ZendeskHelper(
         oauthClientId: String,
         enableLogs: Boolean = BuildConfig.DEBUG
     ) {
-        require(!isZendeskEnabled) {
-            "Zendesk shouldn't be initialized more than once!"
+        if (isZendeskEnabled) {
+            if (PackageUtils.isUITesting()) return
+            else error("Zendesk shouldn't be initialized more than once!")
         }
         if (zendeskUrl.isEmpty() || applicationId.isEmpty() || oauthClientId.isEmpty()) {
             return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
@@ -29,6 +29,15 @@ object PackageUtils {
         return isTesting!!
     }
 
+    fun isUITesting(): Boolean {
+        return try {
+            Class.forName("com.woocommerce.android.helpers.TestBase")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
+        }
+    }
+
     fun isBetaBuild(context: Context): Boolean {
         val versionName = getVersionName(context).toLowerCase(Locale.ROOT)
         return (versionName.contains("beta") || versionName.contains("rc"))


### PR DESCRIPTION
### Description
When running multiple tests during the same sessions, Hilt will reset the state after running the test, and will create new copies for all components for subsequent tests.
This PR makes the following changes to make UI tests work across multiple tests:
- since Zendesk is using a static singleton `Zendesk.INSTANCE`, its state is being kept across tests, which causes a crash when we try to initialize the app, this PR relaxes the check we do on `ZendeskHelper` when running UI tests.
- We use DataStore in the app, but without providing our own CoroutineScope, it will stay active when the test is finished, this PR makes sure we pass our CoroutineScope, and we cancel it properly after finishing the test.
- The login library is not migrated to Hilt yet, and instead it still uses AndroidInjector, in our Application for tests, we were caching the AndroidInjector in a field, but this meant that after a second test is launched, we'll keep track of the past graph, which meant using nonconsistent components (different instances of Stores), and failure during login.
- The FCMMessageService is called sometimes on app launch if a token is received, which leads to a race condition where the injection of the service happens before Hilt tests are initialized (check [this ](https://github.com/google/dagger/issues/2016) for more details), since we don't need this service for tests, I added a dummy implementation that does nothing.

### Testing instructions
run `./gradlew connectedVanillaDebugAndroidTest -P android.testInstrumentationRunnerArguments.package=com.woocommerce.android.ui.main` and confirm tests run successfully.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
