### PR TITLE
Issue/5458 simple payments ro take payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
@@ -31,8 +31,10 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
 
         val binding = FragmentSimplePaymentsBinding.bind(view)
         binding.buttonDone.setOnClickListener {
-            validateEmail(binding.editEmail)
-            // TODO nbradbury - take payment if email is valid
+            // TODO nbradbury - save changes to order
+            if (validateEmail(binding.editEmail)) {
+                showTakePaymentScreen()
+            }
         }
 
         setupObservers(binding)
@@ -118,6 +120,10 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
             R.id.action_simplePaymentsFragment_to_simplePaymentsCustomerNoteFragment,
             bundle
         )
+    }
+
+    private fun showTakePaymentScreen() {
+        findNavController().navigate(R.id.action_simplePaymentsFragment_to_takePaymentFragment)
     }
 
     private fun validateEmail(emailEditText: EditText): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
@@ -141,7 +141,9 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
     }
 
     private fun showTakePaymentScreen() {
-        findNavController().navigate(R.id.action_simplePaymentsFragment_to_takePaymentFragment)
+        SimplePaymentsFragmentDirections
+            .actionSimplePaymentsFragmentToTakePaymentFragment()
+            .let { findNavController().navigateSafely(it) }
     }
 
     private fun validateEmail(emailEditText: EditText): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
@@ -28,6 +28,6 @@ class TakePaymentFragment : BaseFragment(R.layout.fragment_take_payment) {
         AnalyticsTracker.trackViewShown(this)
     }
 
-    // TODO nbradbury show payment amount in title
-    override fun getFragmentTitle() = getString(R.string.simple_payments_take_payment_button)
+    // TODO nbradbury show payment amount in title via simple_payments_take_payment_button
+    override fun getFragmentTitle() = getString(R.string.simple_payments_dialog_title)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
@@ -2,28 +2,18 @@ package com.woocommerce.android.ui.orders.simplepayments
 
 import android.os.Bundle
 import android.view.View
