### PR TITLE
Issue/5400 update stripe account screens

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -38,7 +38,7 @@ class AppPrefsTest {
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.STRIPE_TERMINAL_GATEWAY
+            pluginType = PluginType.STRIPE_EXTENSION_GATEWAY
         )
 
         assertThat(
@@ -56,7 +56,7 @@ class AppPrefsTest {
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.STRIPE_TERMINAL_GATEWAY
+            pluginType = PluginType.STRIPE_EXTENSION_GATEWAY
         )
 
         assertThat(
@@ -159,7 +159,7 @@ class AppPrefsTest {
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.STRIPE_TERMINAL_GATEWAY
+            pluginType = PluginType.STRIPE_EXTENSION_GATEWAY
         )
 
         assertThat(
@@ -177,7 +177,7 @@ class AppPrefsTest {
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.STRIPE_TERMINAL_GATEWAY
+            pluginType = PluginType.STRIPE_EXTENSION_GATEWAY
         )
 
         assertThat(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -456,7 +456,7 @@ object AppPrefs {
                 PluginType.WOOCOMMERCE_PAYMENTS
             CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION,
             CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION ->
-                PluginType.STRIPE_TERMINAL_GATEWAY
+                PluginType.STRIPE_EXTENSION_GATEWAY
             CARD_READER_ONBOARDING_NOT_COMPLETED ->
                 throw IllegalStateException("Onboarding not completed. Plugin Type is null")
         }
@@ -470,7 +470,7 @@ object AppPrefs {
     ) {
         val pluginName = when (pluginType) {
             PluginType.WOOCOMMERCE_PAYMENTS -> CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY
-            PluginType.STRIPE_TERMINAL_GATEWAY -> CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
+            PluginType.STRIPE_EXTENSION_GATEWAY -> CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
             null -> CARD_READER_ONBOARDING_NOT_COMPLETED
         }
         PreferenceUtils.setString(
@@ -488,7 +488,7 @@ object AppPrefs {
     ) {
         val pluginName = when (pluginType) {
             PluginType.WOOCOMMERCE_PAYMENTS -> CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY
-            PluginType.STRIPE_TERMINAL_GATEWAY -> CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
+            PluginType.STRIPE_EXTENSION_GATEWAY -> CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
             null -> CARD_READER_ONBOARDING_NOT_COMPLETED
         }
         PreferenceUtils.setString(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -7,7 +7,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.StripeExtensionFeatureFlag
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.*
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.STRIPE_TERMINAL_GATEWAY
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
@@ -66,14 +66,14 @@ class CardReaderOnboardingChecker @Inject constructor(
 
         if (!isPluginInstalled(preferredPlugin)) when (preferredPlugin.type) {
             WOOCOMMERCE_PAYMENTS -> return WcpayNotInstalled
-            STRIPE_TERMINAL_GATEWAY -> throw IllegalStateException("Developer error: `preferredPlugin` should be WCPay")
+            STRIPE_EXTENSION_GATEWAY -> throw IllegalStateException("Developer error:`preferredPlugin` should be WCPay")
         }
 
         if (!isPluginVersionSupported(preferredPlugin)) return PluginUnsupportedVersion(preferredPlugin.type)
 
         if (!isPluginActivated(preferredPlugin.info)) when (preferredPlugin.type) {
             WOOCOMMERCE_PAYMENTS -> return WcpayNotActivated
-            STRIPE_TERMINAL_GATEWAY -> throw IllegalStateException("Developer error: `preferredPlugin` should be WCPay")
+            STRIPE_EXTENSION_GATEWAY -> throw IllegalStateException("Developer error:`preferredPlugin` should be WCPay")
         }
 
         val fluxCPluginType = preferredPlugin.type.toInPersonPaymentsPluginType()
@@ -108,7 +108,7 @@ class CardReaderOnboardingChecker @Inject constructor(
             isPluginActivated(stripePluginInfo) &&
             !isPluginActivated(wcPayPluginInfo)
         ) {
-            PluginWrapper(STRIPE_TERMINAL_GATEWAY, stripePluginInfo)
+            PluginWrapper(STRIPE_EXTENSION_GATEWAY, stripePluginInfo)
         } else {
             // Default to WCPay when Stripe Extension is not active
             PluginWrapper(WOOCOMMERCE_PAYMENTS, wcPayPluginInfo)
@@ -188,14 +188,14 @@ class CardReaderOnboardingChecker @Inject constructor(
 
 fun PluginType.toInPersonPaymentsPluginType(): InPersonPaymentsPluginType = when (this) {
     WOOCOMMERCE_PAYMENTS -> InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
-    STRIPE_TERMINAL_GATEWAY -> InPersonPaymentsPluginType.STRIPE
+    STRIPE_EXTENSION_GATEWAY -> InPersonPaymentsPluginType.STRIPE
 }
 
 private data class PluginWrapper(val type: PluginType, val info: WCPluginModel?)
 
 enum class PluginType(val minSupportedVersion: String) {
     WOOCOMMERCE_PAYMENTS(SUPPORTED_WCPAY_VERSION),
-    STRIPE_TERMINAL_GATEWAY(SUPPORTED_STRIPE_EXTENSION_VERSION)
+    STRIPE_EXTENSION_GATEWAY(SUPPORTED_STRIPE_EXTENSION_VERSION)
 }
 
 sealed class CardReaderOnboardingState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -87,8 +87,8 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                 showCountryNotSupportedState(layout, state)
             is CardReaderOnboardingViewModel.OnboardingViewState.WCPayError ->
                 showWCPayErrorState(layout, state)
-            is CardReaderOnboardingViewModel.OnboardingViewState.WCStripeError ->
-                showWCStripeError(layout, state)
+            is CardReaderOnboardingViewModel.OnboardingViewState.StripeAcountError ->
+                showStripeAccountError(layout, state)
             is CardReaderOnboardingViewModel.OnboardingViewState.StripeTerminalError ->
                 showStripeTerminalErrorState(layout, state)
             is CardReaderOnboardingViewModel.OnboardingViewState.WcPayAndStripeInstalledState ->
@@ -143,9 +143,9 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         }
     }
 
-    private fun showWCStripeError(
+    private fun showStripeAccountError(
         view: View,
-        state: CardReaderOnboardingViewModel.OnboardingViewState.WCStripeError
+        state: CardReaderOnboardingViewModel.OnboardingViewState.StripeAcountError
     ) {
         val binding = FragmentCardReaderOnboardingStripeBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -89,8 +89,8 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                 showWCPayErrorState(layout, state)
             is CardReaderOnboardingViewModel.OnboardingViewState.StripeAcountError ->
                 showStripeAccountError(layout, state)
-            is CardReaderOnboardingViewModel.OnboardingViewState.StripeTerminalError ->
-                showStripeTerminalErrorState(layout, state)
+            is CardReaderOnboardingViewModel.OnboardingViewState.StripeExtensionError ->
+                showStripeExtensionErrorState(layout, state)
             is CardReaderOnboardingViewModel.OnboardingViewState.WcPayAndStripeInstalledState ->
                 showBothPluginsInstalledState(layout, state)
         }.exhaustive
@@ -186,9 +186,9 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         }
     }
 
-    private fun showStripeTerminalErrorState(
+    private fun showStripeExtensionErrorState(
         view: View,
-        state: CardReaderOnboardingViewModel.OnboardingViewState.StripeTerminalError
+        state: CardReaderOnboardingViewModel.OnboardingViewState.StripeExtensionError
     ) {
         val binding = FragmentCardReaderOnboardingWcpayBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -84,30 +84,30 @@ class CardReaderOnboardingViewModel @Inject constructor(
                             )
                     }
                 CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount ->
-                    viewState.value = OnboardingViewState.WCStripeError.WCPayInTestModeWithLiveAccountState(
+                    viewState.value = OnboardingViewState.StripeAcountError.WCPayInTestModeWithLiveAccountState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
                     )
                 CardReaderOnboardingState.StripeAccountUnderReview ->
-                    viewState.value = OnboardingViewState.WCStripeError.WCPayAccountUnderReviewState(
+                    viewState.value = OnboardingViewState.StripeAcountError.StripeAccountUnderReviewState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
                     )
                 is CardReaderOnboardingState.StripeAccountPendingRequirement ->
-                    viewState.value = OnboardingViewState.WCStripeError
-                        .WCPayAccountPendingRequirementsState(
+                    viewState.value = OnboardingViewState.StripeAcountError
+                        .StripeAccountPendingRequirementsState(
                             onContactSupportActionClicked = ::onContactSupportClicked,
                             onLearnMoreActionClicked = ::onLearnMoreClicked,
                             onButtonActionClicked = ::onSkipPendingRequirementsClicked,
                             dueDate = formatDueDate(state)
                         )
                 CardReaderOnboardingState.StripeAccountOverdueRequirement ->
-                    viewState.value = OnboardingViewState.WCStripeError.WCPayAccountOverdueRequirementsState(
+                    viewState.value = OnboardingViewState.StripeAcountError.StripeAccountOverdueRequirementsState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
                     )
                 CardReaderOnboardingState.StripeAccountRejected ->
-                    viewState.value = OnboardingViewState.WCStripeError.WCPayAccountRejectedState(
+                    viewState.value = OnboardingViewState.StripeAcountError.StripeAccountRejectedState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
                     )
@@ -274,7 +274,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
             )
         }
 
-        sealed class WCStripeError(
+        sealed class StripeAcountError(
             val headerLabel: UiString,
             val hintLabel: UiString,
             val buttonLabel: UiString? = null
@@ -290,26 +290,26 @@ class CardReaderOnboardingViewModel @Inject constructor(
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
 
-            data class WCPayAccountUnderReviewState(
+            data class StripeAccountUnderReviewState(
                 override val onContactSupportActionClicked: () -> Unit,
                 override val onLearnMoreActionClicked: () -> Unit
-            ) : WCStripeError(
+            ) : StripeAcountError(
                 headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_account_under_review_header),
                 hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_account_under_review_hint),
             )
 
-            data class WCPayAccountRejectedState(
+            data class StripeAccountRejectedState(
                 override val onContactSupportActionClicked: () -> Unit,
                 override val onLearnMoreActionClicked: () -> Unit
-            ) : WCStripeError(
+            ) : StripeAcountError(
                 headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_account_rejected_header),
                 hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_account_rejected_hint)
             )
 
-            data class WCPayAccountOverdueRequirementsState(
+            data class StripeAccountOverdueRequirementsState(
                 override val onContactSupportActionClicked: () -> Unit,
                 override val onLearnMoreActionClicked: () -> Unit
-            ) : WCStripeError(
+            ) : StripeAcountError(
                 headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_account_overdue_requirements_header),
                 hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_account_overdue_requirements_hint)
             )
@@ -317,19 +317,19 @@ class CardReaderOnboardingViewModel @Inject constructor(
             data class WCPayInTestModeWithLiveAccountState(
                 override val onContactSupportActionClicked: () -> Unit,
                 override val onLearnMoreActionClicked: () -> Unit
-            ) : WCStripeError(
+            ) : StripeAcountError(
                 headerLabel = UiString
                     .UiStringRes(R.string.card_reader_onboarding_wcpay_in_test_mode_with_live_account_header),
                 hintLabel = UiString
                     .UiStringRes(R.string.card_reader_onboarding_wcpay_in_test_mode_with_live_account_hint)
             )
 
-            data class WCPayAccountPendingRequirementsState(
+            data class StripeAccountPendingRequirementsState(
                 override val onContactSupportActionClicked: () -> Unit,
                 override val onLearnMoreActionClicked: () -> Unit,
                 override val onButtonActionClicked: () -> Unit,
                 val dueDate: String
-            ) : WCStripeError(
+            ) : StripeAcountError(
                 headerLabel = UiString
                     .UiStringRes(R.string.card_reader_onboarding_account_pending_requirements_header),
                 hintLabel = UiString.UiStringRes(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -65,9 +65,9 @@ class CardReaderOnboardingViewModel @Inject constructor(
                                     ::refreshState,
                                     ::onLearnMoreClicked
                                 )
-                        PluginType.STRIPE_TERMINAL_GATEWAY ->
+                        PluginType.STRIPE_EXTENSION_GATEWAY ->
                             viewState.value =
-                                OnboardingViewState.StripeTerminalError.StripeTerminalUnsupportedVersionState(
+                                OnboardingViewState.StripeExtensionError.StripeExtensionUnsupportedVersionState(
                                     ::refreshState, ::onLearnMoreClicked
                                 )
                     }
@@ -78,8 +78,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     viewState.value = when (state.pluginType) {
                         PluginType.WOOCOMMERCE_PAYMENTS ->
                             OnboardingViewState.WCPayError.WCPayNotSetupState(::refreshState, ::onLearnMoreClicked)
-                        PluginType.STRIPE_TERMINAL_GATEWAY ->
-                            OnboardingViewState.StripeTerminalError.StripeTerminalNotSetupState(
+                        PluginType.STRIPE_EXTENSION_GATEWAY ->
+                            OnboardingViewState.StripeExtensionError.StripeExtensionNotSetupState(
                                 ::refreshState, ::onLearnMoreClicked
                             )
                     }
@@ -167,7 +167,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
     private fun getPluginNameForAnalyticsFrom(pluginType: PluginType): String {
         return when (pluginType) {
             PluginType.WOOCOMMERCE_PAYMENTS -> "wcpay"
-            PluginType.STRIPE_TERMINAL_GATEWAY -> "stripe_extension"
+            PluginType.STRIPE_EXTENSION_GATEWAY -> "stripe_extension"
         }
     }
 
@@ -397,7 +397,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
             )
         }
 
-        sealed class StripeTerminalError(
+        sealed class StripeExtensionError(
             val headerLabel: UiString,
             val hintLabel: UiString,
             val learnMoreLabel: UiString,
@@ -409,10 +409,10 @@ class CardReaderOnboardingViewModel @Inject constructor(
             @DrawableRes
             val illustration = R.drawable.img_stripe_extension
 
-            data class StripeTerminalNotSetupState(
+            data class StripeExtensionNotSetupState(
                 override val refreshButtonAction: () -> Unit,
                 override val onLearnMoreActionClicked: (() -> Unit)
-            ) : StripeTerminalError(
+            ) : StripeExtensionError(
                 headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_stripe_extension_not_setup_header),
                 hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_stripe_extension_not_setup_hint),
                 learnMoreLabel = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
@@ -420,10 +420,10 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     .UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_refresh_button)
             )
 
-            data class StripeTerminalUnsupportedVersionState(
+            data class StripeExtensionUnsupportedVersionState(
                 override val refreshButtonAction: () -> Unit,
                 override val onLearnMoreActionClicked: (() -> Unit)
-            ) : StripeTerminalError(
+            ) : StripeExtensionError(
                 headerLabel = UiString.UiStringRes(
                     R.string.card_reader_onboarding_stripe_extension_unsupported_version_header
                 ),

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1047,14 +1047,14 @@
     <string name="card_reader_onboarding_stripe_extension_unsupported_version_refresh_button">Refresh after updating</string>
 
 
-    <string name="card_reader_onboarding_account_rejected_header">In-Person Payments isn\’t available for this store</string>
+    <string name="card_reader_onboarding_account_rejected_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_account_rejected_hint">We are sorry but we can\’t support In-Person Payments for this store.</string>
 
     <string name="card_reader_onboarding_account_under_review_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_account_under_review_hint">You\’ll be able to accept In-Person Payments as soon as we finish reviewing your account.</string>
 
     <string name="card_reader_onboarding_account_overdue_requirements_header">In-Person Payments is currently unavailable</string>
-    <string name="card_reader_onboarding_account_overdue_requirements_hint">You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments</string>
+    <string name="card_reader_onboarding_account_overdue_requirements_hint">You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments.</string>
 
     <string name="card_reader_onboarding_account_pending_requirements_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_account_pending_requirements_hint">There are pending requirements in your account. Please complete those requirements by %1$s to keep accepting In-Person Payments.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1056,7 +1056,7 @@
     <string name="card_reader_onboarding_account_overdue_requirements_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_account_overdue_requirements_hint">You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments</string>
 
-    <string name="card_reader_onboarding_account_pending_requirements_header">Your WooCommerce Payments account has pending requirements</string>
+    <string name="card_reader_onboarding_account_pending_requirements_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_account_pending_requirements_hint">There are pending requirements in your account. Please complete those requirements by %1$s to keep accepting In-Person Payments.</string>
     <string name="card_reader_onboarding_account_pending_requirements_dismiss_button" translatable="false">@string/dismiss</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -184,7 +184,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(null)
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(false)
@@ -216,7 +216,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(null)
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -225,32 +225,32 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             assertThat(result).isEqualTo(
                 CardReaderOnboardingState.OnboardingCompleted(
-                    PluginType.STRIPE_TERMINAL_GATEWAY
+                    PluginType.STRIPE_EXTENSION_GATEWAY
                 )
             )
         }
 
     @Test
-    fun `when stripe terminal plugin outdated, then UNSUPPORTED_VERSION returned`() =
+    fun `when stripe extension plugin outdated, then UNSUPPORTED_VERSION returned`() =
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(version = "2.8.1"))
+                .thenReturn(buildStripeExtensionPluginInfo(version = "2.8.1"))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS)).thenReturn(null)
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
 
             val result = checker.getOnboardingState()
 
             assertThat(result).isEqualTo(
-                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_TERMINAL_GATEWAY)
+                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_EXTENSION_GATEWAY)
             )
         }
 
     @Test
-    fun `given stripe terminal plugin, when stripe account not connected, then SETUP_NOT_COMPLETED returned`() =
+    fun `given stripe extension plugin, when stripe account not connected, then SETUP_NOT_COMPLETED returned`() =
         testBlocking {
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS)).thenReturn(null)
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
             whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
@@ -263,7 +263,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             assertThat(result).isEqualTo(
                 CardReaderOnboardingState.SetupNotCompleted(
-                    PluginType.STRIPE_TERMINAL_GATEWAY
+                    PluginType.STRIPE_EXTENSION_GATEWAY
                 )
             )
         }
@@ -273,7 +273,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = false))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = false))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(buildWCPayPluginInfo(isActive = true))
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -288,7 +288,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = false))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = false))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(buildWCPayPluginInfo(isActive = true))
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -303,7 +303,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = false))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = false))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(buildWCPayPluginInfo(isActive = false))
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -318,7 +318,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(buildWCPayPluginInfo(isActive = false))
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -333,7 +333,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(buildWCPayPluginInfo(isActive = false))
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -342,7 +342,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             assertThat(result).isEqualTo(
                 CardReaderOnboardingState.OnboardingCompleted(
-                    PluginType.STRIPE_TERMINAL_GATEWAY
+                    PluginType.STRIPE_EXTENSION_GATEWAY
                 )
             )
         }
