### PR TITLE
Drop jcenter repository and use jcenter-mirror when necessary

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -33,14 +33,14 @@ repositories {
         }
     }
     mavenCentral()
-    //noinspection JcenterRepositoryObsolete
-    jcenter {
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android/jcenter-mirror"
         content {
-            includeModule("org.wordpress", "wellsql")
-            includeModule("org.wordpress", "wellsql-core")
-            includeModule("com.google.android", "flexbox")
-            includeModule("com.android.volley", "volley")
-            includeModule("com.jraska", "falcon")
+            includeVersion "com.android.volley", "volley", "1.1.1"
+            includeVersion "com.google.android", "flexbox", "2.0.1"
+            includeVersion "com.jraska", "falcon", "2.1.1"
+            includeVersion "org.wordpress", "wellsql", "1.6.0"
+            includeVersion "org.wordpress", "wellsql-core", "1.6.0"
         }
     }
     maven {


### PR DESCRIPTION
### Description
In the last week, we have had a lot of dependency resolution issues from `jcenter`, especially in [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android/), so we are dropping it from our projects. In order to have a smooth transition and not try to update all our dependencies at once, we created a `jcenter-mirror` s3 maven repository to serve the artifacts we need from `jcenter`. This PR removes `jcenter` as a repository and adds `jcenter-mirror` as a limited repository.

We use the [includeVersion](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.html#includeVersion-java.lang.String-java.lang.String-java.lang.String-) syntax to declare which versions & dependencies we use from `jcenter-mirror`, so that it is clear to us which dependencies we need to update to drop it. Our preference moving forward will be to upgrade these dependencies to versions which are hosted in other maven repositories, such as `mavenCentral`. However, there is no rush to do these upgrades right now as hosting the `jcenter-mirror` repository has no considerable maintenance cost to us.

_P.S:_ Kudos to @wzieba for adding the modules we use from `jcenter` in #5414, this was the easiest project so far to make this update. Note that, I have been going one step further than the `includeModule` and using `includeVersion` since later versions will not be available in `jcenter-mirror`.

### Testing instructions
No testing should be necessary since the changes only impact the dependency resolution, but a smoke test is always appreciated.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
