### PR TITLE
issue/5729 Runs `fetchWooCommerceSites` on IO thread during site selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -88,7 +88,7 @@ class SitePickerPresenter
     override fun fetchSitesFromAPI() {
         coroutineScope.launch {
             val startTime = System.currentTimeMillis()
-            val result = wooCommerceStore.fetchWooCommerceSites()
+            val result = withContext(Dispatchers.IO) { wooCommerceStore.fetchWooCommerceSites() }
             val duration = System.currentTimeMillis() - startTime
             view?.showLoadingView(false)
             if (result.isError) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5729
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Runs `fetchWooCommerceSites` on the IO thread during site selection. It doesn't fix all similar issues on the screen, but this looks like the biggest one

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open site selection screen via settings in debug
* Notice that the red frame is not visible anymore

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### Before:

https://user-images.githubusercontent.com/4923871/151559027-456f9a2d-ca14-4bcf-93aa-1645897c36ca.mp4

#### After:

https://user-images.githubusercontent.com/4923871/151559046-bd572f9c-14b5-439f-9fa2-2e19732f0389.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
