### PR TITLE
Issue/5588 push notifications reviews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
@@ -13,7 +13,7 @@ enum class BottomNavigationPosition(val position: Int, val id: Int) {
     ANALYTICS(ANALYTICS_POSITION, R.id.dashboard),
     ORDERS(ORDERS_POSITION, R.id.orders),
     PRODUCTS(PRODUCTS_POSITION, R.id.products),
-    MORE(MORE_POSITION, R.id.more_menu)
+    MORE(MORE_POSITION, R.id.moreMenu)
 }
 
 fun findNavigationPositionById(id: Int): BottomNavigationPosition = when (id) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -714,40 +714,37 @@ class MainActivity :
     // endregion
 
     private fun setupObservers() {
-        viewModel.event.observe(
-            this,
-            { event ->
-                when (event) {
-                    is ViewMyStoreStats -> binding.bottomNav.currentPosition = MY_STORE
-                    is ViewOrderList -> binding.bottomNav.currentPosition = ORDERS
-                    is ViewZendeskTickets -> {
-                        binding.bottomNav.currentPosition = MY_STORE
-                        startActivity(HelpActivity.createIntent(this, Origin.ZENDESK_NOTIFICATION, null))
-                    }
-                    is ViewOrderDetail -> {
-                        showOrderDetail(
-                            orderId = event.uniqueId,
-                            remoteNoteId = event.remoteNoteId,
-                            launchedFromNotification = true
-                        )
-                    }
-                    is ViewReviewDetail -> {
-                        showReviewDetail(event.uniqueId, launchedFromNotification = true, enableModeration = true)
-                    }
-                    is RestartActivityForNotification -> {
-                        // Add flags for handling the push notification after restart
-                        intent.putExtra(FIELD_OPENED_FROM_PUSH, true)
-                        intent.putExtra(FIELD_REMOTE_NOTIFICATION, event.notification)
-                        intent.putExtra(FIELD_PUSH_ID, event.pushId)
-                        restart()
-                    }
-                    is ShowFeatureAnnouncement -> {
-                        val action = NavGraphMainDirections.actionOpenWhatsnewFromMain(event.announcement)
-                        navController.navigateSafely(action)
-                    }
+        viewModel.event.observe(this) { event ->
+            when (event) {
+                is ViewMyStoreStats -> binding.bottomNav.currentPosition = MY_STORE
+                is ViewOrderList -> binding.bottomNav.currentPosition = ORDERS
+                is ViewZendeskTickets -> {
+                    binding.bottomNav.currentPosition = MY_STORE
+                    startActivity(HelpActivity.createIntent(this, Origin.ZENDESK_NOTIFICATION, null))
+                }
+                is ViewOrderDetail -> {
+                    showOrderDetail(
+                        orderId = event.uniqueId,
+                        remoteNoteId = event.remoteNoteId,
+                        launchedFromNotification = true
+                    )
+                }
+                is ViewReviewDetail -> {
+                    showReviewDetail(event.uniqueId, launchedFromNotification = true, enableModeration = true)
+                }
+                is RestartActivityForNotification -> {
+                    // Add flags for handling the push notification after restart
+                    intent.putExtra(FIELD_OPENED_FROM_PUSH, true)
+                    intent.putExtra(FIELD_REMOTE_NOTIFICATION, event.notification)
+                    intent.putExtra(FIELD_PUSH_ID, event.pushId)
+                    restart()
+                }
+                is ShowFeatureAnnouncement -> {
+                    val action = NavGraphMainDirections.actionOpenWhatsnewFromMain(event.announcement)
+                    navController.navigateSafely(action)
                 }
             }
-        )
+        }
     }
 
     override fun showProductDetail(remoteProductId: Long, enableTrash: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.main.BottomNavigationPosition.*
 import com.woocommerce.android.ui.main.MainActivityViewModel.*
+import com.woocommerce.android.ui.moremenu.MoreMenuFragmentDirections
 import com.woocommerce.android.ui.orders.list.OrderListFragmentDirections
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.products.ProductListFragmentDirections
@@ -788,7 +789,13 @@ class MainActivity :
         enableModeration: Boolean,
         tempStatus: String?
     ) {
-        val action = ReviewListFragmentDirections.actionReviewListFragmentToReviewDetailFragment(
+        if (launchedFromNotification) {
+            showBottomNav()
+            binding.bottomNav.currentPosition = MORE
+            binding.bottomNav.active(MORE.position)
+        }
+
+        val action = MoreMenuFragmentDirections.actionMoreMenuFragmentToReviewDetailFragment(
             remoteReviewId = remoteReviewId,
             tempStatus = tempStatus,
             launchedFromNotification = launchedFromNotification,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -31,7 +31,10 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivityMainBinding
-import com.woocommerce.android.extensions.*
+import com.woocommerce.android.extensions.active
+import com.woocommerce.android.extensions.collapse
+import com.woocommerce.android.extensions.expand
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -56,7 +59,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
-import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -796,7 +798,6 @@ class MainActivity :
         tempStatus: String?
     ) {
         if (launchedFromNotification) {
-            showBottomNav()
             binding.bottomNav.currentPosition = MORE
             binding.bottomNav.active(MORE.position)
         }
@@ -851,7 +852,6 @@ class MainActivity :
         launchedFromNotification: Boolean
     ) {
         if (launchedFromNotification) {
-            showBottomNav()
             binding.bottomNav.currentPosition = ORDERS
             binding.bottomNav.active(ORDERS.position)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -335,7 +335,7 @@ class MainActivity :
             currentDestinationId == R.id.dashboard ||
                 currentDestinationId == R.id.orders ||
                 currentDestinationId == R.id.products ||
-                currentDestinationId == R.id.more_menu ||
+                currentDestinationId == R.id.moreMenu ||
                 currentDestinationId == R.id.analytics
         } else {
             true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -732,6 +732,7 @@ class MainActivity :
                 is ViewReviewDetail -> {
                     showReviewDetail(event.uniqueId, launchedFromNotification = true, enableModeration = true)
                 }
+                is ViewReviewList -> showReviewList()
                 is RestartActivityForNotification -> {
                     // Add flags for handling the push notification after restart
                     intent.putExtra(FIELD_OPENED_FROM_PUSH, true)
@@ -777,6 +778,14 @@ class MainActivity :
     override fun showAddProduct() {
         showBottomNav()
         val action = NavGraphMainDirections.actionGlobalProductDetailFragment(isAddProduct = true)
+        navController.navigateSafely(action)
+    }
+
+    private fun showReviewList() {
+        showBottomNav()
+        binding.bottomNav.currentPosition = MORE
+        binding.bottomNav.active(MORE.position)
+        val action = MoreMenuFragmentDirections.actionMoreMenuToReviewList()
         navController.navigateSafely(action)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenu.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenu.kt
@@ -29,7 +29,7 @@ import com.woocommerce.android.R.color
 
 @ExperimentalFoundationApi
 @Composable
-fun MoreMenu(buttons: List<MenuButton>, settingsOnClick: () -> Unit = {}) {
+fun moreMenu(buttons: List<MenuButton>, settingsOnClick: () -> Unit = {}) {
     Column {
         Row(
             modifier = Modifier
@@ -53,7 +53,7 @@ fun MoreMenu(buttons: List<MenuButton>, settingsOnClick: () -> Unit = {}) {
             verticalArrangement = Arrangement.spacedBy(ButtonDefaults.IconSpacing)
         ) {
             itemsIndexed(buttons) { _, item ->
-                MoreMenuButton(
+                moreMenuButton(
                     text = item.text,
                     iconDrawable = item.icon,
                     onClick = item.onClick
@@ -64,7 +64,7 @@ fun MoreMenu(buttons: List<MenuButton>, settingsOnClick: () -> Unit = {}) {
 }
 
 @Composable
-private fun MoreMenuButton(
+private fun moreMenuButton(
     @StringRes text: Int,
     @DrawableRes iconDrawable: Int,
     onClick: () -> Unit
@@ -112,7 +112,7 @@ private fun MoreMenuButton(
 @ExperimentalFoundationApi
 @Preview
 @Composable
-fun MoreMenuPreview() {
+fun moreMenuPreview() {
     val buttons = listOf(
         MenuButton(R.string.more_menu_button_woo_admin, R.drawable.ic_more_menu_wp_admin),
         MenuButton(R.string.more_menu_button_store, R.drawable.ic_more_menu_store),
@@ -121,5 +121,5 @@ fun MoreMenuPreview() {
         MenuButton(R.string.more_menu_button_inbox, R.drawable.ic_more_menu_inbox),
         MenuButton(R.string.more_menu_button_reviews, R.drawable.ic_more_menu_reviews)
     )
-    MoreMenu(buttons)
+    moreMenu(buttons)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -67,7 +67,7 @@ class MoreMenuFragment : TopLevelFragment(R.layout.fragment_more_menu) {
             setContent {
                 // In Compose world
                 MaterialTheme {
-                    MoreMenu(buttons) {
+                    moreMenu(buttons) {
                         findNavController().navigateSafely(
                             MoreMenuFragmentDirections.actionMoreMenuToSettingsActivity()
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -139,8 +139,7 @@ class ReviewDetailFragment :
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
         }
 
-        viewModel.event.observe(viewLifecycleOwner)
-        { event ->
+        viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MarkNotificationAsRead -> {
@@ -277,5 +276,4 @@ class ReviewDetailFragment :
     }
 
     override fun onRequestAllowBackPress(): Boolean = viewModel.onBackPressed()
-
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -13,7 +13,6 @@ import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.transition.MaterialContainerTransform
@@ -29,10 +28,7 @@ import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.reviews.ProductReviewStatus.APPROVED
-import com.woocommerce.android.ui.reviews.ProductReviewStatus.HOLD
-import com.woocommerce.android.ui.reviews.ProductReviewStatus.SPAM
-import com.woocommerce.android.ui.reviews.ProductReviewStatus.TRASH
+import com.woocommerce.android.ui.reviews.ProductReviewStatus.*
 import com.woocommerce.android.ui.reviews.ReviewDetailViewModel.ReviewDetailEvent.MarkNotificationAsRead
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.WooLog
@@ -41,11 +37,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.DateTimeUtils
-import org.wordpress.android.util.DisplayUtils
-import org.wordpress.android.util.HtmlUtils
-import org.wordpress.android.util.PhotonUtils
-import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.*
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -143,19 +135,18 @@ class ReviewDetailFragment : BaseFragment(R.layout.fragment_review_detail) {
         }
 
         viewModel.event.observe(
-            viewLifecycleOwner,
-            Observer { event ->
-                when (event) {
-                    is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                    is MarkNotificationAsRead -> {
-                        notificationMessageHandler.removeNotificationByRemoteIdFromSystemsBar(
-                            event.remoteNoteId
-                        )
-                    }
-                    is Exit -> exitDetailView()
+            viewLifecycleOwner
+        ) { event ->
+            when (event) {
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is MarkNotificationAsRead -> {
+                    notificationMessageHandler.removeNotificationByRemoteIdFromSystemsBar(
+                        event.remoteNoteId
+                    )
                 }
+                is Exit -> exitDetailView()
             }
-        )
+        }
     }
 
     private fun setReview(review: ProductReview) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.model.RequestResult.NO_ACTION_NEEDED
 import com.woocommerce.android.model.RequestResult.SUCCESS
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.reviews.ReviewDetailViewModel.ReviewDetailEvent.MarkNotificationAsRead
+import com.woocommerce.android.ui.reviews.ReviewDetailViewModel.ReviewDetailEvent.NavigateBackFromNotification
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -33,7 +34,10 @@ class ReviewDetailViewModel @Inject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
+    private var launchedFromNotification: Boolean = false
+
     fun start(remoteReviewId: Long, launchedFromNotification: Boolean) {
+        this.launchedFromNotification = launchedFromNotification
         loadProductReview(remoteReviewId, launchedFromNotification)
     }
 
@@ -127,6 +131,16 @@ class ReviewDetailViewModel @Inject constructor(
         }
     }
 
+    fun onBackPressed(): Boolean {
+        if (launchedFromNotification) {
+            triggerEvent(NavigateBackFromNotification)
+
+        } else {
+            triggerEvent(Exit)
+        }
+        return false
+    }
+
     @Parcelize
     data class ViewState(
         val productReview: ProductReview? = null,
@@ -135,5 +149,6 @@ class ReviewDetailViewModel @Inject constructor(
 
     sealed class ReviewDetailEvent : Event() {
         data class MarkNotificationAsRead(val remoteNoteId: Long) : ReviewDetailEvent()
+        object NavigateBackFromNotification : ReviewDetailEvent()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -134,7 +134,6 @@ class ReviewDetailViewModel @Inject constructor(
     fun onBackPressed(): Boolean {
         if (launchedFromNotification) {
             triggerEvent(NavigateBackFromNotification)
-
         } else {
             triggerEvent(Exit)
         }

--- a/WooCommerce/src/main/res/menu/menu_bottom_bar.xml
+++ b/WooCommerce/src/main/res/menu/menu_bottom_bar.xml
@@ -23,7 +23,7 @@
         android:title="@string/products" />
 
     <item
-        android:id="@+id/more_menu"
+        android:id="@+id/moreMenu"
         android:icon="@drawable/ic_more_menu"
         android:title="@string/more_menu" />
 </menu>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -140,13 +140,16 @@
         android:id="@+id/more_menu"
         android:name="com.woocommerce.android.ui.moremenu.MoreMenuFragment"
         android:label="fragment_more_menu"
-        tools:layout="@layout/fragment_more_menu" >
+        tools:layout="@layout/fragment_more_menu">
         <action
             android:id="@+id/action_moreMenu_to_reviewList"
             app:destination="@id/reviews" />
         <action
             android:id="@+id/action_moreMenu_to_settingsActivity"
             app:destination="@id/appSettingsActivity" />
+        <action
+            android:id="@+id/action_moreMenuFragment_to_reviewDetailFragment"
+            app:destination="@id/reviewDetailFragment" />
     </fragment>
     <fragment
         android:id="@+id/feedbackSurveyFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -137,7 +137,7 @@
         android:id="@+id/action_global_item_selector_dialog"
         app:destination="@id/itemSelectorDialog" />
     <fragment
-        android:id="@+id/more_menu"
+        android:id="@+id/moreMenu"
         android:name="com.woocommerce.android.ui.moremenu.MoreMenuFragment"
         android:label="fragment_more_menu"
         tools:layout="@layout/fragment_more_menu">
@@ -221,6 +221,10 @@
         <argument
             android:name="enableModeration"
             app:argType="boolean" />
+        <action
+            android:id="@+id/action_reviewDetailFromNotification_to_reviewListFragment"
+            app:destination="@id/reviews"
+            app:popUpTo="@+id/moreMenu" />
     </fragment>
 
     <include app:graph="@navigation/nav_graph_orders" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.reviews.ProductReviewStatus.SPAM
 import com.woocommerce.android.ui.reviews.ReviewDetailViewModel.ReviewDetailEvent.MarkNotificationAsRead
+import com.woocommerce.android.ui.reviews.ReviewDetailViewModel.ReviewDetailEvent.NavigateBackFromNotification
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -159,4 +160,24 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
             assertFalse(exitCalled)
             Assertions.assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.offline_error))
         }
+
+    @Test
+    fun `Given review detail opened from notification, when navigating back, trigger NavigateBackFromNotification`() {
+        doReturn(false).whenever(networkStatus).isConnected()
+        viewModel.start(REVIEW_ID, launchedFromNotification = true)
+
+        viewModel.onBackPressed()
+
+        Assertions.assertThat(viewModel.event.value).isEqualTo(NavigateBackFromNotification)
+    }
+
+    @Test
+    fun `Given review detail not opened from notification, when navigating back, trigger Exit`() {
+        doReturn(false).whenever(networkStatus).isConnected()
+        viewModel.start(REVIEW_ID, launchedFromNotification = false)
+
+        viewModel.onBackPressed()
+
+        Assertions.assertThat(viewModel.event.value).isEqualTo(Exit)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5588
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
With the addition of the new more menu tab. navigation to reviews list and review detail screen from a push notification was broken. This PR fixes that. 

### Testing instructions
1. Add a new product review from test site
2. Wait until notification is received and open it
3. Check that the review detail screen is opened
4. Navigate back from review detail and check app lands in review list screen
5. Navigate back again and check app lands on more menu tab

Repeat this same flow but opening a group notification for product review. 

### Images/gif

https://user-images.githubusercontent.com/2663464/150553933-75e73cd3-c7b8-4e08-a54c-bf98239586f6.mp4

