### PR TITLE
Order creation: pass the customer note to the network request

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -23,8 +23,6 @@ class OrderCreationRepository @Inject constructor(
                 ?: error("Couldn't find a status with key ${order.status.value}")
         }
 
-        // TODO pass the customer note to the request
-
         val request = CreateOrderRequest(
             status = status,
             lineItems = order.items.map {
@@ -36,7 +34,8 @@ class OrderCreationRepository @Inject constructor(
                 )
             },
             shippingAddress = order.shippingAddress.toShippingAddressModel(),
-            billingAddress = order.billingAddress.toBillingAddressModel()
+            billingAddress = order.billingAddress.toBillingAddressModel(),
+            customerNote = order.customerNote
         )
         val result = orderStore.createOrder(selectedSite.get(), request)
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2222-97c2783466f080ca67d5c655acdf48e37db6655d'
+    fluxCVersion = 'develop-39757e908f358ebf5524673eff72cbf8b5c08cdc'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-675a97d5e2ce13a0d25ce57da5935174ee4843ae'
+    fluxCVersion = '2222-97c2783466f080ca67d5c655acdf48e37db6655d'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
### Description
This is just a simple change to use the latest changes from FluxC's [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2222) to pass the customer note to the created order.

### Testing instructions
Nothing to test.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.