### PR TITLE
Add correct "stripe extension Outdated" labels and illustration

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -424,10 +424,10 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 override val onLearnMoreActionClicked: (() -> Unit)
             ) : StripeTerminalError(
                 headerLabel = UiString.UiStringRes(
-                    R.string.card_reader_onboarding_stripe_terminal_unsupported_version_header
+                    R.string.card_reader_onboarding_stripe_extension_unsupported_version_header
                 ),
                 hintLabel = UiString.UiStringRes(
-                    R.string.card_reader_onboarding_stripe_terminal_unsupported_version_hint
+                    R.string.card_reader_onboarding_stripe_extension_unsupported_version_hint
                 ),
                 learnMoreLabel = UiString.UiStringRes(
                     R.string.card_reader_onboarding_learn_more, containsHtml = true

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1008,9 +1008,9 @@
     <string name="card_reader_onboarding_stripe_extension_not_setup_hint">You’re almost there! Please finish setting up Stripe to start accepting Card-Present Payments.</string>
     <string name="card_reader_onboarding_stripe_extension_not_setup_refresh_button">Refresh</string>
 
-    <string name="card_reader_onboarding_stripe_terminal_unsupported_version_header">Update WooCommerce Stripe Payment Gateway</string>
-    <string name="card_reader_onboarding_stripe_terminal_unsupported_version_hint">Outdated version of the WooCommerce Stripe Payment Gateway extension is installed on your store. Please update it to accept In-Person Payments.</string>
-    <string name="card_reader_onboarding_stripe_terminal_unsupported_version_refresh_button">Refresh after updating</string>
+    <string name="card_reader_onboarding_stripe_extension_unsupported_version_header">Update Stripe</string>
+    <string name="card_reader_onboarding_stripe_extension_unsupported_version_hint">Outdated version of the WooCommerce Stripe Gateway extension is installed on your store. Please update it to accept In-Person Payments.</string>
+    <string name="card_reader_onboarding_stripe_extension_unsupported_version_refresh_button">Refresh after updating</string>
 
 
     <string name="card_reader_onboarding_account_rejected_header">In-Person Payments isn\’t available for this store</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardi
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.GenericErrorState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.LoadingState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.NoConnectionErrorState
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.StripeTerminalError
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.UnsupportedCountryState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.WCPayError
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.WCStripeError
@@ -170,7 +171,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                OnboardingViewState.StripeTerminalError.StripeTerminalNotSetupState::class.java
+                StripeTerminalError.StripeTerminalNotSetupState::class.java
             )
         }
 
@@ -183,7 +184,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             val state = (
-                viewModel.viewStateData.value as OnboardingViewState.StripeTerminalError.StripeTerminalNotSetupState
+                viewModel.viewStateData.value as StripeTerminalError.StripeTerminalNotSetupState
                 )
             assertThat(state.headerLabel)
                 .describedAs("Check header")
@@ -233,8 +234,46 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                OnboardingViewState.StripeTerminalError.StripeTerminalUnsupportedVersionState::class.java
+                StripeTerminalError.StripeTerminalUnsupportedVersionState::class.java
             )
+        }
+
+    @Test
+    fun `when stripe terminal outdated, then correct labels and illustrations shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(
+                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_TERMINAL_GATEWAY)
+            )
+
+            val viewModel = createVM()
+
+            val state = (
+                viewModel.viewStateData.value as StripeTerminalError.StripeTerminalUnsupportedVersionState
+                )
+            assertThat(state.headerLabel)
+                .describedAs("Check header")
+                .isEqualTo(
+                    UiString.UiStringRes(
+                        R.string.card_reader_onboarding_stripe_extension_unsupported_version_header
+                    )
+                )
+            assertThat(state.hintLabel)
+                .describedAs("Check hint")
+                .isEqualTo(
+                    UiString.UiStringRes(
+                        R.string.card_reader_onboarding_stripe_extension_unsupported_version_hint
+                    )
+                )
+            assertThat(state.refreshButtonLabel)
+                .describedAs("Check refreshButtonLabel")
+                .isEqualTo(
+                    UiString.UiStringRes(
+                        R.string.card_reader_onboarding_wcpay_unsupported_version_refresh_button
+                    )
+                )
+            assertThat(state.illustration)
+                .describedAs("Check illustration")
+                .isEqualTo(R.drawable.img_stripe_extension)
         }
 
     @Test(expected = AssertionError::class)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5330 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR takes care of displaying correct illustrations and labels when the Stripe Extension is outdated
Here is the Figma link for the designs: vaw3DvewbUwuQnPXpdNGGH-fi-2538%3A229187

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure the Stripe Extension plugin is installed but its Outdated version (< 5.8.1) **OR** add this line `return PluginUnsupportedVersion(STRIPE_TERMINAL_GATEWAY)` in `CardReaderOnboardingChecker` line no: 57
2. Navigate to In-Person Payments via Settings
3. Make sure you see the correct illustrations and labels

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src=https://user-images.githubusercontent.com/1331230/146725817-66c9866b-a469-4039-8f52-96ce8b4b8102.png width=250px/>


<img src=https://user-images.githubusercontent.com/1331230/146725852-b0b41371-c87e-4714-9a43-a179269a08f4.png width=250px/>



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->