### PR TITLE
Fix a crash on MyStoreFragment when the user is not eligible for the selected store

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -36,13 +36,11 @@ import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.leaderboards.WCTopPerformerProductModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.NetworkUtils
-import java.util.Calendar
+import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -182,6 +180,7 @@ class MyStoreFragment :
         refreshMyStoreStats(forced = this.isRefreshPending)
     }
 
+    @Suppress("ForbiddenComment")
     private fun prepareJetpackBenefitsBanner() {
         binding.jetpackBenefitsBanner.dismissButton.setOnClickListener {
             presenter.dismissJetpackBenefitsBanner()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5478 

### Description
This fixes a crash that's a result of an issue that Google is not willing to fix (check the comment on the code)

### Testing instructions
1. Build the app using the branch `/release/8.2`
2. Login to the app.
3. Close the app.
4. Open wp-admin, and update your user's role to `Editor`.
5. Open the app, and give it some time to fetch the user's role, then close it.
6. Re-open the app, notice the crash.
7. Pull changes from this branch.
8. Re-open the app, confirm it doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