@@ -352,7 +352,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(buildWCPayPluginInfo(isActive = true))
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -663,7 +663,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
             .thenReturn(null)
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
 
         checker.getOnboardingState()
@@ -672,7 +672,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.STRIPE_TERMINAL_GATEWAY)
+            eq(PluginType.STRIPE_EXTENSION_GATEWAY)
         )
     }
 
@@ -682,7 +682,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
             .thenReturn(null)
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
         whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
             buildPaymentAccountResult(
                 hasPendingRequirements = true,
@@ -697,7 +697,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.STRIPE_TERMINAL_GATEWAY)
+            eq(PluginType.STRIPE_EXTENSION_GATEWAY)
         )
     }
 
@@ -740,7 +740,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `given stripe ext active, when verifying state, then stripe ext account endpoint used`() = testBlocking {
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
             .thenReturn(null)
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -767,7 +767,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     fun `when onboarding completed using stripe, then onboarding completed plugin type saved`() = testBlocking {
         whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeTerminalPluginInfo(isActive = true))
+            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
             .thenReturn(null)
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
@@ -778,7 +778,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.STRIPE_TERMINAL_GATEWAY)
+            eq(PluginType.STRIPE_EXTENSION_GATEWAY)
         )
     }
 
@@ -826,7 +826,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         version: String = SUPPORTED_WCPAY_VERSION
     ) = WCPluginSqlUtils.WCPluginModel(1, 1, isActive, "", "", version)
 
