### PR TITLE
Handle null filePath in MediaUploadErrors screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
@@ -75,9 +75,9 @@ class MediaUploadErrorListViewModel @Inject constructor(
         val filePath: String
     ) : Parcelable {
         constructor(state: UploadStatus.Failed) : this(
-            fileName = state.media.fileName ?: "",
+            fileName = state.media.fileName.orEmpty(),
             errorMessage = state.mediaErrorMessage,
-            filePath = state.media.filePath
+            filePath = state.media.filePath.orEmpty()
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5479 

### Description
This is a simple fix to avoid NPE on this screen.

### Testing instructions
I couldn't reproduce the original issue, but the fix should be clear.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
