### PR TITLE
Add Canada to the supported countries list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/InPersonPaymentsCanadaFeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/InPersonPaymentsCanadaFeatureFlag.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.prefs.cardreader
+
+import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+
+class InPersonPaymentsCanadaFeatureFlag @Inject constructor() {
+    fun isEnabled() = FeatureFlag.IN_PERSON_PAYMENTS_CANADA.isEnabled(null)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -37,6 +37,13 @@ class CardReaderOnboardingChecker @Inject constructor(
     private val stripeExtensionFeatureFlag: StripeExtensionFeatureFlag,
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
 ) {
+    private val supportedCountries: List<String>
+        get() = if (inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
+            listOf("US", "CA")
+        } else {
+            listOf("US")
+        }
+
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         if (!networkStatus.isConnected()) return NoConnectionError
 
@@ -96,14 +103,6 @@ class CardReaderOnboardingChecker @Inject constructor(
         return OnboardingCompleted(preferredPlugin.type)
     }
 
-    private fun getSupportedCountries(): List<String> {
-        return if (inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
-            listOf("US", "CA")
-        } else {
-            listOf("US")
-        }
-    }
-
     private fun isBothPluginsActivated(
         wcPayPluginInfo: WCPluginModel?,
         stripePluginInfo: WCPluginModel?
@@ -132,7 +131,7 @@ class CardReaderOnboardingChecker @Inject constructor(
 
     private fun isCountrySupported(countryCode: String?): Boolean {
         return countryCode?.let { storeCountryCode ->
-            getSupportedCountries().any { it.equals(storeCountryCode, ignoreCase = true) }
+            supportedCountries.any { it.equals(storeCountryCode, ignoreCase = true) }
         } ?: false.also { WooLog.e(WooLog.T.CARD_READER, "Store's country code not found.") }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.prefs.cardreader.onboarding
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.prefs.cardreader.InPersonPaymentsCanadaFeatureFlag
 import com.woocommerce.android.ui.prefs.cardreader.StripeExtensionFeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,6 +32,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     private val networkStatus: NetworkStatus = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val stripeExtensionFeatureFlag: StripeExtensionFeatureFlag = mock()
+    private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag = mock()
 
     private val site = SiteModel()
 
@@ -44,6 +46,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             coroutinesTestRule.testDispatchers,
             networkStatus,
             stripeExtensionFeatureFlag,
+            inPersonPaymentsCanadaFeatureFlag,
         )
         whenever(networkStatus.isConnected()).thenReturn(true)
         whenever(selectedSite.get()).thenReturn(site)
@@ -56,6 +59,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
             .thenReturn(buildWCPayPluginInfo())
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(false)
+        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
     }
 
     @Test
@@ -798,6 +802,26 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             anyLong(),
             eq(null)
         )
+    }
+
+    @Test
+    fun `given Canada flag true, when store is Canada, then STORE_COUNTRY_NOT_SUPPORTED not returned`() = testBlocking {
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
+        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isNotInstanceOf(CardReaderOnboardingState.StoreCountryNotSupported::class.java)
+    }
+
+    @Test
+    fun `given Canada flag false, when store is Canada, then STORE_COUNTRY_NOT_SUPPORTED returned`() = testBlocking {
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
+        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isInstanceOf(CardReaderOnboardingState.StoreCountryNotSupported::class.java)
     }
 
     private fun buildPaymentAccountResult(


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #5702 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add Canada to the supported countries list when In Persons Payment Canada feature flag is enabled. When the flag is off, we just add the US to the supported countries

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Green CI should be enough

However, you can also verify this by
1. Enabling the IPP Canada feature flag in the `FeatureFlag.kt` file, changing the store address to Canada, and verifying that while card reader onboarding, you won't see "Store not supported".
2. When the IPP Canada flag is disabled and your store address is set to Canada, you must see the "Store not supported" screen.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
