### PR TITLE
Issue/5329 both plugins active UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -46,4 +46,6 @@ object AppUrls {
     const val M2_MANUAL_CARD_READER = "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf"
 
     const val PLAY_STORE_APP_PREFIX = "http://play.google.com/store/apps/details?id="
+
+    const val PLUGIN_MANAGEMENT_SUFFIX = "/wp-admin/plugins.php"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.AppUrls
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.*
 import com.woocommerce.android.extensions.exhaustive
@@ -36,8 +36,13 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                     is CardReaderOnboardingViewModel.OnboardingEvent.NavigateToSupport -> {
                         requireActivity().startHelpActivity(HelpActivity.Origin.CARD_READER_ONBOARDING)
                     }
-                    is CardReaderOnboardingViewModel.OnboardingEvent.ViewLearnMore -> {
-                        ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
+                    is CardReaderOnboardingViewModel.OnboardingEvent.NavigateToUrlInWPComWebView -> {
+                        findNavController().navigate(
+                            NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
+                        )
+                    }
+                    is CardReaderOnboardingViewModel.OnboardingEvent.NavigateToUrlInGenericWebView -> {
+                        ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                     }
                     is CardReaderOnboardingViewModel.OnboardingEvent.Continue -> {
                         val inSettingsGraph = findNavController().graph.id == R.id.nav_graph_settings

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -7,13 +7,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
-import com.woocommerce.android.databinding.FragmentCardReaderOnboardingBinding
-import com.woocommerce.android.databinding.FragmentCardReaderOnboardingGenericErrorBinding
-import com.woocommerce.android.databinding.FragmentCardReaderOnboardingLoadingBinding
-import com.woocommerce.android.databinding.FragmentCardReaderOnboardingNetworkErrorBinding
-import com.woocommerce.android.databinding.FragmentCardReaderOnboardingStripeBinding
-import com.woocommerce.android.databinding.FragmentCardReaderOnboardingUnsupportedCountryBinding
-import com.woocommerce.android.databinding.FragmentCardReaderOnboardingWcpayBinding
+import com.woocommerce.android.databinding.*
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.startHelpActivity
@@ -100,10 +94,32 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         view: View,
         state: CardReaderOnboardingViewModel.OnboardingViewState.WcPayAndStripeInstalledState
     ) {
-        val binding = FragmentCardReaderOnboardingStripeBinding.bind(view)
+        val binding = FragmentCardReaderOnboardingBothPluginsActivatedBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
-        UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
+        UiHelpers.setTextOrHide(binding.hintLabel, state.hintLabel)
+        UiHelpers.setTextOrHide(binding.hintPluginOneLabel, state.hintPluginOneLabel)
+        UiHelpers.setTextOrHide(binding.hintPluginTwoLabel, state.hintPluginTwoLabel)
+        UiHelpers.setTextOrHide(binding.hintOrLabel, state.hintOrLabel)
         UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
+
+        UiHelpers.setTextOrHide(binding.textSupport, state.contactSupportLabel)
+        UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
+
+        UiHelpers.setTextOrHide(binding.openPluginStore, state.openWPAdminLabel)
+        UiHelpers.setTextOrHide(binding.refreshAfterUpdating, state.refreshButtonLabel)
+
+        binding.textSupport.setOnClickListener {
+            state.onContactSupportActionClicked.invoke()
+        }
+        binding.learnMoreContainer.learnMore.setOnClickListener {
+            state.onLearnMoreActionClicked.invoke()
+        }
+        binding.openPluginStore.setOnClickListener {
+            state.openWPAdminActionClicked?.invoke()
+        }
+        binding.refreshAfterUpdating.setOnClickListener {
+            state.onRefreshAfterUpdatingClicked?.invoke()
+        }
     }
 
     private fun showLoadingState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -284,7 +284,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_both_plugins_activated_hint_plugin_two)
             val hintOrLabel: UiString = UiString.UiStringRes(R.string.exclusive_or)
 
-            val illustration = R.drawable.img_hot_air_balloon
+            val illustration = R.drawable.img_products_error
             val contactSupportLabel = UiString.UiStringRes(
                 stringRes = R.string.card_reader_onboarding_contact_support,
                 containsHtml = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -204,14 +204,10 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private fun onWPAdminActionClicked() {
         val url = selectedSite.get().url + AppUrls.PLUGIN_MANAGEMENT_SUFFIX
-        if (selectedSite.getIfExists()?.isWPCom == true || selectedSite.getIfExists()?.isWPComAtomic == true) {
-            triggerEvent(
-                NavigateToUrlInWPComWebView(url)
-            )
+        if (selectedSite.get().isWPCom || selectedSite.get().isWPComAtomic) {
+            triggerEvent(NavigateToUrlInWPComWebView(url))
         } else {
-            triggerEvent(
-                NavigateToUrlInGenericWebView(url)
-            )
+            triggerEvent(NavigateToUrlInGenericWebView(url))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -14,8 +14,8 @@ import com.woocommerce.android.extensions.formatToMMMMdd
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingEvent.NavigateToUrlInWPComWebView
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingEvent.NavigateToUrlInGenericWebView
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingEvent.NavigateToUrlInWPComWebView
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.WcPayAndStripeInstalledState
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -298,7 +298,9 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 .UiStringRes(R.string.card_reader_onboarding_both_plugins_activated_refresh_button)
 
             val openWPAdminLabel =
-                openWPAdminActionClicked?.let { UiString.UiStringRes(R.string.card_reader_onboarding_both_plugins_activated_open_store_admin_label) }
+                openWPAdminActionClicked?.let {
+                    UiString.UiStringRes(R.string.card_reader_onboarding_both_plugins_activated_open_store_admin_label)
+                }
         }
 
         class NoConnectionErrorState(

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_both_plugins_activated.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_both_plugins_activated.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/textHeader"
+        style="@style/TextAppearance.Woo.Headline6"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:gravity="center"
+        android:paddingHorizontal="@dimen/major_200"
+        app:layout_constraintBottom_toTopOf="@id/illustration"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="@string/card_reader_onboarding_both_plugins_activated_header" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/illustration"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_275"
+        app:layout_constraintBottom_toTopOf="@id/hintLabel"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textHeader"
+        tools:src="@drawable/img_products_error" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/hintLabel"
+        style="@style/TextAppearance.Woo.Body1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_275"
+        android:gravity="center"
+        android:paddingHorizontal="@dimen/major_200"
+        android:textColor="@color/color_on_surface_high"
+        app:layout_constraintBottom_toTopOf="@id/hintPluginOneLabel"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/illustration"
+        tools:text="@string/card_reader_onboarding_both_plugins_activated_hint_admin" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/hintPluginOneLabel"
+        style="@style/TextAppearance.Woo.Body1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:gravity="center"
+        android:paddingHorizontal="@dimen/major_200"
+        android:textColor="@color/color_on_surface_high"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/hintOrLabel"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/hintLabel"
+        tools:text="@string/card_reader_onboarding_both_plugins_activated_hint_plugin_one" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/hintOrLabel"
+        style="@style/TextAppearance.Woo.Body1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingHorizontal="@dimen/major_200"
+        android:textColor="@color/color_on_surface_high"
+        app:layout_constraintBottom_toTopOf="@id/hintPluginTwoLabel"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/hintPluginOneLabel"
+        tools:text="@string/exclusive_or" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/hintPluginTwoLabel"
+        style="@style/TextAppearance.Woo.Body1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingHorizontal="@dimen/major_200"
+        android:textColor="@color/color_on_surface_high"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/textSupport"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/hintOrLabel"
+        tools:text="@string/card_reader_onboarding_both_plugins_activated_hint_plugin_two" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/textSupport"
+        style="@style/TextAppearance.Woo.Body1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:background="?attr/selectableItemBackground"
+        android:gravity="center"
+        android:paddingHorizontal="@dimen/major_200"
+        android:paddingVertical="@dimen/major_100"
+        android:textColor="@color/color_on_surface_high"
+        app:layout_constraintBottom_toTopOf="@+id/learn_more_container"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/hintPluginTwoLabel"
+        app:layout_constraintVertical_bias="0"
+        tools:text="@string/card_reader_onboarding_contact_support" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/openPluginStore"
+        style="@style/Woo.Button.Colored"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/refreshAfterUpdating"
+        app:layout_constraintTop_toBottomOf="@+id/textSupport"
+        app:layout_constraintVertical_bias="1"
+        tools:text="@string/refresh_button"
+        tools:visibility="visible" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/refreshAfterUpdating"
+        style="@style/Woo.Button.Outlined"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/learn_more_container"
+        app:layout_constraintTop_toBottomOf="@+id/openPluginStore"
+        app:layout_constraintVertical_bias="1"
+        tools:text="@string/refresh_button"
+        tools:visibility="visible" />
+
+    <include
+        android:id="@+id/learn_more_container"
+        layout="@layout/card_reader_learn_more_section"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_350"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_both_plugins_activated.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_both_plugins_activated.xml
@@ -102,7 +102,7 @@
         android:paddingHorizontal="@dimen/major_200"
         android:paddingVertical="@dimen/major_100"
         android:textColor="@color/color_on_surface_high"
-        app:layout_constraintBottom_toTopOf="@+id/learn_more_container"
+        app:layout_constraintBottom_toTopOf="@+id/openPluginStore"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/hintPluginTwoLabel"

--- a/WooCommerce/src/main/res/layout/fragment_wpcom_webview.xml
+++ b/WooCommerce/src/main/res/layout/fragment_wpcom_webview.xml
@@ -6,7 +6,7 @@
     <WebView
         android:id="@+id/webView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content" />
 
     <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/progress_bar"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -128,6 +128,7 @@
     <string name="card">Card</string>
     <string name="cash">Cash</string>
     <string name="create">Create</string>
+    <string name="exclusive_or">or</string>
 
     <!--
         Date/Time Labels
@@ -1073,6 +1074,15 @@
 
     <string name="card_reader_onboarding_wcpay_in_test_mode_with_live_account_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_wcpay_in_test_mode_with_live_account_hint">In-Person Payments isn\’t available in Test Mode. Please turn it off to continue.</string>
+
+    <string name="card_reader_onboarding_both_plugins_activated_header">Multiple payment providers detected</string>
+    <string name="card_reader_onboarding_both_plugins_activated_hint_admin">In-Person Payments will only work with one provider activated. Please deactivate one of these to continue:</string>
+    <string name="card_reader_onboarding_both_plugins_activated_hint_store_owner">In-Person Payments will only work with one provider activated. Please contact a site administrator to deactivate one of these to continue:</string>
+    <string name="card_reader_onboarding_both_plugins_activated_hint_plugin_one">WooCommerce Stripe Gateway</string>
+    <string name="card_reader_onboarding_both_plugins_activated_hint_plugin_two">WooCommerce Payments</string>
+    <string name="card_reader_onboarding_both_plugins_activated_open_store_admin_label">Go to Plugin Admin</string>
+    <string name="card_reader_onboarding_both_plugins_activated_refresh_button">Refresh after updating</string>
+
 
     <string name="card_reader_onboarding_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting payments with your mobile device and ordering card readers</string>
     <string name="card_reader_onboarding_contact_support">Need some help? &lt;a href=\'\'&gt;Contact support&lt;/a&gt;</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -103,8 +103,8 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as UnsupportedCountryState).onLearnMoreActionClicked.invoke()
 
-            assertThat(viewModel.event.value)
-                .isInstanceOf(OnboardingEvent.NavigateToUrlInGenericWebView::class.java)
+            val event = viewModel.event.value as OnboardingEvent.NavigateToUrlInGenericWebView
+            assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -333,6 +333,24 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when refresh clicked, then loading screen shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(
+                CardReaderOnboardingState.WcpayAndStripeActivated
+            )
+            val viewModel = createVM()
+            val receivedViewStates = mutableListOf<OnboardingViewState>()
+            viewModel.viewStateData.observeForever {
+                receivedViewStates.add(it)
+            }
+
+            (viewModel.viewStateData.value as OnboardingViewState.WcPayAndStripeInstalledState)
+                .onRefreshAfterUpdatingClicked.invoke()
+
+            assertThat(receivedViewStates[1]).isEqualTo(LoadingState)
+        }
+
+    @Test
     fun `given site is self-hosted, when user taps on Go To Plugin Admin, then generic webview shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(selectedSite.get())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -319,6 +319,20 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when wcpay and stripe extension active, then refresh screen button shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(
+                CardReaderOnboardingState.WcpayAndStripeActivated
+            )
+
+            val viewModel = createVM()
+
+            val viewStateData = viewModel.viewStateData.value as OnboardingViewState.WcPayAndStripeInstalledState
+            assertThat(viewStateData.onRefreshAfterUpdatingClicked != null).isTrue
+            assertThat(viewStateData.refreshButtonLabel).isNotNull
+        }
+
+    @Test
     fun `given site is self-hosted, when user taps on Go To Plugin Admin, then generic webview shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(selectedSite.get())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -304,7 +304,6 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             )
         }
 
-
     @Test
     fun `given user is admin, when wcpay and stripe extension active, then open wpadmin button shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
@@ -322,10 +321,14 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `given site is self-hosted, when user taps on Go To Plugin Admin, then generic webview shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(selectedSite.get()).thenReturn(SiteModel().apply {
-                setIsWPComAtomic(false)
-                setIsWPCom(false)
-            })
+            whenever(selectedSite.get())
+                .thenReturn(
+                    SiteModel()
+                        .apply {
+                            setIsWPComAtomic(false)
+                            setIsWPCom(false)
+                        }
+                )
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated
             )
@@ -342,9 +345,12 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `given site is wpcom, when user taps on Go To Plugin Admin, then wpcom webview shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(selectedSite.get()).thenReturn(SiteModel().apply {
-                setIsWPCom(true)
-            })
+            whenever(selectedSite.get()).thenReturn(
+                SiteModel()
+                    .apply {
+                        setIsWPCom(true)
+                    }
+            )
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated
             )
@@ -361,9 +367,11 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `given site is atomic, when user taps on Go To Plugin Admin, then wpcom webview shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(selectedSite.get()).thenReturn(SiteModel().apply {
-                setIsWPComAtomic(true)
-            })
+            whenever(selectedSite.get()).thenReturn(
+                SiteModel().apply {
+                    setIsWPComAtomic(true)
+                }
+            )
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated
             )
