### PR TITLE
Add warning about using Automattic email to create support request

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
@@ -46,8 +46,12 @@ class SupportHelper {
                 val newEmail = emailEditText.text
                 val newName = nameEditText.text
                 if (StringUtils.isValidEmail(newEmail)) {
-                    emailAndNameSelected(newEmail, newName)
-                    dialog.dismiss()
+                    if (StringUtils.isA8cEmail(newEmail)) {
+                        emailEditText.error = context.getString(R.string.a8c_email_message)
+                    } else {
+                        emailAndNameSelected(newEmail, newName)
+                        dialog.dismiss()
+                    }
                 } else {
                     emailEditText.error = context.getString(R.string.invalid_email_message)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -109,10 +109,7 @@ object StringUtils {
      * Returns true if the passed string is an Automattic/A8c email
      */
     fun isA8cEmail(email: String?): Boolean {
-        if (email != null && (AUTOMATTIC in email.lowercase() || A8C in email.lowercase())) {
-            return true
-        }
-        return false
+        return email != null && (AUTOMATTIC in email.lowercase() || A8C in email.lowercase())
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -22,6 +22,8 @@ object StringUtils {
     const val EMPTY = ""
     private const val ONE_MILLION = 1000000
     private const val ONE_THOUSAND = 1000
+    private const val A8C = "@a8c.com"
+    private const val AUTOMATTIC = "@automattic.com"
 
     /**
      * Borrowed and modified from WordPress-Android :)
@@ -101,6 +103,16 @@ object StringUtils {
         return email?.let {
             return Patterns.EMAIL_ADDRESS.matcher(it).matches()
         } ?: false
+    }
+
+    /**
+     * Returns true if the passed string is an Automattic/A8c email
+     */
+    fun isA8cEmail(email: String?): Boolean {
+        if (email != null && (AUTOMATTIC in email.lowercase() || A8C in email.lowercase())) {
+            return true
+        }
+        return false
     }
 
     /**

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1527,6 +1527,7 @@
     <string name="support_help">Help &amp; support</string>
     <string name="support_email_subject">WooCommerce Android %s support</string>
     <string name="invalid_email_message">Your email address isn\'t valid</string>
+    <string name="a8c_email_message">Please use a non-Automattic email to submit a support ticket</string>
     <string name="support_identity_input_dialog_enter_email_and_name">To continue please enter your email address and name</string>
     <string name="support_identity_input_dialog_enter_email">Please enter your email address</string>
     <string name="support_identity_input_dialog_email_label">Email</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5464 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This checks if the email provided by the user when trying to create a support ticket is an @automattic.com or @a8c.com  email (ignoring case) and displays a warning in the email dialogue box advising to use a non-Automattic email to create a support request

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open the app and tap on the settings icon
2. tap on Help & Support
3. tap on the Contact email tab 
4. enter an email address ending on either @automattic.com or @a8c.com (both upper and lowercase)
5. check if the warning message asking to use a non-Automattic email is displayed

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/152547102-4f6851bb-0b49-4af4-8573-fc87e68e551d.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/152547568-6be794da-a5f5-4552-9e97-c5175259d7d2.gif" width="350"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
