### PR TITLE
Use of a value class instead of RemoteId from fluxc as an order id

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.DATABASE_DOWNGRADED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.products.ProductType
@@ -223,17 +224,17 @@ object AppPrefs {
 
     fun setUserEmail(email: String) = setString(DeletablePrefKey.USER_EMAIL, email)
 
-    fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
+    fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: OrderId) =
         PreferenceUtils.getString(getPreferences(), getReceiptKey(localSiteId, remoteSiteId, selfHostedSiteId, orderId))
 
-    fun setReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long, url: String) =
+    fun setReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: OrderId, url: String) =
         PreferenceUtils.setString(
             getPreferences(),
             getReceiptKey(localSiteId, remoteSiteId, selfHostedSiteId, orderId),
             url
         )
 
-    private fun getReceiptKey(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
+    private fun getReceiptKey(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: OrderId) =
         "$RECEIPT_PREFIX:$localSiteId:$remoteSiteId:$selfHostedSiteId:$orderId"
 
     fun setLastConnectedCardReaderId(readerId: String) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -1,17 +1,18 @@
 package com.woocommerce.android
 
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType
 import javax.inject.Inject
 
 class AppPrefsWrapper @Inject constructor() {
-    fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
+    fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: OrderId) =
         AppPrefs.getReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId)
 
     fun setReceiptUrl(
         localSiteId: Int,
         remoteSiteId: Long,
         selfHostedSiteId: Long,
-        orderId: Long,
+        orderId: OrderId,
         url: String
     ) = AppPrefs.setReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId, url)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -50,14 +50,14 @@ data class Order(
     val items: List<Item>,
     val shippingLines: List<ShippingLine>,
     val feesLines: List<FeeLine>,
-    val metaData: List<MetaData<String>>
+    val metaData: List<MetaData<String>>,
 ) : Parcelable {
     @Deprecated(replaceWith = ReplaceWith("remoteId"), message = "Use remote id to identify order.")
     val localId
         get() = LocalOrRemoteId.LocalId(this.rawLocalOrderId)
 
-    val remoteId
-        get() = LocalOrRemoteId.RemoteId(this.rawRemoteOrderId)
+    @IgnoredOnParcel
+    val id: OrderId = OrderId(rawRemoteOrderId)
 
     @IgnoredOnParcel
     val isOrderPaid = datePaid != null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderId.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderId.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.model
+
+import android.os.Parcel
+import android.os.Parcelable
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+
+// Can not use @Parcelize due to the bug - https://issuetracker.google.com/issues/177856519
+@JvmInline
+value class OrderId(val value: Long) : Parcelable {
+    override fun toString() = value.toString()
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(parcel: Parcel?, flags: Int) {
+        parcel?.writeLong(value)
+    }
+
+    companion object {
+        val CREATOR: Parcelable.Creator<OrderId> = object : Parcelable.Creator<OrderId> {
+            override fun createFromParcel(parcel: Parcel) = OrderId(parcel.readLong())
+
+            override fun newArray(size: Int): Array<OrderId?> = arrayOfNulls(size)
+        }
+    }
+}
+
+fun OrderId.toFluxcRemoteId() = LocalOrRemoteId.RemoteId(value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivityMainBinding
 import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.Notification
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
@@ -748,7 +749,7 @@ class MainActivity :
                     is ViewOrderDetail -> {
                         showOrderDetail(
                             event.localSiteId,
-                            remoteOrderId = event.uniqueId,
+                            remoteOrderId = OrderId(event.uniqueId),
                             remoteNoteId = event.remoteNoteId,
                             launchedFromNotification = true
                         )
@@ -865,7 +866,7 @@ class MainActivity :
     override fun showOrderDetail(
         localSiteId: Int,
         localOrderId: Int,
-        remoteOrderId: Long,
+        remoteOrderId: OrderId,
         remoteNoteId: Long,
         launchedFromNotification: Boolean
     ) {
@@ -875,7 +876,7 @@ class MainActivity :
             binding.bottomNav.active(ORDERS.position)
         }
 
-        val orderId = OrderIdentifier(localOrderId, localSiteId, remoteOrderId)
+        val orderId = OrderIdentifier(localOrderId, localSiteId, remoteOrderId.value)
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderDetailFragment(orderId, remoteNoteId)
         navController.navigateSafely(action)
     }
@@ -883,14 +884,14 @@ class MainActivity :
     override fun showOrderDetailWithSharedTransition(
         localSiteId: Int,
         localOrderId: Int,
-        remoteOrderId: Long,
+        remoteOrderId: OrderId,
         remoteNoteId: Long,
         sharedView: View
     ) {
         val orderCardDetailTransitionName = getString(R.string.order_card_detail_transition_name)
         val extras = FragmentNavigatorExtras(sharedView to orderCardDetailTransitionName)
 
-        val orderId = OrderIdentifier(localOrderId, localSiteId, remoteOrderId)
+        val orderId = OrderIdentifier(localOrderId, localSiteId, remoteOrderId.value)
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderDetailFragment(orderId, remoteNoteId)
         navController.navigateSafely(directions = action, extras = extras)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.main
 
 import android.view.View
+import com.woocommerce.android.model.OrderId
 
 interface MainNavigationRouter {
     fun isAtNavigationRoot(): Boolean
@@ -17,7 +18,7 @@ interface MainNavigationRouter {
     fun showOrderDetail(
         localSiteId: Int,
         localOrderId: Int = 0,
-        remoteOrderId: Long,
+        remoteOrderId: OrderId,
         remoteNoteId: Long = 0,
         launchedFromNotification: Boolean = false
     )
@@ -25,7 +26,7 @@ interface MainNavigationRouter {
     fun showOrderDetailWithSharedTransition(
         localSiteId: Int,
         localOrderId: Int = 0,
-        remoteOrderId: Long,
+        remoteOrderId: OrderId,
         remoteNoteId: Long = 0,
         sharedView: View
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
@@ -26,7 +26,7 @@ object OrderCustomerHelper {
         AnalyticsTracker.track(
             Stat.ORDER_CONTACT_ACTION,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_TYPE to Action.EMAIL.name.toLowerCase(Locale.US)
             )
@@ -55,7 +55,7 @@ object OrderCustomerHelper {
         AnalyticsTracker.track(
             Stat.ORDER_CONTACT_ACTION,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_TYPE to Action.CALL.name.toLowerCase(Locale.US)
             )
@@ -84,7 +84,7 @@ object OrderCustomerHelper {
         AnalyticsTracker.track(
             Stat.ORDER_CONTACT_ACTION,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_TYPE to Action.SMS.name.toLowerCase(Locale.US)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders
 
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelPaperSizeSelectorDialog.ShippingLabelPaperSize
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
@@ -28,11 +29,11 @@ sealed class OrderNavigationTarget : Event() {
         }
     }
 
-    data class IssueOrderRefund(val remoteOrderId: Long) : OrderNavigationTarget()
-    data class ViewRefundedProducts(val remoteOrderId: Long) : OrderNavigationTarget()
+    data class IssueOrderRefund(val remoteOrderId: OrderId) : OrderNavigationTarget()
+    data class ViewRefundedProducts(val remoteOrderId: OrderId) : OrderNavigationTarget()
     data class ViewOrderFulfillInfo(val orderIdentifier: String) : OrderNavigationTarget()
     data class AddOrderNote(val orderIdentifier: String, val orderNumber: String) : OrderNavigationTarget()
-    data class RefundShippingLabel(val remoteOrderId: Long, val shippingLabelId: Long) : OrderNavigationTarget()
+    data class RefundShippingLabel(val remoteOrderId: OrderId, val shippingLabelId: Long) : OrderNavigationTarget()
     data class AddOrderShipmentTracking(
         val orderIdentifier: String,
         val orderTrackingProvider: String,
@@ -43,7 +44,7 @@ sealed class OrderNavigationTarget : Event() {
         val orderIdentifier: String,
         val selectedProvider: String
     ) : OrderNavigationTarget()
-    data class PrintShippingLabel(val remoteOrderId: Long, val shippingLabelId: Long) : OrderNavigationTarget()
+    data class PrintShippingLabel(val remoteOrderId: OrderId, val shippingLabelId: Long) : OrderNavigationTarget()
     data class ViewShippingLabelPaperSizes(val currentPaperSize: ShippingLabelPaperSize) : OrderNavigationTarget()
     object ViewCreateShippingLabelInfo : OrderNavigationTarget()
     object ViewPrintShippingLabelInfo : OrderNavigationTarget()
@@ -54,8 +55,8 @@ sealed class OrderNavigationTarget : Event() {
     object ShowCardReaderWelcomeDialog : OrderNavigationTarget()
     data class StartCardReaderPaymentFlow(val orderIdentifier: String) : OrderNavigationTarget()
     object ViewPrintingInstructions : OrderNavigationTarget()
-    data class PreviewReceipt(val billingEmail: String, val receiptUrl: String, val orderId: Long) :
+    data class PreviewReceipt(val billingEmail: String, val receiptUrl: String, val orderId: OrderId) :
         OrderNavigationTarget()
-    data class ViewOrderedAddons(val remoteOrderID: Long, val orderItemID: Long, val addonsProductID: Long) :
+    data class ViewOrderedAddons(val remoteOrderID: OrderId, val orderItemID: Long, val addonsProductID: Long) :
         OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -214,7 +214,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onIssueOrderRefundClicked() {
-        triggerEvent(IssueOrderRefund(remoteOrderId = order.remoteId.value))
+        triggerEvent(IssueOrderRefund(remoteOrderId = order.id))
     }
 
     fun onAcceptCardPresentPaymentClicked(cardReaderManager: CardReaderManager) {
@@ -239,7 +239,7 @@ class OrderDetailViewModel @Inject constructor(
 
     fun onSeeReceiptClicked() {
         loadReceiptUrl()?.let {
-            triggerEvent(PreviewReceipt(order.billingAddress.email, it, order.remoteId.value))
+            triggerEvent(PreviewReceipt(order.billingAddress.email, it, order.id))
         } ?: WooLog.e(T.ORDERS, "ReceiptUrl is null, but SeeReceipt button is visible")
     }
 
@@ -264,7 +264,7 @@ class OrderDetailViewModel @Inject constructor(
 
     private fun loadReceiptUrl(): String? {
         return selectedSite.getIfExists()?.let {
-            appPrefs.getReceiptUrl(it.id, it.siteId, it.selfHostedSiteId, order.remoteId.value)
+            appPrefs.getReceiptUrl(it.id, it.siteId, it.selfHostedSiteId, order.id)
         }
     }
 
@@ -280,7 +280,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onViewRefundedProductsClicked() {
-        triggerEvent(ViewRefundedProducts(remoteOrderId = order.remoteId.value))
+        triggerEvent(ViewRefundedProducts(remoteOrderId = order.id))
     }
 
     fun onAddOrderNoteClicked() {
@@ -288,11 +288,11 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onRefundShippingLabelClick(shippingLabelId: Long) {
-        triggerEvent(RefundShippingLabel(remoteOrderId = order.remoteId.value, shippingLabelId = shippingLabelId))
+        triggerEvent(RefundShippingLabel(remoteOrderId = order.id, shippingLabelId = shippingLabelId))
     }
 
     fun onPrintShippingLabelClicked(shippingLabelId: Long) {
-        triggerEvent(PrintShippingLabel(remoteOrderId = order.remoteId.value, shippingLabelId = shippingLabelId))
+        triggerEvent(PrintShippingLabel(remoteOrderId = order.id, shippingLabelId = shippingLabelId))
     }
 
     fun onPrintCustomsFormClicked(shippingLabel: ShippingLabel) {
@@ -315,7 +315,7 @@ class OrderDetailViewModel @Inject constructor(
         AnalyticsTracker.track(
             ORDER_TRACKING_ADD,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_CARRIER to shipmentTracking.trackingProvider
             )
@@ -351,7 +351,7 @@ class OrderDetailViewModel @Inject constructor(
         AnalyticsTracker.track(
             Stat.ORDER_STATUS_CHANGE,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_FROM to order.status.value,
                 AnalyticsTracker.KEY_TO to updateSource.newStatus
             )
@@ -441,7 +441,7 @@ class OrderDetailViewModel @Inject constructor(
     private fun updateOrderStatus(newStatus: String) {
         if (networkStatus.isConnected()) {
             launch {
-                orderDetailRepository.updateOrderStatus(order.remoteId, newStatus)
+                orderDetailRepository.updateOrderStatus(order.id, newStatus)
                     .collect { result ->
                         when (result) {
                             is OptimisticUpdateResult -> reloadOrderDetails()
@@ -483,7 +483,7 @@ class OrderDetailViewModel @Inject constructor(
         AnalyticsTracker.track(PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED)
         triggerEvent(
             ViewOrderedAddons(
-                orderIdSet.remoteOrderId,
+                OrderId(orderIdSet.remoteOrderId),
                 orderItem.itemId,
                 orderItem.productId
             )
@@ -549,7 +549,7 @@ class OrderDetailViewModel @Inject constructor(
 
     private fun fetchSLCreationEligibilityAsync() = async {
         if (isShippingPluginReady) {
-            orderDetailRepository.fetchSLCreationEligibility(order.remoteId.value)
+            orderDetailRepository.fetchSLCreationEligibility(order.id)
         }
     }
 
@@ -620,7 +620,7 @@ class OrderDetailViewModel @Inject constructor(
             FeatureFlag.CARD_READER.isEnabled()
 
         val isOrderEligibleForSLCreation = isShippingPluginReady &&
-            orderDetailRepository.isOrderEligibleForSLCreation(order.remoteId.value) &&
+            orderDetailRepository.isOrderEligibleForSLCreation(order.id) &&
             !orderEligibleForInPersonPayments
 
         if (isOrderEligibleForSLCreation &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
@@ -1,9 +1,10 @@
 package com.woocommerce.android.ui.orders.details.editing
 
+import com.woocommerce.android.model.OrderId
+import com.woocommerce.android.model.toFluxcRemoteId
 import com.woocommerce.android.tools.SelectedSite
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
-import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.store.OrderUpdateStore
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -16,26 +17,34 @@ class OrderEditingRepository @Inject constructor(
     private val selectedSite: SelectedSite
 ) {
     suspend fun updateCustomerOrderNote(
-        remoteOrderId: LocalOrRemoteId.RemoteId,
+        remoteOrderId: OrderId,
         customerOrderNote: String
     ): Flow<WCOrderStore.UpdateOrderResult> {
-        return orderUpdateStore.updateCustomerOrderNote(remoteOrderId, selectedSite.get(), customerOrderNote)
+        return orderUpdateStore.updateCustomerOrderNote(
+            remoteOrderId.toFluxcRemoteId(),
+            selectedSite.get(),
+            customerOrderNote
+        )
     }
 
     suspend fun updateOrderAddress(
-        remoteOrderId: LocalOrRemoteId.RemoteId,
+        remoteOrderId: OrderId,
         orderAddress: OrderAddress
     ): Flow<WCOrderStore.UpdateOrderResult> {
-        return orderUpdateStore.updateOrderAddress(remoteOrderId, selectedSite.get().localId(), orderAddress)
+        return orderUpdateStore.updateOrderAddress(
+            remoteOrderId.toFluxcRemoteId(),
+            selectedSite.get().localId(),
+            orderAddress
+        )
     }
 
     suspend fun updateBothOrderAddresses(
-        remoteOrderId: LocalOrRemoteId.RemoteId,
+        remoteOrderId: OrderId,
         shippingAddress: OrderAddress.Shipping,
         billingAddress: OrderAddress.Billing
     ): Flow<WCOrderStore.UpdateOrderResult> {
         return orderUpdateStore.updateBothOrderAddresses(
-            remoteOrderId,
+            remoteOrderId.toFluxcRemoteId(),
             selectedSite.get().localId(),
             shippingAddress,
             billingAddress

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -67,7 +67,7 @@ class OrderEditingViewModel @Inject constructor(
 
     fun updateCustomerOrderNote(updatedNote: String) = runWhenUpdateIsPossible {
         orderEditingRepository.updateCustomerOrderNote(
-            order.remoteId, updatedNote
+            order.id, updatedNote
         ).collectOrderUpdate(AnalyticsTracker.ORDER_EDIT_CUSTOMER_NOTE)
     }
 
@@ -76,7 +76,7 @@ class OrderEditingViewModel @Inject constructor(
             sendReplicateShippingAndBillingAddressesWith(updatedShippingAddress)
         } else {
             orderEditingRepository.updateOrderAddress(
-                order.remoteId,
+                order.id,
                 updatedShippingAddress.toShippingAddressModel()
             )
         }.collectOrderUpdate(AnalyticsTracker.ORDER_EDIT_SHIPPING_ADDRESS)
@@ -87,7 +87,7 @@ class OrderEditingViewModel @Inject constructor(
             sendReplicateShippingAndBillingAddressesWith(updatedBillingAddress)
         } else {
             orderEditingRepository.updateOrderAddress(
-                order.remoteId,
+                order.id,
                 updatedBillingAddress.toBillingAddressModel()
             )
         }.collectOrderUpdate(AnalyticsTracker.ORDER_EDIT_BILLING_ADDRESS)
@@ -95,7 +95,7 @@ class OrderEditingViewModel @Inject constructor(
 
     private suspend fun sendReplicateShippingAndBillingAddressesWith(orderAddress: Address) =
         orderEditingRepository.updateBothOrderAddresses(
-            order.remoteId,
+            order.id,
             orderAddress.toShippingAddressModel(),
             orderAddress.toBillingAddressModel(
                 customEmail = orderAddress.email

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -151,7 +151,7 @@ class OrderFulfillViewModel @Inject constructor(
         AnalyticsTracker.track(
             ORDER_TRACKING_ADD,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_CARRIER to shipmentTracking.trackingProvider
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -157,7 +157,7 @@ class OrderListAdapter(
             this.itemView.setOnClickListener {
                 listener.openOrderDetail(
                     orderItemUI.localOrderId.value,
-                    orderItemUI.remoteOrderId.value,
+                    orderItemUI.orderId,
                     orderItemUI.status,
                     viewBinding.root
                 )
@@ -204,10 +204,10 @@ private val OrderListDiffItemCallback = object : DiffUtil.ItemCallback<OrderList
             return oldItem.remoteId == newItem.remoteId
         }
         if (oldItem is OrderListItemUI && newItem is OrderListItemUI) {
-            return oldItem.remoteOrderId == newItem.remoteOrderId
+            return oldItem.orderId == newItem.orderId
         }
         if (oldItem is LoadingItem && newItem is OrderListItemUI) {
-            return oldItem.remoteId == newItem.remoteOrderId
+            return oldItem.remoteId == newItem.orderId
         }
         return false
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -382,11 +383,11 @@ class OrderListFragment :
             }
             findNavController().navigate(R.id.action_orderListFragment_to_simplePaymentsFragment, bundle)
         } else {
-            openOrderDetail(order.localId.value, order.remoteId.value, order.status.value)
+            openOrderDetail(order.localId.value, order.id, order.status.value)
         }
     }
 
-    override fun openOrderDetail(localOrderId: Int, remoteOrderId: Long, orderStatus: String, sharedView: View?) {
+    override fun openOrderDetail(localOrderId: Int, remoteOrderId: OrderId, orderStatus: String, sharedView: View?) {
         // Track user clicked to open an order and the status of that order
         AnalyticsTracker.track(
             Stat.ORDER_OPEN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.list
 
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.getBillingName
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.model.TimeGroup.GROUP_FUTURE
 import com.woocommerce.android.model.TimeGroup.GROUP_OLDER_MONTH
@@ -63,12 +64,12 @@ class OrderListItemDataSource(
         val mapSummary = { remoteOrderId: RemoteId ->
             ordersMap[remoteOrderId].let { order ->
                 if (order == null) {
-                    LoadingItem(remoteOrderId)
+                    LoadingItem(OrderId(remoteOrderId.value))
                 } else {
                     @Suppress("DEPRECATION_ERROR")
                     OrderListItemUI(
                         localOrderId = LocalId(order.id),
-                        remoteOrderId = order.remoteOrderId,
+                        orderId = OrderId(order.remoteOrderId.value),
                         orderNumber = order.number,
                         orderName = order.getBillingName(
                             resourceProvider.getString(R.string.orderdetail_customer_name_default)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemUIType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemUIType.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.orders.list
 
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.model.TimeGroup
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 
 /**
  * This class represents three possible list item view states for the order list page,
@@ -24,14 +24,14 @@ sealed class OrderListItemUIType {
      * Flag that the data or a single order item is not yet available for
      * display. Signals a loading view for that item should be displayed.
      */
-    data class LoadingItem(val remoteId: RemoteId) : OrderListItemUIType()
+    data class LoadingItem(val remoteId: OrderId) : OrderListItemUIType()
 
     /**
      * Data required to populate a single order item in the order list view.
      */
     data class OrderListItemUI(
         val localOrderId: LocalId,
-        val remoteOrderId: RemoteId,
+        val orderId: OrderId,
         val orderNumber: String,
         val orderName: String,
         val orderTotal: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListListener.kt
@@ -1,11 +1,12 @@
 package com.woocommerce.android.ui.orders.list
 
 import android.view.View
+import com.woocommerce.android.model.OrderId
 
 interface OrderListListener {
     fun openOrderDetail(
         localOrderId: Int,
-        remoteOrderId: Long,
+        remoteOrderId: OrderId,
         orderStatus: String,
         sharedView: View? = null
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
@@ -90,13 +90,13 @@ class AddOrderNoteViewModel @Inject constructor(
             triggerEvent(ShowSnackbar(R.string.add_order_note_error))
             return
         }
-        AnalyticsTracker.track(ORDER_NOTE_ADD, mapOf(AnalyticsTracker.KEY_PARENT_ID to order.remoteId))
+        AnalyticsTracker.track(ORDER_NOTE_ADD, mapOf(AnalyticsTracker.KEY_PARENT_ID to order.id))
 
         addOrderNoteViewState = addOrderNoteViewState.copy(isProgressDialogShown = true)
 
         val note = addOrderNoteViewState.draftNote
         launch {
-            val onOrderChanged = orderDetailRepository.addOrderNote(order.identifier, order.remoteId.value, note)
+            val onOrderChanged = orderDetailRepository.addOrderNote(order.identifier, order.id, note)
             if (!onOrderChanged.isError) {
                 AnalyticsTracker.track(Stat.ORDER_NOTE_ADD_SUCCESS)
                 addOrderNoteViewState = addOrderNoteViewState.copy(isProgressDialogShown = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -29,22 +29,22 @@ class ShippingLabelRepository @Inject constructor(
     private var availablePackages: List<ShippingPackage>? = null
     private var selectableServicePackages: List<ShippingPackage>? = null
 
-    suspend fun refundShippingLabel(orderId: Long, shippingLabelId: Long): WooResult<Boolean> {
+    suspend fun refundShippingLabel(orderId: OrderId, shippingLabelId: Long): WooResult<Boolean> {
         return withContext(Dispatchers.IO) {
             shippingLabelStore.refundShippingLabelForOrder(
                 site = selectedSite.get(),
-                orderId = orderId,
+                orderId = orderId.value,
                 remoteShippingLabelId = shippingLabelId
             )
         }
     }
 
     fun getShippingLabelByOrderIdAndLabelId(
-        orderId: Long,
+        orderId: OrderId,
         shippingLabelId: Long
     ): ShippingLabel? {
         return shippingLabelStore.getShippingLabelById(
-            selectedSite.get(), orderId, shippingLabelId
+            selectedSite.get(), orderId.value, shippingLabelId
         )
             ?.toAppModel()
     }
@@ -100,7 +100,7 @@ class ShippingLabelRepository @Inject constructor(
     ): WooResult<List<WCShippingRatesResult.ShippingPackage>> {
         val carrierRates = shippingLabelStore.getShippingRates(
             site = selectedSite.get(),
-            orderId = order.remoteId.value,
+            orderId = order.id.value,
             origin = origin.toShippingLabelModel(),
             destination = destination.toShippingLabelModel(),
             packages = packages.mapIndexed { i, box ->
@@ -174,7 +174,7 @@ class ShippingLabelRepository @Inject constructor(
     }
 
     suspend fun purchaseLabels(
-        orderId: Long,
+        orderId: OrderId,
         origin: Address,
         destination: Address,
         packages: List<ShippingLabelPackage>,
@@ -207,7 +207,7 @@ class ShippingLabelRepository @Inject constructor(
 
         return shippingLabelStore.purchaseShippingLabels(
             site = selectedSite.get(),
-            orderId = orderId,
+            orderId = orderId.value,
             origin = origin.toShippingLabelModel(),
             destination = destination.toShippingLabelModel(),
             packagesData = packagesData,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -1,6 +1,13 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
-import com.woocommerce.android.model.*
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.CustomsPackage
+import com.woocommerce.android.model.Location
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderId
+import com.woocommerce.android.model.ShippingLabel
+import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.model.ShippingRate
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -65,7 +72,8 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
 
     object ShowPaymentDetails : CreateShippingLabelEvent()
 
-    data class ShowPrintShippingLabels(val orderId: Long, val labels: List<ShippingLabel>) : CreateShippingLabelEvent()
+    data class ShowPrintShippingLabels(val orderId: OrderId, val labels: List<ShippingLabel>) :
+        CreateShippingLabelEvent()
 
     object ShowWooDiscountBottomSheet : CreateShippingLabelEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -305,7 +305,7 @@ class CreateShippingLabelViewModel @Inject constructor(
         triggerEvent(ShowPaymentDetails)
     }
 
-    private fun openPrintLabelsScreen(orderId: Long, labels: List<ShippingLabel>) {
+    private fun openPrintLabelsScreen(orderId: OrderId, labels: List<ShippingLabel>) {
         triggerEvent(ShowPrintShippingLabels(orderId, labels))
     }
 
@@ -441,7 +441,7 @@ class CreateShippingLabelViewModel @Inject constructor(
         var result: WooResult<List<ShippingLabel>>
         val duration = measureTimeMillis {
             result = shippingLabelRepository.purchaseLabels(
-                orderId = data.order.remoteId.value,
+                orderId = data.order.id,
                 origin = data.stepsState.originAddressStep.data,
                 destination = data.stepsState.shippingAddressStep.data,
                 packages = data.stepsState.packagingStep.data,
@@ -462,7 +462,7 @@ class CreateShippingLabelViewModel @Inject constructor(
         } else {
             if (fulfillOrder) {
                 orderDetailRepository.updateOrderStatus(
-                    remoteOrderId = data.order.remoteId,
+                    remoteOrderId = data.order.id,
                     newStatus = CoreOrderStatus.COMPLETED.value
                 ).collect { result ->
                     when (result) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -416,7 +416,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
             }
 
             on<Event.PurchaseSuccess> {
-                transitionTo(State.Idle, SideEffect.ShowLabelsPrint(data.order.remoteId.value, it.labels))
+                transitionTo(State.Idle, SideEffect.ShowLabelsPrint(data.order.id, it.labels))
             }
         }
 
@@ -825,7 +825,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         object ShowPaymentOptions : SideEffect()
 
         data class ShowLabelsPrint(
-            val orderId: Long,
+            val orderId: OrderId,
             val labels: List<ShippingLabel>
         ) : SideEffect()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products.addons
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.Item.Attribute
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
@@ -38,16 +39,16 @@ class AddonRepository @Inject constructor(
         observeProductSpecificAddons(productRemoteID).firstOrNull().isNullOrEmpty().not()
 
     suspend fun getOrderAddonsData(
-        orderID: Long,
+        orderID: OrderId,
         orderItemID: Long,
         productID: Long
     ) = getOrder(orderID)
         ?.findOrderAttributesWith(orderItemID)
         ?.joinWithAddonsFrom(productID)
 
-    private fun getOrder(orderID: Long) =
+    private fun getOrder(orderID: OrderId) =
         orderStore.getOrderByIdentifier(
-            OrderIdentifier(selectedSite.get().id, orderID)
+            OrderIdentifier(selectedSite.get().id, orderID.value)
         )
 
     private fun WCOrderModel.findOrderAttributesWith(orderItemID: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.ui.products.addons.order.OrderedAddonFragment.Companion.TAG
@@ -59,7 +60,7 @@ class OrderedAddonViewModel @Inject constructor(
             .orEmpty()
 
     fun start(
-        orderID: Long,
+        orderID: OrderId,
         orderItemID: Long,
         productID: Long
     ) = viewState.copy(isSkeletonShown = true).let { viewState = it }.also {
@@ -95,7 +96,7 @@ class OrderedAddonViewModel @Inject constructor(
     }
 
     private suspend fun loadOrderAddonsData(
-        orderID: Long,
+        orderID: OrderId,
         orderItemID: Long,
         productID: Long
     ) = addonsRepository.getOrderAddonsData(orderID, orderItemID, productID)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -295,7 +295,7 @@ class IssueRefundViewModel @Inject constructor(
             CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,
             mapOf(
                 AnalyticsTracker.KEY_REFUND_TYPE to ITEMS.name,
-                AnalyticsTracker.KEY_ORDER_ID to order.remoteId
+                AnalyticsTracker.KEY_ORDER_ID to order.id
             )
         )
 
@@ -307,7 +307,7 @@ class IssueRefundViewModel @Inject constructor(
             CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,
             mapOf(
                 AnalyticsTracker.KEY_REFUND_TYPE to AMOUNT.name,
-                AnalyticsTracker.KEY_ORDER_ID to order.remoteId
+                AnalyticsTracker.KEY_ORDER_ID to order.id
             )
         )
 
@@ -357,7 +357,7 @@ class IssueRefundViewModel @Inject constructor(
                     AnalyticsTracker.track(
                         REFUND_CREATE,
                         mapOf(
-                            AnalyticsTracker.KEY_ORDER_ID to order.remoteId,
+                            AnalyticsTracker.KEY_ORDER_ID to order.id,
                             AnalyticsTracker.KEY_REFUND_IS_FULL to
                                 (commonState.refundTotal isEqualTo maxRefund).toString(),
                             AnalyticsTracker.KEY_REFUND_TYPE to commonState.refundType.name,
@@ -383,7 +383,7 @@ class IssueRefundViewModel @Inject constructor(
 
                                 refundStore.createItemsRefund(
                                     selectedSite.get(),
-                                    order.remoteId.value,
+                                    order.id.value,
                                     refundSummaryState.refundReason ?: "",
                                     true,
                                     gateway.supportsRefunds,
@@ -393,7 +393,7 @@ class IssueRefundViewModel @Inject constructor(
                             AMOUNT -> {
                                 refundStore.createAmountRefund(
                                     selectedSite.get(),
-                                    order.remoteId.value,
+                                    order.id.value,
                                     commonState.refundTotal,
                                     refundSummaryState.refundReason ?: "",
                                     gateway.supportsRefunds
@@ -407,7 +407,7 @@ class IssueRefundViewModel @Inject constructor(
                         AnalyticsTracker.track(
                             REFUND_CREATE_FAILED,
                             mapOf(
-                                AnalyticsTracker.KEY_ORDER_ID to order.remoteId,
+                                AnalyticsTracker.KEY_ORDER_ID to order.id,
                                 AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
                                 AnalyticsTracker.KEY_ERROR_TYPE to result.error.type.toString(),
                                 AnalyticsTracker.KEY_ERROR_DESC to result.error.message
@@ -419,7 +419,7 @@ class IssueRefundViewModel @Inject constructor(
                         AnalyticsTracker.track(
                             REFUND_CREATE_SUCCESS,
                             mapOf(
-                                AnalyticsTracker.KEY_ORDER_ID to order.remoteId,
+                                AnalyticsTracker.KEY_ORDER_ID to order.id,
                                 AnalyticsTracker.KEY_ID to result.model?.id
                             )
                         )
@@ -445,7 +445,7 @@ class IssueRefundViewModel @Inject constructor(
     private suspend fun addOrderNote(reason: String) {
         val note = OrderNote(note = reason, isCustomerNote = false)
         val onOrderChanged = orderDetailRepository
-            .addOrderNote(order.identifier, order.remoteId.value, note)
+            .addOrderNote(order.identifier, order.id, note)
         if (!onOrderChanged.isError) {
             AnalyticsTracker.track(ORDER_NOTE_ADD_SUCCESS)
         } else {
@@ -460,7 +460,7 @@ class IssueRefundViewModel @Inject constructor(
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_SUMMARY_REFUND_BUTTON_TAPPED,
             mapOf(
-                AnalyticsTracker.KEY_ORDER_ID to order.remoteId
+                AnalyticsTracker.KEY_ORDER_ID to order.id
             )
         )
 
@@ -487,7 +487,7 @@ class IssueRefundViewModel @Inject constructor(
 
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_ITEM_QUANTITY_DIALOG_OPENED,
-            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.remoteId)
+            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )
     }
 
@@ -511,7 +511,7 @@ class IssueRefundViewModel @Inject constructor(
 
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_PRODUCT_AMOUNT_DIALOG_OPENED,
-            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.remoteId)
+            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )
     }
 
@@ -578,7 +578,7 @@ class IssueRefundViewModel @Inject constructor(
 
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_SELECT_ALL_ITEMS_BUTTON_TAPPED,
-            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.remoteId)
+            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )
     }
 
@@ -595,7 +595,7 @@ class IssueRefundViewModel @Inject constructor(
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_TAB_CHANGED,
             mapOf(
-                AnalyticsTracker.KEY_ORDER_ID to order.remoteId,
+                AnalyticsTracker.KEY_ORDER_ID to order.id,
                 AnalyticsTracker.KEY_TYPE to type.name
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.calculateTotals
 import com.woocommerce.android.extensions.isCashPayment
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderId
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
@@ -55,16 +56,18 @@ class RefundDetailViewModel @Inject constructor(
     private val navArgs: RefundDetailFragmentArgs by savedState.navArgs()
 
     init {
-        val orderModel = orderStore.getOrderByIdentifier(OrderIdentifier(selectedSite.get().id, navArgs.orderId))
+        val orderModel = orderStore.getOrderByIdentifier(OrderIdentifier(selectedSite.get().id, navArgs.orderId.value))
         orderModel?.toAppModel()?.let { order ->
             formatCurrency = currencyFormatter.buildBigDecimalFormatter(order.currency)
             if (navArgs.refundId > 0) {
-                refundStore.getRefund(selectedSite.get(), navArgs.orderId, navArgs.refundId)
+                refundStore.getRefund(selectedSite.get(), navArgs.orderId.value, navArgs.refundId)
                     ?.toAppModel()?.let { refund ->
                         displayRefundDetails(refund, order)
                     }
             } else {
-                val refunds = refundStore.getAllRefunds(selectedSite.get(), navArgs.orderId).map { it.toAppModel() }
+                val refunds = refundStore.getAllRefunds(
+                    selectedSite.get(), navArgs.orderId.value
+                ).map { it.toAppModel() }
                 displayRefundedProducts(order, refunds)
             }
         }
@@ -168,7 +171,7 @@ class RefundDetailViewModel @Inject constructor(
     ) : Parcelable
 
     data class ViewOrderedAddons(
-        val remoteOrderID: Long,
+        val remoteOrderID: OrderId,
         val orderItemID: Long,
         val addonsProductID: Long
     ) : Event()

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -34,8 +34,7 @@
         tools:layout="@layout/fragment_print_shipping_label">
         <argument
             android:name="orderId"
-            android:defaultValue="0L"
-            app:argType="long" />
+            app:argType="com.woocommerce.android.model.OrderId" />
         <argument
             android:name="shippingLabelIds"
             app:argType="long[]" />
@@ -155,8 +154,7 @@
         android:label="RefundDetailFragment">
         <argument
             android:name="orderId"
-            android:defaultValue="0L"
-            app:argType="long" />
+            app:argType="com.woocommerce.android.model.OrderId" />
         <argument
             android:name="refundId"
             android:defaultValue="0L"
@@ -219,8 +217,7 @@
             app:popExitAnim="@anim/activity_slide_out_to_right">
             <argument
                 android:name="orderId"
-                android:defaultValue="0L"
-                app:argType="long" />
+                app:argType="com.woocommerce.android.model.OrderId" />
         </action>
         <action
             android:id="@+id/action_orderDetailFragment_to_refundDetailFragment"
@@ -327,8 +324,7 @@
         tools:layout="@layout/fragment_shipping_label_refund">
         <argument
             android:name="orderId"
-            android:defaultValue="0L"
-            app:argType="long" />
+            app:argType="com.woocommerce.android.model.OrderId" />
         <argument
             android:name="shippingLabelId"
             android:defaultValue="0L"
@@ -585,7 +581,7 @@
 
         <argument
             android:name="orderId"
-            app:argType="long"
+            app:argType="com.woocommerce.android.model.OrderId"
             app:nullable="false" />
     </fragment>
     <fragment
@@ -640,7 +636,7 @@
         tools:layout="@layout/fragment_ordered_addon">
         <argument
             android:name="orderId"
-            app:argType="long"
+            app:argType="com.woocommerce.android.model.OrderId"
             app:nullable="false" />
         <argument
             android:name="orderItemId"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -443,8 +443,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                     version = OrderDetailViewModel.SUPPORTED_WCS_VERSION
                 )
             ).whenever(repository).getWooServicesPluginInfo()
-            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id.value)
+            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.id.value)
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {
@@ -491,8 +491,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 )
             ).whenever(repository).getWooServicesPluginInfo()
 
-            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id.value)
+            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.id.value)
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {
@@ -572,8 +572,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 )
             ).whenever(repository).getWooServicesPluginInfo()
 
-            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id.value)
+            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.id.value)
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {
@@ -690,7 +690,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         snackbar?.undoAction?.onClick(mock())
         assertThat(snackbar?.message).isEqualTo(resources.getString(string.order_status_updated))
 
-        verify(repository, times(2)).updateOrderStatus(eq(order.remoteId), statusChangeCaptor.capture())
+        verify(repository, times(2)).updateOrderStatus(eq(order.id), statusChangeCaptor.capture())
 
         assertThat(listOf(initialStatus) + statusChangeCaptor.allValues).containsExactly(
             initialStatus, newStatus, initialStatus
@@ -800,8 +800,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION))
             .whenever(repository).getWooServicesPluginInfo()
-        doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-        doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+        doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id.value)
+        doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.id.value)
 
         doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
         doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
@@ -863,8 +863,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 )
             )
                 .whenever(repository).getWooServicesPluginInfo()
-            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-            doReturn(false).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id.value)
+            doReturn(false).whenever(repository).isOrderEligibleForSLCreation(order.id.value)
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -113,7 +113,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(address.lastName).thenReturn("Test")
         whenever(mockedOrder.orderKey).thenReturn("wc_order_j0LMK3bFhalEL")
         whenever(mockedOrder.number).thenReturn(DUMMY_ORDER_NUMBER)
-        whenever(mockedOrder.remoteId).thenReturn(LocalOrRemoteId.RemoteId(1))
+        whenever(mockedOrder.id).thenReturn(LocalOrRemoteId.RemoteId(1))
         whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER)).thenReturn(mockedOrder)
         whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
         whenever(cardReaderManager.collectPayment(any())).thenAnswer {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
@@ -58,7 +58,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
             verify(orderEditingRepository)
                 .updateBothOrderAddresses(
-                    testOrder.remoteId,
+                    testOrder.id,
                     addressToUpdate.toShippingAddressModel(),
                     addressToUpdate.toBillingAddressModel("")
                 )
@@ -81,7 +81,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
             verify(orderEditingRepository)
                 .updateBothOrderAddresses(
-                    testOrder.remoteId,
+                    testOrder.id,
                     addressToUpdate.toShippingAddressModel(),
                     addressToUpdate.toBillingAddressModel("")
                 )
@@ -152,7 +152,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
             verify(orderEditingRepository)
                 .updateBothOrderAddresses(
-                    testOrder.remoteId,
+                    testOrder.id,
                     addressToUpdate.toShippingAddressModel(),
                     addressToUpdate.toBillingAddressModel("original@email.com")
                 )
@@ -229,7 +229,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
         var eventWasCalled = false
         orderEditingRepository.stub {
             onBlocking {
-                updateOrderAddress(testOrder.remoteId, addressToUpdate.toBillingAddressModel())
+                updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 UpdateOrderResult.OptimisticUpdateResult(
                     OnOrderChanged()
@@ -254,7 +254,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     fun `should emit generic error event for errors other than empty billing mail error`() {
         orderEditingRepository.stub {
             onBlocking {
-                updateOrderAddress(testOrder.remoteId, addressToUpdate.toBillingAddressModel())
+                updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 RemoteUpdateResult(
                     OnOrderChanged(orderError = OrderError(type = OrderErrorType.INVALID_RESPONSE))
@@ -276,7 +276,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     fun `should emit empty mail failure if store returns empty billing mail error`() {
         orderEditingRepository.stub {
             onBlocking {
-                updateOrderAddress(testOrder.remoteId, addressToUpdate.toBillingAddressModel())
+                updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 RemoteUpdateResult(
                     OnOrderChanged(orderError = OrderError(type = OrderErrorType.EMPTY_BILLING_EMAIL))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
@@ -137,7 +137,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
             doReturn(testOrder).whenever(repository).getOrder(REMOTE_ORDER_ID)
             doReturn(
                 OnOrderChanged()
-            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.remoteId.value), any())
+            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.id.value), any())
 
             initViewModel()
 
@@ -149,7 +149,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
             viewModel.pushOrderNote()
 
             verify(repository, times(1)).addOrderNote(
-                eq(REMOTE_ORDER_ID), eq(testOrder.remoteId.value),
+                eq(REMOTE_ORDER_ID), eq(testOrder.id.value),
                 argThat {
                     this.note == note
                     this.isCustomerNote == isCustomerNote
@@ -192,7 +192,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
             doReturn(testOrder).whenever(repository).getOrder(REMOTE_ORDER_ID)
             doReturn(
                 OnOrderChanged().apply { this.error = OrderError(GENERIC_ERROR) }
-            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.remoteId.value), any())
+            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.id.value), any())
 
             initViewModel()
 
@@ -204,7 +204,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
             viewModel.pushOrderNote()
 
             verify(repository, times(1)).addOrderNote(
-                eq(REMOTE_ORDER_ID), eq(testOrder.remoteId.value),
+                eq(REMOTE_ORDER_ID), eq(testOrder.id.value),
                 argThat {
                     this.note == note
                     this.isCustomerNote == isCustomerNote

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -325,9 +325,9 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             event = it
         }
 
-        stateFlow.value = Transition(Idle, SideEffect.ShowLabelsPrint(doneData.order.remoteId.value, purchasedLabels))
+        stateFlow.value = Transition(Idle, SideEffect.ShowLabelsPrint(doneData.order.id.value, purchasedLabels))
 
-        assertThat(event).isEqualTo(ShowPrintShippingLabels(doneData.order.remoteId.value, purchasedLabels))
+        assertThat(event).isEqualTo(ShowPrintShippingLabels(doneData.order.id.value, purchasedLabels))
     }
 
     @Test
@@ -350,7 +350,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
         stateFlow.value = Transition(PurchaseLabels(doneData, fulfillOrder = true), null)
 
         verify(orderDetailRepository).updateOrderStatus(
-            doneData.order.remoteId, CoreOrderStatus.COMPLETED.value
+            doneData.order.id, CoreOrderStatus.COMPLETED.value
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -74,9 +74,9 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
 
         assertThat(transition?.sideEffect).isEqualTo(SideEffect.NoOp)
 
-        stateMachine.start(order.remoteId.toString())
+        stateMachine.start(order.id.toString())
 
-        assertThat(transition?.state).isEqualTo(State.DataLoading(order.remoteId.toString()))
+        assertThat(transition?.state).isEqualTo(State.DataLoading(order.id.toString()))
 
         stateMachine.handleEvent(
             Event.DataLoaded(
@@ -100,7 +100,7 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
             }
         }
 
-        stateMachine.start(order.remoteId.toString())
+        stateMachine.start(order.id.toString())
         stateMachine.handleEvent(Event.DataLoaded(order, originAddress, shippingAddress, null))
         stateMachine.handleEvent(Event.OriginAddressValidationStarted)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
