### PR TITLE
Fix for next button enabled/disabled state in RefundByItem screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -224,7 +224,6 @@ class IssueRefundViewModel @Inject constructor(
                 feesSubtotal = formatCurrency(order.feesTotal),
                 feesTaxes = formatCurrency(order.feesLines.sumByBigDecimal { it.totalTax }),
                 formattedProductsRefund = formatCurrency(BigDecimal.ZERO),
-                isNextButtonEnabled = false,
                 formattedShippingRefundTotal = formatCurrency(BigDecimal.ZERO),
                 formattedFeesRefundTotal = formatCurrency(BigDecimal.ZERO),
                 refundNotice = getRefundNotice(),
@@ -537,9 +536,7 @@ class IssueRefundViewModel @Inject constructor(
     fun onProductsRefundAmountChanged(newAmount: BigDecimal) {
         refundByItemsState = refundByItemsState.copy(
             productsRefund = newAmount,
-            formattedProductsRefund = formatCurrency(newAmount),
-            isNextButtonEnabled =  isTotalRefundAmountGreaterThanZero(newAmount ,
-                refundByItemsState.shippingRefund ,refundByItemsState.feesRefund)
+            formattedProductsRefund = formatCurrency(newAmount)
         )
     }
 
@@ -563,8 +560,6 @@ class IssueRefundViewModel @Inject constructor(
             formattedProductsRefund = formatCurrency(productsRefund),
             taxes = formatCurrency(taxes),
             subtotal = formatCurrency(subtotal),
-            isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
-                refundByItemsState.shippingRefund ,refundByItemsState.feesRefund),
             selectButtonTitle = selectButtonTitle
         )
     }
@@ -671,8 +666,6 @@ class IssueRefundViewModel @Inject constructor(
                 shippingRefund = shippingRefund,
                 formattedShippingRefundTotal = formatCurrency(shippingRefund),
                 isShippingMainSwitchChecked = true,
-                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
-                    shippingRefund ,refundByItemsState.feesRefund),
                 selectedShippingLines = allShippingLineIds
             )
         } else {
@@ -680,8 +673,6 @@ class IssueRefundViewModel @Inject constructor(
                 shippingRefund = 0.toBigDecimal(),
                 formattedShippingRefundTotal = formatCurrency(0.toBigDecimal()),
                 isShippingMainSwitchChecked = false,
-                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
-                    0.toBigDecimal() ,refundByItemsState.feesRefund),
                 selectedShippingLines = emptyList()
             )
         }
@@ -697,8 +688,6 @@ class IssueRefundViewModel @Inject constructor(
                 feesRefund = feesRefund,
                 formattedFeesRefundTotal = formatCurrency(feesRefund),
                 isFeesMainSwitchChecked = true,
-                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
-                    refundByItemsState.shippingRefund ,feesRefund),
                 selectedFeeLines = allFeeLineIds
             )
         } else {
@@ -706,8 +695,6 @@ class IssueRefundViewModel @Inject constructor(
                 feesRefund = 0.toBigDecimal(),
                 formattedFeesRefundTotal = formatCurrency(0.toBigDecimal()),
                 isFeesMainSwitchChecked = false,
-                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
-                    refundByItemsState.shippingRefund ,0.toBigDecimal()),
                 selectedFeeLines = emptyList()
             )
         }
@@ -733,16 +720,8 @@ class IssueRefundViewModel @Inject constructor(
                 shippingTaxes = formatCurrency(calculatePartialShippingTaxes(list)),
                 shippingRefund = newShippingRefundTotal,
                 formattedShippingRefundTotal = formatCurrency(newShippingRefundTotal),
-                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,newShippingRefundTotal ,
-                    refundByItemsState.feesRefund)
             )
         }
