### PR TITLE
Jetpack Installation: update selected site after the installation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.jetpack.JetpackInstallViewModel.FailureType.*
 import com.woocommerce.android.ui.jetpack.JetpackInstallViewModel.InstallStatus
 import com.woocommerce.android.ui.jetpack.JetpackInstallViewModel.InstallStatus.*
-import com.woocommerce.android.ui.mystore.MyStoreViewModel
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
@@ -42,7 +41,6 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
     @Inject lateinit var selectedSite: SelectedSite
 
     private val viewModel: JetpackInstallViewModel by viewModels()
-    private val myStoreViewModel: MyStoreViewModel by activityViewModels()
 
     private var isReturningFromWpAdmin = false
 
@@ -83,7 +81,6 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 destinationId = R.id.jetpackBenefitsDialog,
                 inclusive = true
             )
-            myStoreViewModel.handleSuccessfulJetpackInstallation()
         }
 
         binding.contactButton.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -7,7 +7,6 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.button.MaterialButton
@@ -109,11 +108,13 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         }
     }
 
+    private fun setViewVisibility(visibility: Int, vararg views: View) = views.forEach { it.visibility = visibility }
+
     private fun updateInstallProgressUi(status: InstallStatus, binding: DialogJetpackInstallProgressBinding) {
         when (status) {
             is Installing -> {
-                binding.showStep1Group.show()
-                binding.hideStep1Group.visibility = View.INVISIBLE
+                setViewVisibility(View.INVISIBLE, binding.icon1, binding.progress2, binding.progress3)
+                setViewVisibility(View.VISIBLE, binding.progress1, binding.icon2, binding.icon3, binding.icon4)
                 setViewImage(ICON_NOT_DONE, binding.icon2, binding.icon3, binding.icon4)
                 setTextWeight(Typeface.BOLD, binding.message1)
                 setTextWeight(Typeface.NORMAL, binding.message2, binding.message3, binding.message4)
@@ -121,8 +122,8 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 binding.jetpackProgressActionButton.hide()
             }
             is Activating -> {
-                binding.showStep2Group.show()
-                binding.hideStep2Group.visibility = View.INVISIBLE
+                setViewVisibility(View.INVISIBLE, binding.progress1, binding.icon2, binding.progress3)
+                setViewVisibility(View.VISIBLE, binding.icon1, binding.progress2, binding.icon3, binding.icon4)
                 setViewImage(ICON_DONE, binding.icon1)
                 setViewImage(ICON_NOT_DONE, binding.icon3, binding.icon4)
                 setTextWeight(Typeface.BOLD, binding.message1, binding.message2)
@@ -131,22 +132,25 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 binding.jetpackProgressActionButton.hide()
             }
             is Connecting -> {
-                binding.showStep3Group.show()
-                binding.hideStep3Group.visibility = View.INVISIBLE
+                setViewVisibility(View.INVISIBLE, binding.progress1, binding.progress2, binding.icon3)
+                setViewVisibility(View.VISIBLE, binding.icon1, binding.icon2, binding.progress3, binding.icon4)
                 setViewImage(ICON_DONE, binding.icon1, binding.icon2)
                 setViewImage(ICON_NOT_DONE, binding.icon4)
                 setTextWeight(Typeface.BOLD, binding.message1, binding.message2, binding.message3)
                 setTextWeight(Typeface.NORMAL, binding.message4)
 
                 if (status.retry) {
-                    binding.messagesGroup.show()
+                    setViewVisibility(
+                        View.VISIBLE,
+                        binding.message1, binding.message2, binding.message3, binding.message4
+                    )
                 }
 
                 binding.jetpackProgressActionButton.hide()
             }
             is Finished -> {
-                binding.showStep4Group.show()
-                binding.hideStep4Group.visibility = View.INVISIBLE
+                setViewVisibility(View.INVISIBLE, binding.progress1, binding.progress2, binding.progress3)
+                setViewVisibility(View.VISIBLE, binding.icon1, binding.icon2, binding.icon3, binding.icon4)
                 setViewImage(ICON_DONE, binding.icon1, binding.icon2, binding.icon3, binding.icon4)
                 setTextWeight(Typeface.BOLD, binding.message1, binding.message2, binding.message3, binding.message4)
 
@@ -161,13 +165,12 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         }
     }
 
+    @Suppress("LongMethod")
     private fun handleFailedState(
         errorType: JetpackInstallViewModel.FailureType,
         binding: DialogJetpackInstallProgressBinding
     ) {
         val ctx = binding.root.context
-
-        // Title copy
         binding.jetpackProgressTitleTextView.text = ctx.getString(
             R.string.jetpack_install_progress_failed_title,
             when (errorType) {
@@ -222,8 +225,12 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
         binding.openAdminOrRetryButton.text = btnText
 
         // Visibilities
-        binding.hideFailureGroup.visibility = View.INVISIBLE
-        binding.messagesGroup.visibility = View.INVISIBLE
+        setViewVisibility(
+            View.INVISIBLE,
+            binding.icon1, binding.icon2, binding.icon3, binding.icon4,
+            binding.message1, binding.message2, binding.message3, binding.message4,
+            binding.progress1, binding.progress2, binding.progress3
+        )
         binding.contactButton.show()
         binding.openAdminOrRetryButton.show()
         binding.jetpackProgressActionButton.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallViewModel.kt
@@ -108,7 +108,7 @@ class JetpackInstallViewModel @Inject constructor(
             val sites = result.model
             if (sites != null) {
                 val syncedSite = sites.firstOrNull { it.siteId == selectedSite.get().siteId }
-                if (syncedSite?.hasWooCommerce == true) {
+                if (syncedSite?.isJetpackConnected == true && syncedSite.hasWooCommerce) {
                     selectedSite.set(syncedSite)
                     return true
                 } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup.LayoutParams
 import androidx.core.view.children
 import androidx.core.view.isVisible
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -185,7 +184,10 @@ class MyStoreFragment :
         viewModel.visitorStatsState.observe(viewLifecycleOwner) { stats ->
             when (stats) {
                 is VisitorStatsViewState.Content -> showVisitorStats(stats.stats)
-                VisitorStatsViewState.Error -> binding.myStoreStats.showVisitorStatsError()
+                VisitorStatsViewState.Error -> {
+                    binding.jetpackBenefitsBanner.root.isVisible = false
+                    binding.myStoreStats.showVisitorStatsError()
+                }
                 is VisitorStatsViewState.JetpackCpConnected -> onJetpackCpConnected(stats.benefitsBanner)
             }
         }
@@ -341,6 +343,7 @@ class MyStoreFragment :
     }
 
     private fun showVisitorStats(visitorStats: Map<String, Int>) {
+        binding.jetpackBenefitsBanner.root.isVisible = false
         binding.myStoreStats.showVisitorStats(visitorStats)
         if (activeGranularity == StatsGranularity.DAYS) {
             binding.emptyStatsView.updateVisitorCount(visitorStats.values.sum())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup.LayoutParams
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.AppBarLayout
@@ -59,7 +60,7 @@ class MyStoreFragment :
         val DEFAULT_STATS_GRANULARITY = StatsGranularity.DAYS
     }
 
-    private val viewModel: MyStoreViewModel by activityViewModels()
+    private val viewModel: MyStoreViewModel by viewModels()
 
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var currencyFormatter: CurrencyFormatter
@@ -186,7 +187,6 @@ class MyStoreFragment :
                 is VisitorStatsViewState.Content -> showVisitorStats(stats.stats)
                 VisitorStatsViewState.Error -> binding.myStoreStats.showVisitorStatsError()
                 is VisitorStatsViewState.JetpackCpConnected -> onJetpackCpConnected(stats.benefitsBanner)
-                is VisitorStatsViewState.PostJetpackInstalled -> binding.jetpackBenefitsBanner.root.isVisible = false
             }
         }
         viewModel.topPerformersState.observe(viewLifecycleOwner) { topPerformers ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -92,11 +92,6 @@ class MyStoreViewModel @Inject constructor(
         }
     }
 
-    fun handleSuccessfulJetpackInstallation() {
-        _visitorStatsState.value =
-            VisitorStatsViewState.PostJetpackInstalled
-    }
-
     override fun onCleared() {
         ConnectionChangeReceiver.getEventBus().unregister(this)
         super.onCleared()
@@ -300,8 +295,6 @@ class MyStoreViewModel @Inject constructor(
         data class Content(
             val stats: Map<String, Int>
         ) : VisitorStatsViewState()
-
-        object PostJetpackInstalled : VisitorStatsViewState()
     }
 
     sealed class TopPerformersViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -207,6 +207,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+        presenter.dropView()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/WooCommerce/src/main/res/layout/dialog_jetpack_install_progress.xml
+++ b/WooCommerce/src/main/res/layout/dialog_jetpack_install_progress.xml
@@ -88,7 +88,7 @@
                 android:layout_marginTop="@dimen/major_200"
                 app:layout_constraintStart_toStartOf="@id/jetpackProgressStartGuideline"
                 app:layout_constraintTop_toBottomOf="@id/jetpackProgressSubtitleTextView"
-                android:visibility="visible" />
+                android:visibility="invisible" />
 
             <ProgressBar
                 android:id="@+id/progress1"
@@ -200,66 +200,6 @@
                 android:layout_marginStart="@dimen/major_150"
                 app:layout_constraintStart_toEndOf="@id/icon4"
                 app:layout_constraintBottom_toBottomOf="@id/icon4" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/showStep1Group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="progress1, icon2, icon3, icon4" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/hideStep1Group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="icon1, progress2, progress3" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/showStep2Group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="icon1, progress2, icon3, icon4" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/hideStep2Group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="progress1, icon2, progress3" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/showStep3Group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="icon1, icon2, progress3, icon4" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/hideStep3Group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="progress1, progress2, icon3" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/showStep4Group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="icon1, icon2, icon3, icon4" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/hideStep4Group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="progress1, progress2, progress3" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/hideFailureGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="icon1, icon2, icon3, icon4, message1, message2, message3, message4, progress1, progress2, progress3" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/messagesGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="message1, message2, message3, message4" />
 
             <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/jetpackProgressStartGuideline"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallViewModelTest.kt
@@ -43,6 +43,7 @@ class JetpackInstallViewModelTest : BaseUnitTest() {
     fun setup() {
         siteModelMock = mock {
             on { siteId }.doReturn(SITE_ID)
+            on { isJetpackConnected }.doReturn(true)
         }
         selectedSiteMock = mock {
             on { get() }.doReturn(siteModelMock)


### PR DESCRIPTION
Closes: #5663

### Description
@hafizrahman this is just an attempt to see how we can refresh the app's status after the Jetpack installation without having to rely on Activity scoped ViewModels.

Feel free to keep it or to make any changes if you want 🙂 


On another subject, when I tested the installation, I noticed that the UI at the step of installation is not accurate, we show a checkbox before the installation si actually finished, and we show three progress indicators at the same time:

<img src="https://user-images.githubusercontent.com/1657201/150322406-7fed27d1-a793-4e0d-afb0-8aa3c3651d25.png" width=360/>

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
