### PR TITLE
Add: Tracks for System Status Report Screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -487,6 +487,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         SUPPORT_APPLICATION_LOG_VIEWED(siteless = true),
         SUPPORT_TICKETS_VIEWED(siteless = true),
         SUPPORT_FAQ_VIEWED(siteless = true),
+        SUPPORT_SSR_OPENED,
+        SUPPORT_SSR_COPY_BUTTON_TAPPED,
 
         // -- Push notifications
         PUSH_NOTIFICATION_RECEIVED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -179,7 +179,6 @@ class HelpActivity : AppCompatActivity() {
     }
 
     private fun showSSR() {
-        AnalyticsTracker.track(Stat.SUPPORT_SSR_OPENED)
         startActivity(Intent(this, SSRActivity::class.java))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -179,6 +179,7 @@ class HelpActivity : AppCompatActivity() {
     }
 
     private fun showSSR() {
+        AnalyticsTracker.track(Stat.SUPPORT_SSR_OPENED)
         startActivity(Intent(this, SSRActivity::class.java))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
@@ -8,6 +8,8 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivitySsrBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
@@ -85,6 +87,7 @@ class SSRActivity : AppCompatActivity() {
     private fun copySSRToClipboard(text: String) {
         try {
             copyToClipboard(getString(R.string.support_system_status_report_clipboard_label), text)
+            AnalyticsTracker.track(Stat.SUPPORT_SSR_COPY_BUTTON_TAPPED)
             ToastUtils.showToast(this, R.string.support_system_status_report_copied_to_clipboard)
         } catch (e: IllegalStateException) {
             WooLog.e(T.UTILS, e)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
@@ -44,6 +44,12 @@ class SSRActivity : AppCompatActivity() {
         setupObservers(binding)
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        AnalyticsTracker.track(Stat.SUPPORT_SSR_OPENED)
+    }
+
     private fun setupObservers(binding: ActivitySsrBinding) {
         viewModel.viewStateData.observe(this) { old, new ->
             new.formattedSSR.takeIfNotEqualTo(old?.formattedSSR) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5449 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds a couple of trackings:
1. When the SSR screen is opened,
2. When the copy button in the SSR screen is used.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to Settings > Help & Support, then open "System status report",
2. Check Logcat and make sure `Tracked: support_ssr_opened` is shown,
3. Tap the copy icon on top right of the screen,
4. Check Logcat and make sure `Tracked: support_ssr_copy_button_tapped` is shown.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
