### PR TITLE
Add a dummy UI when both (WCPay and Stripe Extension) plugins are installed until designs are ready

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -91,8 +91,19 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                 showWCStripeError(layout, state)
             is CardReaderOnboardingViewModel.OnboardingViewState.StripeTerminalError ->
                 showStripeTerminalErrorState(layout, state)
-            is CardReaderOnboardingViewModel.OnboardingViewState.WcPayAndStripeInstalledState -> TODO()
+            is CardReaderOnboardingViewModel.OnboardingViewState.WcPayAndStripeInstalledState ->
+                showBothPluginsInstalledState(layout, state)
         }.exhaustive
+    }
+
+    private fun showBothPluginsInstalledState(
+        view: View,
+        state: CardReaderOnboardingViewModel.OnboardingViewState.WcPayAndStripeInstalledState
+    ) {
+        val binding = FragmentCardReaderOnboardingStripeBinding.bind(view)
+        UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
+        UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
+        UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
     }
 
     private fun showLoadingState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -235,13 +235,14 @@ class CardReaderOnboardingViewModel @Inject constructor(
             val illustration = R.drawable.img_products_error
         }
 
+        // TODO Handle this state properly when designs are ready
         data class WcPayAndStripeInstalledState(
             val refreshButtonAction: () -> Unit,
             val onLearnMoreActionClicked: (() -> Unit)
-        ) : OnboardingViewState(R.layout.fragment_card_reader_onboarding_generic_error) {
-            val contactSupportLabel: Nothing = TODO("Add proper logic after designs are ready")
-            val learnMoreLabel: Nothing = TODO("Add proper logic after designs are ready")
-            val illustration: Nothing = TODO("Add proper logic after designs are ready")
+        ) : OnboardingViewState(R.layout.fragment_card_reader_onboarding_stripe) {
+            val headerLabel = UiString.UiStringText("Both WCPay and Stripe Extension plugin are active")
+            val illustration = R.drawable.img_hot_air_balloon
+            val hintLabel = UiString.UiStringText("Remove one of the plugin and try again")
         }
 
         class NoConnectionErrorState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -276,7 +276,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.drawable.img_stripe_extension)
         }
 
-    @Test(expected = AssertionError::class)
+    @Test
     fun `when wcpay and stripe terminal installed-activated, then wcpay and stripe terminal activated state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->
Closes: #5560 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add a dummy UI when both (WCPay and Stripe Extension) plugins are installed until designs are ready. The current behavior before this PR was to crash the app when we found that the merchant has both the plugins installed. We are replacing this behavior with a dummy UI so that it aids us in testing the feature end to end until designs are ready.


### Note to reviewer
This PR contains code changes that might be removed altogether when the designs are ready. This code change is done just to enable us to aid in testing the Stripe Extension development work. Hence, there are no tests included in this PR and strings are hardcoded since we will be removing those anyway. There is a TODO to keep track of this as well as [issue ](https://github.com/woocommerce/woocommerce-android/issues/5560)created in the project board.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure both WCPay and Stripe Extension plugins are installed on your site 
2. Navigate to the In-Person Payments menu via settings
3. Make sure you see a dummy UI that says "Both the plugins are installed" instead of the app crashing

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src=https://user-images.githubusercontent.com/1331230/147534253-a1bb8811-ae60-4ab8-bc22-06ce802ea456.png width=250px />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
