### PR TITLE
Create product section

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -74,7 +74,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                 AddButton(
                     text = getString(R.string.order_creation_add_products),
                     onClickListener = {
-
+                        formViewModel.onAddSimpleProductsClicked()
                     }
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -69,6 +69,16 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                 )
             )
         )
+        productsSection.setAddButtons(
+            listOf(
+                AddButton(
+                    text = getString(R.string.order_creation_add_products),
+                    onClickListener = {
+
+                    }
+                )
+            )
+        )
     }
 
     private fun setupObserversWith(binding: FragmentOrderCreationFormBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.extensions.runWithContext
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.creation.OrderCreationNavigationTarget.AddSimpleProduct
 import com.woocommerce.android.ui.orders.creation.OrderCreationNavigationTarget.EditCustomerNote
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -44,6 +45,6 @@ class OrderCreationFormViewModel @Inject constructor(
     }
 
     fun onAddSimpleProductsClicked() {
-
+        triggerEvent(AddSimpleProduct)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormViewModel.kt
@@ -42,4 +42,8 @@ class OrderCreationFormViewModel @Inject constructor(
     fun onCustomerNoteClicked() {
         triggerEvent(EditCustomerNote)
     }
+
+    fun onAddSimpleProductsClicked() {
+
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigationTarget.kt
@@ -5,4 +5,5 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 sealed class OrderCreationNavigationTarget : Event() {
     object EditCustomer : OrderCreationNavigationTarget()
     object EditCustomerNote : OrderCreationNavigationTarget()
+    object AddSimpleProduct : OrderCreationNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
@@ -16,7 +16,7 @@ object OrderCreationNavigator {
                 OrderCreationFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCustomerNoteFragment()
             AddSimpleProduct ->
                 OrderCreationFormFragmentDirections.actionOrderCreationFragmentToOrderCreationProductSelectionFragment()
-         }
+        }
 
         navController.navigate(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationNavigator.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.creation
 
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.ui.orders.creation.OrderCreationNavigationTarget.AddSimpleProduct
 import com.woocommerce.android.ui.orders.creation.OrderCreationNavigationTarget.EditCustomerNote
 
 object OrderCreationNavigator {
@@ -13,7 +14,9 @@ object OrderCreationNavigator {
                 TODO()
             EditCustomerNote ->
                 OrderCreationFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCustomerNoteFragment()
-        }
+            AddSimpleProduct ->
+                OrderCreationFormFragmentDirections.actionOrderCreationFragmentToOrderCreationProductSelectionFragment()
+         }
 
         navController.navigate(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductSelectionFragment.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+
+class OrderCreationProductSelectionFragment
+    : BaseFragment(R.layout.fragment_order_creation_product_selection)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductSelectionFragment.kt
@@ -3,5 +3,5 @@ package com.woocommerce.android.ui.orders.creation
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 
-class OrderCreationProductSelectionFragment
-    : BaseFragment(R.layout.fragment_order_creation_product_selection)
+class OrderCreationProductSelectionFragment :
+    BaseFragment(R.layout.fragment_order_creation_product_selection)

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
@@ -12,6 +12,13 @@
         android:layout_height="wrap_content" />
 
     <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
+        android:id="@+id/products_section"
+        style="@style/Woo.Card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:header="@string/products" />
+
+    <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
         android:id="@+id/customer_section"
         style="@style/Woo.Card"
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_product_selection.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_product_selection.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -17,6 +17,10 @@
         <action
             android:id="@+id/action_orderCreationFragment_to_orderCreationCustomerNoteFragment"
             app:destination="@id/orderCreationCustomerNoteFragment" />
+        <action
+            android:id="@+id/action_orderCreationFragment_to_orderCreationProductSelectionFragment"
+            app:destination="@id/orderCreationProductSelectionFragment" />
+
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -33,5 +33,8 @@
         android:id="@+id/orderCreationCustomerNoteFragment"
         android:name="com.woocommerce.android.ui.orders.creation.OrderCreationCustomerNoteFragment"
         android:label="OrderCreationCustomerNoteFragment" />
-
+    <fragment
+        android:id="@+id/orderCreationProductSelectionFragment"
+        android:name="com.woocommerce.android.ui.orders.creation.OrderCreationProductSelectionFragment"
+        android:label="OrderCreationProductSelectionFragment"/>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -19,7 +19,11 @@
             app:destination="@id/orderCreationCustomerNoteFragment" />
         <action
             android:id="@+id/action_orderCreationFragment_to_orderCreationProductSelectionFragment"
-            app:destination="@id/orderCreationProductSelectionFragment" />
+            app:destination="@id/orderCreationProductSelectionFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
 
     </fragment>
     <dialog

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2131,6 +2131,7 @@
     <string name="shipping_label_payments_cant_edit_warning">Only the site owner can manage the shipping label payment methods. Please contact Store Owner %1$s (%2$s) to manage payment methods.</string>
     <string name="magic_link_not_meaning_to_create_account">Didn\'t mean to create a new account? Go back to re-enter your email address.</string>
     <string name="order_creation_customer">Customer</string>
+    <string name="order_creation_products">Products</string>
     <string name="order_creation_customer_note">Customer Note</string>
     <string name="order_creation_add_customer">Add customer</string>
     <string name="order_creation_add_customer_note">Add note</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2131,8 +2131,9 @@
     <string name="shipping_label_payments_cant_edit_warning">Only the site owner can manage the shipping label payment methods. Please contact Store Owner %1$s (%2$s) to manage payment methods.</string>
     <string name="magic_link_not_meaning_to_create_account">Didn\'t mean to create a new account? Go back to re-enter your email address.</string>
     <string name="order_creation_customer">Customer</string>
-    <string name="order_creation_products">Products</string>
     <string name="order_creation_customer_note">Customer Note</string>
     <string name="order_creation_add_customer">Add customer</string>
     <string name="order_creation_add_customer_note">Add note</string>
+    <string name="order_creation_products">Products</string>
+    <string name="order_creation_add_products">Add Product</string>
 </resources>


### PR DESCRIPTION
Summary
==========
Fixes issue #5276 by configuring the Product section with the `Add Product` action, taking advantage of the `OrderCreationSectionView` component, and leaving all basic structures to call the Add Product fragment view, that's currently empty.

This PR is a slice of an ongoing implementation around the Add Products fragment, I'm making this code available beforehand to enable other tasks to be tackled in parallel.

Screenshots
==========
| Order Creation Form with the `Product Section`  | Empty view for selecting products inside the Order Creations flow |
| ------------- | ------------- |
| ![Screenshot_20211220_213827](https://user-images.githubusercontent.com/5920403/146851730-20387766-50a7-448f-b13e-2e5fa4a5476e.png) | ![Screenshot_20211220_213829](https://user-images.githubusercontent.com/5920403/146851742-942bbba2-41e1-4688-a91c-da8293ec2c09.png) |

How to Test
==========
1. Go to the Order creation flow
2. Verify that the `Product section` shows up with the `Add Products` action button 
3. Interact with the `Add Products` and verify that an empty view is called correctly


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
