### PR TITLE
[Tooling] Localization Support for About Automattic lib

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -220,7 +220,7 @@ dependencies {
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
-    implementation 'com.automattic:about:main-cf4b0efcfa5b5904771e7713986eced12e650d2b'
+    implementation "com.automattic:about:$aboutAutomatticVersion"
 
     // Dagger
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ ext {
     wordPressUtilsVersion = "2.3.0"
     mediapickerVersion = 'trunk-00947a9086ecdf2192b0bdc95a22e1647696d0b1'
     wordPressLoginVersion = '0.10.0'
+    aboutAutomatticVersion = 'main-cf4b0efcfa5b5904771e7713986eced12e650d2b'
 }
 
 // Onboarding and dev env setup tasks

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ ext {
     wordPressUtilsVersion = "2.3.0"
     mediapickerVersion = 'trunk-00947a9086ecdf2192b0bdc95a22e1647696d0b1'
     wordPressLoginVersion = '0.10.0'
-    aboutAutomatticVersion = 'main-cf4b0efcfa5b5904771e7713986eced12e650d2b'
+    aboutAutomatticVersion = '0.0.3'
 }
 
 // Onboarding and dev env setup tasks

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -386,6 +386,14 @@ platform :android do
         github_release_prefix: "",
         exclusions: ["default_web_client_id"]
       },
+      {
+        name: "About Library",
+        import_key: "aboutAutomatticVersion", # key used in build.gradle to reference the version
+        repository: "Automattic/about-automattic-android",
+        strings_file_path: "library/src/main/res/values/strings.xml",
+        github_release_prefix: "",
+        exclusions: []
+      },
     ]
 
     binary_imported_libraries.each do  | lib |
@@ -394,7 +402,8 @@ platform :android do
         import_key: lib[:import_key],
         repository: lib[:repository],
         file_path: lib[:strings_file_path],
-        github_release_prefix: lib[:github_release_prefix])
+        github_release_prefix: lib[:github_release_prefix]
+      )
 
       if download_path.nil?
         error_message = "Can't download strings file for #{lib[:name]}.\r\n"
@@ -403,7 +412,7 @@ platform :android do
         UI.user_error! "Abort." unless UI.confirm(error_message)
       else
         UI.message("Strings.xml file for #{lib[:name]} downloaded to #{download_path}.")
-        lib_to_merge = [ {
+        lib_to_merge = [{
           library: lib[:name],
           strings_path: download_path,
           exclusions: lib[:exclusions]


### PR DESCRIPTION
Addresses the Platform Request ref pdnsEh-5D-p2  

### Description

This enables support for the localization of the AboutAutomattic library, so that the strings from that library are merged into the strings sent to GlotPress for localization during the app's code freeze.

Note: I've also updated the WCAndroid Release Scenario in our mobile toolbox (ref: 236-gh-Automattic/mobile-toolbox) to add a step ensuring that the `aboutAutomatticVersion` is pointing to a tag at code freeze time.

### Testing instructions

- Cut a branch from this one to run the tests
- Run `bundle exec fastlane localize_libs`
- Verify that the strings in `library/src/main/res/values/strings.xml` of `Automattic/about-automattic-android` library has been added at the end of `WordPress/src/main/res/values/strings.xml`

---

- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~