### PR TITLE
Bump About Screen Library Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ ext {
     wordPressUtilsVersion = "2.3.0"
     mediapickerVersion = 'trunk-00947a9086ecdf2192b0bdc95a22e1647696d0b1'
     wordPressLoginVersion = '0.10.0'
-    aboutAutomatticVersion = '0.0.3'
+    aboutAutomatticVersion = '0.0.4'
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
### Description
This PR updates Automattic About library to version 0.0.4 which contains a fix for "cut off Tumblr logo".

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. The library was tested before the PR in the library was merged, so just opening the about screen as a smoke test should be enough. If you want to make sure the issue is fixed use a Samsung device like s10e or z-flip if you have one, otherwise create an emulator with an image like 6.7 Horizontal Fold-in from AVD Manager in AS.
2. Tap on App settings
3. Tap on "WooCommerce" row in the "About the app" section 

P.S. [There are some known issues](https://github.com/Automattic/about-automattic-android/pull/32#pullrequestreview-845089734) in landscape and on devices with small screen resolution.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2261188/148923515-4675c13c-3b6f-409a-9602-6e96cb8662ea.png) | ![30-bot-dark](https://user-images.githubusercontent.com/2261188/148923455-0ab20bd3-1d5a-4e87-8b70-4dd118ff7198.png) |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