-import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentTakePaymentBinding
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class TakePaymentFragment : BaseFragment(R.layout.fragment_take_payment) {
-    private val viewModel: SimplePaymentsFragmentViewModel by viewModels()
-    private val sharedViewModel by hiltNavGraphViewModels<SimplePaymentsSharedViewModel>(R.id.nav_graph_main)
-
-    @Inject lateinit var currencyFormatter: CurrencyFormatter
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentTakePaymentBinding.bind(view)
-        setupObservers(binding)
 
         binding.textCash.setOnClickListener {
             // TODO nbradbury
@@ -36,17 +26,6 @@ class TakePaymentFragment : BaseFragment(R.layout.fragment_take_payment) {
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
-    }
-
-    private fun setupObservers(binding: FragmentTakePaymentBinding) {
-        viewModel.event.observe(
-            viewLifecycleOwner,
-            { event ->
-                when (event) {
-                    // TODO nbradbury
-                }
-            }
-        )
     }
 
     override fun getFragmentTitle() = getString(R.string.simple_payments_take_payment_button)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
@@ -28,5 +28,6 @@ class TakePaymentFragment : BaseFragment(R.layout.fragment_take_payment) {
         AnalyticsTracker.trackViewShown(this)
     }
 
+    // TODO nbradbury show payment amount in title
     override fun getFragmentTitle() = getString(R.string.simple_payments_take_payment_button)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
@@ -1,0 +1,53 @@
+package com.woocommerce.android.ui.orders.simplepayments
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentTakePaymentBinding
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.util.CurrencyFormatter
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class TakePaymentFragment : BaseFragment(R.layout.fragment_take_payment) {
+    private val viewModel: SimplePaymentsFragmentViewModel by viewModels()
+    private val sharedViewModel by hiltNavGraphViewModels<SimplePaymentsSharedViewModel>(R.id.nav_graph_main)
+
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = FragmentTakePaymentBinding.bind(view)
+        setupObservers(binding)
+
+        binding.textCash.setOnClickListener {
+            // TODO nbradbury
+        }
+        binding.textCard.setOnClickListener {
+            // TODO nbradbury
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+
+    private fun setupObservers(binding: FragmentTakePaymentBinding) {
+        viewModel.event.observe(
+            viewLifecycleOwner,
+            { event ->
+                when (event) {
+                    // TODO nbradbury
+                }
+            }
+        )
+    }
+
+    override fun getFragmentTitle() = getString(R.string.simple_payments_take_payment_button)
+}

--- a/WooCommerce/src/main/res/layout/fragment_take_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_take_payment.xml
@@ -6,18 +6,19 @@
     android:background="@color/color_surface"
     android:orientation="vertical">
 
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/default_window_background"
+        android:padding="@dimen/major_100"
+        android:text="@string/simple_payments_choose_method" />
+
     <View
         android:id="@+id/divider1"
         android:layout_width="wrap_content"
         android:layout_height="1dp"
         android:layout_marginBottom="@dimen/major_100"
         android:background="@color/divider_color" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="@dimen/major_100"
-        android:text="@string/simple_payments_choose_method" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textCash"
@@ -27,6 +28,7 @@
         android:drawableStart="@drawable/ic_gridicons_money"
         android:drawableEnd="@drawable/ic_arrow_right"
         android:drawablePadding="@dimen/major_100"
+        android:paddingBottom="@dimen/major_100"
         android:text="@string/cash" />
 
     <View
@@ -44,5 +46,12 @@
         android:drawableStart="@drawable/ic_gridicons_credit_card"
         android:drawableEnd="@drawable/ic_arrow_right"
         android:drawablePadding="@dimen/major_100"
+        android:paddingBottom="@dimen/major_100"
         android:text="@string/card" />
+
+    <View
+        android:id="@+id/divider3"
+        android:layout_width="wrap_content"
+        android:layout_height="1dp"
+        android:background="@color/divider_color" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_take_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_take_payment.xml
@@ -17,7 +17,6 @@
         android:id="@+id/divider1"
         android:layout_width="wrap_content"
         android:layout_height="1dp"
-        android:layout_marginBottom="@dimen/major_100"
         android:background="@color/divider_color" />
 
     <com.google.android.material.textview.MaterialTextView
@@ -25,17 +24,18 @@
         style="@style/Woo.Card.Body.Bold"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="0dp"
+        android:background="?attr/selectableItemBackground"
         android:drawableStart="@drawable/ic_gridicons_money"
         android:drawableEnd="@drawable/ic_arrow_right"
         android:drawablePadding="@dimen/major_100"
-        android:paddingBottom="@dimen/major_100"
+        android:padding="@dimen/major_100"
         android:text="@string/cash" />
 
     <View
         android:id="@+id/divider2"
         android:layout_width="wrap_content"
         android:layout_height="1dp"
-        android:layout_marginBottom="@dimen/major_100"
         android:background="@color/divider_color" />
 
     <com.google.android.material.textview.MaterialTextView
@@ -43,10 +43,12 @@
         style="@style/Woo.Card.Body.Bold"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="0dp"
+        android:background="?attr/selectableItemBackground"
         android:drawableStart="@drawable/ic_gridicons_credit_card"
         android:drawableEnd="@drawable/ic_arrow_right"
         android:drawablePadding="@dimen/major_100"
-        android:paddingBottom="@dimen/major_100"
+        android:padding="@dimen/major_100"
         android:text="@string/card" />
 
     <View

--- a/WooCommerce/src/main/res/layout/fragment_take_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_take_payment.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/color_surface"
+    android:orientation="vertical">
+
+    <View
+        android:id="@+id/divider1"
+        android:layout_width="wrap_content"
+        android:layout_height="1dp"
+        android:layout_marginBottom="@dimen/major_100"
+        android:background="@color/divider_color" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/major_100"
+        android:text="@string/simple_payments_choose_method" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/textCash"
+        style="@style/Woo.Card.Body.Bold"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/ic_gridicons_money"
+        android:drawableEnd="@drawable/ic_arrow_right"
+        android:drawablePadding="@dimen/major_100"
+        android:text="@string/cash" />
+
+    <View
+        android:id="@+id/divider2"
+        android:layout_width="wrap_content"
+        android:layout_height="1dp"
+        android:layout_marginBottom="@dimen/major_100"
+        android:background="@color/divider_color" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/textCard"
+        style="@style/Woo.Card.Body.Bold"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/ic_gridicons_credit_card"
+        android:drawableEnd="@drawable/ic_arrow_right"
+        android:drawablePadding="@dimen/major_100"
+        android:text="@string/card" />
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_take_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_take_payment.xml
@@ -7,6 +7,7 @@
     android:orientation="vertical">
 
     <com.google.android.material.textview.MaterialTextView
+        style="@style/TextAppearance.Woo.Subtitle1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/default_window_background"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -30,6 +30,11 @@
             app:destination="@id/simplePaymentsCustomerNoteFragment"
             app:enterAnim="@anim/activity_fade_in"
             app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_simplePaymentsFragment_to_takePaymentFragment"
+            app:destination="@id/takePaymentFragment"
+            app:enterAnim="@anim/activity_fade_in"
+            app:popExitAnim="@anim/activity_fade_out" />
     </fragment>
     <fragment
         android:id="@+id/simplePaymentsCustomerNoteFragment"
@@ -40,6 +45,10 @@
             android:defaultValue='""'
             app:argType="string" />
     </fragment>
+    <fragment
+        android:id="@+id/takePaymentFragment"
+        android:name="com.woocommerce.android.ui.orders.simplepayments.TakePaymentFragment"
+        android:label="TakePaymentFragment" />
     <fragment
         android:id="@+id/orders"
         android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -31,7 +31,14 @@
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"  />
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
+            android:id="@+id/action_simplePaymentsFragment_to_takePaymentFragment"
+            app:destination="@id/takePaymentFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <fragment
         android:id="@+id/simplePaymentsCustomerNoteFragment"
@@ -42,6 +49,10 @@
             android:defaultValue='""'
             app:argType="string" />
     </fragment>
+    <fragment
+        android:id="@+id/takePaymentFragment"
+        android:name="com.woocommerce.android.ui.orders.simplepayments.TakePaymentFragment"
+        android:label="TakePaymentFragment" />
     <fragment
         android:id="@+id/orders"
         android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -124,6 +124,8 @@
     <string name="analytics">Analytics</string>
     <string name="minus">Minus</string>
     <string name="plus">Plus</string>
+    <string name="card">Card</string>
+    <string name="cash">Cash</string>
 
     <!--
         Date/Time Labels
@@ -315,6 +317,7 @@
     <string name="simple_payments_take_payment_button">Take payment (%s)</string>
     <string name="simple_payments_tax_with_percent">Tax (%s%%)</string>
     <string name="simple_payments_tax_message">Taxes are automatically calculated based on your store address</string>
+    <string name="simple_payments_choose_method">Choose your payment method</string>
     <!--
          Order Creation
     -->


### PR DESCRIPTION
This PR closes #5458 by adding a read-only "take payment" screen. To test:

* Tap the order list FAB and choose to create a simple payment
* Enter any amount and tap Done
* Tap "Take payment"
* Verify the screen below appears

Note that this screen is completely non-functional at this point. Logic will come separately.

![take](https://user-images.githubusercontent.com/3903757/147600843-5d5d48dc-1060-43f8-bd0b-65b8b39d8e62.png)

