### PR TITLE
Fix crash when updating the order status to one that doesn't exist on the DB

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.CreateOrderRequest
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -21,7 +22,7 @@ class OrderCreationRepository @Inject constructor(
         val status = withContext(dispatchers.io) {
             // Currently this query will run on the current thread, so forcing the usage of IO dispatcher
             orderStore.getOrderStatusForSiteAndKey(selectedSite.get(), order.status.value)
-                ?: error("Couldn't find a status with key ${order.status.value}")
+                ?: WCOrderStatusModel(statusKey = order.status.value)
         }
 
         val request = CreateOrderRequest(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -104,7 +104,7 @@ class OrderDetailRepository @Inject constructor(
     ): Flow<UpdateOrderResult> {
         val status = withContext(dispatchers.io) {
             orderStore.getOrderStatusForSiteAndKey(selectedSite.get(), newStatus)
-                ?: error("Couldn't find a status with key $newStatus")
+                ?: WCOrderStatusModel(statusKey = newStatus)
         }
         return orderStore.updateOrderStatus(
             LocalOrRemoteId.RemoteId(remoteOrderId),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5689 

### Description
Recently we update the FluxC functions to accept the model `WCOrderStatusModel` instead of a plain String for handling order statuses, then I did the mistake of assuming we will necessarily have an object in the DB when trying to update the status, but it turns out this is not always the case:
1. If the request to fetch the list of orders failed, then the merchant tries to fulfill an Order after purchasing a shipping label, we will use the status `completed` directly in the app, but we can't still match it in the DB.
2. When creating an order, if the merchant doesn't update the default order status.

IMO a better fix would be to seed the DB with the list of default Order Statuses, or at least update the `Store` to have a default list of values that it can use when the DB is empty, but as it requires more effort, I think this fix is enough for now.

### Testing instructions
This is not easy to reproduce, since it requires the failure of fetching the order statuses, but I think the fix is clear on what it does.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
