### PR TITLE
Issue/5193 fetch single product suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ProductImageMapModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ProductImageMapModule.kt
@@ -2,8 +2,10 @@ package com.woocommerce.android.di
 
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
 import dagger.Module
 import dagger.Provides
+import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Singleton
 
@@ -11,6 +13,11 @@ import javax.inject.Singleton
 class ProductImageMapModule {
     @Provides
     @Singleton
-    fun provideProductImageMap(selectedSite: SelectedSite, productStore: WCProductStore) =
-        ProductImageMap(selectedSite, productStore)
+    fun provideProductImageMap(
+        selectedSite: SelectedSite,
+        productStore: WCProductStore,
+        @AppCoroutineScope appCoroutineScope: CoroutineScope,
+        coroutineDispatchers: CoroutineDispatchers,
+        wcProductStore: WCProductStore,
+    ) = ProductImageMap(selectedSite, productStore, appCoroutineScope, coroutineDispatchers, wcProductStore)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ProductImageMapModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ProductImageMapModule.kt
@@ -18,6 +18,5 @@ class ProductImageMapModule {
         productStore: WCProductStore,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         coroutineDispatchers: CoroutineDispatchers,
-        wcProductStore: WCProductStore,
-    ) = ProductImageMap(selectedSite, productStore, appCoroutineScope, coroutineDispatchers, wcProductStore)
+    ) = ProductImageMap(selectedSite, productStore, appCoroutineScope, coroutineDispatchers)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUploadWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUploadWorker.kt
@@ -242,7 +242,7 @@ class ProductImagesUploadWorker @Inject constructor(
         suspend fun fetchProductWithRetries(productId: Long): Product? {
             var retries = 0
             while (retries < PRODUCT_UPDATE_RETRIES) {
-                val product = productDetailRepository.fetchProduct(productId)
+                val product = productDetailRepository.fetchProductOrLoadFromCache(productId)
                 if (product != null && productDetailRepository.lastFetchProductErrorType == null) {
                     return product
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -1,8 +1,12 @@
 package com.woocommerce.android.tools
 
-import org.greenrobot.eventbus.EventBus
-import org.wordpress.android.fluxc.model.SiteModel
+import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
+import java.lang.ref.WeakReference
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,8 +18,17 @@ import javax.inject.Singleton
 @Singleton
 class ProductImageMap @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val productStore: WCProductStore
+    private val productStore: WCProductStore,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: CoroutineDispatchers,
+    private val wcProductStore: WCProductStore,
 ) {
+    interface OnProductFetchedListener {
+        fun onProductFetched(remoteProductId: Long)
+    }
+
+    private val observers: MutableList<WeakReference<OnProductFetchedListener>> = mutableListOf()
+
     private val map by lazy {
         HashMap<Long, String>()
     }
@@ -23,8 +36,6 @@ class ProductImageMap @Inject constructor(
     private val pendingRequestIds by lazy {
         HashSet<Long>()
     }
-
-    class RequestFetchProductEvent(val site: SiteModel, val remoteProductId: Long)
 
     fun reset() {
         map.clear()
@@ -45,14 +56,20 @@ class ProductImageMap @Inject constructor(
                 return imageUrl
             }
 
-            // product isn't in our database so fire event to fetch it unless there's a pending request for it
+            // product isn't in our database, fetch it unless there's a pending request for it
             if (!pendingRequestIds.contains(remoteProductId)) {
-                EventBus.getDefault().post(
-                    RequestFetchProductEvent(
-                        site,
-                        remoteProductId
-                    )
-                )
+                appCoroutineScope.launch(dispatchers.io) {
+                    // fetch the product, the method also stores it into the local database
+                    val result = wcProductStore.fetchSingleProduct(FetchSingleProductPayload(site, remoteProductId))
+                    if (!result.isError) {
+                        observers.forEach { weakReference ->
+                            // notify the observer
+                            weakReference.get()?.onProductFetched(remoteProductId)
+                            // remove the weak reference if the observer was garbage collected
+                                ?: observers.remove(weakReference)
+                        }
+                    }
+                }
                 // add to the list of pending requests so we don't keep fetching the same product
                 pendingRequestIds.add(remoteProductId)
             }
@@ -63,5 +80,17 @@ class ProductImageMap @Inject constructor(
 
     fun remove(remoteProductId: Long) {
         map.remove(remoteProductId)
+    }
+
+    fun subscribeToOnProductFetchedEvents(observer: OnProductFetchedListener) {
+        observers.add(WeakReference(observer))
+    }
+
+    fun unsubscribeFromOnProductFetchedEvents(observer: OnProductFetchedListener): Boolean {
+        observers.find { observer == it.get() }?.let {
+            observers.remove(it)
+            return true
+        }
+        return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -65,7 +65,7 @@ class ProductImageMap @Inject constructor(
                         observers.forEach { weakReference ->
                             // notify the observer
                             weakReference.get()?.onProductFetched(remoteProductId)
-                            // remove the weak reference if the observer was garbage collected
+                                // remove the weak reference if the observer was garbage collected
                                 ?: observers.remove(weakReference)
                         }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -21,7 +21,6 @@ class ProductImageMap @Inject constructor(
     private val productStore: WCProductStore,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatchers: CoroutineDispatchers,
-    private val wcProductStore: WCProductStore,
 ) {
     interface OnProductFetchedListener {
         fun onProductFetched(remoteProductId: Long)
@@ -60,7 +59,7 @@ class ProductImageMap @Inject constructor(
             if (!pendingRequestIds.contains(remoteProductId)) {
                 appCoroutineScope.launch(dispatchers.io) {
                     // fetch the product, the method also stores it into the local database
-                    val result = wcProductStore.fetchSingleProduct(FetchSingleProductPayload(site, remoteProductId))
+                    val result = productStore.fetchSingleProduct(FetchSingleProductPayload(site, remoteProductId))
                     if (!result.isError) {
                         observers.forEach { weakReference ->
                             // notify the observer

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -66,7 +66,7 @@ class ProductImageMap @Inject constructor(
                             observers.forEach { weakReference ->
                                 // notify the observer
                                 weakReference.get()?.onProductFetched(remoteProductId)
-                                // remove the weak reference if the observer was garbage collected
+                                    // remove the weak reference if the observer was garbage collected
                                     ?: observers.remove(weakReference)
                             }
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
 import java.lang.ref.WeakReference
@@ -61,11 +62,13 @@ class ProductImageMap @Inject constructor(
                     // fetch the product, the method also stores it into the local database
                     val result = productStore.fetchSingleProduct(FetchSingleProductPayload(site, remoteProductId))
                     if (!result.isError) {
-                        observers.forEach { weakReference ->
-                            // notify the observer
-                            weakReference.get()?.onProductFetched(remoteProductId)
+                        withContext(dispatchers.main) {
+                            observers.forEach { weakReference ->
+                                // notify the observer
+                                weakReference.get()?.onProductFetched(remoteProductId)
                                 // remove the weak reference if the observer was garbage collected
-                                ?: observers.remove(weakReference)
+                                    ?: observers.remove(weakReference)
+                            }
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.push.NotificationChannelType.NEW_ORDER
 import com.woocommerce.android.tools.ProductImageMap
-import com.woocommerce.android.tools.ProductImageMap.RequestFetchProductEvent
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SelectedSite.SelectedSiteChangedEvent
 import com.woocommerce.android.util.WooLog
@@ -38,7 +37,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
-import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
@@ -228,16 +226,6 @@ class MainPresenter @Inject constructor(
         if (event.channel == NEW_ORDER) {
             fetchUnfilledOrderCount()
         }
-    }
-
-    /**
-     * A request to fetch a product has been sent - dispatch the action to fetch it
-     */
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onEventMainThread(event: RequestFetchProductEvent) {
-        val payload = WCProductStore.FetchSingleProductPayload(event.site, event.remoteProductId)
-        dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
     }
 
     fun onEventMainThread(event: SelectedSiteChangedEvent) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
-import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -115,12 +115,10 @@ final class OrderDetailViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        dispatcher.unregister(this)
         productImageMap.unsubscribeFromOnProductFetchedEvents(this)
     }
 
     init {
-        dispatcher.register(this)
         productImageMap.subscribeToOnProductFetchedEvents(this)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -54,7 +54,6 @@ import javax.inject.Inject
 @OpenClassOnDebug
 @HiltViewModel
 final class OrderDetailViewModel @Inject constructor(
-    private val dispatcher: Dispatcher,
     private val coroutineDispatchers: CoroutineDispatchers,
     savedState: SavedStateHandle,
     private val appPrefs: AppPrefs,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -102,7 +102,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     private suspend fun loadProductsWeightsIfNeeded(order: Order) {
         suspend fun fetchProductIfNeeded(productId: Long): Boolean {
             if (productDetailRepository.getProduct(productId) == null) {
-                return productDetailRepository.fetchProduct(productId) != null ||
+                return productDetailRepository.fetchProductOrLoadFromCache(productId) != null ||
                     productDetailRepository.lastFetchProductErrorType == ProductErrorType.INVALID_PRODUCT_ID
             }
             return true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -81,7 +81,6 @@ class ProductDetailRepository @Inject constructor(
     }
 
     suspend fun fetchProductOrLoadFromCache(remoteProductId: Long): Product? {
-        this.remoteProductId = remoteProductId
         val payload = WCProductStore.FetchSingleProductPayload(selectedSite.get(), remoteProductId)
         val result = productStore.fetchSingleProduct(payload)
 
@@ -95,6 +94,7 @@ class ProductDetailRepository @Inject constructor(
     }
 
     suspend fun fetchProductPassword(remoteProductId: Long): String? {
+        this.remoteProductId = remoteProductId
         val result = continuationFetchProductPassword.callAndWaitUntilTimeout(AppConstants.REQUEST_TIMEOUT) {
             val payload = WCProductStore.FetchProductPasswordPayload(selectedSite.get(), remoteProductId)
             dispatcher.dispatch(WCProductActionBuilder.newFetchProductPasswordAction(payload))
@@ -151,6 +151,7 @@ class ProductDetailRepository @Inject constructor(
      * @return the result of the action as a [Boolean]
      */
     suspend fun updateProductPassword(remoteProductId: Long, password: String?): Boolean {
+        this.remoteProductId = remoteProductId
         val result = continuationUpdateProductPassword.callAndWaitUntilTimeout(AppConstants.REQUEST_TIMEOUT) {
             val payload = WCProductStore.UpdateProductPasswordPayload(
                 selectedSite.get(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -31,7 +31,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_PASSWORD
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_SKU_AVAILABILITY
-import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS
 import org.wordpress.android.fluxc.action.WCProductAction.UPDATED_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_PASSWORD
@@ -39,7 +38,6 @@ import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload
-import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductCreated
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductPasswordChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClassesChanged

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -80,7 +80,7 @@ class ProductDetailRepository @Inject constructor(
         dispatcher.unregister(this)
     }
 
-    suspend fun fetchProduct(remoteProductId: Long): Product? {
+    suspend fun fetchProductOrLoadFromCache(remoteProductId: Long): Product? {
         this.remoteProductId = remoteProductId
         val payload = WCProductStore.FetchSingleProductPayload(selectedSite.get(), remoteProductId)
         val result = productStore.fetchSingleProduct(payload)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -356,7 +356,7 @@ class ProductDetailViewModel @Inject constructor(
             attributeListViewState = attributeListViewState.copy(isCreatingVariationDialogShown = true)
             variationRepository.createEmptyVariation(draft)
                 ?.let {
-                    productRepository.fetchProduct(draft.remoteId)
+                    productRepository.fetchProductOrLoadFromCache(draft.remoteId)
                         ?.also { updateProductState(productToUpdateFrom = it) }
                 }
         }.also {
@@ -1082,7 +1082,7 @@ class ProductDetailViewModel @Inject constructor(
 
     private suspend fun fetchProduct(remoteProductId: Long) {
         if (checkConnection()) {
-            val fetchedProduct = productRepository.fetchProduct(remoteProductId)
+            val fetchedProduct = productRepository.fetchProductOrLoadFromCache(remoteProductId)
             if (fetchedProduct != null) {
                 updateProductState(fetchedProduct)
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -120,7 +120,7 @@ class VariationListViewModel @Inject constructor(
                 ?.let { remove(it) }
         }?.toList().let { _variationList.value = it }
 
-        productRepository.fetchProduct(productID)
+        productRepository.fetchProductOrLoadFromCache(productID)
             ?.let { viewState = viewState.copy(parentProduct = it) }
     }
 
@@ -162,7 +162,7 @@ class VariationListViewModel @Inject constructor(
 
     private suspend fun syncProductToVariations(productID: Long) {
         loadVariations(productID, withSkeletonView = false)
-        productRepository.fetchProduct(productID)
+        productRepository.fetchProductOrLoadFromCache(productID)
             ?.let { viewState = viewState.copy(parentProduct = it) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailRepository.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.reviews
 
-import com.woocommerce.android.AppConstants
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.getCommentId
@@ -11,18 +10,10 @@ import com.woocommerce.android.model.RequestResult.SUCCESS
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.model.toProductReviewProductModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.ContinuationWrapper
-import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
-import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Success
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.REVIEWS
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode.MAIN
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
-import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.notification.NotificationModel
@@ -31,11 +22,9 @@ import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadPayload
 import org.wordpress.android.fluxc.store.NotificationStore.OnNotificationChanged
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import javax.inject.Inject
 
 class ReviewDetailRepository @Inject constructor(
-    private val dispatcher: Dispatcher,
     private val productStore: WCProductStore,
     private val notificationStore: NotificationStore,
     private val selectedSite: SelectedSite
@@ -45,17 +34,6 @@ class ReviewDetailRepository @Inject constructor(
     }
 
     private var remoteReviewId: Long = 0L
-    private var remoteProductId: Long = 0L
-
-    private var continuationProduct = ContinuationWrapper<Boolean>(REVIEWS)
-
-    init {
-        dispatcher.register(this)
-    }
-
-    fun onCleanup() {
-        dispatcher.unregister(this)
-    }
 
     suspend fun fetchProductReview(remoteId: Long): RequestResult {
         remoteReviewId = remoteId
@@ -127,14 +105,34 @@ class ReviewDetailRepository @Inject constructor(
     }
 
     private suspend fun fetchProductByRemoteId(remoteProductId: Long): Boolean {
-        this.remoteProductId = remoteProductId
-        val result = continuationProduct.callAndWaitUntilTimeout(AppConstants.REQUEST_TIMEOUT) {
-            val payload = WCProductStore.FetchSingleProductPayload(selectedSite.get(), remoteProductId)
-            dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
-        }
-        return when (result) {
-            is Cancellation -> false
-            is Success -> result.value
+        val payload = WCProductStore.FetchSingleProductPayload(selectedSite.get(), remoteProductId)
+        val result = productStore.fetchSingleProduct(payload)
+
+        return if (result.isError) {
+            AnalyticsTracker.track(
+                Stat.REVIEW_PRODUCT_LOAD_FAILED,
+                mapOf(
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+                    AnalyticsTracker.KEY_ERROR_TYPE to result.error?.type?.toString(),
+                    AnalyticsTracker.KEY_ERROR_DESC to result.error?.message
+                )
+            )
+
+            WooLog.e(
+                REVIEWS,
+                "Error fetching matching product for product review: " +
+                    "${result.error?.type} - ${result.error?.message}"
+            )
+            false
+        } else {
+            AnalyticsTracker.track(
+                Stat.REVIEW_PRODUCT_LOADED,
+                mapOf(
+                    AnalyticsTracker.KEY_ID to remoteProductId,
+                    AnalyticsTracker.KEY_REVIEW_ID to this.remoteReviewId
+                )
+            )
+            true
         }
     }
 
@@ -171,41 +169,6 @@ class ReviewDetailRepository @Inject constructor(
     private suspend fun getProductFromDb(remoteProductId: Long): WCProductModel? {
         return withContext(Dispatchers.IO) {
             productStore.getProductByRemoteId(selectedSite.get(), remoteProductId)
-        }
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = MAIN)
-    fun onProductChanged(event: OnProductChanged) {
-        if (event.causeOfChange == FETCH_SINGLE_PRODUCT && event.remoteProductId == remoteProductId) {
-            if (continuationProduct.isWaiting) {
-                if (event.isError) {
-                    AnalyticsTracker.track(
-                        Stat.REVIEW_PRODUCT_LOAD_FAILED,
-                        mapOf(
-                            AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
-                            AnalyticsTracker.KEY_ERROR_TYPE to event.error?.type?.toString(),
-                            AnalyticsTracker.KEY_ERROR_DESC to event.error?.message
-                        )
-                    )
-
-                    WooLog.e(
-                        REVIEWS,
-                        "Error fetching matching product for product review: " +
-                            "${event.error?.type} - ${event.error?.message}"
-                    )
-                    continuationProduct.continueWith(false)
-                } else {
-                    AnalyticsTracker.track(
-                        Stat.REVIEW_PRODUCT_LOADED,
-                        mapOf(
-                            AnalyticsTracker.KEY_ID to remoteProductId,
-                            AnalyticsTracker.KEY_REVIEW_ID to remoteReviewId
-                        )
-                    )
-                    continuationProduct.continueWith(true)
-                }
-            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -37,11 +37,6 @@ class ReviewDetailViewModel @Inject constructor(
         loadProductReview(remoteReviewId, launchedFromNotification)
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        repository.onCleanup()
-    }
-
     fun moderateReview(newStatus: ProductReviewStatus) {
         if (networkStatus.isConnected()) {
             viewState.productReview?.let { review ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -112,7 +112,7 @@ class ReviewDetailViewModel @Inject constructor(
             triggerEvent(MarkNotificationAsRead(it.remoteNoteId))
 
             // send request to mark notification as read to the server
-            repository.markNotificationAsRead(it)
+            repository.markNotificationAsRead(it, remoteReviewId)
 
             if (launchedFromNotification) {
                 // Send the track event that a product review notification was opened

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/media/ProductImagesUploadWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/media/ProductImagesUploadWorkerTest.kt
@@ -166,26 +166,26 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     @Test
     fun `when update product is requested, then fetch product`() = testBlocking {
         val product = ProductTestUtils.generateProduct(REMOTE_PRODUCT_ID)
-        whenever(productDetailRepository.fetchProduct(REMOTE_PRODUCT_ID)).thenReturn(product)
+        whenever(productDetailRepository.fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)).thenReturn(product)
 
         worker.enqueueWork(Work.UpdateProduct(REMOTE_PRODUCT_ID, listOf(UPLOADED_MEDIA)))
 
-        verify(productDetailRepository).fetchProduct(REMOTE_PRODUCT_ID)
+        verify(productDetailRepository).fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)
     }
 
     @Test
     fun `when fetching product fails, then retry three times`() = testBlocking {
-        whenever(productDetailRepository.fetchProduct(REMOTE_PRODUCT_ID)).thenReturn(null)
+        whenever(productDetailRepository.fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)).thenReturn(null)
 
         worker.enqueueWork(Work.UpdateProduct(REMOTE_PRODUCT_ID, listOf(UPLOADED_MEDIA)))
 
         verify(productDetailRepository, times(ProductImagesUploadWorker.PRODUCT_UPDATE_RETRIES))
-            .fetchProduct(REMOTE_PRODUCT_ID)
+            .fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)
     }
 
     @Test
     fun `when fetching product fails, then send an event`() = testBlocking {
-        whenever(productDetailRepository.fetchProduct(REMOTE_PRODUCT_ID)).thenReturn(null)
+        whenever(productDetailRepository.fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)).thenReturn(null)
 
         val eventsList = mutableListOf<Event>()
         val job = launch {
@@ -201,7 +201,7 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     @Test
     fun `when update product is requested, then update product`() = testBlocking {
         val product = ProductTestUtils.generateProduct(REMOTE_PRODUCT_ID)
-        whenever(productDetailRepository.fetchProduct(REMOTE_PRODUCT_ID)).thenReturn(product)
+        whenever(productDetailRepository.fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)).thenReturn(product)
 
         worker.enqueueWork(Work.UpdateProduct(REMOTE_PRODUCT_ID, listOf(UPLOADED_MEDIA)))
 
@@ -212,7 +212,7 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     @Test
     fun `when update product succeeds, then send an event`() = testBlocking {
         val product = ProductTestUtils.generateProduct(REMOTE_PRODUCT_ID)
-        whenever(productDetailRepository.fetchProduct(REMOTE_PRODUCT_ID)).thenReturn(product)
+        whenever(productDetailRepository.fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)).thenReturn(product)
         whenever(productDetailRepository.updateProduct(any())).thenReturn(true)
 
         val eventsList = mutableListOf<Event>()
@@ -229,7 +229,7 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     @Test
     fun `when update product fails, then retry three times`() = testBlocking {
         val product = ProductTestUtils.generateProduct(REMOTE_PRODUCT_ID)
-        whenever(productDetailRepository.fetchProduct(REMOTE_PRODUCT_ID)).thenReturn(product)
+        whenever(productDetailRepository.fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)).thenReturn(product)
         whenever(productDetailRepository.updateProduct(any())).thenReturn(false)
 
         worker.enqueueWork(Work.UpdateProduct(REMOTE_PRODUCT_ID, listOf(UPLOADED_MEDIA)))
@@ -242,7 +242,7 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     @Test
     fun `when update product fails, then send an event`() = testBlocking {
         val product = ProductTestUtils.generateProduct(REMOTE_PRODUCT_ID)
-        whenever(productDetailRepository.fetchProduct(REMOTE_PRODUCT_ID)).thenReturn(product)
+        whenever(productDetailRepository.fetchProductOrLoadFromCache(REMOTE_PRODUCT_ID)).thenReturn(product)
         whenever(productDetailRepository.updateProduct(any())).thenReturn(false)
 
         val eventsList = mutableListOf<Event>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -36,7 +36,6 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.*
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore.*
@@ -68,7 +67,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         on { getString(any(), any()) } doAnswer { invocationOnMock -> invocationOnMock.arguments[0].toString() }
     }
     private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker = mock()
-    private val dispatcher: Dispatcher = mock()
 
     private val savedState = OrderDetailFragmentArgs(orderId = ORDER_ID).initSavedStateHandle()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.model.*
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.Order.Status
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.PreviewReceipt
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentCollectibilityChecker
@@ -71,6 +72,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     private val savedState = OrderDetailFragmentArgs(orderId = ORDER_ID).initSavedStateHandle()
 
+    private val productImageMap = mock<ProductImageMap>()
+
     private val order = OrderTestUtils.generateTestOrder(ORDER_ID)
     private val orderInfo = OrderInfo(OrderTestUtils.generateTestOrder(ORDER_ID))
     private val orderStatus = OrderStatus(order.status.value, order.status.value)
@@ -122,7 +125,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel = spy(
             OrderDetailViewModel(
-                dispatcher,
                 coroutinesTestRule.testDispatchers,
                 savedState,
                 appPrefsWrapper,
@@ -131,7 +133,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 repository,
                 addonsRepository,
                 selectedSite,
-                paymentCollectibilityChecker
+                productImageMap,
+                paymentCollectibilityChecker,
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -12,8 +12,6 @@ import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
-import org.wordpress.android.fluxc.model.order.OrderIdentifier
-import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import java.math.BigDecimal
@@ -305,8 +303,7 @@ object OrderTestUtils {
         ).toAppModel()
     }
 
-    fun generateOrderWithFee(orderIdentifier: OrderIdentifier = "1-1-1"): WCOrderModel {
-        val orderIdSet = orderIdentifier.toIdSet()
+    fun generateOrderWithFee(): WCOrderModel {
         val lineItems = "[{\n" +
             "    \"id\":1,\n" +
             "    \"name\":\"A test\",\n" +
@@ -324,13 +321,13 @@ object OrderTestUtils {
             "  }]"
 
         return WCOrderModel(
-            id = orderIdSet.id,
+            id = 1,
             billingFirstName = "Carissa",
             billingLastName = "King",
             currency = "USD",
             dateCreated = "2018-02-02T16:11:13Z",
-            localSiteId = LocalOrRemoteId.LocalId(orderIdSet.localSiteId),
-            remoteOrderId = LocalOrRemoteId.RemoteId(orderIdSet.remoteOrderId),
+            localSiteId = LocalOrRemoteId.LocalId(1),
+            remoteOrderId = LocalOrRemoteId.RemoteId(1L),
             number = "55",
             status = "pending",
             total = "106.00",
@@ -355,17 +352,15 @@ object OrderTestUtils {
         )
     }
 
-    fun generateOrderWithMultipleShippingLines(orderIdentifier: OrderIdentifier = "1-1-1"): WCOrderModel {
-        val orderIdSet = orderIdentifier.toIdSet()
-
+    fun generateOrderWithMultipleShippingLines(): WCOrderModel {
         return WCOrderModel(
-            id = orderIdSet.id,
+            id = 1,
             billingFirstName = "Carissa",
             billingLastName = "King",
             currency = "USD",
             dateCreated = "2018-02-02T16:11:13Z",
-            localSiteId = LocalOrRemoteId.LocalId(orderIdSet.localSiteId),
-            remoteOrderId = LocalOrRemoteId.RemoteId(orderIdSet.remoteOrderId),
+            localSiteId = LocalOrRemoteId.LocalId(1),
+            remoteOrderId = LocalOrRemoteId.RemoteId(1L),
             number = "55",
             status = "pending",
             total = "106.00",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -276,7 +276,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Display error message on fetch product error`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        whenever(productRepository.fetchProduct(PRODUCT_REMOTE_ID)).thenReturn(null)
+        whenever(productRepository.fetchProductOrLoadFromCache(PRODUCT_REMOTE_ID)).thenReturn(null)
         whenever(productRepository.getProduct(PRODUCT_REMOTE_ID)).thenReturn(null)
 
         var snackbar: ShowSnackbar? = null
@@ -286,7 +286,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(productRepository, times(1)).fetchProduct(PRODUCT_REMOTE_ID)
+        verify(productRepository, times(1)).fetchProductOrLoadFromCache(PRODUCT_REMOTE_ID)
 
         assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.product_detail_fetch_product_error))
     }
@@ -304,7 +304,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(productRepository, times(1)).getProduct(PRODUCT_REMOTE_ID)
-        verify(productRepository, times(0)).fetchProduct(any())
+        verify(productRepository, times(0)).fetchProductOrLoadFromCache(any())
 
         assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.offline_error))
     }
@@ -591,7 +591,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     /**
      * Protection for a race condition bug in Variations.
      *
-     * We're requiring [ProductDetailRepository.fetchProduct] to be called right after
+     * We're requiring [ProductDetailRepository.fetchProductOrLoadFromCache] to be called right after
      * [VariationRepository.createEmptyVariation] to fix a race condition problem in the Product Details page. The
      * bug can be reproduced inconsistently by following these steps:
      *
@@ -628,7 +628,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             assertThat(productData?.productDraft?.numVariations).isZero()
 
             doReturn(mock<ProductVariation>()).whenever(variationRepository).createEmptyVariation(any())
-            doReturn(product.copy(numVariations = 1_914)).whenever(productRepository).fetchProduct(eq(product.remoteId))
+            doReturn(product.copy(numVariations = 1_914)).whenever(productRepository).fetchProductOrLoadFromCache(eq(product.remoteId))
 
             // When
             viewModel.onGenerateVariationClicked()
@@ -636,7 +636,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             // Then
             verify(variationRepository, times(1)).createEmptyVariation(eq(product))
             // Prove that we fetched from the API.
-            verify(productRepository, times(1)).fetchProduct(eq(product.remoteId))
+            verify(productRepository, times(1)).fetchProductOrLoadFromCache(eq(product.remoteId))
 
             // The VM state should have been updated with the _fetched_ product's numVariations
             assertThat(productData?.productDraft?.numVariations).isEqualTo(1_914)
@@ -646,7 +646,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     fun `when there image upload errors, then show a snackbar`() = testBlocking {
         val errorEvents = MutableSharedFlow<List<ProductImageUploadData>>()
         doReturn(errorEvents).whenever(mediaFileUploadHandler).observeCurrentUploadErrors(PRODUCT_REMOTE_ID)
-        doReturn(product).whenever(productRepository).fetchProduct(any())
+        doReturn(product).whenever(productRepository).fetchProductOrLoadFromCache(any())
         doReturn(product).whenever(productRepository).getProduct(any())
         val errorMessage = "message"
         doReturn(errorMessage).whenever(resources).getString(any(), anyVararg())
@@ -675,7 +675,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     fun `when image uploads gets cleared, then auto-dismiss the snackbar`() = testBlocking {
         val errorEvents = MutableSharedFlow<List<ProductImageUploadData>>()
         doReturn(errorEvents).whenever(mediaFileUploadHandler).observeCurrentUploadErrors(PRODUCT_REMOTE_ID)
-        doReturn(product).whenever(productRepository).fetchProduct(any())
+        doReturn(product).whenever(productRepository).fetchProductOrLoadFromCache(any())
         doReturn(product).whenever(productRepository).getProduct(any())
 
         viewModel.start()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -628,7 +628,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             assertThat(productData?.productDraft?.numVariations).isZero()
 
             doReturn(mock<ProductVariation>()).whenever(variationRepository).createEmptyVariation(any())
-            doReturn(product.copy(numVariations = 1_914)).whenever(productRepository).fetchProductOrLoadFromCache(eq(product.remoteId))
+            doReturn(product.copy(numVariations = 1_914)).whenever(productRepository)
+                .fetchProductOrLoadFromCache(eq(product.remoteId))
 
             // When
             viewModel.onGenerateVariationClicked()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
@@ -69,7 +69,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
         Assertions.assertThat(skeletonShown).containsExactly(true, false)
         Assertions.assertThat(markAsRead).isEqualTo(NOTIF_ID)
         Assertions.assertThat(productReview).isEqualTo(review)
-        verify(repository, times(1)).markNotificationAsRead(any())
+        verify(repository, times(1)).markNotificationAsRead(any(), any())
         assertEquals(NOTIF_ID, markAsRead)
     }
 
@@ -101,7 +101,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
             Assertions.assertThat(skeletonShown).containsExactly(true, false)
             assertEquals(NOTIF_ID, markAsRead)
             Assertions.assertThat(productReview).isEqualTo(review)
-            verify(repository, times(1)).markNotificationAsRead(any())
+            verify(repository, times(1)).markNotificationAsRead(any(), any())
             Assertions.assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.wc_load_review_error))
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-0f313e1602baa03bd6d0ded35ab4413cf5c156d3'
+    fluxCVersion = '2236-25caa331b954ed22da7850f51310ac64b4b82586'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5193
<!-- Id number of the GitHub issue this PR addresses. -->

Merge instructions:
1. Review https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2236
2. Review this PR
3. Merge https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2236
4. Update fluxc hash in this PR
5. Remove "do not merge" label
6. Merge this PR

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR refactors fetchSingleProduct into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

### Testing instructions
1. Smoke test the app - detail of an order, detail of a product, review detail.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No user facing changes

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
