### PR TITLE
[Order Creation] fix load more handling for product selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionFragment.kt
@@ -88,7 +88,7 @@ class OrderCreationProductSelectionFragment :
     }
 
     override fun onRequestLoadMore() {
-        productListViewModel.loadProductList(loadMore = true)
+        productListViewModel.onLoadMoreRequest()
     }
 
     private fun onViewStateChanged(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
@@ -60,7 +60,6 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
 
     private fun loadFullProductList(loadMore: Boolean) {
         loadingJob = launch {
-            println("loadFullProductList $loadMore")
             val cachedProducts = productListRepository.getProductList()
                 .takeIf { it.isNotEmpty() }
                 ?.apply {
@@ -70,7 +69,6 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
 
             productListRepository.fetchProductList(loadMore)
                 .takeIf {
-                    println("loadFullProductList ${it.size} vs ${cachedProducts?.size}")
                     it != cachedProducts
                 }
                 ?.let { productList.value = it }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
@@ -40,12 +40,16 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
         get() = viewState.query.orEmpty()
 
     private var searchJob: Job? = null
+    private var loadingJob: Job? = null
+
+    private val isLoading
+        get() = loadingJob?.isActive == true || searchJob?.isActive == true
 
     init {
         loadProductList()
     }
 
-    fun loadProductList(loadMore: Boolean = false) {
+    private fun loadProductList(loadMore: Boolean = false) {
         if (loadMore.not()) {
             viewState = viewState.copy(isSkeletonShown = true)
         }
@@ -55,7 +59,8 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
     }
 
     private fun loadFullProductList(loadMore: Boolean) {
-        launch {
+        loadingJob = launch {
+            println("loadFullProductList $loadMore")
             val cachedProducts = productListRepository.getProductList()
                 .takeIf { it.isNotEmpty() }
                 ?.apply {
@@ -64,7 +69,10 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
                 }
 
             productListRepository.fetchProductList(loadMore)
-                .takeIf { it != cachedProducts }
+                .takeIf {
+                    println("loadFullProductList ${it.size} vs ${cachedProducts?.size}")
+                    it != cachedProducts
+                }
                 ?.let { productList.value = it }
 
             viewState = viewState.copy(isSkeletonShown = false)
@@ -121,6 +129,11 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
         viewState = viewState.copy(
             query = null
         )
+    }
+
+    fun onLoadMoreRequest() {
+        if (isLoading || !productListRepository.canLoadMoreProducts) return
+        loadProductList(loadMore = true)
     }
 
     @Parcelize

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModelTest.kt
@@ -239,6 +239,20 @@ class OrderCreationProductSelectionViewModelTest : BaseUnitTest() {
         assertThat(actualProductList).isEqualTo(filteredProductList)
     }
 
+    @Test
+    fun `when loading more products, then ignore the request if canLoadMoreProducts is false`() = testBlocking {
+        var actualProductList: List<Product>?
+        whenever(productListRepository.canLoadMoreProducts).thenReturn(false)
+        startSut()
+        sut.productListData.observeForever {
+            actualProductList = it
+        }
+        actualProductList = null
+        sut.onLoadMoreRequest()
+        assertThat(actualProductList).isNull()
+        verify(productListRepository, times(0)).fetchProductList(loadMore = true)
+    }
+
     private fun startSut() {
         sut = OrderCreationProductSelectionViewModel(
             SavedStateHandle(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5749 

### Description
This is an attempt to fix #5749, it adds the following two checks before handling any new loadmore request:
1. Checking if there is an ongoing loading job.
2. Checking the `canLoadMoreProducts` property.

@ThomazFB Please feel free to edit anything on this PR, I'm AFK tomorrow, it's just an attempt to understand and fix the issue 🙂 

### Testing instructions
Check the parent ticket, and confirm if the issues are not reproducible anymore.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
