### PR TITLE
Update links for ordering M2 card reader and viewing the manual

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -40,7 +40,7 @@ object AppUrls {
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
-    const val WOOCOMMERCE_PURCHASE_CARD_READER = "https://woocommerce.com/in-person-payments/"
+    const val WOOCOMMERCE_PURCHASE_CARD_READER = "https://woocommerce.com/products/m2-card-reader/"
     const val BBPOS_MANUAL_CARD_READER =
         "https://developer.bbpos.com/quick_start_guide/Chipper%202X%20BT%20Quick%20Start%20Guide.pdf"
     const val M2_MANUAL_CARD_READER = "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
@@ -32,8 +32,8 @@ class CardReaderHubViewModel @Inject constructor(
             ),
             CardReaderHubListItemViewState(
                 icon = R.drawable.ic_card_reader_manual,
-                label = UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader),
-                onItemClicked = ::onBbposManualCardReaderClicked
+                label = UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader),
+                onItemClicked = ::onM2ManualCardReaderClicked
             ),
         )
     )
@@ -48,11 +48,6 @@ class CardReaderHubViewModel @Inject constructor(
         triggerEvent(CardReaderHubEvents.NavigateToPurchaseCardReaderFlow)
     }
 
-    private fun onBbposManualCardReaderClicked() {
-        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.BBPOS_MANUAL_CARD_READER))
-    }
-
-    @Suppress("unused")
     private fun onM2ManualCardReaderClicked() {
         triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.M2_MANUAL_CARD_READER))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
@@ -32,9 +32,14 @@ class CardReaderHubViewModel @Inject constructor(
             ),
             CardReaderHubListItemViewState(
                 icon = R.drawable.ic_card_reader_manual,
+                label = UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader),
+                onItemClicked = ::onBbposManualCardReaderClicked
+            ),
+            CardReaderHubListItemViewState(
+                icon = R.drawable.ic_card_reader_manual,
                 label = UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader),
                 onItemClicked = ::onM2ManualCardReaderClicked
-            ),
+            )
         )
     )
 
@@ -46,6 +51,10 @@ class CardReaderHubViewModel @Inject constructor(
 
     private fun onPurchaseCardReaderClicked() {
         triggerEvent(CardReaderHubEvents.NavigateToPurchaseCardReaderFlow)
+    }
+
+    private fun onBbposManualCardReaderClicked() {
+        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.BBPOS_MANUAL_CARD_READER))
     }
 
     private fun onM2ManualCardReaderClicked() {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -873,6 +873,7 @@
         -->
     <string name="card_reader_manage_card_reader">Manage Card Reader</string>
     <string name="card_reader_purchase_card_reader">Order Card Reader</string>
+    <string name="card_reader_bbpos_manual_card_reader">BBPOS Chipper Card Reader Manual</string>
     <string name="card_reader_m2_manual_card_reader">Stripe M2 Card Reader Manual</string>
     <!--
         Card Reader Payments

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -873,7 +873,6 @@
         -->
     <string name="card_reader_manage_card_reader">Manage Card Reader</string>
     <string name="card_reader_purchase_card_reader">Order Card Reader</string>
-    <string name="card_reader_bbpos_manual_card_reader">BBPOS Chipper Card Reader Manual</string>
     <string name="card_reader_m2_manual_card_reader">Stripe M2 Card Reader Manual</string>
     <!--
         Card Reader Payments

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
 class CardReaderHubViewModelTest : BaseUnitTest() {
@@ -51,14 +50,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when screen shown, then bbpos manual card reader row present`() {
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .anyMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader)
-            }
-    }
-
-    @Test
     fun `when screen shown, then manual card reader row icon is present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
@@ -67,7 +58,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    @Ignore
     fun `when screen shown, then m2 manual card reader row present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
@@ -77,25 +67,9 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when screen shown, then bbpos chipper manual card reader row present`() {
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .anyMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader) &&
-                    it.icon == R.drawable.ic_card_reader_manual
-            }
-    }
-
-    @Test
-    fun `when screen shown, then bbpos manual card reader row present on third position`() {
+    fun `when screen shown, then m2 manual card reader row present at third position`() {
         val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-        assertThat(rows[2].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader))
-    }
-
-    @Test
-    @Ignore("Row with M2 reader is temporarily hidden")
-    fun `when screen shown, then m2 manual card reader row present at fourth last`() {
-        val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-        assertThat(rows[3].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader))
+        assertThat(rows[2].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader))
     }
 
     @Test
@@ -133,22 +107,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when user clicks on bbpos manual card reader, then app opens external webview with bbpos link`() {
-        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-            .find {
-                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader)
-            }!!.onItemClicked.invoke()
-
-        assertThat(viewModel.event.value)
-            .isEqualTo(
-                CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow(
-                    AppUrls.BBPOS_MANUAL_CARD_READER
-                )
-            )
-    }
-
-    @Test
-    @Ignore("Row with M2 reader is temporarily hidden")
     fun `when user clicks on m2 manual card reader, then app opens external webview with m2 link`() {
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
             .find {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -50,6 +50,14 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when screen shown, then bbpos manual card reader row present`() {
+        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
+            .anyMatch {
+                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader)
+            }
+    }
+
+    @Test
     fun `when screen shown, then manual card reader row icon is present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
@@ -67,9 +75,24 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when screen shown, then m2 manual card reader row present at third position`() {
+    fun `when screen shown, then bbpos chipper manual card reader row present`() {
+        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
+            .anyMatch {
+                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader) &&
+                    it.icon == R.drawable.ic_card_reader_manual
+            }
+    }
+
+    @Test
+    fun `when screen shown, then bbpos manual card reader row present on third position`() {
         val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-        assertThat(rows[2].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader))
+        assertThat(rows[2].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader))
+    }
+
+    @Test
+    fun `when screen shown, then m2 manual card reader row present at fourth last`() {
+        val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
+        assertThat(rows[3].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader))
     }
 
     @Test
@@ -104,6 +127,21 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         assertThat(
             (viewModel.event.value as CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow).url
         ).isEqualTo(AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER)
+    }
+
+    @Test
+    fun `when user clicks on bbpos manual card reader, then app opens external webview with bbpos link`() {
+        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
+            .find {
+                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader)
+            }!!.onItemClicked.invoke()
+
+        assertThat(viewModel.event.value)
+            .isEqualTo(
+                CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow(
+                    AppUrls.BBPOS_MANUAL_CARD_READER
+                )
+            )
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5619 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Update the purchase URL and the link to the user guide, to point to those corresponding to the Stripe M2 reader.

For context see pdfdoF-kx-p2

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Log in to an eligible store, navigate to Settings > In-Person Payments.

1. Tap Order Card Reader. The app should present a web view, that will navigate to a 404 error, as the actual purchase URL has not been published yet.
2. Tap Card Reader Manual. The app should present a web view with the Stripe M2 user guide. 

**Note:** Regarding step 2. On Android 12, the device may prompt to download the manual rather than displaying the manual in the web view as soon as you tap "Stripe M2 card reader manual". 


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
