### PR TITLE
Fix about screen vertical spacing

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -220,7 +220,7 @@ dependencies {
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
-    implementation 'com.automattic:about:29-754c15abba18dd8e732dec6f455007704031cc34'
+    implementation 'com.automattic:about:main-cf4b0efcfa5b5904771e7713986eced12e650d2b'
 
     // Dagger
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -48,16 +48,16 @@ so that's the baseline as defined in `major_100`.
     <dimen name="text_major_200">96sp</dimen>
 
     <!-- Regular text line heights -->
-    <dimen name="line_height_minor_70">16dp</dimen>
-    <dimen name="line_height_minor_80">20dp</dimen>
-    <dimen name="line_height_minor_100">24dp</dimen>
+    <dimen name="line_height_minor_70">16sp</dimen>
+    <dimen name="line_height_minor_80">20sp</dimen>
+    <dimen name="line_height_minor_100">24sp</dimen>
 
     <!-- Large text line heights -->
-    <dimen name="line_height_major_25">24dp</dimen>
-    <dimen name="line_height_major_50">36dp</dimen>
-    <dimen name="line_height_major_100">56dp</dimen>
-    <dimen name="line_height_major_150">72dp</dimen>
-    <dimen name="line_height_major_200">112dp</dimen>
+    <dimen name="line_height_major_25">24sp</dimen>
+    <dimen name="line_height_major_50">36sp</dimen>
+    <dimen name="line_height_major_100">56sp</dimen>
+    <dimen name="line_height_major_150">72sp</dimen>
+    <dimen name="line_height_major_200">112sp</dimen>
 
     <!-- Line spacing extra -->
     <dimen name="line_spacing_extra_50">2sp</dimen>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR replaces `dp` with `sp` for line height. Technically, even `dp` [are supported](https://developer.android.com/reference/android/widget/TextView#attr_android:lineHeight) to be used for lineHeight. However, there is [a bug in Compose Theme Adapter](https://github.com/material-components/material-components-android-compose-theme-adapter/issues/86) which breaks vertical spacing when `dp` is used. It's quite tricky since `lineHeight` in Compose accepts only `TextUnit` [which doesn't support `dp`](https://developer.android.com/reference/kotlin/androidx/compose/ui/unit/TextUnit).

I'm on the edge if we should update our styles from dp to sp or wait for the fix in the library. However, I'm inclined towards updating our code as I suspect this might cause even other side-effects/bugs and we might waste time on them in the future. The change has very minimal impact on the UI only when the OS font size settings is not set to default.

Props to @AnirudhBhat for [noticing the issue](https://github.com/woocommerce/woocommerce-android/pull/5568#issuecomment-1002891542). It occurs only in `jalapeno` builds since vanilla and wasabi have shorter app name so the app name fits one line. 

P.S. This PR also updates the hashcode of the `Automattic About` library. This doesn't have any affect, I just forgot to update the commit hash with the merge commit in the previous PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Use jalapeno build
2. Open App settings
3. Tap on "WooCommerce (Pre-Alpha)" row under "About the app" section
4. Notice the screen looks ok
--------
Change font size in OS settings and smoke test the app -> there will be some changes in lineHeight spacing, but they should be minimal. Notice for example the `Top Performers` section on the screenshots below.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| --- | --- |
| ![Screenshot_1640867963](https://user-images.githubusercontent.com/2261188/147752960-896c0e05-5866-4f86-9a9d-ca8a8f2a32c2.png) |  ![Screenshot_1640868176](https://user-images.githubusercontent.com/2261188/147752968-297aead4-adba-4d8b-a759-e5c38e1c469e.png) |
| ![Screenshot_1640862208](https://user-images.githubusercontent.com/2261188/147752998-7a318bf4-c6ba-420f-a0b7-f732762db493.png) | ![Screenshot_1640862197](https://user-images.githubusercontent.com/2261188/147753002-9b1b5a41-7388-4191-a0a8-e66c8716b8a6.png) |




- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
