### PR TITLE
Handle onboarding completed status when Stripe account has pending requirement

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -51,6 +51,26 @@ class AppPrefsTest {
     }
 
     @Test
+    fun whenCardReaderOnboardingPendingRequirementWithStripeExtThenCorrectOnboardingStatusIsStored() {
+        AppPrefs.setCardReaderOnboardingPending(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            pluginType = PluginType.STRIPE_TERMINAL_GATEWAY
+        )
+
+        assertThat(
+            AppPrefs.getCardReaderOnboardingCompletedStatus(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isEqualTo(
+            CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
+        )
+    }
+
+    @Test
     fun whenCardReaderOnboardingCompletedWithWCPayThenCorrectOnboardingStatusIsStored() {
         AppPrefs.setCardReaderOnboardingCompleted(
             localSiteId = 0,
@@ -66,6 +86,24 @@ class AppPrefsTest {
                 selfHostedSiteId = 0L
             )
         ).isEqualTo(CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY)
+    }
+
+    @Test
+    fun whenCardReaderOnboardingPendingRequirementsWithWCPayThenCorrectOnboardingStatusIsStored() {
+        AppPrefs.setCardReaderOnboardingPending(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            pluginType = PluginType.WOOCOMMERCE_PAYMENTS
+        )
+
+        assertThat(
+            AppPrefs.getCardReaderOnboardingCompletedStatus(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isEqualTo(CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY)
     }
 
     @Test
@@ -98,6 +136,24 @@ class AppPrefsTest {
     }
 
     @Test
+    fun whenCardReaderOnboardingPendingRequirementsWithWCPayThenCorrectOnboardingStatusFlagIsReturned() {
+        AppPrefs.setCardReaderOnboardingPending(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            pluginType = PluginType.WOOCOMMERCE_PAYMENTS
+        )
+
+        assertThat(
+            AppPrefs.isCardReaderOnboardingCompleted(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isFalse
+    }
+
+    @Test
     fun whenCardReaderOnboardingCompletedWithStripeExtThenCorrectOnboardingStatusFlagIsReturned() {
         AppPrefs.setCardReaderOnboardingCompleted(
             localSiteId = 0,
@@ -113,6 +169,24 @@ class AppPrefsTest {
                 selfHostedSiteId = 0L
             )
         ).isTrue
+    }
+
+    @Test
+    fun whenCardReaderOnboardingPendingRequirementsWithStripeExtThenCorrectOnboardingStatusFlagIsReturned() {
+        AppPrefs.setCardReaderOnboardingPending(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            pluginType = PluginType.STRIPE_TERMINAL_GATEWAY
+        )
+
+        assertThat(
+            AppPrefs.isCardReaderOnboardingCompleted(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isFalse
     }
 
     @Test

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -10,6 +10,8 @@ import androidx.preference.PreferenceManager
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
+import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
+import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_ONBOARDING_COMPLETED_STATUS
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.DATABASE_DOWNGRADED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED
@@ -438,11 +440,13 @@ object AppPrefs {
     }
 
     fun isCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long): Boolean {
-        return getCardReaderOnboardingCompletedStatus(
+        val completedStatus = getCardReaderOnboardingCompletedStatus(
             localSiteId,
             remoteSiteId,
             selfHostedSiteId
-        ) != CARD_READER_ONBOARDING_NOT_COMPLETED
+        )
+        return completedStatus == CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY ||
+        completedStatus == CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
     }
 
     fun setCardReaderOnboardingCompleted(
@@ -454,6 +458,24 @@ object AppPrefs {
         val pluginName = when (pluginType) {
             PluginType.WOOCOMMERCE_PAYMENTS -> CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY
             PluginType.STRIPE_TERMINAL_GATEWAY -> CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
+            null -> CARD_READER_ONBOARDING_NOT_COMPLETED
+        }
+        PreferenceUtils.setString(
+            getPreferences(),
+            getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
+            pluginName.name
+        )
+    }
+
+    fun setCardReaderOnboardingPending(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long,
+        pluginType: PluginType?
+    ) {
+        val pluginName = when (pluginType) {
+            PluginType.WOOCOMMERCE_PAYMENTS -> CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY
+            PluginType.STRIPE_TERMINAL_GATEWAY -> CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
             null -> CARD_READER_ONBOARDING_NOT_COMPLETED
         }
         PreferenceUtils.setString(
@@ -636,6 +658,8 @@ object AppPrefs {
     enum class CardReaderOnboardingCompletedStatus {
         CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY,
         CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION,
+        CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY,
+        CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION,
         CARD_READER_ONBOARDING_NOT_COMPLETED,
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -446,7 +446,7 @@ object AppPrefs {
             selfHostedSiteId
         )
         return completedStatus == CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY ||
-        completedStatus == CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
+            completedStatus == CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
     }
 
     fun setCardReaderOnboardingCompleted(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -25,6 +25,13 @@ class AppPrefsWrapper @Inject constructor() {
         pluginType: PluginType?
     ) = AppPrefs.setCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId, pluginType)
 
+    fun setCardReaderOnboardingPending(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long,
+        pluginType: PluginType?
+    ) = AppPrefs.setCardReaderOnboardingPending(localSiteId, remoteSiteId, selfHostedSiteId, pluginType)
+
     fun setLastConnectedCardReaderId(readerId: String) = AppPrefs.setLastConnectedCardReaderId(readerId)
 
     fun getLastConnectedCardReaderId() = AppPrefs.getLastConnectedCardReaderId()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -252,7 +252,8 @@ sealed class CardReaderOnboardingState {
      */
     data class StripeAccountPendingRequirement(
         val dueDate: Long?,
-        val pluginType: PluginType) : CardReaderOnboardingState()
+        val pluginType: PluginType
+    ) : CardReaderOnboardingState()
 
     /**
      * There are some overdue requirements on the connected Stripe account. Connecting to a reader or accepting

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -664,11 +664,6 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             .thenReturn(null)
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
             .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
-        whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
-            buildPaymentAccountResult(
-                hasPendingRequirements = true
-            )
-        )
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
 
         checker.getOnboardingState()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -633,17 +633,72 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given wcpay installed, when onboarding pending, then onboarding pending status saved`() = testBlocking {
+        whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+            .thenReturn(buildWCPayPluginInfo(isActive = true))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+            .thenReturn(null)
+        whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
+            buildPaymentAccountResult(
+                hasPendingRequirements = true,
+                status = WCPaymentAccountResult.WCPaymentAccountStatus.RESTRICTED
+            )
+        )
+        whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
+
+        checker.getOnboardingState()
+
+        verify(appPrefsWrapper).setCardReaderOnboardingPending(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            eq(PluginType.WOOCOMMERCE_PAYMENTS)
+        )
+    }
+
+    @Test
     fun `given stripe ext installed, when onboarding completed, then onboarding status saved`() = testBlocking {
         whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
             .thenReturn(null)
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
             .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+        whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
+            buildPaymentAccountResult(
+                hasPendingRequirements = true
+            )
+        )
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
 
         checker.getOnboardingState()
 
         verify(appPrefsWrapper).setCardReaderOnboardingCompleted(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            eq(PluginType.STRIPE_TERMINAL_GATEWAY)
+        )
+    }
+
+    @Test
+    fun `given stripe ext installed, when onboarding pending, then pending status saved`() = testBlocking {
+        whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+            .thenReturn(null)
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+            .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+        whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
+            buildPaymentAccountResult(
+                hasPendingRequirements = true,
+                status = WCPaymentAccountResult.WCPaymentAccountStatus.RESTRICTED
+            )
+        )
+        whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
+
+        checker.getOnboardingState()
+
+        verify(appPrefsWrapper).setCardReaderOnboardingPending(
             anyInt(),
             anyLong(),
             anyLong(),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -305,7 +305,12 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account pending requirements, then account pending requirements state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement(0L))
+                .thenReturn(
+                    CardReaderOnboardingState.StripeAccountPendingRequirement(
+                    0L,
+                        PluginType.WOOCOMMERCE_PAYMENTS
+                    )
+                )
 
             val viewModel = createVM()
 
@@ -318,7 +323,12 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account pending requirements, then due date not empty`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement(0L))
+                .thenReturn(
+                    CardReaderOnboardingState.StripeAccountPendingRequirement(
+                        0L,
+                        PluginType.WOOCOMMERCE_PAYMENTS
+                    )
+                )
 
             val viewModel = createVM()
 
@@ -485,7 +495,12 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account pending requirements, then event tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement(0L))
+                .thenReturn(
+                    CardReaderOnboardingState.StripeAccountPendingRequirement(
+                        0L,
+                        PluginType.WOOCOMMERCE_PAYMENTS
+                    )
+                )
 
             createVM()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -307,7 +307,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.StripeAccountPendingRequirement(
-                    0L,
+                        0L,
                         PluginType.WOOCOMMERCE_PAYMENTS
                     )
                 )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5502 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles onboarding completed status when the Stripe account has a pending requirement.

**Before this PR**, the onboarding completed status would be `CARD_ONBOARDING_NOT_COMPLETED` when the Stripe account has any pending requirement. This was causing a crash in the app since merchants with the pending requirement can still proceed with the payment collection until a set deadline.

**After this PR**, the onboarding completed status would be `CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION` OR  `CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY` depending on the active plugin when the Stripe account has any pending requirement.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Green CI should be enough since this does not have any user-visible changes. However, it would be appreciated if this can be verified by monitoring the shared preference and making sure the correct value is been stored when there are any pending requirements from Stripe for the active plugin.

1. Make sure either Stripe Extension or WCPay plugin is installed and activated
2. In `CardReaderOnboardingChecker` file, inside `fetchOnboardingState` method return `StripeAccountUnderReview` state on the very first line
3. Navigate to the "In-Person Payments" screen via settings
4. Notice you see the pending requirements screen
5. Monitor the shared preference and ensure that correct value (CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION or CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY) is stored

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
