### PR TITLE
Restore logic for fetching and displaying order status in the list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -249,6 +249,13 @@ class OrderListFragment :
     @Suppress("LongMethod")
     private fun initObservers() {
         // setup observers
+        viewModel.orderStatusOptions.observe(viewLifecycleOwner) {
+            it?.let { options ->
+                // So the order status can be matched to the appropriate label
+                binding.orderListView.setOrderStatusOptions(options)
+            }
+        }
+
         viewModel.isFetchingFirstPage.observe(viewLifecycleOwner) {
             binding.orderRefreshLayout.isRefreshing = it == true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -3,12 +3,7 @@ package com.woocommerce.android.ui.orders.list
 import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.*
 import androidx.paging.PagedList
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
@@ -44,6 +39,7 @@ import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.list.PagedListWrapper
 import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.WCOrderFetcher
@@ -100,6 +96,9 @@ class OrderListViewModel @Inject constructor(
     private val _isFetchingFirstPage = MediatorLiveData<Boolean>()
     val isFetchingFirstPage: LiveData<Boolean> = _isFetchingFirstPage
 
+    private val _orderStatusOptions = MutableLiveData<Map<String, WCOrderStatusModel>>()
+    val orderStatusOptions: LiveData<Map<String, WCOrderStatusModel>> = _orderStatusOptions
+
     private val _isEmpty = MediatorLiveData<Boolean>()
     val isEmpty: LiveData<Boolean> = _isEmpty
 
@@ -124,6 +123,10 @@ class OrderListViewModel @Inject constructor(
         dispatcher.register(this)
 
         launch {
+            // Populate any cached order status options immediately since we use this
+            // value in many different places in the order list view.
+            _orderStatusOptions.value = orderListRepository.getCachedOrderStatusOptions()
+
             _emptyViewType.postValue(EmptyViewType.ORDER_LIST_LOADING)
             if (selectedSite.exists()) {
                 wooCommerceStore.fetchSitePlugins(selectedSite.get())
@@ -167,6 +170,7 @@ class OrderListViewModel @Inject constructor(
             launch(dispatchers.main) {
                 activePagedListWrapper?.fetchFirstPage()
                 orderListRepository.fetchOrderStatusOptionsFromApi()
+                fetchOrderStatusOptions()
                 fetchPaymentGateways()
             }
         } else {
@@ -185,6 +189,20 @@ class OrderListViewModel @Inject constructor(
                 }
                 else -> {
                     /* do nothing */
+                }
+            }
+        }
+    }
+
+    /**
+     * Refresh the order count by order status list with fresh data from the API
+     */
+    fun fetchOrderStatusOptions() {
+        launch(dispatchers.main) {
+            // Fetch and load order status options
+            when (orderListRepository.fetchOrderStatusOptionsFromApi()) {
+                SUCCESS -> _orderStatusOptions.value = orderListRepository.getCachedOrderStatusOptions()
+                else -> { /* do nothing */
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -169,7 +169,6 @@ class OrderListViewModel @Inject constructor(
         if (networkStatus.isConnected()) {
             launch(dispatchers.main) {
                 activePagedListWrapper?.fetchFirstPage()
-                orderListRepository.fetchOrderStatusOptionsFromApi()
                 fetchOrderStatusOptions()
                 fetchPaymentGateways()
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -47,6 +47,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val resourceProvider: ResourceProvider = mock()
     private val savedStateHandle: SavedStateHandle = SavedStateHandle()
 
+    private val orderStatusOptions = OrderTestUtils.generateOrderStatusOptionsMappedByStatus()
     private lateinit var viewModel: OrderListViewModel
     private val listStore: ListStore = mock()
     private val pagedListWrapper: PagedListWrapper<OrderListItemUIType> = mock()
@@ -99,6 +100,7 @@ class OrderListViewModelTest : BaseUnitTest() {
 
         verify(viewModel.activePagedListWrapper, times(1))?.fetchFirstPage()
         verify(orderListRepository, times(1)).fetchPaymentGateways()
+        verify(orderListRepository, times(1)).fetchOrderStatusOptionsFromApi()
     }
 
     @Test
@@ -139,6 +141,23 @@ class OrderListViewModelTest : BaseUnitTest() {
             }
         }
         assertTrue(isRefreshPending)
+    }
+
+    /* Test order status options are emitted via [OrderListViewModel.orderStatusOptions]
+    * once fetched, and verify expected methods are called the correct number of
+    * times.
+    */
+    @Test
+    fun `Request to fetch order status options emits options`() = testBlocking {
+        doReturn(RequestResult.SUCCESS).whenever(orderListRepository).fetchOrderStatusOptionsFromApi()
+        doReturn(orderStatusOptions).whenever(orderListRepository).getCachedOrderStatusOptions()
+
+        clearInvocations(orderListRepository)
+        viewModel.fetchOrderStatusOptions()
+
+        verify(orderListRepository, times(1)).fetchOrderStatusOptionsFromApi()
+        verify(orderListRepository, times(1)).getCachedOrderStatusOptions()
+        assertEquals(orderStatusOptions, viewModel.orderStatusOptions.getOrAwaitValue())
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5492 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes the regression explained in the issue #5492.

### Testing instructions
1. Change your site's admin language.
2. Launch the app, and open orders' list.
3. Confirm that the order statuses have the correct language (you may need to refresh the list to make it work for the first time).

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
