### PR TITLE
Allow characters for postal code

### DIFF
--- a/WooCommerce/src/main/res/layout/layout_address_form.xml
+++ b/WooCommerce/src/main/res/layout/layout_address_form.xml
@@ -150,7 +150,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_100"
             android:hint="@string/order_detail_edit_address_zip"
-            android:inputType="phone"
+            android:inputType="textPostalAddress"
             android:saveEnabled="false"
             app:errorEnabled="true" />
 


### PR DESCRIPTION
Canada postal code can be in the form of "A1A B2B". Yes, we have letters. 🤪 

Closes #5659 

## Design

Before | After 
--------|-------
![2022-01-28 10 59 40](https://user-images.githubusercontent.com/198826/151599603-9df97def-cd2b-4808-9068-6d0932864f74.png)|![2022-01-28 11 01 58](https://user-images.githubusercontent.com/198826/151599635-67943b63-779c-40b3-962e-83aa02228678.png)

## Changes

I mainly changed the input type to text. This affects both Order Editing and Order Creation.

## Testing

### Editing

1. Open an existing order.
2. Edit the shipping or billing address.
3. Change the postal code to "T3J 4R1" or anything with letters.
4. Save it.
5. Confirm that the postal code was updated in wp-admin. 

### Creation 

6. Create a new order using the new Order Creation. 
7. Tap Add Customer
8. Confirm that you can enter letters in the postal code. 
9. Fill in the rest of the address details, including email. 
10. Add a product
11. Save the new order. 
12. Confirm the order is saved with the correct postal code in wp-admin. 

## Reviewing

Only 1 reviewer is needed but anyone can review.

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


