### PR TITLE
Issue/5790 crash more menu badge

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -67,7 +67,9 @@ class MainPresenter @Inject constructor(
                 }
             }
         }
-        mainView?.showMoreMenuBadge(appPrefsWrapper.hasUnseenReviews())
+        if (selectedSite.exists()) {
+            mainView?.showMoreMenuBadge(appPrefsWrapper.hasUnseenReviews())
+        }
     }
 
     override fun dropView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenu.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenu.kt
@@ -60,7 +60,7 @@ fun MoreMenu(
     val siteUrl = state.siteUrl
     val userAvatarUrl = state.userAvatarUrl
 
-    Column {
+    Column(Modifier.padding(start = 12.dp, end = 12.dp)) {
         Spacer(modifier = Modifier.height(32.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5790
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When login in for the first time the app crashes when trying to display more menu badge

```

     Caused by: java.lang.IllegalStateException: SelectedSite.get() was accessed before being initialized - siteId -1.
    Consider calling selectedSite.exists() to ensure site exists prior to calling selectedSite.get().
        at com.woocommerce.android.tools.SelectedSite.get(SelectedSite.kt:48)
        at com.woocommerce.android.ui.main.MainActivityViewModel.removeReviewNotifications(MainActivityViewModel.kt:40)
        at com.woocommerce.android.ui.main.MainActivity.showMoreMenuBadge(MainActivity.kt:659)
        at com.woocommerce.android.ui.main.MainPresenter.takeView(MainPresenter.kt:70)
        at com.woocommerce.android.ui.main.MainPresenter.takeView(MainPresenter.kt:31)
        at com.woocommerce.android.ui.main.MainActivity.onCreate(MainActivity.kt:206)
```

Also added some missing padding in the Hub Menu. 

### Testing instructions
To reproduce the crash, just compile `feature/more-menu-screen` and make a fresh login. 
