### PR TITLE
Release the Jetpack CP Feature.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 8.5
 -----
-
+- [***] Store admins can now access sites with plugins that have Jetpack Connection Package (e.g. WooCommerce Payments, Jetpack Backup) in the app. These sites do not require Jetpack-the-plugin to connect anymore. Store admins can still install Jetpack-the-plugin from the app through settings or a Jetpack banner. [https://github.com/woocommerce/woocommerce-android/pull/5771]
 
 8.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -23,8 +23,8 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
             ORDER_CREATION,
-            ORDER_CREATION_M2,
-            JETPACK_CP -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            ORDER_CREATION_M2 -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            JETPACK_CP,
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
             PAYMENTS_STRIPE_EXTENSION -> false
             ORDER_FILTERS,


### PR DESCRIPTION
### Description
This feature enables the complete Jetpack CP feature into the app.

Essentially this allows two things:
1. WooCommerce sites without Jetpack plugin, but connected using the Jetpack Connection Package as provided by plugins such as WooCommerce Payments or Jetpack Backup, can now be selected and accessed in the app.
2. Once inside the app, if a site like above is selected, a banner is shown at the bottom of the My Store screen offering to install the Jetpack plugin, to unlock more features such as statistics. If the merchants choose to, they can install Jetpack plugin directly from the app by selecting the banner.

### Testing instructions
**Prepare a test site:**
1. Create a test site with WooCommerce and WooCommerce Payments plugin, but no Jetpack plugin,
2. Go through WooCommerce Payments setup and connect account to WordPress.com. Once connected, you can skip the rest of the setup (e.g Stripe setup) by going back to wp-admin.

**Test the Jetpack CP app:**
1. Run app, sign out first just to start fresh, then sign back in,
2. In the site selection step, make sure the test site above is listed,
3. Select the site, and eventually My Store will open,
4. Check and test out the app's functionality in general.

**Test the Jetpack installation inside the app:**
1. Still in the app with the test site selected, go to My Store,
2. Tap the Jetpack banner at the bottom,
3. Go through the installation steps until Jetpack is installed properly,
4. Once returning back to My Store, check and test out the app's functionality in general,
5. Open the site's wp-admin on a browse and ensure that the Jetpack plugin is installed properly.

Another option to install Jetpack is also available in Settings > Install Jetpack. To test this, you will need to create another test site first.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
