### PR TITLE
Issue/5505 Change type of order id  to long

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -19,10 +19,10 @@ import java.util.*
 
 @Parcelize
 data class Order(
+    val id: Long,
     @Deprecated(replaceWith = ReplaceWith("remoteId"), message = "Use remote id to identify order.")
     val identifier: OrderIdentifier,
     private val rawLocalOrderId: Int,
-    private val rawRemoteOrderId: Long,
     val number: String,
     val dateCreated: Date,
     val dateModified: Date,
@@ -55,9 +55,6 @@ data class Order(
     @Deprecated(replaceWith = ReplaceWith("remoteId"), message = "Use remote id to identify order.")
     val localId
         get() = LocalOrRemoteId.LocalId(this.rawLocalOrderId)
-
-    val remoteId
-        get() = LocalOrRemoteId.RemoteId(this.rawRemoteOrderId)
 
     @IgnoredOnParcel
     val isOrderPaid = datePaid != null
@@ -251,9 +248,9 @@ data class Order(
     companion object {
         val EMPTY by lazy {
             Order(
+                id = 0,
                 identifier = OrderIdentifier(),
                 rawLocalOrderId = 0,
-                rawRemoteOrderId = 0,
                 number = "",
                 dateCreated = Date(),
                 dateModified = Date(),
@@ -292,7 +289,7 @@ fun WCOrderModel.toAppModel(): Order {
     return Order(
         identifier = OrderIdentifier(this),
         rawLocalOrderId = this.id,
-        rawRemoteOrderId = this.remoteOrderId.value,
+        id = this.remoteOrderId.value,
         number = this.number,
         dateCreated = DateTimeUtils.dateUTCFromIso8601(this.dateCreated) ?: Date(),
         dateModified = DateTimeUtils.dateUTCFromIso8601(this.dateModified) ?: Date(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
@@ -26,7 +26,7 @@ object OrderCustomerHelper {
         AnalyticsTracker.track(
             Stat.ORDER_CONTACT_ACTION,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_TYPE to Action.EMAIL.name.toLowerCase(Locale.US)
             )
@@ -55,7 +55,7 @@ object OrderCustomerHelper {
         AnalyticsTracker.track(
             Stat.ORDER_CONTACT_ACTION,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_TYPE to Action.CALL.name.toLowerCase(Locale.US)
             )
@@ -84,7 +84,7 @@ object OrderCustomerHelper {
         AnalyticsTracker.track(
             Stat.ORDER_CONTACT_ACTION,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_TYPE to Action.SMS.name.toLowerCase(Locale.US)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -173,7 +173,7 @@ class CardReaderPaymentViewModel
         cardReaderManager.collectPayment(
             PaymentInfo(
                 paymentDescription = order.getPaymentDescription(),
-                orderId = order.remoteId.value,
+                orderId = order.id,
                 amount = order.total,
                 currency = order.currency,
                 orderKey = order.orderKey,
@@ -183,7 +183,7 @@ class CardReaderPaymentViewModel
                 siteUrl = selectedSite.get().url.ifEmpty { null },
             )
         ).collect { paymentStatus ->
-            onPaymentStatusChanged(order.remoteId.value, customerEmail, paymentStatus, order.getAmountLabel())
+            onPaymentStatusChanged(order.id, customerEmail, paymentStatus, order.getAmountLabel())
         }
     }
 
@@ -274,7 +274,7 @@ class CardReaderPaymentViewModel
             val order = orderRepository.getOrder(arguments.orderIdentifier)
                 ?: throw IllegalStateException("Order URL not available.")
             val amountLabel = order.getAmountLabel()
-            val receiptUrl = getReceiptUrl(order.remoteId.value)
+            val receiptUrl = getReceiptUrl(order.id)
 
             viewState.postValue(
                 PaymentSuccessfulState(
@@ -327,7 +327,7 @@ class CardReaderPaymentViewModel
     private fun startPrintingFlow() {
         val order = orderRepository.getOrder(arguments.orderIdentifier)
             ?: throw IllegalStateException("Order URL not available.")
-        triggerEvent(PrintReceipt(getReceiptUrl(order.remoteId.value), order.getReceiptDocumentName()))
+        triggerEvent(PrintReceipt(getReceiptUrl(order.id), order.getReceiptDocumentName()))
     }
 
     private fun onSendReceiptClicked(receiptUrl: String, billingEmail: String) {
@@ -444,7 +444,7 @@ class CardReaderPaymentViewModel
     private fun Order.getAmountLabel(): String = currencyFormatter
         .formatAmountWithCurrency(this.currency, this.total.toDouble())
 
-    private fun Order.getReceiptDocumentName() = "receipt-order-$remoteId"
+    private fun Order.getReceiptDocumentName() = "receipt-order-$id"
 
     class ShowSnackbarInDialog(@StringRes val message: Int) : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -116,7 +116,7 @@ class OrderDetailRepository @Inject constructor(
     }
 
     suspend fun updateOrderStatus(
-        remoteOrderId: LocalOrRemoteId.RemoteId,
+        remoteOrderId: Long,
         newStatus: String
     ): Flow<UpdateOrderResult> {
         val status = withContext(dispatchers.io) {
@@ -124,7 +124,7 @@ class OrderDetailRepository @Inject constructor(
                 ?: error("Couldn't find a status with key $newStatus")
         }
         return orderStore.updateOrderStatus(
-            remoteOrderId,
+            LocalOrRemoteId.RemoteId(remoteOrderId),
             selectedSite.get(),
             status
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -214,7 +214,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onIssueOrderRefundClicked() {
-        triggerEvent(IssueOrderRefund(remoteOrderId = order.remoteId.value))
+        triggerEvent(IssueOrderRefund(remoteOrderId = order.id))
     }
 
     fun onAcceptCardPresentPaymentClicked(cardReaderManager: CardReaderManager) {
@@ -239,7 +239,7 @@ class OrderDetailViewModel @Inject constructor(
 
     fun onSeeReceiptClicked() {
         loadReceiptUrl()?.let {
-            triggerEvent(PreviewReceipt(order.billingAddress.email, it, order.remoteId.value))
+            triggerEvent(PreviewReceipt(order.billingAddress.email, it, order.id))
         } ?: WooLog.e(T.ORDERS, "ReceiptUrl is null, but SeeReceipt button is visible")
     }
 
@@ -264,7 +264,7 @@ class OrderDetailViewModel @Inject constructor(
 
     private fun loadReceiptUrl(): String? {
         return selectedSite.getIfExists()?.let {
-            appPrefs.getReceiptUrl(it.id, it.siteId, it.selfHostedSiteId, order.remoteId.value)
+            appPrefs.getReceiptUrl(it.id, it.siteId, it.selfHostedSiteId, order.id)
         }
     }
 
@@ -280,7 +280,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onViewRefundedProductsClicked() {
-        triggerEvent(ViewRefundedProducts(remoteOrderId = order.remoteId.value))
+        triggerEvent(ViewRefundedProducts(remoteOrderId = order.id))
     }
 
     fun onAddOrderNoteClicked() {
@@ -288,11 +288,11 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onRefundShippingLabelClick(shippingLabelId: Long) {
-        triggerEvent(RefundShippingLabel(remoteOrderId = order.remoteId.value, shippingLabelId = shippingLabelId))
+        triggerEvent(RefundShippingLabel(remoteOrderId = order.id, shippingLabelId = shippingLabelId))
     }
 
     fun onPrintShippingLabelClicked(shippingLabelId: Long) {
-        triggerEvent(PrintShippingLabel(remoteOrderId = order.remoteId.value, shippingLabelId = shippingLabelId))
+        triggerEvent(PrintShippingLabel(remoteOrderId = order.id, shippingLabelId = shippingLabelId))
     }
 
     fun onPrintCustomsFormClicked(shippingLabel: ShippingLabel) {
@@ -315,7 +315,7 @@ class OrderDetailViewModel @Inject constructor(
         AnalyticsTracker.track(
             ORDER_TRACKING_ADD,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_CARRIER to shipmentTracking.trackingProvider
             )
@@ -351,7 +351,7 @@ class OrderDetailViewModel @Inject constructor(
         AnalyticsTracker.track(
             Stat.ORDER_STATUS_CHANGE,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_FROM to order.status.value,
                 AnalyticsTracker.KEY_TO to updateSource.newStatus
             )
@@ -441,7 +441,7 @@ class OrderDetailViewModel @Inject constructor(
     private fun updateOrderStatus(newStatus: String) {
         if (networkStatus.isConnected()) {
             launch {
-                orderDetailRepository.updateOrderStatus(order.remoteId, newStatus)
+                orderDetailRepository.updateOrderStatus(order.id, newStatus)
                     .collect { result ->
                         when (result) {
                             is OptimisticUpdateResult -> reloadOrderDetails()
@@ -549,7 +549,7 @@ class OrderDetailViewModel @Inject constructor(
 
     private fun fetchSLCreationEligibilityAsync() = async {
         if (isShippingPluginReady) {
-            orderDetailRepository.fetchSLCreationEligibility(order.remoteId.value)
+            orderDetailRepository.fetchSLCreationEligibility(order.id)
         }
     }
 
@@ -620,7 +620,7 @@ class OrderDetailViewModel @Inject constructor(
             FeatureFlag.CARD_READER.isEnabled()
 
         val isOrderEligibleForSLCreation = isShippingPluginReady &&
-            orderDetailRepository.isOrderEligibleForSLCreation(order.remoteId.value) &&
+            orderDetailRepository.isOrderEligibleForSLCreation(order.id) &&
             !orderEligibleForInPersonPayments
 
         if (isOrderEligibleForSLCreation &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingRepository.kt
@@ -16,26 +16,34 @@ class OrderEditingRepository @Inject constructor(
     private val selectedSite: SelectedSite
 ) {
     suspend fun updateCustomerOrderNote(
-        remoteOrderId: LocalOrRemoteId.RemoteId,
+        remoteOrderId: Long,
         customerOrderNote: String
     ): Flow<WCOrderStore.UpdateOrderResult> {
-        return orderUpdateStore.updateCustomerOrderNote(remoteOrderId, selectedSite.get(), customerOrderNote)
+        return orderUpdateStore.updateCustomerOrderNote(
+            LocalOrRemoteId.RemoteId(remoteOrderId),
+            selectedSite.get(),
+            customerOrderNote
+        )
     }
 
     suspend fun updateOrderAddress(
-        remoteOrderId: LocalOrRemoteId.RemoteId,
+        remoteOrderId: Long,
         orderAddress: OrderAddress
     ): Flow<WCOrderStore.UpdateOrderResult> {
-        return orderUpdateStore.updateOrderAddress(remoteOrderId, selectedSite.get().localId(), orderAddress)
+        return orderUpdateStore.updateOrderAddress(
+            LocalOrRemoteId.RemoteId(remoteOrderId),
+            selectedSite.get().localId(),
+            orderAddress
+        )
     }
 
     suspend fun updateBothOrderAddresses(
-        remoteOrderId: LocalOrRemoteId.RemoteId,
+        remoteOrderId: Long,
         shippingAddress: OrderAddress.Shipping,
         billingAddress: OrderAddress.Billing
     ): Flow<WCOrderStore.UpdateOrderResult> {
         return orderUpdateStore.updateBothOrderAddresses(
-            remoteOrderId,
+            LocalOrRemoteId.RemoteId(remoteOrderId),
             selectedSite.get().localId(),
             shippingAddress,
             billingAddress

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -67,7 +67,7 @@ class OrderEditingViewModel @Inject constructor(
 
     fun updateCustomerOrderNote(updatedNote: String) = runWhenUpdateIsPossible {
         orderEditingRepository.updateCustomerOrderNote(
-            order.remoteId, updatedNote
+            order.id, updatedNote
         ).collectOrderUpdate(AnalyticsTracker.ORDER_EDIT_CUSTOMER_NOTE)
     }
 
@@ -76,7 +76,7 @@ class OrderEditingViewModel @Inject constructor(
             sendReplicateShippingAndBillingAddressesWith(updatedShippingAddress)
         } else {
             orderEditingRepository.updateOrderAddress(
-                order.remoteId,
+                order.id,
                 updatedShippingAddress.toShippingAddressModel()
             )
         }.collectOrderUpdate(AnalyticsTracker.ORDER_EDIT_SHIPPING_ADDRESS)
@@ -87,7 +87,7 @@ class OrderEditingViewModel @Inject constructor(
             sendReplicateShippingAndBillingAddressesWith(updatedBillingAddress)
         } else {
             orderEditingRepository.updateOrderAddress(
-                order.remoteId,
+                order.id,
                 updatedBillingAddress.toBillingAddressModel()
             )
         }.collectOrderUpdate(AnalyticsTracker.ORDER_EDIT_BILLING_ADDRESS)
@@ -95,7 +95,7 @@ class OrderEditingViewModel @Inject constructor(
 
     private suspend fun sendReplicateShippingAndBillingAddressesWith(orderAddress: Address) =
         orderEditingRepository.updateBothOrderAddresses(
-            order.remoteId,
+            order.id,
             orderAddress.toShippingAddressModel(),
             orderAddress.toBillingAddressModel(
                 customEmail = orderAddress.email

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -151,7 +151,7 @@ class OrderFulfillViewModel @Inject constructor(
         AnalyticsTracker.track(
             ORDER_TRACKING_ADD,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteId,
+                AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status,
                 AnalyticsTracker.KEY_CARRIER to shipmentTracking.trackingProvider
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -382,7 +382,7 @@ class OrderListFragment :
             }
             findNavController().navigate(R.id.action_orderListFragment_to_simplePaymentsFragment, bundle)
         } else {
-            openOrderDetail(order.localId.value, order.remoteId.value, order.status.value)
+            openOrderDetail(order.localId.value, order.id, order.status.value)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.notes
 
-import android.content.DialogInterface
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
@@ -90,13 +89,13 @@ class AddOrderNoteViewModel @Inject constructor(
             triggerEvent(ShowSnackbar(R.string.add_order_note_error))
             return
         }
-        AnalyticsTracker.track(ORDER_NOTE_ADD, mapOf(AnalyticsTracker.KEY_PARENT_ID to order.remoteId))
+        AnalyticsTracker.track(ORDER_NOTE_ADD, mapOf(AnalyticsTracker.KEY_PARENT_ID to order.id))
 
         addOrderNoteViewState = addOrderNoteViewState.copy(isProgressDialogShown = true)
 
         val note = addOrderNoteViewState.draftNote
         launch {
-            val onOrderChanged = orderDetailRepository.addOrderNote(order.identifier, order.remoteId.value, note)
+            val onOrderChanged = orderDetailRepository.addOrderNote(order.identifier, order.id, note)
             if (!onOrderChanged.isError) {
                 AnalyticsTracker.track(Stat.ORDER_NOTE_ADD_SUCCESS)
                 addOrderNoteViewState = addOrderNoteViewState.copy(isProgressDialogShown = false)
@@ -123,7 +122,7 @@ class AddOrderNoteViewModel @Inject constructor(
         if (addOrderNoteViewState.draftNote.note.trim().isNotEmpty()) {
             triggerEvent(
                 ShowDialog.buildDiscardDialogEvent(
-                    positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
+                    positiveBtnAction = { _, _ ->
                         triggerEvent(Exit)
                     }
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -100,7 +100,7 @@ class ShippingLabelRepository @Inject constructor(
     ): WooResult<List<WCShippingRatesResult.ShippingPackage>> {
         val carrierRates = shippingLabelStore.getShippingRates(
             site = selectedSite.get(),
-            orderId = order.remoteId.value,
+            orderId = order.id,
             origin = origin.toShippingLabelModel(),
             destination = destination.toShippingLabelModel(),
             packages = packages.mapIndexed { i, box ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -441,7 +441,7 @@ class CreateShippingLabelViewModel @Inject constructor(
         var result: WooResult<List<ShippingLabel>>
         val duration = measureTimeMillis {
             result = shippingLabelRepository.purchaseLabels(
-                orderId = data.order.remoteId.value,
+                orderId = data.order.id,
                 origin = data.stepsState.originAddressStep.data,
                 destination = data.stepsState.shippingAddressStep.data,
                 packages = data.stepsState.packagingStep.data,
@@ -462,7 +462,7 @@ class CreateShippingLabelViewModel @Inject constructor(
         } else {
             if (fulfillOrder) {
                 orderDetailRepository.updateOrderStatus(
-                    remoteOrderId = data.order.remoteId,
+                    remoteOrderId = data.order.id,
                     newStatus = CoreOrderStatus.COMPLETED.value
                 ).collect { result ->
                     when (result) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -416,7 +416,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
             }
 
             on<Event.PurchaseSuccess> {
-                transitionTo(State.Idle, SideEffect.ShowLabelsPrint(data.order.remoteId.value, it.labels))
+                transitionTo(State.Idle, SideEffect.ShowLabelsPrint(data.order.id, it.labels))
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -295,7 +295,7 @@ class IssueRefundViewModel @Inject constructor(
             CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,
             mapOf(
                 AnalyticsTracker.KEY_REFUND_TYPE to ITEMS.name,
-                AnalyticsTracker.KEY_ORDER_ID to order.remoteId
+                AnalyticsTracker.KEY_ORDER_ID to order.id
             )
         )
 
@@ -307,7 +307,7 @@ class IssueRefundViewModel @Inject constructor(
             CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,
             mapOf(
                 AnalyticsTracker.KEY_REFUND_TYPE to AMOUNT.name,
-                AnalyticsTracker.KEY_ORDER_ID to order.remoteId
+                AnalyticsTracker.KEY_ORDER_ID to order.id
             )
         )
 
@@ -357,7 +357,7 @@ class IssueRefundViewModel @Inject constructor(
                     AnalyticsTracker.track(
                         REFUND_CREATE,
                         mapOf(
-                            AnalyticsTracker.KEY_ORDER_ID to order.remoteId,
+                            AnalyticsTracker.KEY_ORDER_ID to order.id,
                             AnalyticsTracker.KEY_REFUND_IS_FULL to
                                 (commonState.refundTotal isEqualTo maxRefund).toString(),
                             AnalyticsTracker.KEY_REFUND_TYPE to commonState.refundType.name,
@@ -383,7 +383,7 @@ class IssueRefundViewModel @Inject constructor(
 
                                 refundStore.createItemsRefund(
                                     selectedSite.get(),
-                                    order.remoteId.value,
+                                    order.id,
                                     refundSummaryState.refundReason ?: "",
                                     true,
                                     gateway.supportsRefunds,
@@ -393,7 +393,7 @@ class IssueRefundViewModel @Inject constructor(
                             AMOUNT -> {
                                 refundStore.createAmountRefund(
                                     selectedSite.get(),
-                                    order.remoteId.value,
+                                    order.id,
                                     commonState.refundTotal,
                                     refundSummaryState.refundReason ?: "",
                                     gateway.supportsRefunds
@@ -407,7 +407,7 @@ class IssueRefundViewModel @Inject constructor(
                         AnalyticsTracker.track(
                             REFUND_CREATE_FAILED,
                             mapOf(
-                                AnalyticsTracker.KEY_ORDER_ID to order.remoteId,
+                                AnalyticsTracker.KEY_ORDER_ID to order.id,
                                 AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
                                 AnalyticsTracker.KEY_ERROR_TYPE to result.error.type.toString(),
                                 AnalyticsTracker.KEY_ERROR_DESC to result.error.message
@@ -419,7 +419,7 @@ class IssueRefundViewModel @Inject constructor(
                         AnalyticsTracker.track(
                             REFUND_CREATE_SUCCESS,
                             mapOf(
-                                AnalyticsTracker.KEY_ORDER_ID to order.remoteId,
+                                AnalyticsTracker.KEY_ORDER_ID to order.id,
                                 AnalyticsTracker.KEY_ID to result.model?.id
                             )
                         )
@@ -445,7 +445,7 @@ class IssueRefundViewModel @Inject constructor(
     private suspend fun addOrderNote(reason: String) {
         val note = OrderNote(note = reason, isCustomerNote = false)
         val onOrderChanged = orderDetailRepository
-            .addOrderNote(order.identifier, order.remoteId.value, note)
+            .addOrderNote(order.identifier, order.id, note)
         if (!onOrderChanged.isError) {
             AnalyticsTracker.track(ORDER_NOTE_ADD_SUCCESS)
         } else {
@@ -460,7 +460,7 @@ class IssueRefundViewModel @Inject constructor(
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_SUMMARY_REFUND_BUTTON_TAPPED,
             mapOf(
-                AnalyticsTracker.KEY_ORDER_ID to order.remoteId
+                AnalyticsTracker.KEY_ORDER_ID to order.id
             )
         )
 
@@ -487,7 +487,7 @@ class IssueRefundViewModel @Inject constructor(
 
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_ITEM_QUANTITY_DIALOG_OPENED,
-            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.remoteId)
+            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )
     }
 
@@ -511,7 +511,7 @@ class IssueRefundViewModel @Inject constructor(
 
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_PRODUCT_AMOUNT_DIALOG_OPENED,
-            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.remoteId)
+            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )
     }
 
@@ -578,7 +578,7 @@ class IssueRefundViewModel @Inject constructor(
 
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_SELECT_ALL_ITEMS_BUTTON_TAPPED,
-            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.remoteId)
+            mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )
     }
 
@@ -595,7 +595,7 @@ class IssueRefundViewModel @Inject constructor(
         AnalyticsTracker.track(
             CREATE_ORDER_REFUND_TAB_CHANGED,
             mapOf(
-                AnalyticsTracker.KEY_ORDER_ID to order.remoteId,
+                AnalyticsTracker.KEY_ORDER_ID to order.id,
                 AnalyticsTracker.KEY_TYPE to type.name
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -443,8 +443,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                     version = OrderDetailViewModel.SUPPORTED_WCS_VERSION
                 )
             ).whenever(repository).getWooServicesPluginInfo()
-            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id)
+            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.id)
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {
@@ -491,8 +491,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 )
             ).whenever(repository).getWooServicesPluginInfo()
 
-            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id)
+            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.id)
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {
@@ -572,8 +572,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 )
             ).whenever(repository).getWooServicesPluginInfo()
 
-            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id)
+            doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.id)
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {
@@ -690,7 +690,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         snackbar?.undoAction?.onClick(mock())
         assertThat(snackbar?.message).isEqualTo(resources.getString(string.order_status_updated))
 
-        verify(repository, times(2)).updateOrderStatus(eq(order.remoteId), statusChangeCaptor.capture())
+        verify(repository, times(2)).updateOrderStatus(eq(order.id), statusChangeCaptor.capture())
 
         assertThat(listOf(initialStatus) + statusChangeCaptor.allValues).containsExactly(
             initialStatus, newStatus, initialStatus
@@ -800,8 +800,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION))
             .whenever(repository).getWooServicesPluginInfo()
-        doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-        doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+        doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id)
+        doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.id)
 
         doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
         doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
@@ -863,8 +863,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 )
             )
                 .whenever(repository).getWooServicesPluginInfo()
-            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId.value)
-            doReturn(false).whenever(repository).isOrderEligibleForSLCreation(order.remoteId.value)
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.id)
+            doReturn(false).whenever(repository).isOrderEligibleForSLCreation(order.id)
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -43,7 +43,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.*
-import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import java.math.BigDecimal
 import kotlin.test.assertEquals

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -113,7 +113,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(address.lastName).thenReturn("Test")
         whenever(mockedOrder.orderKey).thenReturn("wc_order_j0LMK3bFhalEL")
         whenever(mockedOrder.number).thenReturn(DUMMY_ORDER_NUMBER)
-        whenever(mockedOrder.remoteId).thenReturn(LocalOrRemoteId.RemoteId(1))
+        whenever(mockedOrder.id).thenReturn(1)
         whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER)).thenReturn(mockedOrder)
         whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
         whenever(cardReaderManager.collectPayment(any())).thenAnswer {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
@@ -58,7 +58,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
             verify(orderEditingRepository)
                 .updateBothOrderAddresses(
-                    testOrder.remoteId,
+                    testOrder.id,
                     addressToUpdate.toShippingAddressModel(),
                     addressToUpdate.toBillingAddressModel("")
                 )
@@ -81,7 +81,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
             verify(orderEditingRepository)
                 .updateBothOrderAddresses(
-                    testOrder.remoteId,
+                    testOrder.id,
                     addressToUpdate.toShippingAddressModel(),
                     addressToUpdate.toBillingAddressModel("")
                 )
@@ -152,7 +152,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
             verify(orderEditingRepository)
                 .updateBothOrderAddresses(
-                    testOrder.remoteId,
+                    testOrder.id,
                     addressToUpdate.toShippingAddressModel(),
                     addressToUpdate.toBillingAddressModel("original@email.com")
                 )
@@ -229,7 +229,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
         var eventWasCalled = false
         orderEditingRepository.stub {
             onBlocking {
-                updateOrderAddress(testOrder.remoteId, addressToUpdate.toBillingAddressModel())
+                updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 UpdateOrderResult.OptimisticUpdateResult(
                     OnOrderChanged()
@@ -254,7 +254,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     fun `should emit generic error event for errors other than empty billing mail error`() {
         orderEditingRepository.stub {
             onBlocking {
-                updateOrderAddress(testOrder.remoteId, addressToUpdate.toBillingAddressModel())
+                updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 RemoteUpdateResult(
                     OnOrderChanged(orderError = OrderError(type = OrderErrorType.INVALID_RESPONSE))
@@ -276,7 +276,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     fun `should emit empty mail failure if store returns empty billing mail error`() {
         orderEditingRepository.stub {
             onBlocking {
-                updateOrderAddress(testOrder.remoteId, addressToUpdate.toBillingAddressModel())
+                updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 RemoteUpdateResult(
                     OnOrderChanged(orderError = OrderError(type = OrderErrorType.EMPTY_BILLING_EMAIL))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
@@ -137,7 +137,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
             doReturn(testOrder).whenever(repository).getOrder(REMOTE_ORDER_ID)
             doReturn(
                 OnOrderChanged()
-            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.remoteId.value), any())
+            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.id), any())
 
             initViewModel()
 
@@ -149,7 +149,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
             viewModel.pushOrderNote()
 
             verify(repository, times(1)).addOrderNote(
-                eq(REMOTE_ORDER_ID), eq(testOrder.remoteId.value),
+                eq(REMOTE_ORDER_ID), eq(testOrder.id),
                 argThat {
                     this.note == note
                     this.isCustomerNote == isCustomerNote
@@ -192,7 +192,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
             doReturn(testOrder).whenever(repository).getOrder(REMOTE_ORDER_ID)
             doReturn(
                 OnOrderChanged().apply { this.error = OrderError(GENERIC_ERROR) }
-            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.remoteId.value), any())
+            ).whenever(repository).addOrderNote(eq(REMOTE_ORDER_ID), eq(testOrder.id), any())
 
             initViewModel()
 
@@ -204,7 +204,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
             viewModel.pushOrderNote()
 
             verify(repository, times(1)).addOrderNote(
-                eq(REMOTE_ORDER_ID), eq(testOrder.remoteId.value),
+                eq(REMOTE_ORDER_ID), eq(testOrder.id),
                 argThat {
                     this.note == note
                     this.isCustomerNote == isCustomerNote

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -325,9 +325,9 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             event = it
         }
 
-        stateFlow.value = Transition(Idle, SideEffect.ShowLabelsPrint(doneData.order.remoteId.value, purchasedLabels))
+        stateFlow.value = Transition(Idle, SideEffect.ShowLabelsPrint(doneData.order.id, purchasedLabels))
 
-        assertThat(event).isEqualTo(ShowPrintShippingLabels(doneData.order.remoteId.value, purchasedLabels))
+        assertThat(event).isEqualTo(ShowPrintShippingLabels(doneData.order.id, purchasedLabels))
     }
 
     @Test
@@ -350,7 +350,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
         stateFlow.value = Transition(PurchaseLabels(doneData, fulfillOrder = true), null)
 
         verify(orderDetailRepository).updateOrderStatus(
-            doneData.order.remoteId, CoreOrderStatus.COMPLETED.value
+            doneData.order.id, CoreOrderStatus.COMPLETED.value
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -74,9 +74,9 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
 
         assertThat(transition?.sideEffect).isEqualTo(SideEffect.NoOp)
 
-        stateMachine.start(order.remoteId.toString())
+        stateMachine.start(order.id.toString())
 
-        assertThat(transition?.state).isEqualTo(State.DataLoading(order.remoteId.toString()))
+        assertThat(transition?.state).isEqualTo(State.DataLoading(order.id.toString()))
 
         stateMachine.handleEvent(
             Event.DataLoaded(
@@ -100,7 +100,7 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
             }
         }
 
-        stateMachine.start(order.remoteId.toString())
+        stateMachine.start(order.id.toString())
         stateMachine.handleEvent(Event.DataLoaded(order, originAddress, shippingAddress, null))
         stateMachine.handleEvent(Event.OriginAddressValidationStarted)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5505
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Following [the discussion](https://github.com/woocommerce/woocommerce-android/issues/5505) the PR changes type of the Order `id` to long 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Smoke test everything what uses Order model

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
