### PR TITLE
Issue/5587 more menu tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import org.json.JSONObject
 import org.wordpress.android.fluxc.model.SiteModel
-import java.util.*
+import java.util.UUID
 
 class AnalyticsTracker private constructor(private val context: Context) {
     // region Track Event Enums
@@ -301,8 +301,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         MAIN_TAB_ORDERS_RESELECTED,
         MAIN_TAB_PRODUCTS_SELECTED,
         MAIN_TAB_PRODUCTS_RESELECTED,
-        MAIN_TAB_MORE_MENU_SELECTED,
-        MAIN_TAB_MORE_MENU_RESELECTED,
+        MAIN_TAB_HUB_MENU_SELECTED,
+        MAIN_TAB_HUB_MENU_RESELECTED,
 
         // -- Settings
         SETTING_CHANGE,
@@ -580,7 +580,12 @@ class AnalyticsTracker private constructor(private val context: Context) {
         MEDIA_PICKER_SELECTION_CLEARED,
         MEDIA_PICKER_OPENED,
         MEDIA_PICKER_OPEN_SYSTEM_PICKER,
-        MEDIA_PICKER_OPEN_WORDPRESS_MEDIA_LIBRARY_PICKER
+        MEDIA_PICKER_OPEN_WORDPRESS_MEDIA_LIBRARY_PICKER,
+
+        // -- More Menu (aka Hub Menu)
+        HUB_MENU_SWITCH_STORE_TAPPED,
+        HUB_MENU_OPTION_TAPPED,
+        HUB_MENU_SETTINGS_TAPPED
     }
     // endregion
 
@@ -858,6 +863,11 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_ANNOUNCEMENT_VIEW_SOURCE = "source"
         const val VALUE_ANNOUNCEMENT_SOURCE_UPGRADE = "app_upgrade"
         const val VALUE_ANNOUNCEMENT_SOURCE_SETTINGS = "app_settings"
+
+        // -- More Menu (aka Hub Menu) option values
+        const val VALUE_MORE_MENU_VIEW_STORE = "view_store"
+        const val VALUE_MORE_MENU_ADMIN_MENU = "admin_menu"
+        const val VALUE_MORE_MENU_REVIEWS = "reviews"
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -7,10 +7,7 @@ import android.content.Intent
 import android.content.res.Resources.Theme
 import android.net.Uri
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuItem
-import android.view.View
-import android.view.WindowManager
+import android.view.*
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
@@ -31,10 +28,7 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivityMainBinding
-import com.woocommerce.android.extensions.active
-import com.woocommerce.android.extensions.collapse
-import com.woocommerce.android.extensions.expand
-import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -657,7 +651,7 @@ class MainActivity :
             ANALYTICS -> Stat.MAIN_TAB_ANALYTICS_SELECTED
             ORDERS -> Stat.MAIN_TAB_ORDERS_SELECTED
             PRODUCTS -> Stat.MAIN_TAB_PRODUCTS_SELECTED
-            MORE -> Stat.MAIN_TAB_MORE_MENU_SELECTED
+            MORE -> Stat.MAIN_TAB_HUB_MENU_SELECTED
         }
         AnalyticsTracker.track(stat)
 
@@ -672,7 +666,7 @@ class MainActivity :
             ANALYTICS -> Stat.MAIN_TAB_ANALYTICS_RESELECTED
             ORDERS -> Stat.MAIN_TAB_ORDERS_RESELECTED
             PRODUCTS -> Stat.MAIN_TAB_PRODUCTS_RESELECTED
-            MORE -> Stat.MAIN_TAB_MORE_MENU_RESELECTED
+            MORE -> Stat.MAIN_TAB_HUB_MENU_RESELECTED
         }
         AnalyticsTracker.track(stat)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -1,9 +1,13 @@
 package com.woocommerce.android.ui.moremenu
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.*
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_OPTION
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_ADMIN_MENU
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_REVIEWS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_VIEW_STORE
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -48,23 +52,39 @@ class MoreMenuViewModel @Inject constructor(
     }
 
     fun onSettingsClick() {
+        AnalyticsTracker.track(
+            Stat.HUB_MENU_SETTINGS_TAPPED
+        )
         triggerEvent(MoreMenuEvent.NavigateToSettingsEvent)
     }
 
     fun onSwitchStoreClick() {
+        AnalyticsTracker.track(
+            Stat.HUB_MENU_SWITCH_STORE_TAPPED
+        )
         triggerEvent(MoreMenuEvent.StartSitePickerEvent)
     }
 
     private fun onViewAdminButtonClick() {
+        trackMoreMenuOptionSelected(VALUE_MORE_MENU_ADMIN_MENU)
         triggerEvent(MoreMenuEvent.ViewAdminEvent(selectedSite.get().adminUrl))
     }
 
     private fun onViewStoreButtonClick() {
+        trackMoreMenuOptionSelected(VALUE_MORE_MENU_VIEW_STORE)
         triggerEvent(MoreMenuEvent.ViewStoreEvent(selectedSite.get().url))
     }
 
     private fun onReviewsButtonClick() {
+        trackMoreMenuOptionSelected(VALUE_MORE_MENU_REVIEWS)
         triggerEvent(MoreMenuEvent.ViewReviewsEvent)
+    }
+
+    private fun trackMoreMenuOptionSelected(selectedOption: String) {
+        AnalyticsTracker.track(
+            Stat.HUB_MENU_OPTION_TAPPED,
+            mapOf(KEY_OPTION to selectedOption)
+        )
     }
 
     data class MoreMenuViewState(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5587 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Add tracking for Hub Menu according to plan p91TBi-7aB-p2 : 
![Screenshot 2022-02-03 at 10 15 39](https://user-images.githubusercontent.com/2663464/152314063-612d9732-d37d-430d-b793-ba9d8b39d2df.png)

I've suggested a change on the naming for the first 2 events of the table, as they did not match the current pattern we were using. p91TBi-7aB-p2#comment-8331

### Testing instructions
Interact with hub menu and check that the proper events are fired.