### PR TITLE
Order creation tracks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -790,10 +790,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_PURCHASE_READY = "purchase_ready"
 
         const val KEY_FLOW = "flow"
-        const val VALUE_FLOW_CREATION = "creation"
-        const val VALUE_FLOW_EDITING = "editing"
         const val KEY_HAS_BILLING_DETAILS = "has_billing_details"
         const val KEY_HAS_SHIPPING_DETAILS = "has_shipping_details"
+        const val VALUE_FLOW_CREATION = "creation"
+        const val VALUE_FLOW_EDITING = "editing"
 
         const val ORDER_EDIT_CUSTOMER_NOTE = "customer_note"
         const val ORDER_EDIT_SHIPPING_ADDRESS = "shipping_address"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -198,8 +198,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         // -- Order Creation
         ORDER_ADD_NEW,
         ORDER_PRODUCT_ADD,
-        ORDER_CUSTOMER_ADD_BILLING,
-        ORDER_CUSTOMER_ADD_SHIPPING,
+        ORDER_CUSTOMER_ADD,
         ORDER_CREATE_BUTTON_TAPPED,
         ORDER_CREATION_SUCCESS,
         ORDER_CREATION_FAILED,
@@ -790,8 +789,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_PURCHASE_READY = "purchase_ready"
 
         const val KEY_FLOW = "flow"
-        const val KEY_HAS_BILLING_DETAILS = "has_billing_details"
-        const val KEY_HAS_SHIPPING_DETAILS = "has_shipping_details"
+        const val KEY_HAS_DIFFERENT_SHIPPING_DETAILS = "has_different_shipping_details"
+        const val KEY_HAS_CUSTOMER_DETAILS = "has_customer_details"
         const val VALUE_FLOW_CREATION = "creation"
         const val VALUE_FLOW_EDITING = "editing"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -788,6 +788,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_PURCHASE_SUCCEEDED = "purchase_succeeded"
         const val VALUE_PURCHASE_READY = "purchase_ready"
 
+        const val KEY_FLOW = "flow"
+        const val VALUE_FLOW_CREATION = "creation"
+        const val VALUE_FLOW_EDITING = "editing"
+
         const val ORDER_EDIT_CUSTOMER_NOTE = "customer_note"
         const val ORDER_EDIT_SHIPPING_ADDRESS = "shipping_address"
         const val ORDER_EDIT_BILLING_ADDRESS = "billing_address"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -195,6 +195,15 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ORDER_DETAIL_EDIT_FLOW_FAILED,
         ORDER_DETAIL_EDIT_FLOW_CANCELED,
 
+        // -- Order Creation
+        ORDER_ADD_NEW,
+        ORDER_PRODUCT_ADD,
+        ORDER_CUSTOMER_ADD_BILLING,
+        ORDER_CUSTOMER_ADD_SHIPPING,
+        ORDER_CREATE_BUTTON_TAPPED,
+        ORDER_CREATION_SUCCESS,
+        ORDER_CREATION_FAILED,
+
         // -- Refunds
         CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,
         CREATE_ORDER_REFUND_TAB_CHANGED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -726,6 +726,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_ID = "id"
         const val KEY_ORDER_ID = "order_id"
         const val KEY_PRODUCT_ID = "product_id"
+        const val KEY_PRODUCT_COUNT = "product_count"
         const val KEY_IS_LOADING_MORE = "is_loading_more"
         const val KEY_IS_WPCOM_STORE = "is_wpcom_store"
         const val KEY_NAME = "name"
@@ -791,6 +792,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_FLOW = "flow"
         const val VALUE_FLOW_CREATION = "creation"
         const val VALUE_FLOW_EDITING = "editing"
+        const val KEY_HAS_BILLING_DETAILS = "has_billing_details"
+        const val KEY_HAS_SHIPPING_DETAILS = "has_shipping_details"
 
         const val ORDER_EDIT_CUSTOMER_NOTE = "customer_note"
         const val ORDER_EDIT_SHIPPING_ADDRESS = "shipping_address"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.orders.creation
 
 import android.os.Parcelable
