### PR TITLE
[Order Creation] fix crash on variations list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/variations/OrderCreationVariationSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/variations/OrderCreationVariationSelectionViewModel.kt
@@ -35,7 +35,10 @@ class OrderCreationVariationSelectionViewModel @Inject constructor(
 
     private val variationsListFlow = flow {
         // Let's start with the cached variations
-        emit(variationRepository.getProductVariationList(navArgs.productId).takeIf { it.isNotEmpty() })
+        val cachedVariations = withContext(dispatchers.io) {
+            variationRepository.getProductVariationList(navArgs.productId).takeIf { it.isNotEmpty() }
+        }
+        emit(cachedVariations)
         // Then fetch from network
         emit(variationRepository.fetchProductVariations(navArgs.productId))
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/variations/OrderCreationVariationSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/variations/OrderCreationVariationSelectionViewModel.kt
@@ -26,8 +26,9 @@ class OrderCreationVariationSelectionViewModel @Inject constructor(
     private val loadMoreTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     private val parentProductFlow = flow {
+        val productId = navArgs.productId
         val parentProduct = withContext(dispatchers.io) {
-            productRepository.getProduct(navArgs.productId)
+            productRepository.getProduct(productId)
         }
         emit(parentProduct)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
@@ -39,6 +39,8 @@ inline fun <reified Args : NavArgs> SavedStateHandle.navArgs(): Lazy<Args> {
 }
 
 /** cache the methods for [NavArgsLazy] to avoid depending on reflection for all invocations **/
+// TODO investigate the usage of [ConcurrentHashMap] to avoid getting ConcurrentModificationException when accessing
+// navigation arguments from multiple threads
 private val methodMap = ArrayMap<KClass<out NavArgs>, Method>()
 
 /**


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5737 

### Description
This fixes a crash caused by a concurrent exception thrown when accessing navigation arguments from multiple threads, the fix now just avoids accessing the navigation arguments from threads other than main.

I've put a TODO comment to investigate the possibility to use `ConcurrentHashMap` after updating to navigation 2.4 to avoid having to deal with this in the future.

### Testing instructions
I couldn't reproduce the crash, @shiki if you can please retest and make sure it's not reproducible anymore.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
