### PR TITLE
Issue/5507 simple payments fractional taxes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
 import dagger.hilt.android.AndroidEntryPoint
+import java.text.DecimalFormat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -66,7 +67,8 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
                 }
             }
             new.orderTaxPercent.takeIfNotEqualTo(old?.orderTaxPercent) { taxPercent ->
-                binding.textTaxLabel.text = getString(R.string.simple_payments_tax_with_percent, taxPercent.toString())
+                val df = DecimalFormat("#.##")
+                binding.textTaxLabel.text = getString(R.string.simple_payments_tax_with_percent, df.format(taxPercent))
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
@@ -66,7 +66,7 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
                 }
             }
             new.orderTaxPercent.takeIfNotEqualTo(old?.orderTaxPercent) { taxPercent ->
-                binding.textTaxLabel.text = getString(R.string.simple_payments_tax_with_percent, taxPercent)
+                binding.textTaxLabel.text = getString(R.string.simple_payments_tax_with_percent, taxPercent.toString())
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -38,7 +38,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
 
         if (chargeTaxes) {
             val taxPercent = if (feeLine.total > BigDecimal.ZERO) {
-                (order.totalTax / feeLine.total).multiply(BigDecimal(ONE_HUNDRED)).toFloat()
+                (order.totalTax.toFloat() / feeLine.total.toFloat()) * ONE_HUNDRED
             } else {
                 0f
             }
@@ -74,6 +74,6 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     ) : Parcelable
 
     companion object {
-        private const val ONE_HUNDRED = 100
+        private const val ONE_HUNDRED = 100f
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -37,7 +37,11 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
         val feeLine = order.feesLines[0]
 
         if (chargeTaxes) {
-            val taxPercent = (order.totalTax / feeLine.total).multiply(BigDecimal(ONE_HUNDRED)).toFloat()
+            val taxPercent = if (feeLine.total > BigDecimal.ZERO) {
+                (order.totalTax / feeLine.total).multiply(BigDecimal(ONE_HUNDRED)).toFloat()
+            } else {
+                0f
+            }
             viewState = viewState.copy(
                 chargeTaxes = true,
                 orderSubtotal = feeLine.total,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -37,7 +37,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
         val feeLine = order.feesLines[0]
 
         if (chargeTaxes) {
-            val taxPercent = (order.totalTax / feeLine.total).multiply(BigDecimal(ONE_HUNDRED)).intValueExact()
+            val taxPercent = (order.totalTax / feeLine.total).multiply(BigDecimal(ONE_HUNDRED)).toFloat()
             viewState = viewState.copy(
                 chargeTaxes = true,
                 orderSubtotal = feeLine.total,
@@ -50,7 +50,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
                 chargeTaxes = false,
                 orderSubtotal = feeLine.total,
                 orderTotalTax = BigDecimal.ZERO,
-                orderTaxPercent = 0,
+                orderTaxPercent = 0f,
                 orderTotal = feeLine.total
             )
         }
@@ -65,7 +65,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
         val chargeTaxes: Boolean = false,
         val orderSubtotal: BigDecimal = BigDecimal.ZERO,
         val orderTotalTax: BigDecimal = BigDecimal.ZERO,
-        val orderTaxPercent: Int = 0,
+        val orderTaxPercent: Float = 0f,
         val orderTotal: BigDecimal = BigDecimal.ZERO,
     ) : Parcelable
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -311,7 +311,7 @@
     <string name="simple_payments_custom_amount">Custom amount</string>
     <string name="simple_payments_charge_taxes">Charge taxes</string>
     <string name="simple_payments_take_payment_button">Take payment (%s)</string>
-    <string name="simple_payments_tax_with_percent">Tax (%d%%)</string>
+    <string name="simple_payments_tax_with_percent">Tax (%s%%)</string>
     <string name="simple_payments_tax_message">Taxes are automatically calculated based on your store address</string>
     <!--
          Order Creation


### PR DESCRIPTION
Fixes #5507 - Previously simple payments assumed the tax rate would be an integer, ignoring the fact that it could have decimal places (ex: 5.25). 

To test:

* Go to `WooCommerce > Settings > Tax > Standard Tax Rates` and add/edit a tax rate to include decimal places
* Add a simple payment for $100.00
* Verify that the fractional part is shown

![tax](https://user-images.githubusercontent.com/3903757/147131480-1da3b998-5c93-449d-bf5a-1c915f4e57ad.png)

