### PR TITLE
Fix crash when opening Order Editing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -29,8 +29,10 @@ class AddressViewModel @Inject constructor(
         get() = dataStore.getCountries().map { it.toAppModel() }
 
     private fun statesAvailableFor(type: AddressType): List<Location> {
-        return dataStore.getStates(viewState.countryStatePairs.getValue(type).address.country.code)
-            .map { it.toAppModel() }
+        return viewState.countryStatePairs[type]?.address?.country?.code?.let { locationCode ->
+            dataStore.getStates(locationCode)
+                .map { it.toAppModel() }
+        }.orEmpty()
     }
 
     private fun statesFor(countryCode: LocationCode): List<Location> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -48,7 +48,7 @@ abstract class BaseAddressEditingFragment :
     val addressDraft
         get() = binding.form.run {
             val addressState =
-                addressViewModel.viewStateData.liveData.value!!.countryStatePairs.getValue(addressType).address
+                addressViewModel.viewStateData.liveData.value!!.countryStatePairs[addressType]?.address ?: Address.EMPTY
             Address(
                 firstName = firstName.text,
                 lastName = lastName.text,
@@ -174,7 +174,7 @@ abstract class BaseAddressEditingFragment :
 
     private fun setupObservers() {
         addressViewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
-            val newCountryStatePair = new.countryStatePairs.getValue(addressType)
+            val newCountryStatePair = new.countryStatePairs[addressType]
 
             new.isLoading.takeIfNotEqualTo(old?.isLoading) {
                 binding.progressBar.isVisible = it
@@ -182,7 +182,7 @@ abstract class BaseAddressEditingFragment :
                     updateStateViews()
                 }
             }
-            binding.form.update(newCountryStatePair)
+            newCountryStatePair?.let { binding.form.update(it) }
         }
 
         addressViewModel.event.observe(viewLifecycleOwner) { event ->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5744
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a crash that occurs when editing address of order without previously fetched `Location` data.

The root cause for this crash was that Fragment was expecting ViewModel to contain a specific `AddressType` to observe, while it might not offer it yet, as initialisation of the ViewModel contains lines that will defer the process until `Location` models are fetched from the remote.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Reproduction
1. Remove the app
2. Checkout `release/8.4`
3. Open app
4. Log in
5. Open a random Order
6. Edit its address
7. Expect crash

#### TC1
1. Remove the app
2. Checkout `issue/5744_fix_crashing_order_editting`
3. Open app
4. Log in
5. Open a random Order
6. Edit its address
7. Expect no crash

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
