### PR TITLE
Hub menu: Remove "Settings" icon from My Store and "Switch Site" from Settings.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.mystore
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup.LayoutParams
 import androidx.core.view.children
@@ -272,6 +269,11 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         _binding = null
     }
 
+    /*
+    Hide Settings icon on My Store, because it is moved to the "More" screen.
+    We temporarily comment this instead of outright deleting, because we might want to restore it,
+    based on merchants' feedbacks.
+
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_action_bar, menu)
         super.onCreateOptionsMenu(menu, inflater)
@@ -286,6 +288,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
             else -> super.onOptionsItemSelected(item)
         }
     }
+     */
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -44,6 +44,7 @@ import javax.inject.Inject
 import kotlin.math.abs
 
 @AndroidEntryPoint
+@Suppress("ForbiddenComment")
 class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     companion object {
         val TAG: String = MyStoreFragment::class.java.simpleName

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -271,8 +271,11 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     /*
     Hide Settings icon on My Store, because it is moved to the "More" screen.
-    We temporarily comment this instead of outright deleting, because we might want to restore it,
-    based on merchants' feedbacks.
+    We temporarily comment out the code instead of deleting, because we might want to restore it later,
+    based on merchants feedbacks.
+
+    TODO: Maybe restore Settings icon on My Store, depending on merchants feedbacks.
+    For more context: https://github.com/woocommerce/woocommerce-android/issues/5586
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_action_bar, menu)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -25,7 +25,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
-import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.*
 import com.woocommerce.android.util.FeatureFlag.CARD_READER
 import com.woocommerce.android.util.WooLog.T

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -176,6 +176,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_licensesFragment)
         }
 
+        /*
+        Hide "Switch Store" option in Settings, because it is moved to the "More" screen.
+        We temporarily comment this instead of outright deleting, because we might want to restore it,
+        based on merchants' feedbacks.
+
         if (presenter.hasMultipleStores()) {
             val storeClickListener = View.OnClickListener {
                 AnalyticsTracker.track(SETTINGS_SELECTED_SITE_TAPPED)
@@ -186,6 +191,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         } else {
             binding.optionSwitchStore.hide()
         }
+        */
+        binding.optionSwitchStore.hide()
 
         binding.optionTheme.optionValue = getString(AppPrefs.getAppTheme().label)
         binding.optionTheme.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -56,6 +56,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
     private lateinit var settingsListener: AppSettingsListener
 
+    @Suppress("ForbiddenComment", "LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -177,8 +177,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
         /*
         Hide "Switch Store" option in Settings, because it is moved to the "More" screen.
-        We temporarily comment this instead of outright deleting, because we might want to restore it,
-        based on merchants' feedbacks.
+        We temporarily comment out the code instead of deleting, because we might want to restore it later,
+        based on merchants feedbacks.
+
+        TODO: Maybe restore "Switch Store" option in Settings, depending on merchants feedbacks.
+        For more context: https://github.com/woocommerce/woocommerce-android/issues/5586
 
         if (presenter.hasMultipleStores()) {
             val storeClickListener = View.OnClickListener {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5586 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Now that "Settings" and "Switch Site" are accessible in the Hub menu/more screen, this PR hides them from their original location:
- Removes "Settings" icon on My Store
- Removes "Switch Site" option inside Settings screen.

The related code is commented instead of deleted, because we want to easily restore it again in case those options need to be returned based on merchant feedbacks.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Start app, ensure there's no Settings icon on top right of My Store screen,
2. Go to More screen and tap Settings icon on top right. Ensure there's no Switch Store option on the Settings screen.
