### PR TITLE
Declare AGP plugin in projects `build.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'io.gitlab.arturbosch.detekt'
     id 'io.github.wzieba.tracks.plugin'
     id 'io.sentry.android.gradle'
+    id 'com.android.application' apply false
     id 'dagger.hilt.android.plugin' apply false
     id 'androidx.navigation.safeargs.kotlin' apply false
     id 'com.google.gms.google-services' apply false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5489 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Included builds stopped working because of incompatible AGP versions. Error message claims that `FluxC` is using `4.2.2` when `Woo` - `4.2.0`. 

This sounds strange as in Woo we specifically declare version `4.2.0` in [`settings.gradle`](https://github.com/woocommerce/woocommerce-android/blob/develop/settings.gradle#L2).

---

After research, I've found that AGP bundled with `androidx.navigation.safeargs.kotlin` takes precedence and is used to build app:
![image](https://user-images.githubusercontent.com/5845095/146901772-568a767c-f02f-4fbd-a3e8-c8117cdb3efd.png)

Link to scan: https://scans.gradle.com/s/si4e3edu26ghu
Link to `safeargs` source: https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/navigation/navigation-safe-args-gradle-plugin/build.gradle?source=post_page---------------------------%2F&autodive=0%2F%2F#28

I suspect, this is because we do declare (not apply) `androidx.navigation.safeargs.kotlin` in projects `build.gradle` as we discussed in previous related PR (https://github.com/woocommerce/woocommerce-android/pull/5414#discussion_r763970520).

My fix proposal is about declaring one of AGP plugins in projects `build.gradle` so our version, applied from `settings.gradle` is resolved, instead of version taken from `safeargs`.

I think there are no downsides of this solution besides clanky syntax. I'm also quite surprised by this behaviour of Gradle as it kinda hides this resolution and shadows the real behaviour.

I'd love to spend some time in understanding this but for now, I think this fix is sufficient.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please uncomment any build from `local-builds.gradle` and see if app compiles.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
