### PR TITLE
[2/3] `Location` in `Address`: Order Creation, Details, Editing adjustments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -14,7 +14,8 @@ import javax.inject.Inject
 class OrderCreationRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val orderStore: WCOrderStore,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
+    private val orderMapper: OrderMapper,
 ) {
     suspend fun createOrder(order: Order): Result<Order> {
         val status = withContext(dispatchers.io) {
@@ -41,7 +42,7 @@ class OrderCreationRepository @Inject constructor(
 
         return when {
             result.isError -> Result.failure(WooException(result.error))
-            else -> Result.success(result.model!!.toAppModel())
+            else -> Result.success(orderMapper.toAppModel(result.model!!))
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/LayoutAddressExts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/LayoutAddressExts.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.orders.creation.views
 
+import android.view.View
 import androidx.core.view.isVisible
 import com.woocommerce.android.databinding.LayoutAddressFormBinding
 import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel
 
@@ -31,8 +33,8 @@ val LayoutAddressFormBinding?.textFieldsState
         firstName = this?.firstName?.text.orEmpty(),
         lastName = this?.lastName?.text.orEmpty(),
         phone = this?.phone?.text.orEmpty(),
-        country = "",
-        state = this?.stateEditText?.text.orEmpty(),
+        country = Location.EMPTY,
+        state = AmbiguousLocation.EMPTY,
         address1 = this?.address1?.text.orEmpty(),
         address2 = this?.address2?.text.orEmpty(),
         city = this?.city?.text.orEmpty(),
@@ -41,24 +43,35 @@ val LayoutAddressFormBinding?.textFieldsState
     )
 
 fun LayoutAddressFormBinding?.inflateTextFields(address: Address) {
+    this?.city?.text = address.city
     this?.company?.text = address.company
     this?.firstName?.text = address.firstName
     this?.lastName?.text = address.lastName
     this?.phone?.text = address.phone
-    this?.stateEditText?.text = address.state
     this?.address1?.text = address.address1
     this?.address2?.text = address.address2
     this?.postcode?.text = address.postcode
     this?.email?.text = address.email
 }
 
-fun LayoutAddressFormBinding?.inflateLocationFields(countryLocation: Location, stateLocation: Location) {
+fun LayoutAddressFormBinding?.inflateLocationFields(countryLocation: Location, stateLocation: AmbiguousLocation) {
     this?.countrySpinner?.setText(countryLocation.name)
-    this?.stateSpinner?.setText(stateLocation.name)
+    when (stateLocation) {
+        is AmbiguousLocation.Defined -> {
+            this?.stateSpinner?.visibility = View.VISIBLE
+            this?.stateEditText?.visibility = View.GONE
+            this?.stateSpinner?.setText(stateLocation.value.name)
+        }
+        is AmbiguousLocation.Raw -> {
+            this?.stateSpinner?.visibility = View.GONE
+            this?.stateEditText?.visibility = View.VISIBLE
+            this?.stateEditText?.text = stateLocation.value
+        }
+    }
 }
 
 fun LayoutAddressFormBinding?.update(state: AddressViewModel.AddressSelectionState) {
-    this?.inflateTextFields(state.inputFormValues)
-    this?.inflateLocationFields(countryLocation = state.countryLocation, stateLocation = state.stateLocation)
+    this?.inflateTextFields(state.address)
+    this?.inflateLocationFields(countryLocation = state.address.country, stateLocation = state.address.state)
     this?.updateLocationStateViews(state.stateSpinnerStatus)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -174,7 +174,9 @@ class OrderDetailRepository @Inject constructor(
     }
 
     suspend fun getOrderById(orderId: Long) = withContext(dispatchers.io) {
-        orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.toAppModel()
+        orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.let {
+            orderMapper.toAppModel(it)
+        }
     }
 
     fun getOrderStatus(key: String): OrderStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -91,14 +91,14 @@ abstract class BaseAddressEditingFragment :
             addressViewModel.onStateSpinnerClicked(addressType)
         }
 
+        addressViewModel.start(
+            mapOf(addressType to storedAddress)
+        )
+
         setupObservers()
         setupResultHandlers()
         onViewBound(binding)
         updateStateViews()
-
-        addressViewModel.start(
-            mapOf(addressType to storedAddress)
-        )
     }
 
     override fun hasChanges() =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.UiDimen
+import com.woocommerce.android.ui.orders.creation.views.update
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.details.editing.BaseOrderEditingFragment
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
@@ -43,8 +44,11 @@ abstract class BaseAddressEditingFragment :
 
     protected lateinit var replicateAddressSwitch: SwitchMaterial
 
+    @Deprecated("Rely on state from ViewModel rather than binding")
     val addressDraft
         get() = binding.form.run {
+            val addressState =
+                addressViewModel.viewStateData.liveData.value!!.countryStatePairs.getValue(addressType).address
             Address(
                 firstName = firstName.text,
                 lastName = lastName.text,
@@ -55,12 +59,8 @@ abstract class BaseAddressEditingFragment :
                 address2 = address2.text,
                 city = city.text,
                 postcode = postcode.text,
-                country = addressViewModel.selectedCountryLocationFor(addressType).code,
-                state = if (shouldShowStateSpinner()) {
-                    addressViewModel.selectedStateLocationFor(addressType).code
-                } else {
-                    stateEditText.text
-                }
+                country = addressState.country,
+                state = addressState.state
             )
         }
 
@@ -77,13 +77,11 @@ abstract class BaseAddressEditingFragment :
             )
         }
 
-        storedAddress.bindToView()
+        replicateAddressSwitch.setOnCheckedChangeListener { _, isChecked ->
+            sharedViewModel.onReplicateAddressSwitchChanged(isChecked)
+            updateDoneMenuItem()
+        }
         bindTextWatchers()
-
-        addressViewModel.start(
-            countryCode = storedAddress.country,
-            stateCode = storedAddress.state
-        )
 
         binding.form.countrySpinner.setClickListener {
             addressViewModel.onCountrySpinnerClicked(addressType)
@@ -97,6 +95,10 @@ abstract class BaseAddressEditingFragment :
         setupResultHandlers()
         onViewBound(binding)
         updateStateViews()
+
+        addressViewModel.start(
+            mapOf(addressType to storedAddress)
+        )
     }
 
     override fun hasChanges() =
@@ -113,25 +115,6 @@ abstract class BaseAddressEditingFragment :
     override fun onDetach() {
         addressViewModel.onScreenDetached()
         super.onDetach()
-    }
-
-    private fun Address.bindToView() {
-        binding.form.firstName.text = firstName
-        binding.form.lastName.text = lastName
-        binding.form.email.text = email
-        binding.form.phone.text = phone
-        binding.form.company.text = company
-        binding.form.address1.text = address1
-        binding.form.address2.text = address2
-        binding.form.city.text = city
-        binding.form.postcode.text = postcode
-        binding.form.countrySpinner.setText(getCountryLabelByCountryCode())
-        binding.form.stateSpinner.setText(addressViewModel.selectedStateLocationFor(addressType).name)
-        binding.form.stateEditText.text = state
-        replicateAddressSwitch.setOnCheckedChangeListener { _, isChecked ->
-            sharedViewModel.onReplicateAddressSwitchChanged(isChecked)
-            updateDoneMenuItem()
-        }
     }
 
     private fun bindTextWatchers() {
@@ -153,6 +136,7 @@ abstract class BaseAddressEditingFragment :
      * When the country is empty, or we don't have country or state data, we show an editText
      * for the state rather than a spinner
      */
+    // Remove?
     private fun updateStateViews() {
         binding.form.stateSpinner.isVisible = shouldShowStateSpinner()
         binding.form.stateEditText.isVisible = !shouldShowStateSpinner()
@@ -190,28 +174,15 @@ abstract class BaseAddressEditingFragment :
 
     private fun setupObservers() {
         addressViewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
-            val oldCountryStatePair = old?.countryStatePairs?.get(addressType)
             val newCountryStatePair = new.countryStatePairs.getValue(addressType)
 
-            newCountryStatePair.countryLocation.takeIfNotEqualTo(oldCountryStatePair?.countryLocation) {
-                binding.form.countrySpinner.setText(it.name)
-                updateDoneMenuItem()
-                updateStateViews()
-            }
-            newCountryStatePair.stateLocation.takeIfNotEqualTo(oldCountryStatePair?.stateLocation) {
-                binding.form.stateSpinner.setText(it.name)
-                binding.form.stateEditText.text = it.code
-                updateDoneMenuItem()
-            }
             new.isLoading.takeIfNotEqualTo(old?.isLoading) {
                 binding.progressBar.isVisible = it
                 if (old?.isLoading == true) {
                     updateStateViews()
                 }
             }
-            new.isStateSelectionEnabled.takeIfNotEqualTo(old?.isStateSelectionEnabled) {
-                binding.form.stateSpinner.isEnabled = it
-            }
+            binding.form.update(newCountryStatePair)
         }
 
         addressViewModel.event.observe(viewLifecycleOwner) { event ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -28,7 +29,8 @@ class SimplePaymentsDialogViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val selectedSite: SelectedSite,
     private val orderStore: WCOrderStore,
-    private val networkStatus: NetworkStatus
+    private val networkStatus: NetworkStatus,
+    private val orderMapper: OrderMapper
 ) : ScopedViewModel(savedState) {
     final val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
     internal var viewState by viewStateLiveData
@@ -74,7 +76,7 @@ class SimplePaymentsDialogViewModel @Inject constructor(
                         AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_COMPLETED,
                         mapOf(AnalyticsTracker.KEY_AMOUNT to viewState.currentPrice.toString())
                     )
-                    viewState = viewState.copy(createdOrder = result.order!!.toAppModel())
+                    viewState = viewState.copy(createdOrder = orderMapper.toAppModel(result.order!!))
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -11,12 +11,7 @@ import com.woocommerce.android.extensions.calculateTotals
 import com.woocommerce.android.extensions.isCashPayment
 import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.joinToString
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.OrderNote
-import com.woocommerce.android.model.PaymentGateway
-import com.woocommerce.android.model.Refund
-import com.woocommerce.android.model.getMaxRefundQuantities
-import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.model.*
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
@@ -79,7 +74,8 @@ class IssueRefundViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val orderDetailRepository: OrderDetailRepository,
     private val gatewayStore: WCGatewayStore,
-    private val refundStore: WCRefundStore
+    private val refundStore: WCRefundStore,
+    private val orderMapper: OrderMapper,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val DEFAULT_DECIMAL_PRECISION = 2
@@ -165,7 +161,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     private suspend fun loadOrder(orderId: Long): Order =
-        requireNotNull(orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.toAppModel())
+        requireNotNull(orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.let { orderMapper.toAppModel(it) })
 
     private fun updateRefundTotal(amount: BigDecimal) {
         commonState = commonState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.calculateTotals
 import com.woocommerce.android.extensions.isCashPayment
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
@@ -39,7 +40,8 @@ class RefundDetailViewModel @Inject constructor(
     private val currencyFormatter: CurrencyFormatter,
     private val resourceProvider: ResourceProvider,
     private val addonsRepository: AddonRepository,
-    private val refundStore: WCRefundStore
+    private val refundStore: WCRefundStore,
+    private val orderMapper: OrderMapper,
 ) : ScopedViewModel(savedState) {
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
@@ -56,7 +58,7 @@ class RefundDetailViewModel @Inject constructor(
     init {
         launch {
             val orderModel = orderStore.getOrderByIdAndSite(navArgs.orderId, selectedSite.get())
-            orderModel?.toAppModel()?.let { order ->
+            orderModel?.let { orderMapper.toAppModel(it) }?.let { order ->
                 formatCurrency = currencyFormatter.buildBigDecimalFormatter(order.currency)
                 if (navArgs.refundId > 0) {
                     refundStore.getRefund(selectedSite.get(), navArgs.orderId, navArgs.refundId)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -1,27 +1,27 @@
 package com.woocommerce.android.ui.orders
 
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.OrderNote
-import com.woocommerce.android.model.OrderShipmentTracking
-import com.woocommerce.android.model.Refund
-import com.woocommerce.android.model.ShippingLabel
-import com.woocommerce.android.model.toAppModel
-import org.wordpress.android.fluxc.model.LocalOrRemoteId
-import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
-import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
-import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
-import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import com.woocommerce.android.model.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.*
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
+import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.*
+import kotlin.collections.ArrayList
 
 object OrderTestUtils {
     val TEST_LOCAL_SITE_ID = LocalOrRemoteId.LocalId(1)
     val TEST_REMOTE_ORDER_ID = LocalOrRemoteId.RemoteId(2)
     const val TEST_ORDER_STATUS_COUNT = 20
+
+    val mockedGetLocations = mock<GetLocations> {
+        on { invoke(any(), any()) } doReturn (Location.EMPTY to AmbiguousLocation.EMPTY)
+    }
+    val orderMapper = OrderMapper(mockedGetLocations)
 
     /**
      * Generates an array containing multiple [WCOrderModel] objects.
@@ -200,13 +200,13 @@ object OrderTestUtils {
             packageName = "Package"
             serviceName = "Service"
             dateCreated = Date().time
-        }.toAppModel()
+        }.toAppModel(mockedGetLocations)
     }
 
     fun generateShippingLabels(
         totalCount: Int = 5,
         remoteOrderId: Long = 1L,
-        localSiteId: Int = 1
+        localSiteId: Int = 1,
     ): List<ShippingLabel> {
         val result = ArrayList<ShippingLabel>()
         for (i in totalCount downTo 1) {
@@ -218,7 +218,7 @@ object OrderTestUtils {
                     packageName = "Package$i"
                     serviceName = "Service$i"
                     dateCreated = Date().time
-                }.toAppModel()
+                }.toAppModel(mockedGetLocations)
             )
         }
         return result
@@ -271,35 +271,35 @@ object OrderTestUtils {
         return result
     }
 
-    fun generateTestOrder(orderId: Long = 1, localSiteId: Int = 1): Order {
-        return WCOrderModel(
-            id = 1,
-            billingFirstName = "Carissa",
-            billingLastName = "King",
+    fun generateTestOrder(orderId: Long = 1): Order {
+        return Order.EMPTY.copy(
+            id = orderId,
+            billingAddress = Address.EMPTY.copy(
+                firstName = "Carissa",
+                lastName = "King"
+            ),
             currency = "USD",
-            dateCreated = "2018-02-02T16:11:13Z",
-            localSiteId = LocalOrRemoteId.LocalId(localSiteId),
-            remoteOrderId = LocalOrRemoteId.RemoteId(orderId),
+            dateCreated = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z"),
             number = "55",
-            status = "pending",
-            total = "106.00",
-            lineItems = "[{\n" +
-                "    \"id\":1,\n" +
-                "    \"name\":\"A test\",\n" +
-                "    \"product_id\":15,\n" +
-                "    \"quantity\":1,\n" +
-                "    \"tax_class\":\"\",\n" +
-                "    \"subtotal\":\"10.00\",\n" +
-                "    \"subtotal_tax\":\"0.00\",\n" +
-                "    \"total\":\"10.00\",\n" +
-                "    \"total_tax\":\"0.00\",\n" +
-                "    \"taxes\":[],\n" +
-                "    \"meta_data\":[],\n" +
-                "    \"sku\":null,\n" +
-                "    \"price\":10\n" +
-                "  }]",
+            status = Order.Status.Pending,
+            total = BigDecimal("106.00"),
+            items = listOf(
+                Order.Item(
+                    itemId = 1,
+                    productId = 15,
+                    name = "A test",
+                    price = BigDecimal("10"),
+                    sku = "",
+                    quantity = 1f,
+                    subtotal = BigDecimal("10"),
+                    totalTax = BigDecimal.ZERO,
+                    total = BigDecimal("10"),
+                    variationId = 0,
+                    attributesList = emptyList()
+                )
+            ),
             refundTotal = -BigDecimal.TEN,
-        ).toAppModel()
+        )
     }
 
     fun generateOrderWithFee(): WCOrderModel {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
@@ -6,6 +6,8 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.orders.details.editing.address.testCountry
+import com.woocommerce.android.ui.orders.details.editing.address.testState
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -303,8 +305,8 @@ class OrderEditingViewModelTest : BaseUnitTest() {
             firstName = "Joe",
             lastName = "Doe",
             phone = "123456789",
-            country = "United States",
-            state = "California",
+            country = testCountry,
+            state = testState,
             address1 = "Address 1",
             address2 = "",
             city = "San Francisco",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -2,13 +2,14 @@ package com.woocommerce.android.ui.orders.details.editing.address
 
 import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.AmbiguousLocation
+import com.woocommerce.android.model.GetLocations
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel.*
-import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel.AddressType.BILLING
 import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel.AddressType.SHIPPING
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelTestUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -25,30 +26,38 @@ import kotlin.test.assertTrue
 class AddressViewModelTest : BaseUnitTest() {
     private val savedStateHandle: SavedStateHandle = SavedStateHandle()
     private val selectedSite: SelectedSite = mock()
-    private val country = WCLocationModel().apply {
+    private val newCountry = WCLocationModel().apply {
         name = "Brazil"
         code = "BR"
     }
 
-    private val state = WCLocationModel().apply {
+    private val newState = WCLocationModel().apply {
         name = "Acre"
         code = "AC"
         parentCode = "BR"
     }
 
-    private val countryWithoutStates = WCLocationModel().apply {
+    private val newCountryWithoutStates = WCLocationModel().apply {
         name = "Country without states"
         code = "123"
     }
 
     private val dataStore: WCDataStore = mock {
-        on { getCountries() } doReturn listOf(country, countryWithoutStates)
-        on { getStates(country.code) } doReturn listOf(state)
+        on { getCountries() } doReturn listOf(newCountry, newCountryWithoutStates)
+        on { getStates(newCountry.code) } doReturn listOf(newState)
     }
 
-    private val addressViewModel = AddressViewModel(savedStateHandle, selectedSite, dataStore)
+    private val addressViewModel = AddressViewModel(
+        savedStateHandle,
+        selectedSite,
+        dataStore,
+        GetLocations(dataStore)
+    )
     private val viewStateObserver: Observer<ViewState> = mock()
-    private val addressType = SHIPPING
+    private val shippingAddress = CreateShippingLabelTestUtils.generateAddress().copy(
+        country = testCountry,
+        state = testState
+    )
 
     @Before
     fun setup() {
@@ -60,8 +69,7 @@ class AddressViewModelTest : BaseUnitTest() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
         coroutinesTestRule.testDispatcher.runBlockingTest {
             addressViewModel.start(
-                countryCode = "countryCode",
-                stateCode = "stateCode"
+                mapOf(SHIPPING to shippingAddress)
             )
             verify(dataStore).fetchCountriesAndStates(selectedSite.get())
         }
@@ -72,12 +80,10 @@ class AddressViewModelTest : BaseUnitTest() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
         coroutinesTestRule.testDispatcher.runBlockingTest {
             addressViewModel.start(
-                countryCode = "countryCode",
-                stateCode = "stateCode"
+                mapOf(SHIPPING to shippingAddress)
             )
             addressViewModel.start(
-                countryCode = "countryCode",
-                stateCode = "stateCode"
+                mapOf(SHIPPING to shippingAddress)
             )
             verify(dataStore).fetchCountriesAndStates(selectedSite.get())
         }
@@ -88,13 +94,11 @@ class AddressViewModelTest : BaseUnitTest() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
         coroutinesTestRule.testDispatcher.runBlockingTest {
             addressViewModel.start(
-                countryCode = "countryCode",
-                stateCode = "stateCode"
+                mapOf(SHIPPING to shippingAddress)
             )
             addressViewModel.onScreenDetached()
             addressViewModel.start(
-                countryCode = "countryCode",
-                stateCode = "stateCode"
+                mapOf(SHIPPING to shippingAddress)
             )
             verify(dataStore, times(2)).fetchCountriesAndStates(selectedSite.get())
         }
@@ -102,7 +106,6 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should reset view state when onScreenDetached is called`() {
-        addressViewModel.onCountrySelected(addressType, country.code)
         addressViewModel.onScreenDetached()
         // Default view state is first emitted in the test setup (observeForever) and again on onScreenDetached.
         // That's why we're verifying if default view state was emitted 2 times.
@@ -113,8 +116,7 @@ class AddressViewModelTest : BaseUnitTest() {
     fun `Should NOT fetch countries and states on start if countries have already been fetched`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             addressViewModel.start(
-                countryCode = "countryCode",
-                stateCode = "stateCode"
+                mapOf(SHIPPING to shippingAddress)
             )
             verify(dataStore, times(0)).fetchCountriesAndStates(selectedSite.get())
         }
@@ -123,63 +125,55 @@ class AddressViewModelTest : BaseUnitTest() {
     @Test
     fun `Should apply country and state changes to view state safely on start if countries list is empty`() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
-        val countryCode = "countryCode"
-        val stateCode = "stateCode"
-        addressViewModel.start(countryCode, stateCode)
+        addressViewModel.start(
+            mapOf(SHIPPING to shippingAddress)
+        )
         assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
             ViewState(
                 countryStatePairs = mapOf(
-                    BILLING to AddressSelectionState(
-                        countryLocation = Location(countryCode, countryCode),
-                        stateLocation = Location(stateCode, stateCode),
-                        inputFormValues = Address.EMPTY,
-                        stateSpinnerStatus = StateSpinnerStatus.DISABLED,
-                    ),
                     SHIPPING to AddressSelectionState(
-                        countryLocation = Location(countryCode, countryCode),
-                        stateLocation = Location(stateCode, stateCode),
-                        inputFormValues = Address.EMPTY,
-                        stateSpinnerStatus = StateSpinnerStatus.DISABLED,
+                        address = shippingAddress,
+                        stateSpinnerStatus = StateSpinnerStatus.RAW_VALUE,
                     )
                 ),
-                isStateSelectionEnabled = true
             )
         )
     }
 
     @Test
     fun `Should return true on hasStates if states list is NOT empty`() {
-        whenever(dataStore.getStates(any())).thenReturn(listOf(country))
-        assertTrue(addressViewModel.hasStatesFor(addressType))
+        whenever(dataStore.getStates(any())).thenReturn(listOf(newCountry))
+
+        addressViewModel.start(mapOf(SHIPPING to shippingAddress))
+
+        assertTrue(addressViewModel.hasStatesFor(SHIPPING))
     }
 
     @Test
     fun `Should return false on hasStates if states list is empty`() {
         whenever(dataStore.getStates(any())).thenReturn(emptyList())
-        assertFalse(addressViewModel.hasStatesFor(addressType))
+
+        addressViewModel.start(mapOf(SHIPPING to shippingAddress))
+
+        assertFalse(addressViewModel.hasStatesFor(SHIPPING))
     }
 
     @Test
     fun `Should update viewState with selected country, reset state and enable state selection on country selection`() {
-        addressViewModel.onCountrySelected(SHIPPING, country.code)
+        addressViewModel.start(mapOf(SHIPPING to shippingAddress.copy(country = Location.EMPTY)))
+        addressViewModel.onCountrySelected(SHIPPING, newCountry.code)
 
         assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
             ViewState(
                 countryStatePairs = mapOf(
-                    BILLING to AddressSelectionState(
-                        countryLocation = Location.EMPTY,
-                        stateLocation = Location.EMPTY,
-                        inputFormValues = Address.EMPTY,
-                        stateSpinnerStatus = StateSpinnerStatus.DISABLED,
-                    ),
                     SHIPPING to AddressSelectionState(
-                        countryLocation = Location(country.code, country.name),
-                        stateLocation = Location("", ""),
-                        inputFormValues = Address.EMPTY,
+                        address = shippingAddress.copy(
+                            country = newCountry.toAppModel(),
+                            state = AmbiguousLocation.EMPTY,
+                        ),
                         stateSpinnerStatus = StateSpinnerStatus.HAVING_LOCATIONS,
                     )
                 ),
-                isStateSelectionEnabled = true
             )
         )
     }
@@ -187,52 +181,44 @@ class AddressViewModelTest : BaseUnitTest() {
     @Test
     fun `Should update viewState with country code instead of name if country code is NOT on countries list`() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
-        val countryCode = "countryCode"
-        addressViewModel.onCountrySelected(BILLING, countryCode)
+        val missingCountryCode = "countryCode"
+
+        addressViewModel.start(mapOf(SHIPPING to shippingAddress))
+        addressViewModel.onCountrySelected(SHIPPING, missingCountryCode)
 
         assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
             ViewState(
                 countryStatePairs = mapOf(
-                    BILLING to AddressSelectionState(
-                        countryLocation = Location(countryCode, countryCode),
-                        stateLocation = Location.EMPTY,
-                        inputFormValues = Address.EMPTY,
+                    SHIPPING to AddressSelectionState(
+                        address = shippingAddress.copy(
+                            country = Location(missingCountryCode, missingCountryCode),
+                            state = AmbiguousLocation.EMPTY
+                        ),
                         stateSpinnerStatus = StateSpinnerStatus.RAW_VALUE,
                     ),
-                    SHIPPING to AddressSelectionState(
-                        countryLocation = Location.EMPTY,
-                        stateLocation = Location.EMPTY,
-                        inputFormValues = Address.EMPTY,
-                        stateSpinnerStatus = StateSpinnerStatus.DISABLED,
-                    ),
                 ),
-                isStateSelectionEnabled = true
             )
         )
     }
 
     @Test
     fun `Should update viewState with selected state on state selection`() {
-        addressViewModel.onCountrySelected(SHIPPING, country.code)
-        addressViewModel.onStateSelected(SHIPPING, state.code)
+        addressViewModel.start(mapOf(SHIPPING to shippingAddress))
+
+        addressViewModel.onCountrySelected(SHIPPING, newCountry.code)
+        addressViewModel.onStateSelected(SHIPPING, newState.code)
 
         assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
             ViewState(
                 countryStatePairs = mapOf(
-                    BILLING to AddressSelectionState(
-                        countryLocation = Location.EMPTY,
-                        stateLocation = Location.EMPTY,
-                        inputFormValues = Address.EMPTY,
-                        stateSpinnerStatus = StateSpinnerStatus.DISABLED,
-                    ),
                     SHIPPING to AddressSelectionState(
-                        countryLocation = Location(country.code, country.name),
-                        stateLocation = Location(state.code, state.name),
-                        inputFormValues = Address.EMPTY,
+                        address = shippingAddress.copy(
+                            country = newCountry.toAppModel(),
+                            state = AmbiguousLocation.Defined(newState.toAppModel())
+                        ),
                         stateSpinnerStatus = StateSpinnerStatus.HAVING_LOCATIONS,
                     )
                 ),
-                isStateSelectionEnabled = true
             )
         )
     }
@@ -241,21 +227,16 @@ class AddressViewModelTest : BaseUnitTest() {
     fun `Should update viewState with state code instead of name if state code is NOT on states list`() {
         whenever(dataStore.getStates(any())).thenReturn(emptyList())
         val stateCode = "stateCode"
-        addressViewModel.onStateSelected(addressType, stateCode)
-        verify(viewStateObserver).onChanged(
+
+        addressViewModel.start(mapOf(SHIPPING to shippingAddress))
+        addressViewModel.onStateSelected(SHIPPING, stateCode)
+
+        assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
             ViewState(
                 countryStatePairs = mapOf(
-                    BILLING to AddressSelectionState(
-                        countryLocation = Location.EMPTY,
-                        stateLocation = Location.EMPTY,
-                        inputFormValues = Address.EMPTY,
-                        stateSpinnerStatus = StateSpinnerStatus.DISABLED,
-                    ),
                     SHIPPING to AddressSelectionState(
-                        countryLocation = Location.EMPTY,
-                        stateLocation = Location(stateCode, stateCode),
-                        inputFormValues = Address.EMPTY,
-                        stateSpinnerStatus = StateSpinnerStatus.DISABLED,
+                        address = shippingAddress.copy(state = AmbiguousLocation.Raw(stateCode)),
+                        stateSpinnerStatus = StateSpinnerStatus.RAW_VALUE,
                     )
                 ),
             )
@@ -269,81 +250,17 @@ class AddressViewModelTest : BaseUnitTest() {
         assertThat(addressViewModel.event.value).isEqualTo(
             ShowCountrySelector(
                 SHIPPING,
-                listOf(country.toAppModel(), countryWithoutStates.toAppModel())
+                listOf(newCountry.toAppModel(), newCountryWithoutStates.toAppModel())
             )
         )
     }
 
     @Test
     fun `Should trigger state selection event if state selector clicked`() {
-        addressViewModel.onCountrySelected(SHIPPING, countryCode = country.code)
+        addressViewModel.start(mapOf(SHIPPING to shippingAddress))
+        addressViewModel.onCountrySelected(SHIPPING, countryCode = newCountry.code)
         addressViewModel.onStateSpinnerClicked(SHIPPING)
 
-        assertThat(addressViewModel.event.value).isEqualTo(ShowStateSelector(SHIPPING, listOf(state.toAppModel())))
-    }
-
-    @Test
-    fun `Should prepare rich billing address if country and state are selected from predefined values`() {
-        // when
-        addressViewModel.onCountrySelected(BILLING, countryCode = country.code)
-        addressViewModel.onStateSelected(BILLING, stateCode = state.code)
-        addressViewModel.onDoneSelected(
-            currentFormsState = mapOf(
-                BILLING to onlyInputFieldsValues,
-                SHIPPING to Address.EMPTY
-            )
-        )
-
-        // then
-        val expectedAddress = onlyInputFieldsValues.copy(country = country.name, state = state.name)
-        assertThat(addressViewModel.event.value).isEqualTo(
-            Exit(
-                billingAddress = expectedAddress,
-                shippingAddress = expectedAddress
-            )
-        )
-    }
-
-    @Test
-    fun `Should prepare rich billing address if state is plain text`() {
-        // given
-        val inputFieldsWithState = onlyInputFieldsValues.copy(state = "plain text state")
-
-        // when
-        addressViewModel.onCountrySelected(BILLING, countryCode = countryWithoutStates.code)
-        addressViewModel.onDoneSelected(
-            currentFormsState = mapOf(
-                BILLING to inputFieldsWithState,
-                SHIPPING to Address.EMPTY
-            )
-        )
-
-        // then
-        val expectedAddress = onlyInputFieldsValues.copy(
-            country = countryWithoutStates.name,
-            state = inputFieldsWithState.state
-        )
-        assertThat(addressViewModel.event.value).isEqualTo(
-            Exit(
-                billingAddress = expectedAddress,
-                shippingAddress = expectedAddress
-            )
-        )
-    }
-
-    companion object {
-        val onlyInputFieldsValues = Address(
-            "Company",
-            "First name",
-            "Last name",
-            "Phone",
-            country = "",
-            state = "",
-            "Address1",
-            "Address2",
-            "City",
-            "Postcode",
-            "Email"
-        )
+        assertThat(addressViewModel.event.value).isEqualTo(ShowStateSelector(SHIPPING, listOf(newState.toAppModel())))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/LocationTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/LocationTestUtils.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.orders.details.editing.address
+
+import com.woocommerce.android.model.AmbiguousLocation
+import com.woocommerce.android.model.Location
+
+val testCountry = Location(
+    code = "US",
+    name = "USA",
+)
+
+val testState = AmbiguousLocation.Defined(
+    Location(
+        parentCode = "US",
+        code = "CA",
+        name = "California",
+    )
+)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.products.addons
 
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.OrderTestUtils.orderMapper
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultAddonsList
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultOrderAttributes
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultWCOrderItemList
@@ -17,11 +17,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.times
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.store.WCAddonsStore
@@ -127,7 +123,7 @@ class AddonRepositoryTest {
     fun `containsAddonsFrom should return true for valid OrderItem`() = runBlockingTest {
         configureSuccessfulAddonResponse()
 
-        val orderItem = defaultWCOrderModel.toAppModel().items.first()
+        val orderItem = defaultWCOrderModel.let { orderMapper.toAppModel(it) }.items.first()
 
         assertThat(repositoryUnderTest.containsAddonsFrom(orderItem)).isTrue
     }
@@ -136,7 +132,7 @@ class AddonRepositoryTest {
     fun `containsAddonsFrom should return false when requested with invalid OrderItem`() = runBlockingTest {
         configureSuccessfulAddonResponse()
 
-        val orderItem = defaultWCOrderModel.toAppModel().items.first()
+        val orderItem = defaultWCOrderModel.let { orderMapper.toAppModel(it) }.items.first()
             .copy(
                 attributesList = listOf(
                     Order.Item.Attribute("Invalid", "Invalid"),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.orders.OrderTestUtils.orderMapper
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.RefundByItemsViewState
 import com.woocommerce.android.util.CurrencyFormatter
@@ -64,7 +65,8 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             resourceProvider,
             orderDetailRepository,
             gatewayStore,
-            refundStore
+            refundStore,
+            orderMapper
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to: #5634
<!-- Id number of the GitHub issue this PR addresses. -->

This PR is not meant to build. It's just chunk of work merged to feature branch for making reviews easier.

Other parts:
- https://github.com/woocommerce/woocommerce-android/pull/5644
- https://github.com/woocommerce/woocommerce-android/pull/5646

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adjusts app in areas of Order Creation, Details and Editing to support `Location` and `AmbiguousLocation` for `Address` fields.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Test instructions will be available in the last PR.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
