### PR TITLE
Add Buildkite Support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,54 @@
+# Nodes with values to reuse in the pipeline.
+common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/bash-cache#v1.5.0
+
+steps:
+  - label: "checkstyle"
+    command: |
+      echo "--- 🧹 Linting"
+      cp -v gradle.properties-example gradle.properties
+      ./gradlew checkstyle
+    plugins: *common_plugins
+    artifact_paths:
+      - "**/build/reports/checkstyle/checkstyle.*"
+
+  - label: "detekt"
+    command: |
+      echo "--- 🧹 Linting"
+      cp gradle.properties-example gradle.properties
+      ./gradlew detektAll
+    plugins: *common_plugins
+    artifact_paths:
+      - "**/build/reports/detekt/detekt.html"
+
+  - label: "lint"
+    command: |
+      echo "--- 🧹 Linting"
+      cp gradle.properties-example gradle.properties
+      ./gradlew lintVanillaRelease
+    plugins: *common_plugins
+    artifact_paths:
+      - "**/build/reports/lint-results*.*"
+
+  - label: "Test WooCommerce"
+    command: |
+      echo "--- 🧪 Testing"
+      cp gradle.properties-example gradle.properties
+      ./gradlew testVanillaRelease
+    plugins: *common_plugins
+
+  - label: "Test CardReaderModule"
+    command: |
+      echo "--- 🧪 Testing"
+      cp gradle.properties-example gradle.properties
+      ./gradlew lib:cardreader:testRelease
+    plugins: *common_plugins
+
+  - label: "Ensure Screenshot Tests Build"
+    command: |
+      echo "--- ⚒️ Building"
+      cp gradle.properties-example gradle.properties
+      ./gradlew assembleVanillaDebugAndroidTest
+    plugins: *common_plugins

--- a/settings.gradle
+++ b/settings.gradle
@@ -99,3 +99,15 @@ if (localBuilds.exists()) {
         }
     }
 }
+
+// Use the build cache in CI
+if (System.getenv().containsKey("CI")) {
+    buildCache {
+        remote(HttpBuildCache) {
+            url = "http://10.0.2.215:5071/cache/"
+            allowUntrustedServer = true
+            allowInsecureProtocol = true
+            push = true
+        }
+    }
+}


### PR DESCRIPTION
Adds Buildkite CI support. There's an associated PR for the infrastructure underlying this PR that can be reviewed independently (though if it seems like there are any leaky abstractions here, we should certainly address them).

The pipeline steps all currently reference the shared plugin configuration, even though they aren't used at the moment – next steps will include adding Android-specific actions for Gradle caching (which may or may not make sense, because the gradle build cache is up and running).

One other next step – Installable Builds. These will move over in their own PR, since we'll need to use some of the new release toolkit actions, and remove CircleCI's responsibility for those.

**To Test:**
Ensure that https://buildkite.com/automattic/woocommerce-android/builds?branch=add%2Fbuildkite passes. Note that it is faster overall than CircleCI.