-import androidx.lifecycle.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.*
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
@@ -16,6 +18,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATUS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_TO
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_CREATION
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.runWithContext
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
@@ -38,6 +41,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+
 @HiltViewModel
 class OrderCreationViewModel @Inject constructor(
     savedState: SavedStateHandle,
@@ -245,22 +249,26 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     private fun trackOrderCreationFailure(it: Throwable) {
-        AnalyticsTracker.track(Stat.ORDER_CREATION_FAILED,
+        AnalyticsTracker.track(
+            Stat.ORDER_CREATION_FAILED,
             mapOf(
                 KEY_ERROR_CONTEXT to it::class.java.simpleName,
                 KEY_ERROR_TYPE to it,
                 KEY_ERROR_DESC to it.message
-            ))
+            )
+        )
     }
 
     private fun trackCreateOrderButtonClick() {
-        AnalyticsTracker.track(Stat.ORDER_CREATE_BUTTON_TAPPED,
+        AnalyticsTracker.track(
+            Stat.ORDER_CREATE_BUTTON_TAPPED,
             mapOf(
                 KEY_STATUS to _orderDraft.value.status,
                 KEY_PRODUCT_COUNT to products.value?.count(),
                 KEY_HAS_BILLING_DETAILS to _orderDraft.value.billingAddress.hasInfo(),
                 KEY_HAS_SHIPPING_DETAILS to _orderDraft.value.shippingAddress.hasInfo()
-            ))
+            )
+        )
     }
 
     @Parcelize
@@ -274,7 +282,6 @@ class OrderCreationViewModel @Inject constructor(
         val canCreateOrder: Boolean = isOrderValidForCreation && !isUpdatingOrderDraft && !showOrderUpdateSnackbar
     }
 }