-    private fun buildStripeTerminalPluginInfo(
+    private fun buildStripeExtensionPluginInfo(
         isActive: Boolean = true,
         version: String = SUPPORTED_STRIPE_EXTENSION_VERSION
     ) = WCPluginSqlUtils.WCPluginModel(1, 1, isActive, "", "", version)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardi
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.StripeTerminalError
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.UnsupportedCountryState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.WCPayError
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.WCStripeError
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.StripeAcountError
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -220,7 +220,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                WCStripeError.WCPayInTestModeWithLiveAccountState::class.java
+                StripeAcountError.WCPayInTestModeWithLiveAccountState::class.java
             )
         }
 
@@ -298,7 +298,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             val viewModel = createVM()
 
-            assertThat(viewModel.viewStateData.value).isInstanceOf(WCStripeError.WCPayAccountRejectedState::class.java)
+            assertThat(viewModel.viewStateData.value).isInstanceOf(StripeAcountError.StripeAccountRejectedState::class.java)
         }
 
     @Test
@@ -315,7 +315,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                WCStripeError.WCPayAccountPendingRequirementsState::class.java
+                StripeAcountError.StripeAccountPendingRequirementsState::class.java
             )
         }
 
@@ -332,7 +332,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             val viewModel = createVM()
 
-            assertThat((viewModel.viewStateData.value as WCStripeError.WCPayAccountPendingRequirementsState).dueDate)
+            assertThat((viewModel.viewStateData.value as StripeAcountError.StripeAccountPendingRequirementsState).dueDate)
                 .isNotEmpty()
         }
 
