### PR TITLE
Add Wisepad 3 as supported reader for Canada behind a feature flag

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -1346,7 +1346,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given Canada flag true, then supported readers contains Wisepad 3`() {
+    fun `given ipp Canada feature flag is true, then supported readers contains Wisepad 3`() {
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
 
         assertThat(viewModel.supportedReaders).isEqualTo(
@@ -1357,7 +1357,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given Canada flag false, then supported readers does not contain Wisepad 3`() {
+    fun `given ipp Canada feature flag is false, then supported readers does not contain Wisepad 3`() {
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
 
         assertThat(viewModel.supportedReaders).isEqualTo(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -9,11 +9,13 @@ import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Failed
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.ReadersFound
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.SpecificReader
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.prefs.cardreader.InPersonPaymentsCanadaFeatureFlag
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckBluetoothEnabled
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckBluetoothPermissionsGiven
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectEvent.CheckLocationEnabled
@@ -81,6 +83,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         on { getIfExists() }.thenReturn(siteModel)
         on { get() }.thenReturn(siteModel)
     }
+    private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag = mock()
 
     private val locationId = "location_id"
 
@@ -1342,12 +1345,35 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
     }
 
+    @Test
+    fun `given Canada flag true, then supported readers contains Wisepad 3`() {
+        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
+
+        assertThat(viewModel.supportedReaders).isEqualTo(
+            listOf(
+                SpecificReader.Chipper2X, SpecificReader.StripeM2, SpecificReader.WisePade3
+            )
+        )
+    }
+
+    @Test
+    fun `given Canada flag false, then supported readers does not contain Wisepad 3`() {
+        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
+
+        assertThat(viewModel.supportedReaders).isEqualTo(
+            listOf(
+                SpecificReader.Chipper2X, SpecificReader.StripeM2
+            )
+        )
+    }
+
     private suspend fun initVM(
         onboardingState: CardReaderOnboardingState,
         skipOnboarding: Boolean = false
     ): CardReaderConnectViewModel {
         val savedState = CardReaderConnectDialogFragmentArgs(skipOnboarding = skipOnboarding).initSavedStateHandle()
         whenever(onboardingChecker.getOnboardingState()).thenReturn(onboardingState)
+        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
         return CardReaderConnectViewModel(
             savedState,
             coroutinesTestRule.testDispatchers,
@@ -1357,6 +1383,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             locationRepository,
             selectedSite,
             cardReaderManager,
+            inPersonPaymentsCanadaFeatureFlag,
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5726 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Now that we are supporting In-Person Payments in Canada. We want to support Wisepad 3 card readers. This PR adds Wisepad 3 as supported readers behind a feature flag for Canada.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Green CI should be enough



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
