### PR TITLE
Order creation: update prices when changing quantity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -83,7 +83,14 @@ class OrderCreationViewModel @Inject constructor(
                 total = price.multiply(newQuantity.toBigDecimal())
             )
         }
-        orderDraft = orderDraft.copy(items = items)
+        updateOrderItems(items)
+    }
+
+    private fun updateOrderItems(items: List<Order.Item>) {
+        orderDraft = orderDraft.copy(
+            items = items,
+            total = items.sumOf { it.subtotal }
+        )
     }
 
     private suspend fun Order.Item.toProductUIModel(): ProductUIModel {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -76,7 +76,12 @@ class OrderCreationViewModel @Inject constructor(
         val index = items.indexOfFirst { it.uniqueId == id }
         if (index == -1) error("Couldn't find the product with id $id")
         items[index] = with(items[index]) {
-            copy(quantity = quantity + quantityToAdd)
+            val newQuantity = quantity + quantityToAdd
+            copy(
+                quantity = newQuantity,
+                subtotal = price.multiply(newQuantity.toBigDecimal()),
+                total = price.multiply(newQuantity.toBigDecimal())
+            )
         }
         orderDraft = orderDraft.copy(items = items)
     }


### PR DESCRIPTION
### Description
This PR just fixes the logic of previous PR #5516, we weren't updating neither the item's total price, nor the order's total price.

### Testing instructions
Repeat the same steps as #5516 but using this patch:

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt	(revision aaf0a897b4e91e9c2519a7357d411fdcbf15455c)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt	(date 1640693766199)
@@ -16,6 +16,7 @@
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.withContext
+import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -57,6 +58,49 @@
         orderDraft = orderDraft.copy(
             currency = parameterRepository.getParameters(PARAMETERS_KEY, savedState).currencySymbol.orEmpty()
         )
+        updateOrderItems(
+            listOf(
+                Order.Item(
+                    0L,
+                    productId = 44,
+                    "Test Product",
+                    price = BigDecimal.TEN,
+                    sku = "SKU123",
+                    quantity = 1f,
+                    subtotal = BigDecimal.ONE,
+                    totalTax = BigDecimal.TEN,
+                    total = BigDecimal.TEN,
+                    variationId = 0L,
+                    attributesList = emptyList()
+                ),
+                Order.Item(
+                    0L,
+                    productId = 45,
+                    "Test Product",
+                    price = BigDecimal.TEN,
+                    sku = "SKU124",
+                    quantity = 1f,
+                    subtotal = BigDecimal.ONE,
+                    totalTax = BigDecimal.TEN,
+                    total = BigDecimal.TEN,
+                    variationId = 0L,
+                    attributesList = emptyList()
+                ),
+                Order.Item(
+                    0L,
+                    productId = 47,
+                    "Test Product",
+                    price = BigDecimal.TEN,
+                    sku = "SKU125",
+                    quantity = 1f,
+                    subtotal = BigDecimal.ONE,
+                    totalTax = BigDecimal.TEN,
+                    total = BigDecimal.TEN,
+                    variationId = 0L,
+                    attributesList = emptyList()
+                )
+            )
+        )
     }
 
     fun onOrderStatusChanged(status: Order.Status) {
```


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
