### PR TITLE
Home screen: Add functionalities to More menu items and hide unneeded ones

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -7,8 +7,10 @@ import android.view.ViewGroup
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentMoreMenuBinding
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -51,7 +53,11 @@ class MoreMenuFragment : TopLevelFragment(R.layout.fragment_more_menu) {
             // MenuButton(R.string.more_menu_button_analytics, R.drawable.ic_more_menu_analytics),
             // MenuButton(R.string.more_menu_button_payments, R.drawable.ic_more_menu_payments),
             // MenuButton(R.string.more_menu_button_inbox, R.drawable.ic_more_menu_inbox),
-            MenuButton(R.string.more_menu_button_reviews, R.drawable.ic_more_menu_reviews)
+            MenuButton(R.string.more_menu_button_reviews, R.drawable.ic_more_menu_reviews) {
+                findNavController().navigateSafely(
+                    MoreMenuFragmentDirections.actionMoreMenuToReviewList()
+                )
+            }
         )
 
         binding.menu.apply {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -9,10 +9,17 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentMoreMenuBinding
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 @ExperimentalFoundationApi
 class MoreMenuFragment : TopLevelFragment(R.layout.fragment_more_menu) {
+    @Inject lateinit var selectedSite: SelectedSite
+
     override fun getFragmentTitle() = getString(R.string.more_menu)
 
     override fun shouldExpandToolbar(): Boolean = false
@@ -31,10 +38,16 @@ class MoreMenuFragment : TopLevelFragment(R.layout.fragment_more_menu) {
     ): View {
         _binding = FragmentMoreMenuBinding.inflate(inflater, container, false)
         val view = binding.root
+        val wpAdminUrl = selectedSite.get().adminUrl
+        val storeUrl = selectedSite.get().url
 
         val buttons = listOf(
-            MenuButton(R.string.more_menu_button_woo_admin, R.drawable.ic_more_menu_wp_admin),
-            MenuButton(R.string.more_menu_button_store, R.drawable.ic_more_menu_store),
+            MenuButton(R.string.more_menu_button_woo_admin, R.drawable.ic_more_menu_wp_admin) {
+                ChromeCustomTabUtils.launchUrl(requireContext(), wpAdminUrl)
+            },
+            MenuButton(R.string.more_menu_button_store, R.drawable.ic_more_menu_store) {
+                ChromeCustomTabUtils.launchUrl(requireContext(), storeUrl)
+            },
             // MenuButton(R.string.more_menu_button_analytics, R.drawable.ic_more_menu_analytics),
             // MenuButton(R.string.more_menu_button_payments, R.drawable.ic_more_menu_payments),
             // MenuButton(R.string.more_menu_button_inbox, R.drawable.ic_more_menu_inbox),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -35,9 +35,9 @@ class MoreMenuFragment : TopLevelFragment(R.layout.fragment_more_menu) {
         val buttons = listOf(
             MenuButton(R.string.more_menu_button_woo_admin, R.drawable.ic_more_menu_wp_admin),
             MenuButton(R.string.more_menu_button_store, R.drawable.ic_more_menu_store),
-            MenuButton(R.string.more_menu_button_analytics, R.drawable.ic_more_menu_analytics),
-            MenuButton(R.string.more_menu_button_payments, R.drawable.ic_more_menu_payments),
-            MenuButton(R.string.more_menu_button_inbox, R.drawable.ic_more_menu_inbox),
+            // MenuButton(R.string.more_menu_button_analytics, R.drawable.ic_more_menu_analytics),
+            // MenuButton(R.string.more_menu_button_payments, R.drawable.ic_more_menu_payments),
+            // MenuButton(R.string.more_menu_button_inbox, R.drawable.ic_more_menu_inbox),
             MenuButton(R.string.more_menu_button_reviews, R.drawable.ic_more_menu_reviews)
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -26,7 +26,7 @@ import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.reviews.ProductReviewStatus.SPAM
@@ -46,7 +46,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class ReviewListFragment :
-    TopLevelFragment(R.layout.fragment_reviews_list),
+    BaseFragment(R.layout.fragment_reviews_list),
     ItemDecorationListener,
     ReviewListAdapter.OnReviewClickListener {
     companion object {
@@ -362,10 +362,6 @@ class ReviewListFragment :
 
     override fun getFragmentTitle() = getString(R.string.review_notifications)
 
-    override fun scrollToTop() {
-        binding.reviewsList.smoothScrollToPosition(0)
-    }
-
     override fun getItemTypeAtPosition(position: Int) = reviewsAdapter.getItemTypeAtRecyclerPosition(position)
 
     override fun onReviewClick(review: ProductReview, sharedView: View?) {
@@ -388,6 +384,4 @@ class ReviewListFragment :
             }
         }
     }
-
-    override fun shouldExpandToolbar() = binding.reviewsList.computeVerticalScrollOffset() == 0
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -174,7 +174,11 @@
         android:id="@+id/more_menu"
         android:name="com.woocommerce.android.ui.moremenu.MoreMenuFragment"
         android:label="fragment_more_menu"
-        tools:layout="@layout/fragment_more_menu" />
+        tools:layout="@layout/fragment_more_menu" >
+        <action
+            android:id="@+id/action_moreMenu_to_reviewList"
+            app:destination="@id/reviews" />
+    </fragment>
     <fragment
         android:id="@+id/feedbackSurveyFragment"
         android:name="com.woocommerce.android.ui.feedback.FeedbackSurveyFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5582
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR does a few things:
1. Only show "WooCommerce Admin", "View Store", and "Reviews" menu items in "More" screen (as the other ones are not ready yet),
2. Make each menu item work:
2.1. "WooCommerce Admin" opens Chrome Custom Tab to the site's wp-admin
2.2. "View Store" opens Chrome Custom Tab to the site's front page
2.3. "Reviews" opens the "Reviews" screen
3. Converts ReviewListFragment from `TopLevelFragment` to `BaseFragment`, since it no longer becomes a bottom nav item with the existence of the More screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to More screen
2. Try all three icons and make sure they work properly.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
