### PR TITLE
Add links in project-overview.md

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -87,3 +87,14 @@ Contributors can build and run the app without issue, but Google Sign-In will al
 Google Sign-In requires configuration files which contain client and server information
 that can't be shared publicly. More documentation and guides can be found on the
 [Google Identity Platform website][google-ident].
+
+
+
+[wp-com-apps]: https://developer.wordpress.com/apps/
+[wp-app]: https://apps.wordpress.com/mobile/
+[wp-api]: https://developer.wordpress.org/rest-api/
+[oauth]: https://oauth.net
+[google-ident]: https://cloud.google.com/identity-platform/docs/
+[detekt]: https://detekt.github.io/detekt/
+[jetpack]: https://wordpress.org/plugins/jetpack/
+[checkstyle]: https://checkstyle.org


### PR DESCRIPTION
### Description
The reference-style links were already in place but had no definitions to resolve to, which resulted in them rendering as [WordPress.com applications manager][wp-com-apps] in the rendered markdown, giving the reader no clear direction of where they should look for the referenced resources.

These are my best effort to find the right links, so I'd appreciate a sense-check in this review, in case there are better URLs to use or I've got the wrong end of the stick with any of these.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
N/A

### Images/gif
Before | After
---|---
<img width="1016" alt="docs with unrendered links" src="https://user-images.githubusercontent.com/2472348/147083680-288128d3-005b-4372-a4ee-09e4f400766e.png">|<img width="992" alt="docs with rendered links" src="https://user-images.githubusercontent.com/2472348/147083852-3244858a-ce00-4b6f-8741-fbb9d649e298.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
`
<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
