### PR TITLE
Adds org.wordpress.wellsql to s3 repositories

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -21,6 +21,7 @@ repositories {
             includeGroup "org.wordpress"
             includeGroup "org.wordpress.fluxc"
             includeGroup "org.wordpress.fluxc.plugins"
+            includeGroup "org.wordpress.wellsql"
             includeGroup "org.wordpress.mediapicker"
             includeGroup "com.automattic"
         }


### PR DESCRIPTION
### Description

With https://github.com/wordpress-mobile/wellsql/pull/20, we started to publish `wellsql` to our S3 Maven repository. This PR updates the S3 repositories to include `org.wordpress.wellsql`, so `> 1.7.0` version of the library can be fetched from there.

### Testing instructions
N/A

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
