### PR TITLE
Fix deactivating shipping address not causing `Done` button to be visible

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
@@ -88,8 +88,11 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
                 }
             }
         }
-        addressViewModel.isAnyAddressEdited.observe(viewLifecycleOwner) { isAnyAddressEdited ->
-            doneMenuItem?.isVisible = isAnyAddressEdited
+        addressViewModel.shouldShowDoneButton.observe(viewLifecycleOwner) { shouldShowDoneButton: Boolean ->
+            doneMenuItem?.isVisible = shouldShowDoneButton
+        }
+        addressViewModel.isDifferentShippingAddressChecked.observe(viewLifecycleOwner) { checked ->
+            updateShippingBindingVisibility(checked)
         }
     }
 
@@ -142,7 +145,7 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
         updateShippingBindingVisibility(showShippingAddressFormSwitch?.addressSwitch?.isChecked ?: false)
         showShippingAddressFormSwitch?.let {
             it.addressSwitch.setOnCheckedChangeListener { _, checked ->
-                updateShippingBindingVisibility(checked)
+                addressViewModel.onDifferentShippingAddressChecked(checked)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.details.editing.address
 
 import android.os.Parcelable
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.map
 import com.woocommerce.android.model.*
@@ -10,6 +11,7 @@ import com.woocommerce.android.ui.orders.details.editing.address.AddressViewMode
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.combineWith
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -48,6 +50,19 @@ class AddressViewModel @Inject constructor(
         viewState.addressSelectionStates.mapValues { it.value.address } != initialState
     }
 
+    private val _isDifferentShippingAddressChecked = MutableLiveData<Boolean>()
+    val isDifferentShippingAddressChecked: LiveData<Boolean> = _isDifferentShippingAddressChecked
+
+    val shouldShowDoneButton = isAnyAddressEdited.combineWith(
+        isDifferentShippingAddressChecked,
+        viewStateData.liveData.map { it.addressSelectionStates[AddressType.SHIPPING]?.address }
+    ) { isAnyAddressEdited, isDifferentShippingAddressChecked, shippingAddress ->
+        val isDifferentShippingAddressDisabled =
+            isDifferentShippingAddressChecked == false && (shippingAddress != Address.EMPTY)
+
+        isAnyAddressEdited == true || isDifferentShippingAddressDisabled
+    }
+
     /**
      * The start method is called when the view is created. When the view is recreated (e.g. navigating to country
      * search and back) we don't want this method to be called again, otherwise the ViewModel will replace the newly
@@ -84,8 +99,9 @@ class AddressViewModel @Inject constructor(
         }
     }
 
-    @Deprecated("Use stateSpinnerStatus of corresponding AddressSelectionState")
-    fun hasStatesFor(type: AddressType) = statesAvailableFor(type).isNotEmpty()
+    fun onDifferentShippingAddressChecked(checked: Boolean) {
+        _isDifferentShippingAddressChecked.value = checked
+    }
 
     /**
      * Even when the [BaseAddressEditingFragment] instance is destroyed the instance of [AddressViewModel] will still

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataExt.kt
@@ -16,3 +16,21 @@ fun <T, K, R> LiveData<T>.combineWith(
     }
     return result
 }
+
+fun <T, K, G, R> LiveData<T>.combineWith(
+    liveData1: LiveData<K>,
+    liveData2: LiveData<G>,
+    block: (T?, K?, G?) -> R
+): LiveData<R> {
+    val result = MediatorLiveData<R>()
+    result.addSource(this) {
+        result.value = block(this.value, liveData1.value, liveData2.value)
+    }
+    result.addSource(liveData1) {
+        result.value = block(this.value, liveData1.value, liveData2.value)
+    }
+    result.addSource(liveData2) {
+        result.value = block(this.value, liveData1.value, liveData2.value)
+    }
+    return result
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5692 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes an issue of not showing `Done` button (and allowing user to save change) if user entered `Edit` of Customer with shipping and billing addresses being different (see video).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to Order Creation
2. Add customer: make sure shipping and billing addresses are different
3. Save the change
4. **Assert that shipping and billing addresses are saved correctly**
5. Click on `Edit` for `Customer` section
6. **Assert the `Done` button is not visible**
7. Uncheck "Add a different shipping address" checkbox
8. **Assert the `Done` button is visible**

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5845095/152539028-7b96efa6-4cdb-4a3e-b476-5b21c48e1173.mov



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
