### PR TITLE
Jetpack CP: Add Option to Install Jetpack in Settings 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -69,8 +69,9 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         }
 
         binding.jetpackProgressActionButton.setOnClickListener {
-            findNavController().navigateSafely(
-                JetpackInstallProgressDialogDirections.actionJetpackInstallProgressDialogToDashboard()
+            findNavController().popBackStack(
+                destinationId = R.id.jetpackBenefitsDialog,
+                inclusive = true
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -17,6 +17,6 @@ interface MainSettingsContract {
     interface View : BaseView<Presenter> {
         fun showDeviceAppNotificationSettings()
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
-        fun handleJetpackInstallOption(show: Boolean)
+        fun handleJetpackInstallOption(isJetpackCPSite: Boolean)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -11,10 +11,12 @@ interface MainSettingsContract {
         fun hasMultipleStores(): Boolean
         fun isCardReaderOnboardingCompleted(): Boolean
         fun setupAnnouncementOption()
+        fun setupJetpackInstallOption()
     }
 
     interface View : BaseView<Presenter> {
         fun showDeviceAppNotificationSettings()
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
+        fun handleJetpackInstallOption(show: Boolean)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -194,6 +194,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
 
         presenter.setupAnnouncementOption()
+        presenter.setupJetpackInstallOption()
     }
 
     override fun onResume() {
@@ -217,6 +218,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             updateStoreViews()
             updateStoreSettings()
             settingsListener.onSiteChanged()
+            presenter.setupJetpackInstallOption()
         }
     }
 
@@ -269,8 +271,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     private fun updateStoreViews() {
         binding.optionStore.optionTitle = presenter.getStoreDomainName()
         binding.optionStore.optionValue = presenter.getUserDisplayName()
-
-        presenter.setupJetpackInstallOption()
     }
 
     private fun updateStoreSettings() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -233,6 +233,17 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
     }
 
+    override fun handleJetpackInstallOption(show: Boolean) {
+        if (show) {
+            binding.optionInstallJetpack.visibility = View.VISIBLE
+            binding.optionInstallJetpack.setOnClickListener {
+                // todo
+            }
+        } else {
+            binding.optionInstallJetpack.visibility = View.GONE
+        }
+    }
+
     override fun showLatestAnnouncementOption(announcement: FeatureAnnouncement) {
         binding.optionWhatsNew.show()
         binding.optionWhatsNew.setOnClickListener {
@@ -256,6 +267,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     private fun updateStoreViews() {
         binding.optionStore.optionTitle = presenter.getStoreDomainName()
         binding.optionStore.optionValue = presenter.getUserDisplayName()
+
+        presenter.setupJetpackInstallOption()
     }
 
     private fun updateStoreSettings() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -237,7 +237,9 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         if (show) {
             binding.optionInstallJetpack.visibility = View.VISIBLE
             binding.optionInstallJetpack.setOnClickListener {
-                // todo
+                findNavController().navigateSafely(
+                    MainSettingsFragmentDirections.actionMainSettingsFragmentToNavGraphJetpackInstall()
+                )
             }
         } else {
             binding.optionInstallJetpack.visibility = View.GONE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -235,8 +235,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
     }
 
-    override fun handleJetpackInstallOption(show: Boolean) {
-        if (show) {
+    override fun handleJetpackInstallOption(isJetpackCPSite: Boolean) {
+        if (isJetpackCPSite) {
             binding.optionInstallJetpack.visibility = View.VISIBLE
             binding.optionInstallJetpack.setOnClickListener {
                 findNavController().navigateSafely(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -17,8 +17,7 @@ class MainSettingsPresenter @Inject constructor(
     private val accountStore: AccountStore,
     private val wooCommerceStore: WooCommerceStore,
     private val featureAnnouncementRepository: FeatureAnnouncementRepository,
-    private val buildConfigWrapper: BuildConfigWrapper,
-    private val userEligibilityFetcher: UserEligibilityFetcher
+    private val buildConfigWrapper: BuildConfigWrapper
 ) : MainSettingsContract.Presenter {
     private var appSettingsFragmentView: MainSettingsContract.View? = null
 
@@ -53,23 +52,7 @@ class MainSettingsPresenter @Inject constructor(
     }
 
     override fun setupJetpackInstallOption() {
-        if (!selectedSite.get().isJetpackCPConnected) {
-            appSettingsFragmentView?.handleJetpackInstallOption(show = false)
-            return
-        }
-
-        coroutineScope.launch {
-            val userModel = userEligibilityFetcher.fetchUserInfo()
-            userModel?.let {
-                val userRoles = it.getUserRoles()
-
-                if (WCUserRole.ADMINISTRATOR in userRoles ||
-                    WCUserRole.SHOP_MANAGER in userRoles
-                ) {
-                    appSettingsFragmentView?.handleJetpackInstallOption(show = true)
-                }
-            }
-        }
+        appSettingsFragmentView?.handleJetpackInstallOption(selectedSite.get().isJetpackCPConnected)
     }
 
     override fun isCardReaderOnboardingCompleted(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -2,12 +2,10 @@ package com.woocommerce.android.ui.prefs
 
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.model.user.WCUserRole
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -61,7 +61,11 @@ class MainSettingsPresenter @Inject constructor(
         coroutineScope.launch {
             val userModel = userEligibilityFetcher.fetchUserInfo()
             userModel?.let {
-                if (it.getUserRoles().contains(WCUserRole.ADMINISTRATOR)) {
+                val userRoles = it.getUserRoles()
+
+                if (WCUserRole.ADMINISTRATOR in userRoles ||
+                    WCUserRole.SHOP_MANAGER in userRoles
+                ) {
                     appSettingsFragmentView?.handleJetpackInstallOption(show = true)
                 }
             }

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -64,6 +64,17 @@
             android:layout_height="wrap_content"
             app:optionTitle="@string/settings_card_reader_payments" />
 
+        <!--
+            Install Jetpack
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_install_jetpack"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/settings_install_jetpack"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
     </LinearLayout>
 
     <View style="@style/Woo.Divider" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_install.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_install.xml
@@ -18,9 +18,6 @@
         android:name="com.woocommerce.android.ui.jetpack.JetpackInstallProgressDialog"
         android:label="JetpackInstallProgressDialog"
         tools:layout="@layout/dialog_jetpack_install_progress">
-        <action
-            android:id="@+id/action_jetpackInstallProgressDialog_to_dashboard"
-            app:destination="@id/nav_graph_main" />
     </dialog>
     <dialog
         android:id="@+id/jetpackBenefitsDialog"
@@ -30,5 +27,4 @@
             android:id="@+id/action_jetpackBenefitsDialog_to_jetpackInstallStartDialog"
             app:destination="@id/jetpackInstallStartDialog" />
     </dialog>
-    <include app:graph="@navigation/nav_graph_main" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_install.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_install.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph_jetpack_install"
+    app:startDestination="@id/jetpackBenefitsDialog">
+    <dialog
+        android:id="@+id/jetpackInstallStartDialog"
+        android:name="com.woocommerce.android.ui.jetpack.JetpackInstallStartDialog"
+        android:label="JetpackInstallStartDialog"
+        tools:layout="@layout/dialog_jetpack_install_start">
+        <action
+            android:id="@+id/action_jetpackInstallStartDialog_to_jetpackInstallProgressDialog"
+            app:destination="@id/jetpackInstallProgressDialog" />
+    </dialog>
+    <dialog
+        android:id="@+id/jetpackInstallProgressDialog"
+        android:name="com.woocommerce.android.ui.jetpack.JetpackInstallProgressDialog"
+        android:label="JetpackInstallProgressDialog"
+        tools:layout="@layout/dialog_jetpack_install_progress">
+        <action
+            android:id="@+id/action_jetpackInstallProgressDialog_to_dashboard"
+            app:destination="@id/nav_graph_main" />
+    </dialog>
+    <dialog
+        android:id="@+id/jetpackBenefitsDialog"
+        android:name="com.woocommerce.android.ui.jetpack.JetpackBenefitsDialog"
+        android:label="JetpackBenefitsDialog">
+        <action
+            android:id="@+id/action_jetpackBenefitsDialog_to_jetpackInstallStartDialog"
+            app:destination="@id/jetpackInstallStartDialog" />
+    </dialog>
+    <include app:graph="@navigation/nav_graph_main" />
+</navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -11,7 +11,7 @@
         tools:layout="@layout/fragment_my_store">
         <action
             android:id="@+id/action_myStore_to_jetpackBenefitsDialog"
-            app:destination="@id/jetpackBenefitsDialog" />
+            app:destination="@id/nav_graph_jetpack_install" />
     </fragment>
     <fragment
         android:id="@+id/orders"
@@ -306,33 +306,8 @@
         app:enterAnim="@anim/activity_fade_in"
         app:popExitAnim="@anim/activity_fade_out" />
     <dialog
-        android:id="@+id/jetpackBenefitsDialog"
-        android:name="com.woocommerce.android.ui.jetpack.JetpackBenefitsDialog"
-        android:label="JetpackBenefitsDialog">
-        <action
-            android:id="@+id/action_jetpackBenefitsDialog_to_jetpackInstallStartDialog"
-            app:destination="@id/jetpackInstallStartDialog" />
-    </dialog>
-    <dialog
-        android:id="@+id/jetpackInstallStartDialog"
-        android:name="com.woocommerce.android.ui.jetpack.JetpackInstallStartDialog"
-        android:label="JetpackInstallStartDialog"
-        tools:layout="@layout/dialog_jetpack_install_start">
-        <action
-            android:id="@+id/action_jetpackInstallStartDialog_to_jetpackInstallProgressDialog"
-            app:destination="@id/jetpackInstallProgressDialog" />
-    </dialog>
-    <dialog
-        android:id="@+id/jetpackInstallProgressDialog"
-        android:name="com.woocommerce.android.ui.jetpack.JetpackInstallProgressDialog"
-        android:label="JetpackInstallProgressDialog"
-        tools:layout="@layout/dialog_jetpack_install_progress">
-        <action
-            android:id="@+id/action_jetpackInstallProgressDialog_to_dashboard"
-            app:destination="@id/dashboard" />
-    </dialog>
-    <dialog
         android:id="@+id/orderCreationBottomSheetFragment"
         android:name="com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment"
         tools:layout="@layout/dialog_order_creation_bottom_sheet"/>
+    <include app:graph="@navigation/nav_graph_jetpack_install" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -55,6 +55,9 @@
         <action
             android:id="@+id/action_mainSettingsFragment_to_featureAnnouncementDialogFragment"
             app:destination="@id/featureAnnouncementDialogFragment" />
+        <action
+            android:id="@+id/action_mainSettingsFragment_to_nav_graph_jetpack_install"
+            app:destination="@id/nav_graph_jetpack_install" />
     </fragment>
     <dialog
         android:id="@+id/cardReaderConnectDialogFragment"
@@ -202,4 +205,5 @@
             android:defaultValue="@null"/>
     </fragment>
     <action android:id="@+id/action_global_WPComWebViewFragment" app:destination="@id/WPComWebViewFragment"/>
+    <include app:graph="@navigation/nav_graph_jetpack_install" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1464,6 +1464,7 @@
     <string name="settings_card_reader">Manage card reader</string>
     <string name="settings_card_reader_payments">In-Person Payments</string>
     <string name="settings_card_reader_connect">Connect card reader</string>
+    <string name="settings_install_jetpack">Install Jetpack</string>
     <string name="settings_notifs">Notifications</string>
     <string name="settings_notifs_device">Manage notifications</string>
     <string name="settings_notifs_device_detail">Sounds, urgency, and notification dot</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Solves #5185
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds:
1. The "Install Jetpack" option on Settings screen,
2. Logic to only show the option when current site is a Jetpack CP site, and user has Administrator or Role Manager role.
3. Refactor Jetpack Install dialogs's flow to be its own nav graph


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create a new .org site with WooCommerce, but no Jetpack (Jurassic Ninja works for this),
2. Install WooComerce Payments plugin, activate it and go through steps to connect to your WordPress.com account. Skip the Stripe account afterward and just return to wp-admin,
3. Start app,
4. Make sure the new .org site is selected, then go to Settings,
5. Make sure "Install Jetpack" option is shown,
6. Tap the option and make sure Jetpack Benefit Dialog is shown,
7. Go back, go to My Store, and find the Jetpack banner,
8. Tap the banner and make sure Jetpack Benefit Dialog is shown,
9. Go back to Settings,
10. Switch to a non-Jetpack CP site,
11. Make sure "Install Jetpack" option is not shown.
