### PR TITLE
Track order list search in a separated event than order filtering

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import org.json.JSONObject
 import org.wordpress.android.fluxc.model.SiteModel
-import java.util.HashMap
 import java.util.UUID
 
 class AnalyticsTracker private constructor(private val context: Context) {
@@ -145,6 +144,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
 
         // -- Orders List
         ORDERS_LIST_FILTER,
+        ORDERS_LIST_SEARCH,
         ORDERS_LIST_LOADED,
         ORDERS_LIST_SHARE_YOUR_STORE_BUTTON_TAPPED,
         ORDERS_LIST_PULLED_TO_REFRESH,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,19 +1,12 @@
 package com.woocommerce.android.ui.orders.list
 
-import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
+import android.os.*
+import android.view.*
 import android.view.MenuItem.OnActionExpandListener
-import android.view.View
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
-import androidx.core.view.ViewGroupCompat
-import androidx.core.view.doOnPreDraw
-import androidx.core.view.isVisible
+import androidx.core.view.*
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.paging.PagedList
@@ -35,9 +28,7 @@ import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.C
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.OrderCreationAction
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
-import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.*
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
@@ -472,7 +463,7 @@ class OrderListFragment :
      */
     private fun handleNewSearchRequest(query: String) {
         AnalyticsTracker.track(
-            Stat.ORDERS_LIST_FILTER,
+            Stat.ORDERS_LIST_SEARCH,
             mapOf(AnalyticsTracker.KEY_SEARCH to query)
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5768
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Fix order filters tracking issues.  Updated the tracking plan p91TBi-6i1-p2 for order filters so that we now track order searches and order filtering in a different events. For that, a new event `orders_list_search` has been created. `orders_list_filter` has been kept and will only be triggered from filters flow. 

More discussion on the matter here: p91TBi-7m3-p2