### PR TITLE
Change logic to have a single source of truth for the active granularity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -50,7 +50,6 @@ import kotlin.math.abs
 class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     companion object {
         val TAG: String = MyStoreFragment::class.java.simpleName
-        private const val STATE_KEY_TAB_POSITION = "tab-stats-position"
 
         fun newInstance() = MyStoreFragment()
 
@@ -69,14 +68,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     private var errorSnackbar: Snackbar? = null
 
-    private var tabStatsPosition: Int = 0 // Save the current position of stats tab view
-    private val activeGranularity: StatsGranularity
-        get() {
-            return tabLayout.getTabAt(tabStatsPosition)?.let {
-                it.tag as StatsGranularity
-            } ?: DEFAULT_STATS_GRANULARITY
-        }
-
     private var _tabLayout: TabLayout? = null
     private val tabLayout
         get() = _tabLayout!!
@@ -91,10 +82,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     private val tabSelectedListener = object : TabLayout.OnTabSelectedListener {
         override fun onTabSelected(tab: TabLayout.Tab) {
-            tabStatsPosition = tab.position
-            viewModel.onStatsGranularityChanged(activeGranularity)
-            binding.myStoreStats.loadDashboardStats(activeGranularity)
-            binding.myStoreTopPerformers.onDateGranularityChanged(activeGranularity)
+            viewModel.onStatsGranularityChanged(tab.tag as StatsGranularity)
         }
 
         override fun onTabUnselected(tab: TabLayout.Tab) {}
@@ -117,10 +105,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
             binding.myStoreStats.clearChartData()
         }
 
-        savedInstanceState?.let { bundle ->
-            tabStatsPosition = bundle.getInt(STATE_KEY_TAB_POSITION)
-        }
-
         // Create tabs and add to appbar
         StatsGranularity.values().forEach { granularity ->
             val tab = tabLayout.newTab().apply {
@@ -128,15 +112,10 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                 tag = granularity
             }
             tabLayout.addTab(tab)
-
-            // Start with the given time period selected
-            if (granularity == activeGranularity) {
-                tab.select()
-            }
         }
 
         binding.myStoreStats.initView(
-            activeGranularity,
+            viewModel.activeStatsGranularity.value ?: DEFAULT_STATS_GRANULARITY,
             selectedSite,
             dateUtils,
             currencyFormatter
@@ -160,6 +139,14 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     @Suppress("ComplexMethod")
     private fun setupStateObservers() {
+        viewModel.activeStatsGranularity.observe(viewLifecycleOwner) { activeGranularity ->
+            if (tabLayout.getTabAt(tabLayout.selectedTabPosition)?.tag != activeGranularity) {
+                val index = StatsGranularity.values().indexOf(activeGranularity)
+                tabLayout.getTabAt(index)?.select()
+            }
+            binding.myStoreStats.loadDashboardStats(activeGranularity)
+            binding.myStoreTopPerformers.onDateGranularityChanged(activeGranularity)
+        }
         viewModel.revenueStatsState.observe(viewLifecycleOwner) { revenueStats ->
             when (revenueStats) {
                 is RevenueStatsViewState.Content -> showStats(revenueStats.revenueStats)
@@ -285,11 +272,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
             }
             else -> super.onOptionsItemSelected(item)
         }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putInt(STATE_KEY_TAB_POSITION, tabStatsPosition)
     }
 
     private fun showStats(revenueStatsModel: RevenueStatsUiModel?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
@@ -69,9 +70,10 @@ class MyStoreViewModel @Inject constructor(
     val hasOrders: LiveData<OrderState> = _hasOrders
 
     private val refreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    private var activeStatsGranularity = MutableStateFlow(
+    private var _activeStatsGranularity = MutableStateFlow(
         savedState.get<StatsGranularity>(ACTIVE_STATS_GRANULARITY_KEY) ?: StatsGranularity.DAYS
     )
+    val activeStatsGranularity = _activeStatsGranularity.asLiveData()
 
     @VisibleForTesting val refreshStoreStats = BooleanArray(StatsGranularity.values().size) { true }
     @VisibleForTesting val refreshTopPerformerStats = BooleanArray(StatsGranularity.values().size) { true }
@@ -80,7 +82,7 @@ class MyStoreViewModel @Inject constructor(
         ConnectionChangeReceiver.getEventBus().register(this)
         viewModelScope.launch {
             combine(
-                activeStatsGranularity,
+                _activeStatsGranularity,
                 refreshTrigger.onStart { emit(Unit) }
             ) { granularity, _ ->
                 granularity
@@ -114,7 +116,7 @@ class MyStoreViewModel @Inject constructor(
     }
 
     fun onStatsGranularityChanged(granularity: StatsGranularity) {
-        activeStatsGranularity.update { granularity }
+        _activeStatsGranularity.update { granularity }
         savedState[ACTIVE_STATS_GRANULARITY_KEY] = granularity
     }
 


### PR DESCRIPTION
Closes: #5746 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Occasionally, there is an inconsistent state between the stats loaded in Home Screen and the selected stats granularity (days, week,month or year), when this happens an `ParseException: Unparseable date: "2022-06"` will be thrown. This won't make the app crash but the labels from the X-axis will be invisible: 

Kudos to @hichamboushaba for finding a way to reproduce it and a clean way to fix and improve the existing implementation.

| Bug  | Fixed |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2663464/152518014-f4dd94b2-d0f2-49bf-a46c-15f1883233ad.png" width="300">  | <img src="https://user-images.githubusercontent.com/2663464/152381797-59c6a7db-3a4d-44c5-b572-e03660bd0533.png" width="300 ">  |

Don't bother about the strange colors. Somehow, the screenshot from the emulator came out that way. 

Context on what is happening

```kotlin
        private fun getLabelValue(dateString: String): String {
            return when (activeGranularity) {
                StatsGranularity.DAYS -> dateUtils.getShortHourString(dateString).orEmpty()
                StatsGranularity.WEEKS -> getWeekLabelValue(dateString)
                StatsGranularity.MONTHS -> dateString.formatToDateOnly()
                StatsGranularity.YEARS -> dateUtils.getShortMonthString(dateString).orEmpty()
            }
        }
```

This method will try to parse the param `dateString` base on the `activeGranularity` value. The format of the `dateString` comes from that back end, and depends on the `statsGranularity` we send when doing the request. The possible formats of `dateStrings` are: 

```
activeGranularity == DAYS -> 2022-02-03 07
activeGranularity == WEEK-> 2022-01-31
activeGranularity == MONTH -> 2022-01-31
activeGranularity == YEAR -> 2022-04
```

Now from what I see on the stacktrace from the errors: 

```
java.text.ParseException: Unparseable date: "2022-06"
    at java.text.DateFormat.parse(DateFormat.java:362)
    at com.woocommerce.android.util.DateUtils.getShortHourString(DateUtils.kt:206)
    at com.woocommerce.android.ui.mystore.MyStoreStatsView$StartEndDateAxisFormatter.getLabelValue(MyStoreStatsView.kt:576)
```
The cause for this exception is that once you rotate the phone the first time, a new instance of the MyStoreFragment will be created, and it will have tabStatsPosition set to the default value 0, so after the second rotation, and since we didn't go through onViewCreated to restore the previous value, we will override the saved state with 0.

### Testing instructions
In order to reproduce the bug. Checkout `release/8.4` or `Trunk` and follow the steps: 

1. Enable "Don't keep activities" from the developer options
2. Open MyStore, and switch to a different granularity.
3. Open a different tab in the app (from the bottom navigation)
4. Rotate the phone two times
5. Go back to MyStore.
6. You will notice that Today has been selected, but the data of previously selected granularity is still shown.
