### PR TITLE
[Order Creation M2] fix duplicate orders on created orders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -31,12 +31,13 @@ class OrderCreationRepository @Inject constructor(
 
         val request = UpdateOrderRequest(
             status = status,
-            lineItems = order.items.map {
+            lineItems = order.items.map { item ->
                 LineItem(
-                    name = it.name,
-                    productId = it.productId,
-                    variationId = it.variationId,
-                    quantity = it.quantity
+                    id = item.itemId.takeIf { it != 0L },
+                    name = item.name,
+                    productId = item.productId,
+                    variationId = item.variationId,
+                    quantity = item.quantity
                 )
             },
             shippingAddress = order.shippingAddress.toShippingAddressModel(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5742 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This fixes the duplicate products on created orders when the M2 flag is enabled.

### Testing instructions
Please test order creation with and without the M2 flag, and confirm everything works as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
