### PR TITLE
Add Customer Section UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.orders.creation
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
-import android.view.ViewGroup
-import androidx.core.view.updateMargins
 import androidx.core.widget.TextViewCompat
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
@@ -20,7 +18,6 @@ import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.UiDimen
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
@@ -29,7 +26,6 @@ import com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog.Companion.KEY_ORDER_STATUS_RESULT
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -133,13 +133,6 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
             }
             .let {
                 notesSection.content = it
-                it?.apply {
-                    val verticalMargin = UiHelpers.getPxOfUiDimen(context, UiDimen.UiDimenRes(R.dimen.major_100))
-                    (layoutParams as ViewGroup.MarginLayoutParams).updateMargins(
-                        left = verticalMargin,
-                        right = verticalMargin
-                    )
-                }
             }
     }
 
@@ -173,6 +166,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
 
     @SuppressLint("SetTextI18n")
     private fun bindCustomerAddressSection(customerAddressSection: OrderCreationSectionView, order: Order) {
+        customerAddressSection.setContentHorizontalPadding(R.dimen.minor_00)
         order.takeIf { it.shippingAddress != Address.EMPTY }
             ?.let {
                 val view = LayoutOrderCreationCustomerInfoBinding.inflate(layoutInflater)

--- a/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.motion.widget.MotionLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:layoutDescription="@xml/layout_order_creation_customer_info_scene">
+
+    <TextView
+        android:id="@+id/name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="George Costanza" />
+
+    <TextView
+        android:id="@+id/email"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        app:layout_constraintStart_toStartOf="@id/name"
+        app:layout_constraintTop_toBottomOf="@id/name"
+        tools:text="george@woo.com" />
+
+    <View
+        android:id="@+id/name_divider"
+        style="@style/Woo.Divider"
+        android:layout_width="0dp"
+        android:layout_marginTop="@dimen/minor_100"
+        app:layout_constraintStart_toStartOf="@id/email"
+        app:layout_constraintTop_toBottomOf="@id/email" />
+
+    <TextView
+        android:id="@+id/shipping_header"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_100"
+        android:text="@string/order_detail_shipping_address_section"
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        app:layout_constraintStart_toStartOf="@id/name_divider"
+        app:layout_constraintTop_toBottomOf="@id/name_divider" />
+
+    <TextView
+        android:id="@+id/shipping_address_details"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/woo_black"
+        app:layout_constraintStart_toStartOf="@id/shipping_header"
+        app:layout_constraintTop_toBottomOf="@id/shipping_header"
+        tools:text="George Costanza\n2270 Oak Street\nNew York, NY 13420\nUnited States" />
+
+    <View
+        android:id="@+id/shipping_divider"
+        style="@style/Woo.Divider"
+        android:layout_width="0dp"
+        android:layout_marginTop="@dimen/minor_100"
+        app:layout_constraintStart_toStartOf="@id/shipping_address_details"
+        app:layout_constraintTop_toBottomOf="@id/shipping_address_details" />
+
+    <TextView
+        android:id="@+id/billing_header"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_100"
+        android:text="@string/order_detail_billing_address_section"
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/shipping_address_details"
+        app:layout_constraintTop_toBottomOf="@id/shipping_divider" />
+
+    <TextView
+        android:id="@+id/billing_address_details"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/woo_black"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/shipping_address_details"
+        app:layout_constraintTop_toBottomOf="@id/billing_header"
+        tools:text="George Costanza\n2270 Oak Street\nNew York, NY 13420\nUnited States" />
+
+    <Button
+        android:id="@+id/customerInfo_viewMoreButtonTitle"
+        style="@style/Woo.Button.TextButton.TextStart"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:importantForAccessibility="no"
+        android:text="@string/orderdetail_show_billing"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/billing_address_details" />
+
+    <ImageView
+        android:id="@+id/customerInfo_viewMoreButtonImage"
+        android:layout_width="@dimen/min_tap_target"
+        android:layout_height="@dimen/min_tap_target"
+        android:importantForAccessibility="no"
+        android:padding="@dimen/minor_100"
+        android:src="@drawable/ic_arrow_down"
+        app:layout_constraintBottom_toBottomOf="@id/customerInfo_viewMoreButtonTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/customerInfo_viewMoreButtonTitle" />
+
+</androidx.constraintlayout.motion.widget.MotionLayout>

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -32,6 +32,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
+        android:paddingHorizontal="@dimen/major_100"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/add_buttons_layout"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -32,7 +32,6 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
-        android:paddingHorizontal="@dimen/major_100"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/add_buttons_layout"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/xml/layout_order_creation_customer_info_scene.xml
+++ b/WooCommerce/src/main/res/xml/layout_order_creation_customer_info_scene.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:motion="http://schemas.android.com/apk/res-auto">
+
+    <Transition
+        motion:constraintSetEnd="@+id/end"
+        motion:constraintSetStart="@id/start"
+        motion:duration="@android:integer/config_mediumAnimTime" />
+
+    <ConstraintSet android:id="@+id/start">
+        <Constraint
+            android:id="@+id/billing_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_100"
+            android:visibility="gone"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintHorizontal_bias="0.0"
+            motion:layout_constraintStart_toStartOf="@id/shipping_address_details"
+            motion:layout_constraintTop_toBottomOf="@id/shipping_divider" />
+        <Constraint
+            android:id="@+id/billing_address_details"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintHorizontal_bias="0.0"
+            motion:layout_constraintStart_toStartOf="@id/shipping_address_details"
+            motion:layout_constraintTop_toBottomOf="@id/billing_header" />
+        <Constraint
+            android:id="@+id/customerInfo_viewMoreButtonImage"
+            android:layout_width="@dimen/min_tap_target"
+            android:layout_height="@dimen/min_tap_target"
+            android:rotation="0"
+            motion:layout_constraintBottom_toBottomOf="@id/customerInfo_viewMoreButtonTitle"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintTop_toTopOf="@id/customerInfo_viewMoreButtonTitle" />
+    </ConstraintSet>
+
+    <ConstraintSet android:id="@+id/end">
+        <Constraint
+            android:id="@+id/billing_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_100"
+            android:visibility="visible"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintStart_toStartOf="@id/shipping_address_details"
+            motion:layout_constraintTop_toBottomOf="@id/shipping_divider" />
+        <Constraint
+            android:id="@+id/billing_address_details"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:visibility="visible"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintStart_toStartOf="@id/shipping_address_details"
+            motion:layout_constraintTop_toBottomOf="@id/billing_header" />
+        <Constraint
+            android:id="@+id/customerInfo_viewMoreButtonImage"
+            android:layout_width="@dimen/min_tap_target"
+            android:layout_height="@dimen/min_tap_target"
+            android:rotation="180"
+            motion:layout_constraintBottom_toBottomOf="@id/customerInfo_viewMoreButtonTitle"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintTop_toTopOf="@id/customerInfo_viewMoreButtonTitle" />
+    </ConstraintSet>
+</MotionScene>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Relates to: #5286 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Apply PATCH
2. Go to create order and open/close animation. Try to break it 🙂

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt	(revision c927dcc40dd09870cf56d980e498b9932eca06e0)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt	(date 1640702413954)
@@ -5,6 +5,7 @@
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import com.woocommerce.android.extensions.mapAsync
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
@@ -54,8 +55,11 @@
         get() = orderDraft
 
     init {
+        val testAddress = Address("Company", "Firstname", "Lastname", "123456789", "United States", "Washington", "Random", "Street", "Seattle", "12345", "mail@mail.com")
         orderDraft = orderDraft.copy(
-            currency = parameterRepository.getParameters(PARAMETERS_KEY, savedState).currencySymbol.orEmpty()
+            currency = parameterRepository.getParameters(PARAMETERS_KEY, savedState).currencySymbol.orEmpty(),
+            billingAddress = testAddress,
+            shippingAddress = testAddress
         )
     }
 
```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5845095/147577193-0d78cef8-81f4-42c7-85b6-f4691bc67015.mov



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