@@ -345,7 +345,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                WCStripeError.WCPayAccountOverdueRequirementsState::class.java
+                StripeAcountError.StripeAccountOverdueRequirementsState::class.java
             )
         }
 
@@ -358,7 +358,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                WCStripeError.WCPayAccountUnderReviewState::class.java
+                StripeAcountError.StripeAccountUnderReviewState::class.java
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -10,7 +10,7 @@ import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardi
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.GenericErrorState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.LoadingState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.NoConnectionErrorState
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.StripeTerminalError
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.StripeExtensionError
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.UnsupportedCountryState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.WCPayError
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.StripeAcountError
@@ -163,28 +163,28 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when stripe terminal not setup, then stripe terminal not setup state shown`() =
+    fun `when stripe extension not setup, then stripe extension not setup state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.SetupNotCompleted(PluginType.STRIPE_TERMINAL_GATEWAY))
+                .thenReturn(CardReaderOnboardingState.SetupNotCompleted(PluginType.STRIPE_EXTENSION_GATEWAY))
 
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                StripeTerminalError.StripeTerminalNotSetupState::class.java
+                StripeExtensionError.StripeExtensionNotSetupState::class.java
             )
         }
 
     @Test
-    fun `when stripe terminal not setup, then correct labels and illustrations shown`() =
+    fun `when stripe extension not setup, then correct labels and illustrations shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.SetupNotCompleted(PluginType.STRIPE_TERMINAL_GATEWAY))
+                .thenReturn(CardReaderOnboardingState.SetupNotCompleted(PluginType.STRIPE_EXTENSION_GATEWAY))
 
             val viewModel = createVM()
 
             val state = (
-                viewModel.viewStateData.value as StripeTerminalError.StripeTerminalNotSetupState
+                viewModel.viewStateData.value as StripeExtensionError.StripeExtensionNotSetupState
                 )
             assertThat(state.headerLabel)
                 .describedAs("Check header")
@@ -225,30 +225,30 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when unsupported stripe terminal installed, then unsupported stripe terminal state shown`() =
+    fun `when unsupported stripe extension installed, then unsupported stripe extension state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_TERMINAL_GATEWAY)
+                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_EXTENSION_GATEWAY)
             )
 
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                StripeTerminalError.StripeTerminalUnsupportedVersionState::class.java
+                StripeExtensionError.StripeExtensionUnsupportedVersionState::class.java
             )
         }
 
     @Test
-    fun `when stripe terminal outdated, then correct labels and illustrations shown`() =
+    fun `when stripe extension outdated, then correct labels and illustrations shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_TERMINAL_GATEWAY)
+                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_EXTENSION_GATEWAY)
             )
 
             val viewModel = createVM()
 
             val state = (
-                viewModel.viewStateData.value as StripeTerminalError.StripeTerminalUnsupportedVersionState
+                viewModel.viewStateData.value as StripeExtensionError.StripeExtensionUnsupportedVersionState
                 )
             assertThat(state.headerLabel)
                 .describedAs("Check header")
