### PR TITLE
Issue/5605 simple payments hide tax rate

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
 import dagger.hilt.android.AndroidEntryPoint
-import java.text.DecimalFormat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -106,10 +105,6 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
                     binding.containerTaxes.isVisible = false
                     binding.textTaxMessage.isVisible = false
                 }
-            }
-            new.orderTaxPercent.takeIfNotEqualTo(old?.orderTaxPercent) { taxPercent ->
-                val df = DecimalFormat("#.##")
-                binding.textTaxLabel.text = getString(R.string.simple_payments_tax_with_percent, df.format(taxPercent))
             }
             new.customerNote.takeIfNotEqualTo(old?.customerNote) { customerNote ->
                 bindNotesSection(binding.notesSection, customerNote)

--- a/WooCommerce/src/main/res/layout/fragment_simple_payments.xml
+++ b/WooCommerce/src/main/res/layout/fragment_simple_payments.xml
@@ -150,7 +150,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/taxes" />
+                    android:text="@string/tax" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/textTax"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="edit">Edit</string>
     <string name="payment">Payment</string>
     <string name="taxes">Taxes</string>
+    <string name="tax">Tax</string>
     <string name="subtotal">Subtotal</string>
     <string name="products_total">Products total</string>
     <string name="discount">Discount</string>


### PR DESCRIPTION
This very simple PR removes the tax percentage from the simple payment screen. This is being done because the percentage was being generated by the client and could be different than the actual tax percentage.

![tax](https://user-images.githubusercontent.com/3903757/148420322-7836e49e-5a97-407c-80af-657b4f33eaf6.png)


