### PR TITLE
Update Order Creation view with data added in customer creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
@@ -6,6 +6,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCreationEditCustomerAddressBinding
@@ -36,6 +37,7 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
     }
 
     private val addressViewModel: AddressViewModel by viewModels()
+    private val sharedViewModel by hiltNavGraphViewModels<OrderCreationViewModel>(R.id.nav_graph_order_creations)
 
     private var shippingBinding: LayoutAddressFormBinding? = null
     private var billingBinding: LayoutAddressFormBinding? = null
@@ -88,6 +90,10 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
             when (event) {
                 is AddressViewModel.ShowStateSelector -> showStateSearchScreen(event.type, event.states)
                 is AddressViewModel.ShowCountrySelector -> showCountrySearchScreen(event.type, event.countries)
+                is AddressViewModel.Exit -> {
+                    sharedViewModel.onCustomerAddressEdited(event.billingAddress, event.shippingAddress)
+                    findNavController().navigateUp()
+                }
             }
         }
     }
@@ -184,7 +190,12 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
-                findNavController().navigateUp()
+                addressViewModel.onDoneSelected(
+                    mapOf(
+                        SHIPPING to shippingBinding.textFieldsState,
+                        BILLING to billingBinding.textFieldsState
+                    )
+                )
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import com.woocommerce.android.extensions.mapAsync
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
@@ -136,6 +137,13 @@ class OrderCreationViewModel @Inject constructor(
             stockQuantity = stockQuantity ?: 0.0,
             canDecreaseQuantity = quantity >= 2
             // TODO check if we need to disable the plus button depending on stock quantity
+        )
+    }
+
+    fun onCustomerAddressEdited(billingAddress: Address, shippingAddress: Address) {
+        orderDraft = orderDraft.copy(
+            billingAddress = billingAddress,
+            shippingAddress = shippingAddress
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5286 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds behaviour for saving added customer addresses data after pressing `done`. In case of not added `shipping address`, billing address is populated.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open order creation
2. Click on `Add customer`
3. Enter some data
4. Click `done`
5. Data should be available in `Customer` section

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5845095/148403354-828f6a46-4507-4ed7-9bfe-17c8f055e6a9.mov




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