-    }
-
-    private fun isTotalRefundAmountGreaterThanZero(productsRefund:BigDecimal,shippingRefund:BigDecimal,
-                                                   feesRefund:BigDecimal):Boolean{
-        val total = productsRefund.add(shippingRefund).add(feesRefund)
-        return total > BigDecimal.ZERO
     }
 
     fun onFeeLineSwitchChanged(isChecked: Boolean, itemId: Long) {
@@ -764,9 +743,7 @@ class IssueRefundViewModel @Inject constructor(
                 feesSubtotal = formatCurrency(calculatePartialFeesSubtotal(list)),
                 feesTaxes = formatCurrency(calculatePartialFeesTaxes(list)),
                 feesRefund = newFeesRefundTotal,
-                formattedFeesRefundTotal = formatCurrency(newFeesRefundTotal),
-                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
-                    refundByItemsState.shippingRefund ,newFeesRefundTotal)
+                formattedFeesRefundTotal = formatCurrency(newFeesRefundTotal)
             )
         }
     }
@@ -864,7 +841,6 @@ class IssueRefundViewModel @Inject constructor(
     @Parcelize
     data class RefundByItemsViewState(
         val currency: String? = null,
-        val isNextButtonEnabled: Boolean? = null,
         val productsRefund: BigDecimal = BigDecimal.ZERO,
         val formattedProductsRefund: String? = null,
         val subtotal: String? = null,
@@ -889,6 +865,9 @@ class IssueRefundViewModel @Inject constructor(
     ) : Parcelable {
         val grandTotalRefund: BigDecimal
             get() = max(productsRefund + shippingRefund + feesRefund, BigDecimal.ZERO)
+
+        val isNextButtonEnabled: Boolean
+            get() = grandTotalRefund > BigDecimal.ZERO
 
         val isRefundNoticeVisible = !refundNotice.isNullOrEmpty()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -538,7 +538,8 @@ class IssueRefundViewModel @Inject constructor(
         refundByItemsState = refundByItemsState.copy(
             productsRefund = newAmount,
             formattedProductsRefund = formatCurrency(newAmount),
-            isNextButtonEnabled = newAmount > BigDecimal.ZERO
+            isNextButtonEnabled =  isTotalRefundAmountGreaterThanZero(newAmount ,
+                refundByItemsState.shippingRefund ,refundByItemsState.feesRefund)
         )
     }
 
@@ -562,7 +563,8 @@ class IssueRefundViewModel @Inject constructor(
             formattedProductsRefund = formatCurrency(productsRefund),
             taxes = formatCurrency(taxes),
             subtotal = formatCurrency(subtotal),
-            isNextButtonEnabled = _refundItems.value?.any { it.quantity > 0 } ?: false,
+            isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
+                refundByItemsState.shippingRefund ,refundByItemsState.feesRefund),
             selectButtonTitle = selectButtonTitle
         )
     }
@@ -669,7 +671,8 @@ class IssueRefundViewModel @Inject constructor(
                 shippingRefund = shippingRefund,
                 formattedShippingRefundTotal = formatCurrency(shippingRefund),
                 isShippingMainSwitchChecked = true,
-                isNextButtonEnabled = productsRefund.add(shippingRefund) > BigDecimal.ZERO,
+                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
+                    shippingRefund ,refundByItemsState.feesRefund),
                 selectedShippingLines = allShippingLineIds
             )
         } else {
@@ -677,7 +680,8 @@ class IssueRefundViewModel @Inject constructor(
                 shippingRefund = 0.toBigDecimal(),
                 formattedShippingRefundTotal = formatCurrency(0.toBigDecimal()),
                 isShippingMainSwitchChecked = false,
-                isNextButtonEnabled = productsRefund > BigDecimal.ZERO,
+                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
+                    0.toBigDecimal() ,refundByItemsState.feesRefund),
                 selectedShippingLines = emptyList()
             )
         }
