### PR TITLE
Replace all usages of navigate with navigateSafely

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -331,12 +331,12 @@ class OrderListFragment :
     }
 
     private fun showOrderFilters() {
-        findNavController().navigate(R.id.action_orderListFragment_to_orderFilterListFragment)
+        findNavController().navigateSafely(R.id.action_orderListFragment_to_orderFilterListFragment)
     }
 
     private fun showSimplePaymentsDialog() {
         AnalyticsTracker.track(Stat.SIMPLE_PAYMENTS_FLOW_STARTED)
-        findNavController().navigate(R.id.action_orderListFragment_to_simplePayments)
+        findNavController().navigateSafely(R.id.action_orderListFragment_to_simplePayments)
     }
 
     private fun showOrderCreationBottomSheet() {
@@ -345,7 +345,7 @@ class OrderListFragment :
     }
 
     private fun openOrderCreationFragment() {
-        findNavController().navigate(R.id.action_orderListFragment_to_orderCreationFragment)
+        findNavController().navigateSafely(R.id.action_orderListFragment_to_orderCreationFragment)
     }
 
     private fun hideEmptyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -13,10 +13,7 @@ import com.woocommerce.android.AppUrls
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPaymentBinding
-import com.woocommerce.android.extensions.handleNotice
-import com.woocommerce.android.extensions.navigateBackWithNotice
-import com.woocommerce.android.extensions.navigateBackWithResult
-import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.extensions.*
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
@@ -188,7 +185,7 @@ class EditShippingLabelPaymentFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is AddPaymentMethod -> {
-                    findNavController().navigate(
+                    findNavController().navigateSafely(
                         NavGraphMainDirections.actionGlobalWPComWebViewFragment(
                             urlToLoad = AppUrls.WPCOM_ADD_PAYMENT_METHOD,
                             urlToTriggerExit = FETCH_PAYMENT_METHOD_URL_PATH

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -244,7 +244,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
                 is CardReaderConnectEvent.ShowToast ->
                     ToastUtils.showToast(requireContext(), getString(event.message))
                 is CardReaderConnectEvent.OpenWPComWebView ->
-                    findNavController().navigate(
+                    findNavController().navigateSafely(
                         NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
                     )
                 is CardReaderConnectEvent.OpenGenericWebView ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubFragment.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentCardReaderHubBinding
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 
@@ -39,7 +40,7 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
         ) { event ->
             when (event) {
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderDetail -> {
-                    findNavController().navigate(R.id.action_cardReaderHubFragment_to_cardReaderDetailFragment)
+                    findNavController().navigateSafely(R.id.action_cardReaderHubFragment_to_cardReaderDetailFragment)
                 }
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.databinding.FragmentCardReaderOnboardingUnsupport
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingWcpayBinding
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.navigateBackWithNotice
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.ui.base.BaseFragment
@@ -48,7 +49,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                     is CardReaderOnboardingViewModel.OnboardingEvent.Continue -> {
                         val inSettingsGraph = findNavController().graph.id == R.id.nav_graph_settings
                         if (inSettingsGraph) {
-                            findNavController().navigate(
+                            findNavController().navigateSafely(
                                 R.id.action_cardReaderOnboardingFragment_to_cardReaderHubFragment
                             )
                         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -269,37 +269,37 @@ class ProductNavigator @Inject constructor() {
 
             is ViewProductAdd -> {
                 val action = NavGraphMainDirections.actionGlobalProductDetailFragment(isAddProduct = true)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductDownloads -> {
                 val action = ProductDetailFragmentDirections
                     .actionProductDetailFragmentToProductDownloadsFragment()
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductDownloadsSettings -> {
                 val action = ProductDownloadsFragmentDirections
                     .actionProductDownloadsFragmentToProductDownloadsSettingsFragment()
 
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductDownloadDetails -> {
                 val action = NavGraphProductsDirections
                     .actionGlobalProductDownloadDetailsFragment(target.isEditing, target.file)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductAddonsDetails -> {
                 ProductDetailFragmentDirections
                     .actionProductDetailFragmentToProductAddonsFragment()
-                    .apply { fragment.findNavController().navigate(this) }
+                    .apply { fragment.findNavController().navigateSafely(this) }
             }
 
             is AddProductDownloadableFile -> {
                 val action = NavGraphProductsDirections.actionGlobalAddProductDownloadBottomSheetFragment()
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is AddProductAttribute -> {
@@ -307,19 +307,19 @@ class ProductNavigator @Inject constructor() {
                     true ->
                         ProductDetailFragmentDirections
                             .actionProductDetailFragmentToAddAttributeFragment(isVariationCreation = true)
-                            .run { fragment.findNavController().navigate(this) }
+                            .run { fragment.findNavController().navigateSafely(this) }
 
                     else ->
                         AttributeListFragmentDirections
                             .actionAttributeListFragmentToAddAttributeFragment()
-                            .run { fragment.findNavController().navigate(this) }
+                            .run { fragment.findNavController().navigateSafely(this) }
                 }
             }
 
             is RenameProductAttribute -> {
                 val action = AddAttributeTermsFragmentDirections
                     .actionAttributeTermsFragmentToRenameAttributeFragment(target.attributeName)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is AddProductAttributeTerms -> {
@@ -329,7 +329,7 @@ class ProductNavigator @Inject constructor() {
                     isNewAttribute = target.isNewAttribute,
                     isVariationCreation = target.isVariationCreation
                 )
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewMediaUploadErrors -> {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5716
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR replaces all usages of `navigate` with `navigateSafely` to prevent crashes when the user unintentionally double-taps on a navigation item. `NavigateSafely` internally uses a 200ms throttle.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Smoke test a couple of the changed screens
I tested 
- Tapping on Filter on the Order List screen
- Tapping on "Manage Card Reader" on the In Person Payments Hub screen
- Creating variation product
- In Person Payments Onboarding fragment

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No user facing changes except of a hardly noticable 200ms delay after the user taps on an item.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