@@ -277,7 +277,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when wcpay and stripe terminal installed-activated, then wcpay and stripe terminal activated state shown`() =
+    fun `when wcpay and stripe extension installed-activated, then wcpay and stripe extension activated state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated
@@ -298,7 +298,8 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             val viewModel = createVM()
 
-            assertThat(viewModel.viewStateData.value).isInstanceOf(StripeAcountError.StripeAccountRejectedState::class.java)
+            assertThat(viewModel.viewStateData.value)
+                .isInstanceOf(StripeAcountError.StripeAccountRejectedState::class.java)
         }
 
     @Test
@@ -332,8 +333,9 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             val viewModel = createVM()
 
-            assertThat((viewModel.viewStateData.value as StripeAcountError.StripeAccountPendingRequirementsState).dueDate)
-                .isNotEmpty()
+            assertThat(
+                (viewModel.viewStateData.value as StripeAcountError.StripeAccountPendingRequirementsState).dueDate
+            ).isNotEmpty()
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5400
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR
- Removes explicit mentions of WCPay from Stripe Account error states -> they are re-used for both WCPay and Stripe Extension
- Rename "Stripe Terminal" to "Stripe Extension" for consistency
- Consolidates Stipe Account error string resources

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- All changes except of the changes in strings.xml were done using AS - I'd consider carefully reviewing strings.xml and skip testing this PR.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