@@ -693,7 +697,8 @@ class IssueRefundViewModel @Inject constructor(
                 feesRefund = feesRefund,
                 formattedFeesRefundTotal = formatCurrency(feesRefund),
                 isFeesMainSwitchChecked = true,
-                isNextButtonEnabled = productsRefund.add(feesRefund) > BigDecimal.ZERO,
+                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
+                    refundByItemsState.shippingRefund ,feesRefund),
                 selectedFeeLines = allFeeLineIds
             )
         } else {
@@ -701,7 +706,8 @@ class IssueRefundViewModel @Inject constructor(
                 feesRefund = 0.toBigDecimal(),
                 formattedFeesRefundTotal = formatCurrency(0.toBigDecimal()),
                 isFeesMainSwitchChecked = false,
-                isNextButtonEnabled = productsRefund > BigDecimal.ZERO,
+                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
+                    refundByItemsState.shippingRefund ,0.toBigDecimal()),
                 selectedFeeLines = emptyList()
             )
         }
@@ -727,9 +733,16 @@ class IssueRefundViewModel @Inject constructor(
                 shippingTaxes = formatCurrency(calculatePartialShippingTaxes(list)),
                 shippingRefund = newShippingRefundTotal,
                 formattedShippingRefundTotal = formatCurrency(newShippingRefundTotal),
-                isNextButtonEnabled = productsRefund.add(newShippingRefundTotal) > BigDecimal.ZERO
+                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,newShippingRefundTotal ,
+                    refundByItemsState.feesRefund)
             )
         }
+    }
+
+    private fun isTotalRefundAmountGreaterThanZero(productsRefund:BigDecimal,shippingRefund:BigDecimal,
+                                                   feesRefund:BigDecimal):Boolean{
+        val total = productsRefund.add(shippingRefund).add(feesRefund)
+        return total > BigDecimal.ZERO
     }
 
     fun onFeeLineSwitchChanged(isChecked: Boolean, itemId: Long) {
@@ -752,7 +765,8 @@ class IssueRefundViewModel @Inject constructor(
                 feesTaxes = formatCurrency(calculatePartialFeesTaxes(list)),
                 feesRefund = newFeesRefundTotal,
                 formattedFeesRefundTotal = formatCurrency(newFeesRefundTotal),
-                isNextButtonEnabled = productsRefund.add(newFeesRefundTotal) > BigDecimal.ZERO
+                isNextButtonEnabled = isTotalRefundAmountGreaterThanZero(productsRefund ,
+                    refundByItemsState.shippingRefund ,newFeesRefundTotal)
             )
         }
     }


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Closes: #5628 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The Refund screen should have next button enabled if either Refund Fees , Refund Shipping or  any of the product is selected for refund . This assertion however breaks in the following scenario, 

1. Go Orders tab and select an order with at least one fee item.
2. Tap on the Issue Refund button. 
3. Now switch on the shipping and refund fees toggle . 
4. Switch off one of them , the next button becomes disabled 
5. Alternatively switch on any or both the toggles (this will occur even without fee item) . Now click on select all product  items followed by select none , observe that next button is disabled after selecting none , even though the other refund switch(es) is/are still in ON state .



### Root Cause 
When shipping or fees refund is switched on or off individually or when product refund items are selected the next button state is enabled or disabled depending upon product refund amount + shipping or product refund + fees . So when fees refund is switching  between on or off state the shipping refund amount is not considered similarly  in case for shipping  refund switch the fees refund is missed.
In case of refunding the product item , the next button toggles based only on the condition if one or more item is selected or not. This does not consider shipping or refund amount at all . So even shipping and /or fees switch is in ON state , unselecting all refund items will disable the next button

### Fix 
This fix checks for all the three refund categories  before toggling the state of the next button .

### Issue Video 
**![5628](https://user-images.githubusercontent.com/20752243/151200374-9c1e66a5-dc66-490a-b6d9-13410f62bc7a.gif)**

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go Orders tab and select an order with at least one fee item.
2. Tap on the Issue Refund button. 
3. Keep any one switch in ON state viz .. refund fees , refund shipping or any one product item selected for refund  .
4. Change the state of other switch or/and remove all selected item from the product . Observe that next button remains enabled as long as the as the refund amount is not zero . i.e there is at least one valid fees,shipping or item selected for return.
5. The next button will be off iff and only iff there some money to be returned 

### Video after Fix 
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/20752243/151201246-f26c1e9b-48ac-4153-8e5f-54847a26e15b.mp4



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
