### PR TITLE
Bump the Stripe terminal SDK to v2.6.0

### DIFF
--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 
-    implementation "com.stripe:stripeterminal:2.5.2"
+    implementation "com.stripe:stripeterminal:2.6.0"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5680 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Bump Stripe Terminal SDK Version to the latest i.e 2.6.0

## Changelog
2.6.0 - 2022-01-24
Fix: Resolved an issue where connecting to a WP3 immediately after an M2 can cause update failures.
Fix: Stripe M2 Bluetooth pairing dialog is no longer displayed twice.
Fix: Resolved NullPointerException thrown when BluetoothDevice.name isn't available during discovery. See issue 196 for details.
Fix: Resolved an issue with Gson not being included as an explicit dependency. See issue 188 for details.
Fix: Updated R8 keep rules to resolve an issue where Stripe M2 readers would fail to connect with minification enabled.
Fix: Added Bluetooth scan rate limiting to avoid Android SDK silently failing when the scan rate limit is exceeded.
Update: Added Bluetooth scan error handling and retries when scans fail due to ScanCallback.SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES and ScanCallback.SCAN_FAILED_SCANNING_TOO_FREQUENTLY.
Fix: Resolved an issue where errors thrown by the BBPOS SDK during Bluetooth reader updates can cause a deadlock and break future discovery attempts.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Go through the basic flow and ensure the IPP works end to end.



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
