### PR TITLE
Fix crash, race condition between checking if user is logged and load…

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -189,7 +189,6 @@ class MainActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        presenter.takeView(this)
         // Verify authenticated session
         if (!presenter.userIsLoggedIn()) {
             showLoginScreen()
@@ -202,6 +201,8 @@ class MainActivity :
         toolbar = binding.toolbar.toolbar
         setSupportActionBar(toolbar)
         toolbar.navigationIcon = null
+
+        presenter.takeView(this)
 
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
         navController = navHostFragment.navController

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -31,7 +31,10 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivityMainBinding
-import com.woocommerce.android.extensions.*
+import com.woocommerce.android.extensions.active
+import com.woocommerce.android.extensions.collapse
+import com.woocommerce.android.extensions.expand
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -55,7 +58,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
-import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -187,6 +189,13 @@ class MainActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        presenter.takeView(this)
+        // Verify authenticated session
+        if (!presenter.userIsLoggedIn()) {
+            showLoginScreen()
+            return
+        }
+
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -194,7 +203,6 @@ class MainActivity :
         setSupportActionBar(toolbar)
         toolbar.navigationIcon = null
 
-        presenter.takeView(this)
 
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
         navController = navHostFragment.navController
@@ -203,12 +211,6 @@ class MainActivity :
         navHostFragment.childFragmentManager.registerFragmentLifecycleCallbacks(fragmentLifecycleObserver, false)
 
         binding.bottomNav.init(navController, this)
-
-        // Verify authenticated session
-        if (!presenter.userIsLoggedIn()) {
-            showLoginScreen()
-            return
-        }
 
         // fetch the site list if the database has been downgraded - otherwise the site picker will be displayed,
         // which we don't want in this situation

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -203,13 +203,10 @@ class MainActivity :
         setSupportActionBar(toolbar)
         toolbar.navigationIcon = null
 
-
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
         navController = navHostFragment.navController
         navController.addOnDestinationChangedListener(this@MainActivity)
-
         navHostFragment.childFragmentManager.registerFragmentLifecycleCallbacks(fragmentLifecycleObserver, false)
-
         binding.bottomNav.init(navController, this)
 
         // fetch the site list if the database has been downgraded - otherwise the site picker will be displayed,


### PR DESCRIPTION
Closes: #5688 
Sentry issue ID: [WOOCOMMERCE-ANDROID-2Y7](https://sentry.io/organizations/a8c/issues/2892184480/?project=1459556&referrer=github_integration)

### Description
Coming from this PR #5724, full context and discussion there. 

**TLDR**
There is a crash due to trying to load stats from MyStoreFragment when user is not logged in. It is due to a race condition very well explained here by @hichamboushaba. Kudos for that: 
"In MainActivity, the first thing we do is we attach the navgraph [here](https://github.com/woocommerce/woocommerce-android/blob/a797900c552255bd4d9b20731a19e24c14fe6a93/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt#L199-L205), then we check if the user is logged in or not [here](https://github.com/woocommerce/woocommerce-android/blob/a797900c552255bd4d9b20731a19e24c14fe6a93/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt#L208-L211), as the Activity navigation actions are async, they `MyStoreFragment` may reach the state created before we finish `MainActivity`, and as we are loading stats in the `MyStoreViewModel`'s constructor now, we may start loading them too even if the user is not logged in."

So we need to make sure we don't specify the `nav_graph_main` before checking if the user is logged in. And that is what the changes on this PR are about. Ensuring we check the login state before anything else when creating MainActivity. 


### Testing instructions
This bug is very hard to reproduce. But we can artificially  make it happen to validate the theory of the race condition explained previously. Apply this patch to delay the moment when we check is the user is logged. Run the app unlogged. The app will sometimes crash: 

```
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
index 5ce7665558..47a1ed247f 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -7,6 +7,8 @@ import android.content.Intent
 import android.content.res.Resources.Theme
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -194,7 +196,6 @@ class MainActivity :
         setSupportActionBar(toolbar)
         toolbar.navigationIcon = null
 
-        presenter.takeView(this)
 
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
         navController = navHostFragment.navController
@@ -204,11 +205,14 @@ class MainActivity :
 
         binding.bottomNav.init(navController, this)
 
-        // Verify authenticated session
-        if (!presenter.userIsLoggedIn()) {
-            showLoginScreen()
-            return
-        }
+        presenter.takeView(this)
+        Handler(Looper.getMainLooper()).postDelayed({
+            // Verify authenticated session
+            if (!presenter.userIsLoggedIn()) {
+                showLoginScreen()
+            }
+        }, 100)
+        return
 
         // fetch the site list if the database has been downgraded - otherwise the site picker will be displayed,
         // which we don't want in this situation
@@ -254,6 +258,7 @@ class MainActivity :
 
     override fun onResume() {
         super.onResume()
+        return
         AnalyticsTracker.trackViewShown(this)
```
This will lead to this crash which is the same as we see in Sentry: 
```

2022-01-28 13:27:38.598 8098-8098/com.woocommerce.android.prealpha E/AndroidRuntime:     at com.woocommerce.android.ui.mystore.data.StatsRepository$checkIfStoreHasNoOrders$2.invokeSuspend(StatsRepository.kt:101)
        at com.woocommerce.android.ui.mystore.data.StatsRepository$checkIfStoreHasNoOrders$2.invoke(Unknown Source:8)
        at com.woocommerce.android.ui.mystore.data.StatsRepository$checkIfStoreHasNoOrders$2.invoke(Unknown Source:4)
        at kotlinx.coroutines.flow.SafeFlow.collectSafely(Builders.kt:61)
        at kotlinx.coroutines.flow.AbstractFlow.collect(Flow.kt:212)
        at com.woocommerce.android.ui.mystore.domain.GetStats$hasOrders$$inlined$transform$1.invokeSuspend(Emitters.kt:223)
        at com.woocommerce.android.ui.mystore.domain.GetStats$hasOrders$$inlined$transform$1.invoke(Unknown Source:8)
        at com.woocommerce.android.ui.mystore.domain.GetStats$hasOrders$$inlined$transform$1.invoke(Unknown Source:4)
        		... 9 more
```

