### PR TITLE
Order creation and details: update design of the order status view

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
@@ -5,7 +5,7 @@ import com.woocommerce.android.screenshots.util.Screen
 
 class SingleOrderScreen : Screen {
     companion object {
-        const val ORDER_NUMBER_LABEL = R.id.orderStatus_dateAndOrderNum
+        const val ORDER_NUMBER_LABEL = R.id.orderStatus_subtitle
     }
 
     constructor() : super(ORDER_NUMBER_LABEL)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
 import com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView.AddButton
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog.Companion.KEY_ORDER_STATUS_RESULT
+import com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,10 +47,9 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
     }
 
     private fun FragmentOrderCreationFormBinding.initView() {
-        orderStatusView.customizeViewBehavior(
-            displayOrderNumber = false,
-            editActionAsText = true,
-            customEditClickListener = {
+        orderStatusView.initView(
+            mode = OrderDetailOrderStatusView.Mode.OrderCreation,
+            editOrderStatusClickListener = {
                 sharedViewModel.orderStatusData.value?.let {
                     formViewModel.onEditOrderStatusClicked(it)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -53,6 +53,7 @@ import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentDialogFragm
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.OnShippingLabelClickListener
 import com.woocommerce.android.ui.orders.details.editing.OrderEditingViewModel
+import com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView.Mode
 import com.woocommerce.android.ui.orders.fulfill.OrderFulfillViewModel
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
 import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelFragment
@@ -135,6 +136,9 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         setupOrderEditingObservers(orderEditingViewModel)
         setupResultHandlers(viewModel)
 
+        binding.orderDetailOrderStatus.initView(mode = Mode.OrderEdit) {
+            viewModel.onEditOrderStatusSelected()
+        }
         binding.orderRefreshLayout.apply {
             scrollUpChild = binding.scrollView
             setOnRefreshListener { viewModel.onRefreshRequested() }
@@ -340,9 +344,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
     }
 
     private fun showOrderStatus(orderStatus: OrderStatus) {
-        binding.orderDetailOrderStatus.updateStatus(orderStatus) {
-            viewModel.onEditOrderStatusSelected()
-        }
+        binding.orderDetailOrderStatus.updateStatus(orderStatus)
     }
 
     private fun showMarkOrderCompleteButton(isVisible: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -5,7 +5,6 @@ import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
@@ -54,7 +55,8 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
         when (mode) {
             Mode.OrderEdit -> {
-                binding.headerLabel.text = order.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
+                binding.headerLabel.text =
+                    order.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
             }
             Mode.OrderCreation -> {
                 // TODO
@@ -77,7 +79,25 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
     fun initView(mode: Mode, editOrderStatusClickListener: EditStatusClickListener) {
         this.mode = mode
-        binding.orderStatusEdit.setOnClickListener(editOrderStatusClickListener)
+        when (mode) {
+            Mode.OrderEdit -> {
+                binding.orderStatusEditButton.isVisible = false
+                binding.orderStatusEditImage.isVisible = true
+                with(binding.orderStatusEdit) {
+                    isClickable = true
+                    isFocusable = true
+                    setOnClickListener(editOrderStatusClickListener)
+                }
+            }
+            Mode.OrderCreation -> {
+                binding.orderStatusEditImage.isVisible = false
+                with(binding.orderStatusEditButton) {
+                    isVisible = true
+                    text = context.getString(R.string.edit)
+                    setOnClickListener(editOrderStatusClickListener)
+                }
+            }
+        }
     }
 
     enum class Mode {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -40,7 +40,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
                 false -> getMediumDate(context)
                 null -> ""
             }.let { dateStr ->
-                binding.subtitleLabel.text =
+                binding.orderStatusSubtitle.text =
                     when (mode) {
                         Mode.OrderEdit -> context.getString(
                             R.string.orderdetail_orderstatus_date_and_ordernum,
@@ -54,12 +54,12 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
         when (mode) {
             Mode.OrderEdit -> {
-                binding.headerLabel.text =
+                binding.orderStatusHeader.text =
                     order.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
             }
             Mode.OrderCreation -> {
                 // TODO
-                binding.headerLabel.isVisible = false
+                binding.orderStatusHeader.isVisible = false
             }
         }
     }

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -10,7 +10,7 @@
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/subtitle_label"
+            android:id="@+id/orderStatus_subtitle"
             style="@style/Woo.TextView.Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -18,7 +18,7 @@
             tools:text="Nov 3, 2020 \u2022 #120" />
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/header_label"
+            android:id="@+id/orderStatus_header"
             style="@style/Woo.TextView.Headline6"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -23,6 +23,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/minor_00"
+            android:layout_marginBottom="@dimen/minor_00"
             tools:text="George Carlin" />
 
         <LinearLayout

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_height="wrap_content"
-    android:layout_width="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
     <LinearLayout
-        android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
@@ -16,7 +15,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/minor_50"
-            tools:text="Nov 3, 2020 \u2022 #120"/>
+            tools:text="Nov 3, 2020 \u2022 #120" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/header_label"
@@ -26,36 +25,38 @@
             android:layout_marginTop="@dimen/minor_00"
             tools:text="George Carlin" />
 
-        <FrameLayout
+        <LinearLayout
             android:id="@+id/orderStatus_edit"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?attr/selectableItemBackground"
-            android:clickable="true"
             android:contentDescription="@string/orderdetail_change_order_status"
-            android:focusable="true"
-            android:orientation="horizontal"
-            android:paddingBottom="@dimen/major_75"
-            android:paddingEnd="@dimen/major_100"
-            android:paddingStart="@dimen/major_100">
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
 
-        <com.woocommerce.android.widgets.FlowLayout
+            <com.woocommerce.android.widgets.FlowLayout
                 android:id="@+id/orderStatus_orderTags"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="start"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_weight="1"
                 android:contentDescription="@string/orderstatus_contentDesc" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/orderStatus_editAction"
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/orderStatus_editImage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="end"
-                android:background="@drawable/ic_edit_pencil"
-                android:clickable="false"
-                android:focusable="false"
                 android:importantForAccessibility="no"
-                android:textColor="@color/button_fg_selector" />
-        </FrameLayout>
+                android:paddingHorizontal="@dimen/major_100"
+                android:paddingVertical="@dimen/major_75"
+                android:src="@drawable/ic_edit_pencil" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/orderStatus_editButton"
+                style="@style/Woo.Button.TextButton.Secondary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/edit" />
+        </LinearLayout>
     </LinearLayout>
 </merge>

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -11,7 +11,7 @@
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/orderStatus_dateAndOrderNum"
+            android:id="@+id/subtitle_label"
             style="@style/Woo.TextView.Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -19,7 +19,7 @@
             tools:text="Nov 3, 2020 \u2022 #120"/>
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/orderStatus_name"
+            android:id="@+id/header_label"
             style="@style/Woo.TextView.Headline6"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
### Description
This PR just updates the `OrderDetailOrderStatusView` to be compatible with both the order details and creation screens:

|   | Before | After |
| -- | --- | --- |
| Edit | ![Screenshot_20220105_182126](https://user-images.githubusercontent.com/1657201/148260899-b7500eb9-52f0-402d-a02a-733259dce57a.png) | ![edit_after](https://user-images.githubusercontent.com/1657201/148258949-9c046b7e-4165-46ca-8b91-33291180f1db.png) |
| Creation | ![create_before](https://user-images.githubusercontent.com/1657201/148259020-c30ce358-a603-4f59-88ea-b25176736f86.png) | ![create_after](https://user-images.githubusercontent.com/1657201/148259038-976f0b03-e712-4e20-a965-58c5f783018a.png) |

I tried to fix some margin issues too, for example, the views weren't centered in the clickable layout which gave this effect: 
<img width=360 src="https://user-images.githubusercontent.com/1657201/148259181-99a11bc7-fa7b-47ee-8854-43eb35c2f267.png"/>

### Testing instructions
Test order status editing in both the Order Details and Order Creation form.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
