### PR TITLE
Update FluxC to 1.34.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 -----
 - [*] New Home Screen UI. Store stats are now shown in a line chart, new stats have been added such as conversion rate and revenue stats are not rounded anymore.
 - [*] Fixed an issue which resulted in showing wrong order prices if the store used more than 2 digits for price formatting [https://github.com/woocommerce/woocommerce-android/pull/5612]
+- [***] Fixed a bug that resulted in crashing app on start after upgrading from 7.4 or 7.5
 
 8.3
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.34.0'
+    fluxCVersion = '1.34.1'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
This PR updates FluxC to `1.34.1` which contains the fix from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2257. This fix was originally intended to be shipped as a `8.3.1` hotfix, but since we are about to release `8.4.0` on Monday, we have shifted our plans.

Note that the release note will not be used since there isn't enough time to get it translated. However, it's still good to keep it as a record.

The following is the original PR description from #5760 by @wzieba:

---

<!-- Remember about a good descriptive title. -->

Closes: #5754
<!-- Id number of the GitHub issue this PR addresses. -->

### Test cases

#### Reproduction

1. Remove existing app
2. Install `7.5` (bf48df6)
3. Log in
4. Go to Products
5. Install `8.3` (7408fd4)
6. Experience crash when running app: `A migration from 1 to 5 was required but not found.`

#### TC1 Fix (database from 1->5, via recreating database)

1. Remove existing app
2. Install `7.5` (bf48df6)
3. Log in
4. Go to Products
5. Install `8.3.1` (3d408d6)
6. Run app
7. Experience no crash

#### TC2 Regression test (database from 3->5, via executing migration)

1. Remove existing app
2. Install 8.2 (bfccccf)
3. Log in
4. Go to Products and/or Orders
5. Install 8.3.1 (3d408d6)
6. Experience no crash
