### PR TITLE
Issue/5778 statement descriptor

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -217,4 +217,23 @@ class AppPrefsTest {
             )
         ).isFalse
     }
+
+    @Test
+    fun givenCardReaderStateDescriptorSetWhenGettingDescriptorThenSameDescriptorReturned() {
+        val statementDescriptor = "descriptor"
+        AppPrefs.setCardReaderStatementDescriptor(
+            statementDescriptor = statementDescriptor,
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+        )
+
+        assertThat(
+            AppPrefs.getCardReaderStatementDescriptor(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isEqualTo(statementDescriptor)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -12,11 +12,7 @@ import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_ONBOARDING_COMPLETED_STATUS
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.DATABASE_DOWNGRADED
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.*
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.products.ProductType
@@ -63,6 +59,7 @@ object AppPrefs {
         USER_EMAIL,
         RECEIPT_PREFIX,
         CARD_READER_ONBOARDING_COMPLETED_STATUS,
+        CARD_READER_STATEMENT_DESCRIPTOR,
         ORDER_FILTER_PREFIX,
         ORDER_FILTER_CUSTOM_DATE_RANGE_START,
         ORDER_FILTER_CUSTOM_DATE_RANGE_END,
@@ -503,6 +500,39 @@ object AppPrefs {
         remoteSiteId: Long,
         selfHostedSiteId: Long
     ) = "$CARD_READER_ONBOARDING_COMPLETED_STATUS:$localSiteId:$remoteSiteId:$selfHostedSiteId"
+
+    fun setCardReaderStatementDescriptor(
+        statementDescriptor: String,
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) {
+        PreferenceUtils.setString(
+            getPreferences(),
+            getCardReaderStatementDescriptorKey(localSiteId, remoteSiteId, selfHostedSiteId),
+            statementDescriptor
+        )
+    }
+
+    fun getCardReaderStatementDescriptor(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ): String? = PreferenceUtils.getString(
+        getPreferences(),
+        getCardReaderStatementDescriptorKey(
+            localSiteId,
+            remoteSiteId,
+            selfHostedSiteId
+        ),
+        null
+    )
+
+    private fun getCardReaderStatementDescriptorKey(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = "$CARD_READER_STATEMENT_DESCRIPTOR:$localSiteId:$remoteSiteId:$selfHostedSiteId"
 
     fun getJetpackBenefitsDismissalDate(): Long {
         return getLong(DeletableSitePrefKey.JETPACK_BENEFITS_BANNER_DISMISSAL_DATE, 0L)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -32,6 +32,19 @@ class AppPrefsWrapper @Inject constructor() {
         pluginType: PluginType?
     ) = AppPrefs.setCardReaderOnboardingPending(localSiteId, remoteSiteId, selfHostedSiteId, pluginType)
 
+    fun setCardReaderStatementDescriptor(
+        statementDescriptor: String,
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = AppPrefs.setCardReaderStatementDescriptor(statementDescriptor, localSiteId, remoteSiteId, selfHostedSiteId)
+
+    fun getCardReaderStatementDescriptor(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = AppPrefs.getCardReaderStatementDescriptor(localSiteId, remoteSiteId, selfHostedSiteId)
+
     fun setLastConnectedCardReaderId(readerId: String) = AppPrefs.setLastConnectedCardReaderId(readerId)
 
     fun getLastConnectedCardReaderId() = AppPrefs.getLastConnectedCardReaderId()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -175,9 +175,15 @@ class CardReaderPaymentViewModel
 
     private suspend fun collectPaymentFlow(cardReaderManager: CardReaderManager, order: Order) {
         val customerEmail = order.billingAddress.email
+        val site = selectedSite.get()
         cardReaderManager.collectPayment(
             PaymentInfo(
                 paymentDescription = order.getPaymentDescription(),
+                statementDescriptor = appPrefsWrapper.getCardReaderStatementDescriptor(
+                    localSiteId = site.id,
+                    remoteSiteId = site.siteId,
+                    selfHostedSiteId = site.selfHostedSiteId
+                ),
                 orderId = order.id,
                 amount = order.total,
                 currency = order.currency,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -96,6 +96,8 @@ class CardReaderOnboardingChecker @Inject constructor(
         val paymentAccount =
             inPersonPaymentsStore.loadAccount(fluxCPluginType, selectedSite.get()).model ?: return GenericError
 
+        saveStatementDescriptor(paymentAccount.statementDescriptor)
+
         if (!isCountrySupported(paymentAccount.country)) return StripeAccountCountryNotSupported(paymentAccount.country)
         if (!isPluginSetupCompleted(paymentAccount)) return SetupNotCompleted(preferredPlugin.type)
         if (isPluginInTestModeWithLiveStripeAccount(paymentAccount)) return PluginInTestModeWithLiveStripeAccount
@@ -109,6 +111,16 @@ class CardReaderOnboardingChecker @Inject constructor(
         if (isInUndefinedState(paymentAccount)) return GenericError
 
         return OnboardingCompleted(preferredPlugin.type)
+    }
+
+    private fun saveStatementDescriptor(statementDescriptor: String) {
+        val site = selectedSite.get()
+        appPrefsWrapper.setCardReaderStatementDescriptor(
+            statementDescriptor = statementDescriptor,
+            localSiteId = site.id,
+            remoteSiteId = site.siteId,
+            selfHostedSiteId = site.selfHostedSiteId,
+        )
     }
 
     private fun isBothPluginsActivated(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -128,7 +128,12 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(true)
         whenever(appPrefsWrapper.getReceiptUrl(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
             .thenReturn("test url")
+        whenever(appPrefsWrapper.getCardReaderStatementDescriptor(anyOrNull(), anyOrNull(), anyOrNull()))
+            .thenReturn("test statement descriptor")
         whenever(wooStore.getStoreCountryCode(any())).thenReturn("US")
+        whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
+            flow<BluetoothCardReaderMessages> {}
+        }
     }
 
     @Test
@@ -357,6 +362,20 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             verify(cardReaderManager).collectPayment(captor.capture())
             assertThat(captor.firstValue.paymentDescription).isEqualTo(expectedResult)
+        }
+
+    @Test
+    fun `when flow started, then correct statement descriptor is propagated to CardReaderManager`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val expectedResult = "hooray"
+            whenever(appPrefsWrapper.getCardReaderStatementDescriptor(anyOrNull(), anyOrNull(), anyOrNull()))
+                .thenReturn(expectedResult)
+            val captor = argumentCaptor<PaymentInfo>()
+
+            viewModel.start()
+
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.statementDescriptor).isEqualTo(expectedResult)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -712,6 +712,22 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when payment account loads, then statement descriptor saved`() = testBlocking {
+        val expected = "Woo Site Test"
+        whenever(wcInPersonPaymentsStore.loadAccount(WOOCOMMERCE_PAYMENTS, site))
+            .thenReturn(buildPaymentAccountResult(statementDescriptor = expected))
+
+        checker.getOnboardingState()
+
+        verify(appPrefsWrapper).setCardReaderStatementDescriptor(
+            eq(expected),
+            anyInt(),
+            anyLong(),
+            anyLong(),
+        )
+    }
+
+    @Test
     fun `when onboarding NOT completed, then onboarding completed NOT saved`() = testBlocking {
         whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
             buildPaymentAccountResult(
@@ -869,13 +885,14 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         liveAccount: Boolean = true,
         testModeEnabled: Boolean? = false,
         countryCode: String = "US",
+        statementDescriptor: String = "",
     ) = WooResult(
         WCPaymentAccountResult(
             status,
             hasPendingRequirements = hasPendingRequirements,
             hasOverdueRequirements = hadOverdueRequirements,
             currentDeadline = null,
-            statementDescriptor = "",
+            statementDescriptor = statementDescriptor,
             storeCurrencies = WCPaymentAccountResult.WCPaymentAccountStatus.StoreCurrencies("", listOf()),
             country = countryCode,
             isLive = liveAccount,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -66,6 +66,7 @@ internal class CreatePaymentAction(
         with(paymentInfo) {
             customerId?.let { builder.setCustomer(it) }
             customerEmail?.takeIf { it.isNotEmpty() }?.let { builder.setReceiptEmail(it) }
+            statementDescriptor?.takeIf { it.isNotEmpty() }?.let { builder.setStatementDescriptor(it) }
         }
         return builder.build()
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
@@ -4,6 +4,7 @@ import java.math.BigDecimal
 
 data class PaymentInfo(
     val paymentDescription: String,
+    val statementDescriptor: String?,
     val orderId: Long,
     val amount: BigDecimal,
     val currency: String,

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -533,6 +533,7 @@ class PaymentManagerTest {
         siteUrl: String? = DUMMY_SITE_URL,
         customerId: String? = null,
         orderKey: String? = null,
+        statementDescriptor: String? = null,
     ): PaymentInfo =
         PaymentInfo(
             paymentDescription = paymentDescription,
@@ -544,6 +545,7 @@ class PaymentManagerTest {
             storeName = storeName,
             siteUrl = siteUrl,
             customerId = customerId,
-            orderKey = orderKey
+            orderKey = orderKey,
+            statementDescriptor = statementDescriptor,
         )
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -144,6 +144,33 @@ internal class CreatePaymentActionTest {
     }
 
     @Test
+    fun `when statement descriptor not empty, then PaymentIntent setStatementDescriptor invoked`() = runBlockingTest {
+        val expected = "Site abcd"
+
+        action.createPaymentIntent(createPaymentInfo(statementDescriptor = expected)).toList()
+
+        verify(intentParametersBuilder).setStatementDescriptor(expected)
+    }
+
+    @Test
+    fun `when statement descriptor "", then PaymentIntent setStatementDescriptor NOT invoked`() = runBlockingTest {
+        val expected = ""
+
+        action.createPaymentIntent(createPaymentInfo(statementDescriptor = expected)).toList()
+
+        verify(intentParametersBuilder, never()).setStatementDescriptor(any())
+    }
+
+    @Test
+    fun `when statement descriptor null, then PaymentIntent setStatementDescriptor NOT invoked`() = runBlockingTest {
+        val expected: String? = null
+
+        action.createPaymentIntent(createPaymentInfo(statementDescriptor = expected)).toList()
+
+        verify(intentParametersBuilder, never()).setStatementDescriptor(any())
+    }
+
+    @Test
     fun `when creating payment intent, then payment description set`() = runBlockingTest {
         val expectedDescription = "test description"
 
@@ -370,7 +397,8 @@ internal class CreatePaymentActionTest {
         siteUrl: String? = "",
         customerId: String? = null,
         orderKey: String? = null,
-        countryCode: String? = "US"
+        countryCode: String? = "US",
+        statementDescriptor: String? = null,
     ): PaymentInfo =
         PaymentInfo(
             paymentDescription = paymentDescription,
@@ -383,6 +411,7 @@ internal class CreatePaymentActionTest {
             siteUrl = siteUrl,
             customerId = customerId,
             orderKey = orderKey,
-            countryCode = countryCode
+            countryCode = countryCode,
+            statementDescriptor = statementDescriptor
         )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5778
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Sets store's Statement Descriptor on all IPP payments.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure a statement descriptor is set on your store
<img width="600" alt="Screenshot 2022-02-04 at 11 14 25" src="https://user-images.githubusercontent.com/2261188/152511684-2eb3a6af-fc0c-49dc-9d08-deb49cef1294.png">

2. Open an unpaid order in the app
3. Tap on the collect payment button
4. Collect the payment
5. Open Stripe's dashboard
6. Find the transaction
<img width="600" alt="Screenshot 2022-02-04 at 11 16 21" src="https://user-images.githubusercontent.com/2261188/152511881-2e04b33f-fa6b-46a7-ab02-b1a5a6fe373d.png">

7. Make sure statement descriptor is set to the correct value


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
