### PR TITLE
Fix Compose's compatibility with AGP 4.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
       parameters:
         jvmargs:
           type: string
-          default: "Xmx1536m"
+          default: "Xmx2g"
       steps:
         - run:
             name: Update memory setting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
       - android/restore-gradle-cache:
           cache-prefix: tests-cache-v1
       - copy-gradle-properties
+      - update-gradle-memory
       - run:
           # The instrumentation tests are not currently used and do tend to get
           # out of date when the UI changes, failing to build.

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -104,7 +104,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.0.5'
+        kotlinCompilerExtensionVersion composeVersion
     }
 
     flavorDimensions "buildType"
@@ -323,11 +323,11 @@ dependencies {
 
     // Jetpack Compose
     implementation 'androidx.activity:activity-compose:1.4.0'
-    implementation 'androidx.compose.material:material:1.0.5'
-    implementation 'androidx.compose.animation:animation:1.0.5'
-    implementation 'androidx.compose.ui:ui-tooling:1.0.5'
+    implementation "androidx.compose.material:material:$composeVersion"
+    implementation "androidx.compose.animation:animation:$composeVersion"
+    implementation "androidx.compose.ui:ui-tooling:$composeVersion"
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.4.0'
-    implementation "com.google.android.material:compose-theme-adapter:1.1.1"
+    implementation "com.google.android.material:compose-theme-adapter:$composeVersion"
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.0.5'
 }
 

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -105,6 +105,7 @@ android {
 
     composeOptions {
         kotlinCompilerExtensionVersion composeVersion
+        kotlinCompilerVersion gradle.ext.kotlinVersion
     }
 
     flavorDimensions "buildType"

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ ext {
     wordPressUtilsVersion = "2.3.0"
     mediapickerVersion = 'trunk-00947a9086ecdf2192b0bdc95a22e1647696d0b1'
     wordPressLoginVersion = '0.10.0'
-    composeVersion = "1.0.1"
+    composeVersion = "1.0.5"
 }
 
 // Onboarding and dev env setup tasks

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ ext {
     wordPressUtilsVersion = "2.3.0"
     mediapickerVersion = 'trunk-00947a9086ecdf2192b0bdc95a22e1647696d0b1'
     wordPressLoginVersion = '0.10.0'
+    composeVersion = "1.0.1"
 }
 
 // Onboarding and dev env setup tasks

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.agpVersion = '7.0.3'
+    gradle.ext.agpVersion = '4.2.2'
     gradle.ext.daggerVersion = '2.40.5'
     gradle.ext.detektVersion = '1.18.1'
     gradle.ext.kotlinVersion = '1.5.31'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
This PR just downgrades AGP to 4.2.2 to avoid breaking the composite builds, and fixes the compatibility that was breaking the build previously.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