@@ -380,9 +388,11 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when user taps on Go To Plugin Admin, then app navigates to Plugin Admin url`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(selectedSite.get()).thenReturn(SiteModel().apply {
-                url = DUMMY_SITE_URL
-            })
+            whenever(selectedSite.get()).thenReturn(
+                SiteModel().apply {
+                    url = DUMMY_SITE_URL
+                }
+            )
 
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -314,7 +314,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             val viewStateData = viewModel.viewStateData.value as OnboardingViewState.WcPayAndStripeInstalledState
-            assertThat(viewStateData.openWPAdminLabel).isNotNull
+            assertThat(viewStateData.openWPAdminActionClicked != null).isTrue
             assertThat(viewStateData.openWPAdminLabel).isNotNull
         }
 
@@ -423,7 +423,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             val viewStateData = viewModel.viewStateData.value as OnboardingViewState.WcPayAndStripeInstalledState
             assertThat(viewStateData.openWPAdminLabel).isNull()
-            assertThat(viewStateData.openWPAdminLabel).isNull()
+            assertThat(viewStateData.openWPAdminActionClicked == null).isTrue
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5329 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR implements the "Both Plugins active" screen and adds "Refresh" and "Go To Plugin Admin" actions.

Notes
- "Go to Plugin Admin" action is visible only when the user has "Administrator" role
- "Go to Plugin Admin" action uses WPCom webview on wpcom sites and generic webview on self-hosted sites.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Prerequisite: Install both WCpay and Stripe Extension on your site

** Atomic-Site site with admin  role***
1. Open App Settings
2. Tap on "In Person Payments"
3. Notice "Both plugins active" screen is shown
4. Tap on "Go To Plugin Admin" button
5. Notice wpadmin is shown and you are logged in and verify scrolling works

** Self-hosted site with admin role ***
1. Open App Settings
2. Tap on "In Person Payments"
3. Notice "Both plugins active" screen is shown
4. Tap on "Go To Plugin Admin" button
5. Notice wpadmin is shown and verify scrolling works (you might need to log in)

** Atomic-Site site with shop_manager  role***
1. Open App Settings
2. Tap on "In Person Payments"
3. Notice "Both plugins active" screen is shown
4. Notice "Go To Plugin Admin" action is NOT shown
5. Notice the hint says that you should contact site administrator

- also verify "learn more" and "contact support" actions work as expected

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Role | Light | Dark |
| --- | --- | --- |
| ADMIN | ![Screenshot_20220131-164926_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/151826535-cf4345ab-dcf4-4c2c-9a15-b7dc5e8476d0.jpg) | ![Screenshot_20220131-164906_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/151826522-91cb5b20-9b0a-426a-a6ae-a5fda4984136.jpg) |
| MANAGER | ![Screenshot_20220131-165016_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/151826540-d95c0d02-46d3-4b57-a6be-2af8cb2ecb0c.jpg) | ![Screenshot_20220131-165022_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/151826543-0127fa4c-8295-4d52-b1ed-b58e8d6e21ee.jpg) |



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @allendav 
