### PR TITLE
Refactor `AddressViewModel` to make it useable for Order Creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Location.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Location.kt
@@ -1,15 +1,20 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.data.WCLocationModel
 
 @Parcelize
 data class Location(
-    val code: String,
+    val code: LocationCode,
     val name: String,
     val parentCode: String = ""
-) : Parcelable
+) : Parcelable {
+    companion object {
+        val EMPTY = Location("", "")
+    }
+}
 
 fun WCLocationModel.toAppModel(): Location {
     return Location(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -48,7 +48,7 @@ class AddressViewModel @Inject constructor(
      * search and back) we don't want this method to be called again, otherwise the ViewModel will replace the newly
      * selected country or state with the previously saved values.
      */
-    fun start(countryCode: String, stateCode: String) {
+    fun start(countryCode: LocationCode, stateCode: LocationCode) {
         if (hasStarted) {
             return
         }
@@ -84,22 +84,22 @@ class AddressViewModel @Inject constructor(
         viewState = ViewState()
     }
 
-    private fun getCountryNameFromCode(countryCode: String): String {
+    private fun getCountryNameFromCode(countryCode: LocationCode): String {
         return countries.find { it.code == countryCode }?.name ?: countryCode
     }
 
-    private fun getCountryLocationFromCode(countryCode: String): Location {
+    private fun getCountryLocationFromCode(countryCode: LocationCode): Location {
         return Location(countryCode, getCountryNameFromCode(countryCode))
     }
 
-    private fun getStateLocationFromCode(country: String, stateCode: String): Location {
+    private fun getStateLocationFromCode(countryCode: LocationCode, stateCode: LocationCode): Location {
         return Location(
             code = stateCode,
-            name = dataStore.getStates(country).firstOrNull { state -> state.code == stateCode }?.name ?: stateCode
+            name = dataStore.getStates(countryCode).firstOrNull { state -> state.code == stateCode }?.name ?: stateCode
         )
     }
 
-    fun onCountrySelected(type: AddressType, countryCode: String) {
+    fun onCountrySelected(type: AddressType, countryCode: LocationCode) {
         viewState = viewState.copy(
             countryStatePairs = viewState.countryStatePairs.toMutableMap().apply {
                 put(
@@ -114,7 +114,7 @@ class AddressViewModel @Inject constructor(
         )
     }
 
-    fun onStateSelected(type: AddressType, stateCode: String) {
+    fun onStateSelected(type: AddressType, stateCode: LocationCode) {
         val initialLocation = viewState.countryStatePairs.getValue(type)
         if (stateCode != initialLocation.stateLocation.code) {
             viewState = viewState.copy(
@@ -130,7 +130,7 @@ class AddressViewModel @Inject constructor(
         }
     }
 
-    private fun initializeCountriesAndStates(countryCode: String, stateCode: String) {
+    private fun initializeCountriesAndStates(countryCode: LocationCode, stateCode: LocationCode) {
         viewState = viewState.copy(
             countryStatePairs = mapOf(
                 AddressType.BILLING to CountryStatePair(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -13,6 +13,8 @@ import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.WCDataStore
 import javax.inject.Inject
 
+typealias LocationCode = String
+
 @HiltViewModel
 class AddressViewModel @Inject constructor(
     savedState: SavedStateHandle,
@@ -25,14 +27,19 @@ class AddressViewModel @Inject constructor(
     val countries: List<Location>
         get() = dataStore.getCountries().map { it.toAppModel() }
 
-    val states: List<Location>
-        get() = dataStore.getStates(viewState.countryLocation.code).map { it.toAppModel() }
+    fun statesAvailableFor(type: AddressType): List<Location> {
+        val selectedCountry = selectedCountryLocationFor(type)
+        return dataStore.getStates(selectedCountry.code)
+            .map { it.toAppModel() }
+    }
 
-    val countryLocation: Location
-        get() = viewState.countryLocation
+    fun selectedCountryLocationFor(type: AddressType): Location {
+        return viewState.countryStatePairs.getValue(type).countryLocation
+    }
 
-    val stateLocation: Location
-        get() = viewState.stateLocation
+    fun selectedStateLocationFor(type: AddressType): Location {
+        return viewState.countryStatePairs.getValue(type).stateLocation
+    }
 
     private var hasStarted = false
 
@@ -40,34 +47,30 @@ class AddressViewModel @Inject constructor(
      * The start method is called when the view is created. When the view is recreated (e.g. navigating to country
      * search and back) we don't want this method to be called again, otherwise the ViewModel will replace the newly
      * selected country or state with the previously saved values.
-     *
-     * @see applyCountryStateChangesSafely
      */
     fun start(countryCode: String, stateCode: String) {
         if (hasStarted) {
             return
         }
         hasStarted = true
-        loadCountriesAndStates(countryCode, stateCode)
-        viewState.applyCountryStateChangesSafely(countryCode, stateCode)
+        initialize(countryCode, stateCode)
     }
 
-    private fun loadCountriesAndStates(countryCode: String, stateCode: String) {
+    private fun initialize(countryCode: String, stateCode: String) {
         launch {
             // we only fetch the countries and states if they've never been fetched
             if (countries.isEmpty()) {
                 viewState = viewState.copy(isLoading = true)
                 dataStore.fetchCountriesAndStates(selectedSite.get())
-                viewState.copy(
-                    isLoading = false
-                ).applyCountryStateChangesSafely(countryCode, stateCode)
+                viewState = viewState.copy(isLoading = false)
             }
+            initializeCountriesAndStates(countryCode, stateCode)
         }
     }
 
     fun hasCountries() = countries.isNotEmpty()
 
-    fun hasStates() = states.isNotEmpty()
+    fun hasStatesFor(type: AddressType) = statesAvailableFor(type).isNotEmpty()
 
     /**
      * Even when the [BaseAddressEditingFragment] instance is destroyed the instance of [AddressViewModel] will still
@@ -89,53 +92,80 @@ class AddressViewModel @Inject constructor(
         return Location(countryCode, getCountryNameFromCode(countryCode))
     }
 
-    private fun getStateNameFromCode(stateCode: String): String {
-        return states.find { it.code == stateCode }?.name ?: stateCode
-    }
-
-    private fun getStateLocationFromCode(stateCode: String): Location {
-        return Location(stateCode, getStateNameFromCode(stateCode))
-    }
-
-    fun onCountrySelected(countryCode: String) {
-        if (countryCode != viewState.countryLocation.code) {
-            viewState = viewState.copy(
-                countryLocation = getCountryLocationFromCode(countryCode),
-                stateLocation = Location("", ""),
-                isStateSelectionEnabled = true
-            )
-        }
-    }
-
-    fun onStateSelected(stateCode: String) {
-        if (stateCode != viewState.stateLocation.code) {
-            viewState = viewState.copy(
-                stateLocation = getStateLocationFromCode(stateCode)
-            )
-        }
-    }
-
-    /**
-     * State data acquisition depends on the Country configuration, so when updating the ViewState
-     * we need to make sure that we updated the Country code before applying everything else to avoid
-     * looking into a outdated state information
-     */
-    private fun ViewState.applyCountryStateChangesSafely(countryCode: String, stateCode: String) {
-        viewState = this.copy(
-            countryLocation = getCountryLocationFromCode(countryCode)
+    private fun getStateLocationFromCode(country: String, stateCode: String): Location {
+        return Location(
+            code = stateCode,
+            name = dataStore.getStates(country).firstOrNull { state -> state.code == stateCode }?.name ?: stateCode
         )
+    }
 
+    fun onCountrySelected(type: AddressType, countryCode: String) {
         viewState = viewState.copy(
-            stateLocation = getStateLocationFromCode(stateCode),
+            countryStatePairs = viewState.countryStatePairs.toMutableMap().apply {
+                put(
+                    type,
+                    CountryStatePair(
+                        countryLocation = getCountryLocationFromCode(countryCode),
+                        stateLocation = Location.EMPTY
+                    )
+                )
+            },
+            isStateSelectionEnabled = true
+        )
+    }
+
+    fun onStateSelected(type: AddressType, stateCode: String) {
+        val initialLocation = viewState.countryStatePairs.getValue(type)
+        if (stateCode != initialLocation.stateLocation.code) {
+            viewState = viewState.copy(
+                countryStatePairs = viewState.countryStatePairs.toMutableMap().apply {
+                    put(
+                        type,
+                        initialLocation.copy(
+                            stateLocation = getStateLocationFromCode(initialLocation.countryLocation.code, stateCode)
+                        )
+                    )
+                }
+            )
+        }
+    }
+
+    private fun initializeCountriesAndStates(countryCode: String, stateCode: String) {
+        viewState = viewState.copy(
+            countryStatePairs = mapOf(
+                AddressType.BILLING to CountryStatePair(
+                    countryLocation = getCountryLocationFromCode(countryCode),
+                    stateLocation = getStateLocationFromCode(countryCode, stateCode)
+                ),
+                AddressType.SHIPPING to CountryStatePair(
+                    countryLocation = getCountryLocationFromCode(countryCode),
+                    stateLocation = getStateLocationFromCode(countryCode, stateCode)
+                )
+            ),
             isStateSelectionEnabled = countryCode.isNotEmpty()
         )
     }
 
     @Parcelize
     data class ViewState(
-        val countryLocation: Location = Location("", ""),
-        val stateLocation: Location = Location("", ""),
+        val countryStatePairs: Map<AddressType, CountryStatePair> = mapOf(
+            AddressType.BILLING to CountryStatePair(
+                countryLocation = Location.EMPTY,
+                stateLocation = Location.EMPTY
+            ),
+            AddressType.SHIPPING to CountryStatePair(
+                countryLocation = Location.EMPTY,
+                stateLocation = Location.EMPTY
+            ),
+        ),
         val isLoading: Boolean = false,
         val isStateSelectionEnabled: Boolean = false
     ) : Parcelable
+
+    enum class AddressType {
+        SHIPPING, BILLING
+    }
+
+    @Parcelize
+    data class CountryStatePair(val countryLocation: Location, val stateLocation: Location) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -33,13 +33,11 @@ class AddressViewModel @Inject constructor(
             .map { it.toAppModel() }
     }
 
-    fun selectedCountryLocationFor(type: AddressType): Location {
-        return viewState.countryStatePairs.getValue(type).countryLocation
-    }
+    fun selectedCountryLocationFor(type: AddressType) =
+        viewState.countryStatePairs.getValue(type).countryLocation
 
-    fun selectedStateLocationFor(type: AddressType): Location {
-        return viewState.countryStatePairs.getValue(type).stateLocation
-    }
+    fun selectedStateLocationFor(type: AddressType) =
+        viewState.countryStatePairs.getValue(type).stateLocation
 
     private var hasStarted = false
 
@@ -84,20 +82,16 @@ class AddressViewModel @Inject constructor(
         viewState = ViewState()
     }
 
-    private fun getCountryNameFromCode(countryCode: LocationCode): String {
-        return countries.find { it.code == countryCode }?.name ?: countryCode
-    }
+    private fun getCountryNameFromCode(countryCode: LocationCode): String =
+        countries.find { it.code == countryCode }?.name ?: countryCode
 
-    private fun getCountryLocationFromCode(countryCode: LocationCode): Location {
-        return Location(countryCode, getCountryNameFromCode(countryCode))
-    }
+    private fun getCountryLocationFromCode(countryCode: LocationCode) =
+        Location(countryCode, getCountryNameFromCode(countryCode))
 
-    private fun getStateLocationFromCode(countryCode: LocationCode, stateCode: LocationCode): Location {
-        return Location(
-            code = stateCode,
-            name = dataStore.getStates(countryCode).firstOrNull { state -> state.code == stateCode }?.name ?: stateCode
-        )
-    }
+    private fun getStateLocationFromCode(countryCode: LocationCode, stateCode: LocationCode) = Location(
+        code = stateCode,
+        name = dataStore.getStates(countryCode).firstOrNull { state -> state.code == stateCode }?.name ?: stateCode
+    )
 
     fun onCountrySelected(type: AddressType, countryCode: LocationCode) {
         viewState = viewState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
@@ -11,6 +11,8 @@ class BillingAddressEditingFragment : BaseAddressEditingFragment() {
     override val storedAddress: Address
         get() = sharedViewModel.order.billingAddress
 
+    override val addressType: AddressViewModel.AddressType = AddressViewModel.AddressType.BILLING
+
     override fun saveChanges() = sharedViewModel.updateBillingAddress(addressDraft)
 
     override fun getFragmentTitle() = getString(R.string.order_detail_billing_address_section)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -12,6 +12,8 @@ class ShippingAddressEditingFragment : BaseAddressEditingFragment() {
     override val storedAddress: Address
         get() = sharedViewModel.order.shippingAddress
 
+    override val addressType: AddressViewModel.AddressType = AddressViewModel.AddressType.SHIPPING
+
     override fun saveChanges() = sharedViewModel.updateShippingAddress(addressDraft)
 
     override fun getFragmentTitle() = getString(R.string.order_detail_shipping_address_section)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5466
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR is about adapting `AddressViewModel` to be usable in scope of `Order Creation` by making it capable of holding two different states of `Location` for both `Shipping` and `Billing` addresses.

WDYT about this approach?

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please smoke test address-related `Order Editing` scenarios.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Nothing changed on the UI.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
