### PR TITLE
Issue/5676 round line chart y-axis values

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -425,7 +425,7 @@ class MyStoreStatsView @JvmOverloads constructor(
         fadeInLabelValue(revenueValue, revenue)
         fadeInLabelValue(ordersValue, orders)
 
-        if (chartRevenueStats.isEmpty() || revenueStatsModel?.totalSales?.toInt() == 0) {
+        if (chartRevenueStats.isEmpty() || revenueStatsModel?.totalSales == 0.toDouble()) {
             isRequestingStats = false
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -175,6 +175,7 @@ class MyStoreStatsView @JvmOverloads constructor(
                 setLabelCount(3, false)
                 valueFormatter = RevenueAxisFormatter()
                 setDrawGridLines(true)
+                gridLineWidth = 1f
                 gridColor = ContextCompat.getColor(context, R.color.graph_grid_color)
                 setDrawAxisLine(false)
                 textColor = ContextCompat.getColor(context, R.color.graph_label_color)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -171,17 +171,17 @@ class MyStoreStatsView @JvmOverloads constructor(
                 // Couldn't use the dimension resource here due to the way this component is written :/
                 textSize = 10f
             }
-
-            axisRight.isEnabled = false
             with(axisLeft) {
-                gridColor = ContextCompat.getColor(context, R.color.graph_grid_color)
+                setLabelCount(3, false)
+                valueFormatter = RevenueAxisFormatter()
                 setDrawGridLines(true)
+                gridColor = ContextCompat.getColor(context, R.color.graph_grid_color)
                 setDrawAxisLine(false)
                 textColor = ContextCompat.getColor(context, R.color.graph_label_color)
                 // Couldn't use the dimension resource here due to the way this component is written :/
                 textSize = 10f
             }
-
+            axisRight.isEnabled = false
             description.isEnabled = false
             legend.isEnabled = false
 
@@ -462,8 +462,6 @@ class MyStoreStatsView @JvmOverloads constructor(
                     setDrawZeroLine(true)
                     zeroLineColor = ContextCompat.getColor(context, R.color.divider_color)
                 }
-                labelCount = 3
-                valueFormatter = RevenueAxisFormatter()
             }
             val dot = MarkerImage(context, R.drawable.chart_highlight_dot)
             val offset = DisplayUtils.dpToPx(context, LINE_CHART_DOT_OFFSET).toFloat()
@@ -602,7 +600,10 @@ class MyStoreStatsView @JvmOverloads constructor(
      */
     private inner class RevenueAxisFormatter : ValueFormatter() {
         override fun getFormattedValue(value: Float): String {
-            return getFormattedRevenueValue(value.toDouble())
+            return currencyFormatter.formatCurrencyRounded(
+                value.toDouble(),
+                revenueStatsModel?.currencyCode.orEmpty()
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -602,10 +602,17 @@ class MyStoreStatsView @JvmOverloads constructor(
 
     private inner class RevenueAxisFormatter : ValueFormatter() {
         override fun getAxisLabel(value: Float, axis: AxisBase): String {
-            return currencyFormatter.formatCurrencyRounded(
-                value.toDouble(),
-                revenueStatsModel?.currencyCode.orEmpty()
-            ).replace(".0", "")
+            return if (-1 < value && value < 1 && value != 0f) {
+                currencyFormatter.formatCurrency(
+                    value.toBigDecimal(),
+                    revenueStatsModel?.currencyCode.orEmpty()
+                )
+            } else {
+                currencyFormatter.formatCurrencyRounded(
+                    value.toDouble(),
+                    revenueStatsModel?.currencyCode.orEmpty()
+                ).replace(".0", "")
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -14,6 +14,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import com.github.mikephil.charting.charts.Chart
+import com.github.mikephil.charting.components.AxisBase
 import com.github.mikephil.charting.components.MarkerImage
 import com.github.mikephil.charting.components.XAxis
 import com.github.mikephil.charting.data.Entry
@@ -548,14 +549,14 @@ class MyStoreStatsView @JvmOverloads constructor(
     }
 
     private inner class StartEndDateAxisFormatter : ValueFormatter() {
-        override fun getFormattedValue(value: Float): String {
+        override fun getAxisLabel(value: Float, axis: AxisBase): String {
             var index = round(value).toInt() - 1
             index = if (index == -1) index + 1 else index
             return if (index > -1 && index < chartRevenueStats.keys.size) {
                 // if this is the first entry in the chart, then display the month as well as the date
                 // for weekly and monthly stats
                 val dateString = chartRevenueStats.keys.elementAt(index)
-                if (value == binding.chart.xAxis.mEntries.first()) {
+                if (value == axis.mEntries.first()) {
                     getEntryValue(dateString)
                 } else {
                     getLabelValue(dateString)
@@ -595,12 +596,8 @@ class MyStoreStatsView @JvmOverloads constructor(
         }
     }
 
-    /**
-     * Custom AxisFormatter for the Y-axis which only displays 3 labels:
-     * the maximum, minimum and 0 value labels
-     */
     private inner class RevenueAxisFormatter : ValueFormatter() {
-        override fun getFormattedValue(value: Float): String {
+        override fun getAxisLabel(value: Float, axis: AxisBase): String {
             return currencyFormatter.formatCurrencyRounded(
                 value.toDouble(),
                 revenueStatsModel?.currencyCode.orEmpty()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -36,12 +36,13 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
+import com.woocommerce.android.util.roundToTheNextPowerOfTen
 import com.woocommerce.android.widgets.SkeletonView
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DisplayUtils
 import java.text.DecimalFormat
 import java.util.Locale
-import kotlin.math.*
+import kotlin.math.round
 
 class MyStoreStatsView @JvmOverloads constructor(
     ctx: Context,
@@ -474,26 +475,6 @@ class MyStoreStatsView @JvmOverloads constructor(
             marker = dot
         }
         isRequestingStats = false
-    }
-
-    /**
-     * Returns a rounded value that has the next higher multitude of the same power of 10.
-     * Examples when positive number: 62 --> 70, 134 --> 200, 1450 --> 2000
-     * Examples when negative number: -62 --> -70, -579 --> -600
-     */
-    private fun Float.roundToTheNextPowerOfTen(): Float {
-        if (this == 0f) {
-            return 0f
-        }
-        val isNegative = this < 0
-        val absoluteValue = abs(this)
-        val numberOfDigits = max(floor(log10(absoluteValue)), 0f)
-        val tenthPowerValue = 10f.pow(numberOfDigits)
-        return if (isNegative) {
-            floor(-absoluteValue / tenthPowerValue) * tenthPowerValue
-        } else {
-            ceil(absoluteValue / tenthPowerValue) * tenthPowerValue
-        }
     }
 
     private fun getFormattedRevenueValue(revenue: Double) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/NumberRounding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/NumberRounding.kt
@@ -7,17 +7,19 @@ import kotlin.math.*
  * Examples when positive number: 62 --> 70, 134 --> 200, 1450 --> 2000
  * Examples when negative number: -62 --> -70, -579 --> -600
  */
-fun Float.roundToTheNextPowerOfTen(): Float {
-    if (this == 0f) {
-        return 0f
+fun Float.roundToTheNextPowerOfTen(): Float =
+    when {
+        this == 0f -> 0f
+        -1 < this && this < 1 -> this
+        else -> {
+            val isNegative = this < 0
+            val absoluteValue = abs(this)
+            val numberOfDigits = max(floor(log10(absoluteValue)), 0f)
+            val tenthPowerValue = 10f.pow(numberOfDigits)
+            if (isNegative) {
+                floor(-absoluteValue / tenthPowerValue) * tenthPowerValue
+            } else {
+                ceil(absoluteValue / tenthPowerValue) * tenthPowerValue
+            }
+        }
     }
-    val isNegative = this < 0
-    val absoluteValue = abs(this)
-    val numberOfDigits = max(floor(log10(absoluteValue)), 0f)
-    val tenthPowerValue = 10f.pow(numberOfDigits)
-    return if (isNegative) {
-        floor(-absoluteValue / tenthPowerValue) * tenthPowerValue
-    } else {
-        ceil(absoluteValue / tenthPowerValue) * tenthPowerValue
-    }
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/NumberRounding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/NumberRounding.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.util
+
+import kotlin.math.*
+
+/**
+ * Returns a rounded value that has the next higher multitude of the same power of 10.
+ * Examples when positive number: 62 --> 70, 134 --> 200, 1450 --> 2000
+ * Examples when negative number: -62 --> -70, -579 --> -600
+ */
+fun Float.roundToTheNextPowerOfTen(): Float {
+    if (this == 0f) {
+        return 0f
+    }
+    val isNegative = this < 0
+    val absoluteValue = abs(this)
+    val numberOfDigits = max(floor(log10(absoluteValue)), 0f)
+    val tenthPowerValue = 10f.pow(numberOfDigits)
+    return if (isNegative) {
+        floor(-absoluteValue / tenthPowerValue) * tenthPowerValue
+    } else {
+        ceil(absoluteValue / tenthPowerValue) * tenthPowerValue
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/NumberRoundingTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/NumberRoundingTest.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class NumberRoundingTest(
+    private val initialValue: Float,
+    private val roundedValue: Float
+) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Float>> {
+            return listOf(
+                arrayOf(0f, 0f),
+                arrayOf(23f, 30f),
+                arrayOf(656f, 700f),
+                arrayOf(1526f, 2000f),
+                arrayOf(-18f, -20f),
+                arrayOf(-138f, -200f),
+                arrayOf(-1338f, -2000f),
+                arrayOf(0.3f, 1f),
+                arrayOf(-0.3f, -1f),
+            )
+        }
+    }
+
+    @Test
+    fun `Given float value, when roundToTheNextPowerOfTen, then return the next power of 10 for the value`() {
+        assertEquals(roundedValue, initialValue.roundToTheNextPowerOfTen())
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/NumberRoundingTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/NumberRoundingTest.kt
@@ -23,8 +23,10 @@ class NumberRoundingTest(
                 arrayOf(-18f, -20f),
                 arrayOf(-138f, -200f),
                 arrayOf(-1338f, -2000f),
-                arrayOf(0.3f, 1f),
-                arrayOf(-0.3f, -1f),
+                arrayOf(0.3f, 0.3f),
+                arrayOf(-0.3f, -0.3f),
+                arrayOf(1.3f, 2f),
+                arrayOf(-1.3f, -2f)
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/NumberRoundingTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/NumberRoundingTest.kt
@@ -11,7 +11,6 @@ class NumberRoundingTest(
     private val initialValue: Float,
     private val roundedValue: Float
 ) {
-
     companion object {
         @JvmStatic
         @Parameterized.Parameters

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/NumberRoundingTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/NumberRoundingTest.kt
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
+@Suppress("ArrayPrimitive")
 class NumberRoundingTest(
     private val initialValue: Float,
     private val roundedValue: Float


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5676 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, the y-axis in the dashboard charts shows the absolute number for the highest revenue for the maximum and a negative number for the minimum. To polish the y-axis labels, this PR updates the y-axis range so that:

- Always 3 labels are shown at even spacing from min to max by setting `yAxis.setLabelCount(3, force: true)`
- Manually calculate the y-axis maximum value:
  - The nearest higher multitude of power of tens (e.g. 62.5 --> 70) if there is any positive revenue
  - `0` if revenue is all negative
  - `1` if there is no revenue
- Manually calculate the y-axis minimum value:
  - `0` if there is any positive revenue
  - The nearest lower multitude of power of tens (e.g. -62.5 --> -70) if revenue is all negative
  - `-1` if there is no revenue

Added a new function for calculating the "nearest higher/lower multitude of power of tens"

### Testing instructions
- Open My Store Tab
- Tap each time range tab --> if there is no revenue (like for today), the chart shouldn't show any y-axis labels. If there is any positive revenue, 3 chart y-axis labels should be shown with the max being the "nearest higher multitude of power of tens." If revenue is all negative, the y-axis max should be 0 and the min should be the "nearest lower multitude of power of tens"

### Demo 

https://user-images.githubusercontent.com/2663464/151001498-f6a50cc1-5cd8-4495-85a1-6ef238864b24.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
