### PR TITLE
Issue/5483. Adds a reader model to the metadata of the payment intent

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReader.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReader.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.cardreader.connection
 
 interface CardReader {
     val id: String?
-    val type: String?
+    val type: String
     val currentBatteryLevel: Float?
     val firmwareVersion: String
     val locationId: String?

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
@@ -44,7 +44,12 @@ internal enum class MetaDataKeys(val key: String) {
     /**
      * Serial number of a reader which is used to collect the payment
      */
-    READER_ID("reader_ID");
+    READER_ID("reader_ID"),
+
+    /**
+     * Model name of a reader which is used to collect the payment
+     */
+    READER_MODEL("reader_model");
 
     enum class PaymentTypes(val key: String) {
         /**

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -82,11 +82,18 @@ internal class CreatePaymentAction(
         paymentInfo.orderKey.takeUnless { it.isNullOrBlank() }
             ?.let { map[MetaDataKeys.ORDER_KEY.key] = it }
 
-        val readerId = terminal.getConnectedReader()?.id
-        if (readerId == null) {
-            logWrapper.e(LOG_TAG, "collecting payment with reader without serial number")
+        val connectedReader = terminal.getConnectedReader()
+        if (connectedReader != null) {
+            val readerId = connectedReader.id
+            if (readerId == null) {
+                logWrapper.e(LOG_TAG, "collecting payment with reader without serial number")
+            } else {
+                map[MetaDataKeys.READER_ID.key] = readerId
+            }
+
+            map[MetaDataKeys.READER_MODEL.key] = connectedReader.type
         } else {
-            map[MetaDataKeys.READER_ID.key] = readerId
+            logWrapper.e(LOG_TAG, "collecting payment with connected reader which is null")
         }
 
         map[MetaDataKeys.ORDER_ID.key] = paymentInfo.orderId.toString()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5483
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a reader model to the metadata of the payment intent

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Use debugger in `CreatePaymentAction` to verify that a reader model is added with a key `reader_model`


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
