### PR TITLE
[Order Creation] Basic payment section

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
@@ -17,7 +17,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:header="@string/products"
-        app:keepAddButtons="true"/>
+        app:keepAddButtons="true" />
+
+    <include
+        android:id="@+id/payment_section"
+        layout="@layout/order_creation_payment_section" />
 
     <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
         android:id="@+id/customer_section"

--- a/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Woo.Card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/major_100">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/header_label"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/order_creation_payment"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/products_total_label"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            android:text="@string/order_creation_payment_products_total"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            app:layout_constraintEnd_toStartOf="@id/products_total_value"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header_label" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/products_total_value"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            android:text="@string/order_creation_payment_products_total"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            app:layout_constraintBaseline_toBaselineOf="@id/products_total_label"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/products_total_label"
+            app:layout_constraintWidth_default="wrap"
+            tools:text="$20.00" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/order_total_label"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            android:text="@string/order_creation_payment_order_total"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@id/products_total_value"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/products_total_label" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/order_total_value"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            android:text="@string/order_creation_payment_products_total"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:textStyle="bold"
+            app:layout_constraintBaseline_toBaselineOf="@id/order_total_label"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/products_total_label"
+            app:layout_constraintWidth_default="wrap"
+            tools:text="$20.00" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_100"
+            android:text="@string/order_creation_payment_tax_hint"
+            android:textAppearance="?attr/textAppearanceCaption"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/order_total_label" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -345,6 +345,10 @@
     <string name="order_creation_add_discount">Add discount</string>
     <string name="order_creation_remove_product">Remove product from order</string>
     <string name="order_creation_variations_screen_title">Select variation</string>
+    <string name="order_creation_payment">Payment</string>
+    <string name="order_creation_payment_products_total">Products Total</string>
+    <string name="order_creation_payment_order_total">Order Total</string>
+    <string name="order_creation_payment_tax_hint">Total excluding taxes. Taxes will be automatically calculated based on your store settings.</string>
 
     <!--
         Order Filters


### PR DESCRIPTION
Closes: #5595

### Description
This PR implements the same design as the one shown on #5595, the goal is to have something basic working for M1, until we get a chance to implement taxes and API calculation for M2.

### Testing instructions
1. Make sure order creation flag is enabled.
2. Open order creation form.
3. Add some products and variable products to the list.
4. Confirm that you can see the payments section with correct totals.

### Images/gif
<img width=400 src="https://cdn-std.droplr.net/files/acc_1124144/PKyOiW"/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
