### PR TITLE
Add a card reader config which has all the necessary details related to specific country

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.util.CapturePaymentResponseMapper
 import com.woocommerce.android.util.WooLog
 import dagger.Module
 import dagger.Provides
+import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
@@ -93,5 +94,6 @@ class CardReaderModule {
     }
 
     @Provides
+    @Reusable
     fun provideCardReaderConfigFactory() = CardReaderConfigFactory()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.cardreader.CardReaderManagerFactory
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.toInPersonPaymentsPluginType
 import com.woocommerce.android.util.CapturePaymentResponseMapper
@@ -90,4 +91,7 @@ class CardReaderModule {
             WooLog.e(TAG, "$tag: $message")
         }
     }
+
+    @Provides
+    fun provideCardReaderConfigFactory() = CardReaderConfigFactory()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -72,10 +72,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import java.util.*
-import javax.inject.Inject
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.util.*
+import javax.inject.Inject
 
 private const val ARTIFICIAL_RETRY_DELAY = 500L
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -454,11 +454,11 @@ class CardReaderPaymentViewModel
 
     private fun Order.getReceiptDocumentName() = "receipt-order-$id"
 
-    private suspend fun getStoreCountryCode(): String? {
+    private suspend fun getStoreCountryCode(): String {
         return withContext(dispatchers.io) {
-            wooStore.getStoreCountryCode(selectedSite.get()) ?: null.also {
-                WooLog.e(WooLog.T.CARD_READER, "Store's country code not found.")
-            }
+            wooStore.getStoreCountryCode(
+                selectedSite.get()
+            ) ?: throw IllegalStateException("Store's country code not found.")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -53,6 +53,7 @@ import com.woocommerce.android.ui.orders.cardreader.ViewState.PaymentSuccessfulS
 import com.woocommerce.android.ui.orders.cardreader.ViewState.ProcessingPaymentState
 import com.woocommerce.android.ui.orders.cardreader.ViewState.ReFetchingOrderState
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult
 import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.CANCELLED
@@ -73,6 +74,8 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.util.*
 import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WooCommerceStore
 
 private const val ARTIFICIAL_RETRY_DELAY = 500L
 
@@ -89,6 +92,8 @@ class CardReaderPaymentViewModel
     private val tracker: AnalyticsTrackerWrapper,
     private val currencyFormatter: CurrencyFormatter,
     private val errorMapper: CardReaderPaymentErrorMapper,
+    private val wooStore: WooCommerceStore,
+    private val dispatchers: CoroutineDispatchers,
 ) : ScopedViewModel(savedState) {
     private val arguments: CardReaderPaymentDialogFragmentArgs by savedState.navArgs()
 
@@ -181,6 +186,7 @@ class CardReaderPaymentViewModel
                 customerName = "${order.billingAddress.firstName} ${order.billingAddress.lastName}".ifBlank { null },
                 storeName = selectedSite.get().name.ifEmpty { null },
                 siteUrl = selectedSite.get().url.ifEmpty { null },
+                countryCode = getStoreCountryCode(),
             )
         ).collect { paymentStatus ->
             onPaymentStatusChanged(order.id, customerEmail, paymentStatus, order.getAmountLabel())
@@ -447,6 +453,14 @@ class CardReaderPaymentViewModel
         .formatAmountWithCurrency(this.currency, this.total.toDouble())
 
     private fun Order.getReceiptDocumentName() = "receipt-order-$id"
+
+    private suspend fun getStoreCountryCode(): String? {
+        return withContext(dispatchers.io) {
+            wooStore.getStoreCountryCode(selectedSite.get()) ?: null.also {
+                WooLog.e(WooLog.T.CARD_READER, "Store's country code not found.")
+            }
+        }
+    }
 
     class ShowSnackbarInDialog(@StringRes val message: Int) : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.prefs.cardreader.connect
 
 import androidx.annotation.DrawableRes
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -24,6 +23,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.SpecificReader
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateInProgress
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
@@ -69,6 +69,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 @HiltViewModel
@@ -82,16 +84,10 @@ class CardReaderConnectViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val cardReaderManager: CardReaderManager,
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
+    private val wooStore: WooCommerceStore,
+    private val cardReaderConfigFactory: CardReaderConfigFactory,
 ) : ScopedViewModel(savedState) {
     private val arguments: CardReaderConnectDialogFragmentArgs by savedState.navArgs()
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    val supportedReaders: List<SpecificReader>
-        get() = if (inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
-            listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2, SpecificReader.WisePade3)
-        } else {
-            listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2)
-        }
 
     /**
      * This is a workaround for a bug in MultiLiveEvent, which can't be fixed without vital changes.
@@ -262,7 +258,9 @@ class CardReaderConnectViewModel @Inject constructor(
             cardReaderManager
                 .discoverReaders(
                     isSimulated = BuildConfig.USE_SIMULATED_READER,
-                    cardReaderTypesToDiscover = CardReaderTypesToDiscover.SpecificReaders(supportedReaders)
+                    cardReaderTypesToDiscover = CardReaderTypesToDiscover.SpecificReaders(
+                        getSupportedReaders()
+                    )
                 )
                 .flowOn(dispatchers.io)
                 .collect { discoveryEvent ->
@@ -270,6 +268,19 @@ class CardReaderConnectViewModel @Inject constructor(
                 }
         }
     }
+
+    private suspend fun getSupportedReaders() =
+        if (inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
+            cardReaderConfigFactory.getCardReaderConfigFor(
+                getStoreCountryCode()
+            ).allReaders
+        } else {
+            cardReaderConfigFactory.getCardReaderConfigFor(
+                getStoreCountryCode()
+            ).allReaders.filter { specificReader ->
+                specificReader != SpecificReader.WisePade3
+            }
+        }
 
     private suspend fun listenToConnectionStatus() {
         cardReaderManager.readerStatus.collect { status ->
@@ -503,6 +514,14 @@ class CardReaderConnectViewModel @Inject constructor(
             null,
             errorDescription,
         )
+    }
+
+    private suspend fun getStoreCountryCode(): String? {
+        return withContext(dispatchers.io) {
+            wooStore.getStoreCountryCode(selectedSite.get()) ?: null.also {
+                WooLog.e(WooLog.T.CARD_READER, "Store's country code not found.")
+            }
+        }
     }
 
     sealed class ListItemViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
 import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -36,6 +37,7 @@ class CardReaderOnboardingChecker @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val stripeExtensionFeatureFlag: StripeExtensionFeatureFlag,
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
+    private val cardReaderConfigFactory: CardReaderConfigFactory
 ) {
     private val supportedCountries: List<String>
         get() = if (inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
@@ -60,6 +62,7 @@ class CardReaderOnboardingChecker @Inject constructor(
     @Suppress("ReturnCount", "ComplexMethod")
     private suspend fun fetchOnboardingState(): CardReaderOnboardingState {
         val countryCode = getStoreCountryCode()
+        val cardReaderConfig = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
         if (!isCountrySupported(countryCode)) return StoreCountryNotSupported(countryCode)
 
         val fetchSitePluginsResult = wooStore.fetchSitePlugins(selectedSite.get())
@@ -82,6 +85,11 @@ class CardReaderOnboardingChecker @Inject constructor(
             WOOCOMMERCE_PAYMENTS -> return WcpayNotActivated
             STRIPE_EXTENSION_GATEWAY -> throw IllegalStateException("Developer error:`preferredPlugin` should be WCPay")
         }
+
+        if (
+            preferredPlugin.type == STRIPE_EXTENSION_GATEWAY &&
+            !cardReaderConfig.isStripeExtensionSupported
+        ) return StoreCountryNotSupported(countryCode)
 
         val fluxCPluginType = preferredPlugin.type.toInPersonPaymentsPluginType()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -44,9 +44,9 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import kotlin.test.assertEquals
-import org.wordpress.android.fluxc.store.WooCommerceStore
 
 private val DUMMY_TOTAL = BigDecimal(10.72)
 private const val DUMMY_CURRENCY_SYMBOL = "£"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -128,6 +128,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(true)
         whenever(appPrefsWrapper.getReceiptUrl(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
             .thenReturn("test url")
+        whenever(wooStore.getStoreCountryCode(any())).thenReturn("US")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -46,6 +46,7 @@ import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.model.SiteModel
 import java.math.BigDecimal
 import kotlin.test.assertEquals
+import org.wordpress.android.fluxc.store.WooCommerceStore
 
 private val DUMMY_TOTAL = BigDecimal(10.72)
 private const val DUMMY_CURRENCY_SYMBOL = "£"
@@ -67,6 +68,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     private val tracker: AnalyticsTrackerWrapper = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val currencyFormatter: CurrencyFormatter = mock()
+    private val wooStore: WooCommerceStore = mock()
 
     private val paymentFailedWithEmptyDataForRetry = PaymentFailed(Generic, null, "dummy msg")
     private val paymentFailedWithValidDataForRetry = PaymentFailed(Generic, mock(), "dummy msg")
@@ -94,7 +96,9 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             tracker = tracker,
             appPrefsWrapper = appPrefsWrapper,
             currencyFormatter = currencyFormatter,
-            errorMapper = errorMapper
+            errorMapper = errorMapper,
+            wooStore = wooStore,
+            dispatchers = coroutinesTestRule.testDispatchers
         )
 
         val mockedOrder = mock<Order>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -1373,7 +1373,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
             val captor = argumentCaptor<CardReaderTypesToDiscover.SpecificReaders>()
-            whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA())
+            whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA)
             whenever(wooStore.getStoreCountryCode(any())).thenReturn("US")
 
             init()
@@ -1394,7 +1394,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
             val captor = argumentCaptor<CardReaderTypesToDiscover.SpecificReaders>()
-            whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada())
+            whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada)
             whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
 
             init()
@@ -1417,7 +1417,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         val savedState = CardReaderConnectDialogFragmentArgs(skipOnboarding = skipOnboarding).initSavedStateHandle()
         whenever(onboardingChecker.getOnboardingState()).thenReturn(onboardingState)
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
-        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA())
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA)
         whenever(wooStore.getStoreCountryCode(any())).thenReturn("US")
         return CardReaderConnectViewModel(
             savedState,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -2,15 +2,27 @@ package com.woocommerce.android.ui.prefs.cardreader.connect
 
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_AUTO_CONNECTION_STARTED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_CONNECTION_FAILED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_CONNECTION_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_CONNECTION_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_DISCOVERY_FAILED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_DISCOVERY_READER_DISCOVERED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_FAILURE
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_MISSING_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_LOCATION_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Failed
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.ReadersFound
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.SpecificReader
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForCanada
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -59,8 +71,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyBoolean
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
 
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
@@ -84,6 +105,8 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         on { get() }.thenReturn(siteModel)
     }
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag = mock()
+    private val wooStore: WooCommerceStore = mock()
+    private val cardReaderConfigFactory: CardReaderConfigFactory = mock()
 
     private val locationId = "location_id"
 
@@ -1346,25 +1369,45 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given ipp Canada feature flag is true, then supported readers contains Wisepad 3`() {
-        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
+    fun `when canada flag is disabled, then supported readers does not contains Wisepad 3`() {
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
+            val captor = argumentCaptor<CardReaderTypesToDiscover.SpecificReaders>()
+            whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA())
+            whenever(wooStore.getStoreCountryCode(any())).thenReturn("US")
 
-        assertThat(viewModel.supportedReaders).isEqualTo(
-            listOf(
-                SpecificReader.Chipper2X, SpecificReader.StripeM2, SpecificReader.WisePade3
+            init()
+
+            verify(cardReaderManager).discoverReaders(anyBoolean(), captor.capture())
+            assertThat(captor.firstValue).isEqualTo(
+                CardReaderTypesToDiscover.SpecificReaders(
+                    listOf(
+                        SpecificReader.Chipper2X, SpecificReader.StripeM2
+                    )
+                )
             )
-        )
+        }
     }
 
     @Test
-    fun `given ipp Canada feature flag is false, then supported readers does not contain Wisepad 3`() {
-        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
+    fun `when Canada flag is enabled, then supported readers contains Wisepad 3`() {
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
+            val captor = argumentCaptor<CardReaderTypesToDiscover.SpecificReaders>()
+            whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada())
+            whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
 
-        assertThat(viewModel.supportedReaders).isEqualTo(
-            listOf(
-                SpecificReader.Chipper2X, SpecificReader.StripeM2
+            init()
+
+            verify(cardReaderManager).discoverReaders(anyBoolean(), captor.capture())
+            assertThat(captor.firstValue).isEqualTo(
+                CardReaderTypesToDiscover.SpecificReaders(
+                    listOf(
+                        SpecificReader.Chipper2X, SpecificReader.StripeM2, SpecificReader.WisePade3
+                    )
+                )
             )
-        )
+        }
     }
 
     private suspend fun initVM(
@@ -1374,6 +1417,8 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         val savedState = CardReaderConnectDialogFragmentArgs(skipOnboarding = skipOnboarding).initSavedStateHandle()
         whenever(onboardingChecker.getOnboardingState()).thenReturn(onboardingState)
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA())
+        whenever(wooStore.getStoreCountryCode(any())).thenReturn("US")
         return CardReaderConnectViewModel(
             savedState,
             coroutinesTestRule.testDispatchers,
@@ -1384,6 +1429,8 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             selectedSite,
             cardReaderManager,
             inPersonPaymentsCanadaFeatureFlag,
+            wooStore,
+            cardReaderConfigFactory,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForCanada
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.InPersonPaymentsCanadaFeatureFlag
@@ -33,6 +36,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val stripeExtensionFeatureFlag: StripeExtensionFeatureFlag = mock()
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag = mock()
+    private val cardReaderConfigFactory: CardReaderConfigFactory = mock()
 
     private val site = SiteModel()
 
@@ -47,6 +51,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             networkStatus,
             stripeExtensionFeatureFlag,
             inPersonPaymentsCanadaFeatureFlag,
+            cardReaderConfigFactory
         )
         whenever(networkStatus.isConnected()).thenReturn(true)
         whenever(selectedSite.get()).thenReturn(site)
@@ -60,6 +65,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             .thenReturn(buildWCPayPluginInfo())
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(false)
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA())
     }
 
     @Test
@@ -175,7 +181,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
                 .thenReturn(buildWCPayPluginInfo(isActive = true))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildWCPayPluginInfo(isActive = true))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(false)
 
             val result = checker.getOnboardingState()
@@ -818,10 +824,42 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     fun `given Canada flag false, when store is Canada, then STORE_COUNTRY_NOT_SUPPORTED returned`() = testBlocking {
         whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada())
 
         val result = checker.getOnboardingState()
 
         assertThat(result).isInstanceOf(CardReaderOnboardingState.StoreCountryNotSupported::class.java)
+    }
+
+    @Test
+    fun `given Canada store, when stripe ext activated, then STORE_COUNTRY_NOT_SUPPORTED returned`() = testBlocking {
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
+        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+            .thenReturn(buildWCPayPluginInfo(isActive = false))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+        whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada())
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isInstanceOf(CardReaderOnboardingState.StoreCountryNotSupported::class.java)
+    }
+
+    @Test
+    fun `given Canada store, when wcpay activated, then onboardingcompleted returned`() = testBlocking {
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
+        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+            .thenReturn(buildWCPayPluginInfo(isActive = true))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+            .thenReturn(buildStripeExtensionPluginInfo(isActive = false))
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada())
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isInstanceOf(CardReaderOnboardingState.OnboardingCompleted::class.java)
     }
 
     private fun buildPaymentAccountResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -65,7 +65,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             .thenReturn(buildWCPayPluginInfo())
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(false)
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
-        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA())
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA)
     }
 
     @Test
@@ -824,7 +824,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     fun `given Canada flag false, when store is Canada, then STORE_COUNTRY_NOT_SUPPORTED returned`() = testBlocking {
         whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
-        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada())
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada)
 
         val result = checker.getOnboardingState()
 
@@ -840,7 +840,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
             .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
         whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
-        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada())
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada)
 
         val result = checker.getOnboardingState()
 
@@ -855,7 +855,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             .thenReturn(buildWCPayPluginInfo(isActive = true))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
             .thenReturn(buildStripeExtensionPluginInfo(isActive = false))
-        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada())
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada)
 
         val result = checker.getOnboardingState()
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader
 import android.app.Application
 import com.woocommerce.android.cardreader.internal.CardReaderManagerImpl
 import com.woocommerce.android.cardreader.internal.TokenProvider
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.internal.connection.BluetoothReaderListenerImpl
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.connection.TerminalListenerImpl
@@ -43,7 +44,13 @@ object CardReaderManagerFactory {
             PaymentManager(
                 terminal,
                 cardReaderStore,
-                CreatePaymentAction(PaymentIntentParametersFactory(), terminal, PaymentUtils(), logWrapper),
+                CreatePaymentAction(
+                    PaymentIntentParametersFactory(),
+                    terminal,
+                    PaymentUtils(),
+                    logWrapper,
+                    CardReaderConfigFactory()
+                ),
                 CollectPaymentAction(terminal, logWrapper),
                 ProcessPaymentAction(terminal, logWrapper),
                 CancelPaymentAction(terminal),

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
@@ -9,4 +9,10 @@ interface CardReaderConfig {
     val supportedReaders: List<SpecificReader>
     val paymentMethodType: List<PaymentMethodType>
     val isStripeExtensionSupported: Boolean
+    val allReaders: List<SpecificReader>
+        get() = listOf(
+            SpecificReader.Chipper2X,
+            SpecificReader.StripeM2,
+            SpecificReader.WisePade3
+        )
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.cardreader.internal.config
+
+import com.stripe.stripeterminal.external.models.PaymentMethodType
+import com.woocommerce.android.cardreader.connection.SpecificReader
+
+interface CardReaderConfig {
+    val currency: String
+    val countryCode: String
+    val supportedReaders: List<SpecificReader>
+    val paymentMethodType: List<PaymentMethodType>
+    val isStripeExtensionSupported: Boolean
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactory.kt
@@ -4,10 +4,10 @@ class CardReaderConfigFactory {
     fun getCardReaderConfigFor(countryCode: String?): CardReaderConfig {
         return when (countryCode) {
             "US" -> {
-                CardReaderConfigForUSA()
+                CardReaderConfigForUSA
             }
             "CA" -> {
-                CardReaderConfigForCanada()
+                CardReaderConfigForCanada
             }
             else -> {
                 throw IllegalStateException("Invalid country code")

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactory.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.cardreader.internal.config
+
+class CardReaderConfigFactory {
+    fun getCardReaderConfigFor(countryCode: String?): CardReaderConfig {
+        return when (countryCode) {
+            "US" -> {
+                CardReaderConfigForUSA()
+            }
+            "CA" -> {
+                CardReaderConfigForCanada()
+            }
+            else -> {
+                throw IllegalStateException("Invalid country code")
+            }
+        }
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.cardreader.internal.config
 import com.stripe.stripeterminal.external.models.PaymentMethodType
 import com.woocommerce.android.cardreader.connection.SpecificReader
 
-class CardReaderConfigForCanada : CardReaderConfig {
+object CardReaderConfigForCanada : CardReaderConfig {
     override val currency: String
         get() = "CAD"
     override val countryCode: String

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.cardreader.internal.config
+
+import com.stripe.stripeterminal.external.models.PaymentMethodType
+import com.woocommerce.android.cardreader.connection.SpecificReader
+
+class CardReaderConfigForCanada : CardReaderConfig {
+    override val currency: String
+        get() = "CAD"
+    override val countryCode: String
+        get() = "CA"
+    override val supportedReaders: List<SpecificReader>
+        get() = listOf(
+            SpecificReader.WisePade3
+        )
+    override val paymentMethodType: List<PaymentMethodType>
+        get() = listOf(
+            PaymentMethodType.CARD_PRESENT,
+            PaymentMethodType.INTERAC_PRESENT
+        )
+    override val isStripeExtensionSupported: Boolean
+        get() = false
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.cardreader.internal.config
+
+import com.stripe.stripeterminal.external.models.PaymentMethodType
+import com.woocommerce.android.cardreader.connection.SpecificReader
+
+class CardReaderConfigForUSA : CardReaderConfig {
+    override val currency: String
+        get() = "USD"
+    override val countryCode: String
+        get() = "US"
+    override val supportedReaders: List<SpecificReader>
+        get() = listOf(
+            SpecificReader.Chipper2X,
+            SpecificReader.StripeM2,
+        )
+    override val paymentMethodType: List<PaymentMethodType>
+        get() = listOf(
+            PaymentMethodType.CARD_PRESENT
+        )
+    override val isStripeExtensionSupported: Boolean
+        get() = true
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.cardreader.internal.config
 import com.stripe.stripeterminal.external.models.PaymentMethodType
 import com.woocommerce.android.cardreader.connection.SpecificReader
 
-class CardReaderConfigForUSA : CardReaderConfig {
+object CardReaderConfigForUSA : CardReaderConfig {
     override val currency: String
         get() = "USD"
     override val countryCode: String

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -6,6 +6,7 @@ import com.stripe.stripeterminal.external.models.PaymentIntentParameters
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.internal.LOG_TAG
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.internal.payments.MetaDataKeys
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction.CreatePaymentStatus.Failure
@@ -22,7 +23,8 @@ internal class CreatePaymentAction(
     private val paymentIntentParametersFactory: PaymentIntentParametersFactory,
     private val terminal: TerminalWrapper,
     private val paymentUtils: PaymentUtils,
-    private val logWrapper: LogWrapper
+    private val logWrapper: LogWrapper,
+    private val cardReaderConfigFactory: CardReaderConfigFactory
 ) {
     sealed class CreatePaymentStatus {
         data class Success(val paymentIntent: PaymentIntent) : CreatePaymentStatus()
@@ -53,7 +55,10 @@ internal class CreatePaymentAction(
 
     private fun createParams(paymentInfo: PaymentInfo): PaymentIntentParameters {
         val amountInSmallestCurrencyUnit = paymentUtils.convertBigDecimalInDollarsToLongInCents(paymentInfo.amount)
-        val builder = paymentIntentParametersFactory.createBuilder()
+        val cardReaderConfigFactory = cardReaderConfigFactory.getCardReaderConfigFor(paymentInfo.countryCode)
+        val builder = paymentIntentParametersFactory.createBuilder(
+            cardReaderConfigFactory.paymentMethodType
+        )
             .setDescription(paymentInfo.paymentDescription)
             .setAmount(amountInSmallestCurrencyUnit)
             .setCurrency(paymentInfo.currency)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/PaymentIntentParametersFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/PaymentIntentParametersFactory.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.cardreader.internal.wrappers
 
 import com.stripe.stripeterminal.external.models.PaymentIntentParameters
+import com.stripe.stripeterminal.external.models.PaymentMethodType
 
 internal class PaymentIntentParametersFactory {
-    fun createBuilder() = PaymentIntentParameters.Builder()
+    fun createBuilder(
+        paymentMethodType: List<PaymentMethodType> = listOf(PaymentMethodType.CARD_PRESENT)
+    ) = PaymentIntentParameters.Builder(paymentMethodType)
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
@@ -12,5 +12,6 @@ data class PaymentInfo(
     val storeName: String?,
     val siteUrl: String?,
     val orderKey: String?,
+    internal val countryCode: String? = null,
     internal val customerId: String? = null,
 )

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
@@ -18,7 +18,7 @@ class CardReaderConfigFactoryTest {
     @Test
     fun `given country code US, then US card reader config is returned`() {
         val countryCode = "US"
-        val expectedCardReaderConfig = CardReaderConfigForUSA()
+        val expectedCardReaderConfig = CardReaderConfigForUSA
 
         val cardReaderConfig = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
 
@@ -28,7 +28,7 @@ class CardReaderConfigFactoryTest {
     @Test
     fun `given country code CA, then Canada card reader config is returned`() {
         val countryCode = "CA"
-        val expectedCardReaderConfig = CardReaderConfigForCanada()
+        val expectedCardReaderConfig = CardReaderConfigForCanada
 
         val cardReaderConfig = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.cardreader.internal.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class CardReaderConfigFactoryTest {
+    private lateinit var cardReaderConfigFactory: CardReaderConfigFactory
+
+    @Before
+    fun setUp() {
+        cardReaderConfigFactory = CardReaderConfigFactory()
+    }
+
+    @Test
+    fun `given country code US, then US card reader config is returned`() {
+        val countryCode = "US"
+        val expectedCardReaderConfig = CardReaderConfigForUSA()
+
+        val cardReaderConfig = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
+
+        assertThat(cardReaderConfig).isInstanceOf(expectedCardReaderConfig::class.java)
+    }
+
+    @Test
+    fun `given country code CA, then Canada card reader config is returned`() {
+        val countryCode = "CA"
+        val expectedCardReaderConfig = CardReaderConfigForCanada()
+
+        val cardReaderConfig = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
+
+        assertThat(cardReaderConfig).isInstanceOf(expectedCardReaderConfig::class.java)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given invalid country code, then exception is thrown`() {
+        val countryCode = "invalid country code"
+
+        cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
+    }
+}

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -57,7 +57,7 @@ internal class CreatePaymentActionTest {
         whenever(intentParametersBuilder.setDescription(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setMetadata(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.build()).thenReturn(mock())
-        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA())
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA)
 
         whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
             (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
@@ -337,7 +337,7 @@ internal class CreatePaymentActionTest {
             PaymentMethodType.INTERAC_PRESENT
         )
         whenever(cardReaderConfigFactory.getCardReaderConfigFor("CA")).thenReturn(
-            CardReaderConfigForCanada()
+            CardReaderConfigForCanada
         )
 
         action.createPaymentIntent(createPaymentInfo(countryCode = "CA")).toList()
@@ -351,7 +351,7 @@ internal class CreatePaymentActionTest {
             PaymentMethodType.CARD_PRESENT
         )
         whenever(cardReaderConfigFactory.getCardReaderConfigFor("US")).thenReturn(
-            CardReaderConfigForUSA()
+            CardReaderConfigForUSA
         )
 
         action.createPaymentIntent(createPaymentInfo(countryCode = "US")).toList()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5703 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a card reader config that has all the necessary details for the card reader related to the specific country. 

The need for something like this was born out of the necessity that for In-Person Payments Interac transactions that happen for Canada, [we need to pass payment method type as `interac_present`](https://stripe.com/docs/terminal/payments/regional?integration-country=CA#create-a-paymentintent) along with the `card_present`. 

Whereas, for the US the payment method type must just be `card_present`. Also, Now that we support multiple countries for IPP. We need to verify the currency, supported readers...etc. 

Some config specific to countries like IPP in Canada won't support Stripe Extension for the first iteration whereas Stripe Extension is supported in the US, Should the reader capture the payment in the backend or in the app...etc goes into this configuration class as well.

We needed a place that has all the necessary config details related to the card reader specific to the country it is registered on so that we can verify anything we need with that one instance.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure CI is happy/green
2. Verify IPP works end to end. 
    1.  Navigate to any store eligible for IPP
    2. Navigate to any order eligible for IPP
    3. Tap the `collect payment` button
    4. Make sure the payment succeeds or fails for a valid reason
    5. Make sure there is nothing weird happening during the payment flow


<br />

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