-
 
 data class ProductUIModel(
     val item: Order.Item,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.orders.creation
 import android.os.Parcelable
 import androidx.lifecycle.*
 import com.woocommerce.android.R.string
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.*
 import com.woocommerce.android.extensions.runWithContext
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
@@ -100,6 +102,7 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onProductSelected(remoteProductId: Long, variationId: Long? = null) {
+        AnalyticsTracker.track(Stat.ORDER_PRODUCT_ADD)
         val uniqueId = variationId ?: remoteProductId
         viewModelScope.launch {
             _orderDraft.value.items.toMutableList().apply {
@@ -117,6 +120,14 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onCustomerAddressEdited(billingAddress: Address, shippingAddress: Address) {
+        if (billingAddress != _orderDraft.value.billingAddress) {
+            AnalyticsTracker.track(Stat.ORDER_CUSTOMER_ADD_BILLING)
+        }
+
+        if (shippingAddress != _orderDraft.value.shippingAddress) {
+            AnalyticsTracker.track(Stat.ORDER_CUSTOMER_ADD_SHIPPING)
+        }
+
         _orderDraft.update {
             it.copy(
                 billingAddress = billingAddress,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.*
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.*
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FLOW
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_CREATION
 import com.woocommerce.android.extensions.runWithContext
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
@@ -102,7 +104,10 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onProductSelected(remoteProductId: Long, variationId: Long? = null) {
-        AnalyticsTracker.track(Stat.ORDER_PRODUCT_ADD)
+        AnalyticsTracker.track(
+            Stat.ORDER_PRODUCT_ADD,
+            mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
+        )
         val uniqueId = variationId ?: remoteProductId
         viewModelScope.launch {
             _orderDraft.value.items.toMutableList().apply {
@@ -121,11 +126,17 @@ class OrderCreationViewModel @Inject constructor(
 
     fun onCustomerAddressEdited(billingAddress: Address, shippingAddress: Address) {
         if (billingAddress != _orderDraft.value.billingAddress) {
-            AnalyticsTracker.track(Stat.ORDER_CUSTOMER_ADD_BILLING)
+            AnalyticsTracker.track(
+                Stat.ORDER_CUSTOMER_ADD_BILLING,
+                mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
+            )
         }
 
         if (shippingAddress != _orderDraft.value.shippingAddress) {
-            AnalyticsTracker.track(Stat.ORDER_CUSTOMER_ADD_SHIPPING)
+            AnalyticsTracker.track(
+                Stat.ORDER_CUSTOMER_ADD_SHIPPING,
+                mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
+            )
         }
 
         _orderDraft.update {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -12,8 +12,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FROM
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_BILLING_DETAILS
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_SHIPPING_DETAILS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_CUSTOMER_DETAILS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_DIFFERENT_SHIPPING_DETAILS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATUS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_TO
@@ -147,19 +147,11 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onCustomerAddressEdited(billingAddress: Address, shippingAddress: Address) {
-        if (billingAddress != _orderDraft.value.billingAddress) {
-            AnalyticsTracker.track(
-                Stat.ORDER_CUSTOMER_ADD_BILLING,
-                mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
-            )
-        }
-
-        if (shippingAddress != _orderDraft.value.shippingAddress) {
-            AnalyticsTracker.track(
-                Stat.ORDER_CUSTOMER_ADD_SHIPPING,
-                mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
-            )
-        }
+        val hasDifferentShippingDetails = _orderDraft.value.shippingAddress != _orderDraft.value.billingAddress
+        AnalyticsTracker.track(
+            Stat.ORDER_CUSTOMER_ADD,
+            mapOf(KEY_HAS_DIFFERENT_SHIPPING_DETAILS to hasDifferentShippingDetails)
+        )
 
         _orderDraft.update {
             it.copy(
@@ -265,8 +257,7 @@ class OrderCreationViewModel @Inject constructor(
             mapOf(
                 KEY_STATUS to _orderDraft.value.status,
                 KEY_PRODUCT_COUNT to products.value?.count(),
-                KEY_HAS_BILLING_DETAILS to _orderDraft.value.billingAddress.hasInfo(),
-                KEY_HAS_SHIPPING_DETAILS to _orderDraft.value.shippingAddress.hasInfo()
+                KEY_HAS_CUSTOMER_DETAILS to _orderDraft.value.billingAddress.hasInfo()
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -172,14 +172,17 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onCreateOrderClicked(order: Order) {
+        AnalyticsTracker.track(Stat.ORDER_CREATE_BUTTON_TAPPED)
         viewModelScope.launch {
             viewState = viewState.copy(isProgressDialogShown = true)
             orderCreationRepository.placeOrder(order).fold(
                 onSuccess = {
+                    AnalyticsTracker.track(Stat.ORDER_CREATION_SUCCESS)
                     triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
                     triggerEvent(ShowCreatedOrder(it.id))
                 },
                 onFailure = {
+                    AnalyticsTracker.track(Stat.ORDER_CREATION_FAILED)
                     viewState = viewState.copy(isProgressDialogShown = false)
                     triggerEvent(ShowSnackbar(string.order_creation_failure_snackbar))
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -9,6 +9,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_EDITING
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.cardreader.CardReaderManager
@@ -347,7 +348,8 @@ final class OrderDetailViewModel @Inject constructor(
             mapOf(
                 AnalyticsTracker.KEY_ID to order.id,
                 AnalyticsTracker.KEY_FROM to order.status.value,
-                AnalyticsTracker.KEY_TO to updateSource.newStatus
+                AnalyticsTracker.KEY_TO to updateSource.newStatus,
+                AnalyticsTracker.KEY_FLOW to VALUE_FLOW_EDITING
             )
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -345,6 +345,7 @@ class OrderListFragment :
     }
 
     private fun openOrderCreationFragment() {
+        AnalyticsTracker.track(Stat.ORDER_ADD_NEW)
         findNavController().navigateSafely(R.id.action_orderListFragment_to_orderCreationFragment)
     }
 


### PR DESCRIPTION
Summary
==========
Fixes issue #5733 by introducing the basic Track events for the new features introduced at Order Creation M1 deliverable.

New track events
==========
Event Name | Trigger | Properties
-- | -- | --
*_orders_add_new | User tapped the button to create a new order (on Orders tab or from Orders bottom sheet) |  
*_order_product_add | User added a product to the order | flow:creation\|editing
*order_customer_add | User entered and saved billing/shipping details for the customer on the order | has_different_shipping_details: true\|false
*_order_create_button_tapped | User tapped the button to create the new order | status: $order-status<br />product_count: $total-product-count<br />has_billing_details: true\|false<br />has_customer_details: true\|false
*_order_creation_success | Request to create the new order succeeded |  
*_order_creation_failed | Request to create the new order failed | error_context: $initiated-classname<br />error_type: $errorType<br />error_description: $errorDescription

## Updated events

The following event already exists and needs to be added to order creation and updated to include the `flow` property everywhere it is used:

Event Name | Trigger | Properties
-- | -- | --
*_order_status_change | User selected and saved a new status for the order | from:$order-status<br />to:$order-status<br />flow:creation\|editing


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.