### PR TITLE
[Documentation] Update installation instructions with `configureApply` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 1. Open and modify the newly created `gradle.properties` files. See the [Configuration Files](docs/project-overview.md#configuration-files) section for a breakdown of the properties.
 1. In Android Studio, open the project from the local repository. This will auto-generate `local.properties` with the SDK location.
 1. Go to Tools → AVD Manager and create an emulated device.
+1. Before running the app, in the terminal run `./gradlew configureApply`. This will generate `WooCommerce/google-services.json` with usable values.
 1. Run.
 
 ## Build & Test
@@ -61,6 +62,14 @@ $ ./gradlew installVanillaDebug                           # install the debug ap
 $ ./gradlew :WooCommerce:testVanillaDebugUnitTest         # assemble, install and run unit tests
 $ ./gradlew :WooCommerce:connectedVanillaDebugAndroidTest # assemble, install and run Android tests
 ```
+
+## Troubleshooting
+
+### Unknown client_id
+If you can run the app but not log in, and get an error `Unknown client_id` in a toast when you try, you may have sample data in your `WooCommerce/google-services.json` file. 
+1. Check it for sample values in `WooCommerce/google-services.json`, such as `abc` `123`, and delete the file if that is present. 
+1. In the terminal, run `./gradlew configureApply` to regenerate the file
+2. Run the app
 
 ## 📚 Documentation
 


### PR DESCRIPTION
### Description

The instructions previously would result in a build which could not be used to log in to the app, this adds the required steps to get a valid `google-services.json` file in order to be able to log in when the app is running.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
N/A


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
