### PR TITLE
Update statsGranularity for views before loading new stats

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -1,10 +1,7 @@
 package com.woocommerce.android.ui.mystore
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
-import android.view.View
+import android.view.*
 import android.view.ViewGroup.LayoutParams
 import androidx.core.view.children
 import androidx.core.view.isVisible
@@ -15,19 +12,13 @@ import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.google.android.play.core.review.ReviewManagerFactory
-import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.FeedbackPrefs
+import com.woocommerce.android.*
 import com.woocommerce.android.FeedbackPrefs.userFeedbackIsDue
-import com.woocommerce.android.NavGraphMainDirections
-import com.woocommerce.android.R
 import com.woocommerce.android.R.attr
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentMyStoreBinding
-import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.extensions.setClickableText
-import com.woocommerce.android.extensions.startHelpActivity
-import com.woocommerce.android.extensions.verticalOffsetChanges
+import com.woocommerce.android.extensions.*
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
@@ -162,7 +153,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     private fun setupStateObservers() {
         viewModel.revenueStatsState.observe(viewLifecycleOwner) { revenueStats ->
             when (revenueStats) {
-                is RevenueStatsViewState.Content -> showStats(revenueStats.revenueStats)
+                is RevenueStatsViewState.Content -> showStats(revenueStats.revenueStats, revenueStats.granularity)
                 RevenueStatsViewState.GenericError -> showStatsError()
                 RevenueStatsViewState.Loading -> showChartSkeleton(true)
                 RevenueStatsViewState.PluginNotActiveError -> updateStatsAvailabilityError()
@@ -292,11 +283,11 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         outState.putInt(STATE_KEY_TAB_POSITION, tabStatsPosition)
     }
 
-    private fun showStats(revenueStatsModel: RevenueStatsUiModel?) {
+    private fun showStats(revenueStatsModel: RevenueStatsUiModel?, granularity: StatsGranularity) {
         addTabLayoutToAppBar()
         binding.myStoreStats.showErrorView(false)
         showChartSkeleton(false)
-        binding.myStoreStats.updateView(revenueStatsModel)
+        binding.myStoreStats.updateView(revenueStatsModel, granularity)
     }
 
     private fun showStatsError() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -4,9 +4,7 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
-import android.view.LayoutInflater
-import android.view.MotionEvent
-import android.view.View
+import android.view.*
 import android.widget.TextView
 import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
@@ -16,9 +14,7 @@ import androidx.core.widget.addTextChangedListener
 import com.github.mikephil.charting.charts.Chart
 import com.github.mikephil.charting.components.MarkerImage
 import com.github.mikephil.charting.components.XAxis
-import com.github.mikephil.charting.data.Entry
-import com.github.mikephil.charting.data.LineData
-import com.github.mikephil.charting.data.LineDataSet
+import com.github.mikephil.charting.data.*
 import com.github.mikephil.charting.formatter.ValueFormatter
 import com.github.mikephil.charting.highlight.Highlight
 import com.github.mikephil.charting.listener.ChartTouchListener.ChartGesture
@@ -31,9 +27,7 @@ import com.woocommerce.android.databinding.MyStoreStatsBinding
 import com.woocommerce.android.extensions.*
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.MyStoreFragment.Companion.DEFAULT_STATS_GRANULARITY
-import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.*
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.SkeletonView
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
@@ -329,7 +323,8 @@ class MyStoreStatsView @JvmOverloads constructor(
         }
     }
 
-    fun updateView(revenueStatsModel: RevenueStatsUiModel?) {
+    fun updateView(revenueStatsModel: RevenueStatsUiModel?, granularity: StatsGranularity) {
+        activeGranularity = granularity
         updateDate(revenueStatsModel, activeGranularity)
         this.revenueStatsModel = revenueStatsModel
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -116,7 +116,6 @@ class MyStoreStatsView @JvmOverloads constructor(
     }
 
     fun loadDashboardStats(granularity: StatsGranularity) {
-        this.activeGranularity = granularity
         // Track range change
         AnalyticsTracker.track(
             Stat.DASHBOARD_MAIN_STATS_DATE,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5746 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This is a tentative fix to an exception trying to parse the dates with unexpected format for a given `statsGranularity`.

I've tested all sorts of things, and I'm unable to reproduce the bug. Let me try to explain what the problem is and what I think it's happening so that you get some context of the changes I've applied here to try to fix the issue. 

In order to display the labels on the x-axis from My Home Screen chart: 

<img src="https://user-images.githubusercontent.com/2663464/152381797-59c6a7db-3a4d-44c5-b572-e03660bd0533.png" width="300 ">

We rely on the following method from `MyStoreStatsView.kt`

```kotlin
        private fun getLabelValue(dateString: String): String {
            return when (activeGranularity) {
                StatsGranularity.DAYS -> dateUtils.getShortHourString(dateString).orEmpty()
                StatsGranularity.WEEKS -> getWeekLabelValue(dateString)
                StatsGranularity.MONTHS -> dateString.formatToDateOnly()
                StatsGranularity.YEARS -> dateUtils.getShortMonthString(dateString).orEmpty()
            }
        }
```

This method will try to parse the param `dateString` base on the `activeGranularity` value. The format of the `dateString` comes from that back end, and depends on the `statsGranularity` we send when doing the request. The possible formats of `dateStrings` are: 

```
activeGranularity == DAYS -> 2022-02-03 07
activeGranularity == WEEK-> 2022-01-31
activeGranularity == MONTH -> 2022-01-31
activeGranularity == YEAR -> 2022-04
```

Now from what I see on the stacktrace from the errors: 

```
java.text.ParseException: Unparseable date: "2022-06"
    at java.text.DateFormat.parse(DateFormat.java:362)
    at com.woocommerce.android.util.DateUtils.getShortHourString(DateUtils.kt:206)
    at com.woocommerce.android.ui.mystore.MyStoreStatsView$StartEndDateAxisFormatter.getLabelValue(MyStoreStatsView.kt:576)
```
Is that somehow the input `dateString` which is `2022-06` (year format) is not in a valid format for the given `activeGranularity` which is `DAYS` (as we see `getShortHourString` is called).  From what I've seen this parse exception only happens for DAYS stats granularity, which I don't think is a random coincidence, as DAYS granularity is the default value when there's nothing selected. 

Now I'm not 100% sure how this misalignment between resulting data from backend and `activeGranularity` is happening. My theory is that there must be some kind of race condition, between setting the value of `activeGranularity` field, which is done synchronously from `MyStoreFragment` and loading stats asynchronously. If in between, the loading of stats the `activeGranularity` is changed, when the data is back from server we might get that inconsistent state. After checking the code I'm still not sure how this can happen, but I've made some changes that will make it "imposible" in theory to have that inconsistent state. Lets see if that fixes the problem 🤞🏼 

**Note** that this `ParseException` is not a crash, as the exception is captured. I'm not even sure this is something the user will see/notice. One thing I don't understand is that once the `ParseException` happens then `getShortHourString` would return null and should provoke a null pointer exception somewhere. But apparently, there is no crash from Sentry logs. I did a quick test to check what would happen if I force to return null from `MyStoreStatsView.getLabelValue()` and that leads to a `NullPointerException` 

### Testing instructions
Anything you can come up to try to make the `ParseException` happen due to inconsistent state between the dates returned by the server and the selected `activeGranularity`
