### PR TITLE
Update IPP pending requirements screen

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1056,7 +1056,7 @@
     <string name="card_reader_onboarding_account_overdue_requirements_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_account_overdue_requirements_hint">You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments.</string>
 
-    <string name="card_reader_onboarding_account_pending_requirements_header">In-Person Payments is currently unavailable</string>
+    <string name="card_reader_onboarding_account_pending_requirements_header">Your account has pending requirements</string>
     <string name="card_reader_onboarding_account_pending_requirements_hint">There are pending requirements in your account. Please complete those requirements by %1$s to keep accepting In-Person Payments.</string>
     <string name="card_reader_onboarding_account_pending_requirements_dismiss_button" translatable="false">@string/dismiss</string>
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates header on the IPP `pending requirements` screen. I changed the title from `Your WooCommerce Payments account has pending requirements` to `In-Person Payments is currently unavailable` in https://github.com/woocommerce/woocommerce-android/pull/5622 to make it re-usable for both WCPay and the Stripe Extension. However, I realized today, that the screen contains a `skip` button so the `In-Person Payments is currently unavailable` title is misleading. This PR updates the text to `Your account has pending requirements`. Sorry for the troubles @AnirudhBhat, I should have realized that when [you commented on the previous PR](https://github.com/woocommerce/woocommerce-android/pull/5622#discussion_r782905737).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
No need to test anything.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
