### PR TITLE
Fix UI tests after adding new More Menu screen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
       parameters:
         jvmargs:
           type: string
-          default: "Xmx2048m"
+          default: "Xmx4096m"
       steps:
         - run:
             name: Update memory setting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
       - android/restore-gradle-cache:
           cache-prefix: tests-cache-v1
       - copy-gradle-properties
+      - update-gradle-memory
       - run:
           # The instrumentation tests are not currently used and do tend to get
           # out of date when the UI changes, failing to build.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
       parameters:
         jvmargs:
           type: string
-          default: "Xmx4096m"
+          default: "Xmx2048m"
       steps:
         - run:
             name: Update memory setting

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -336,7 +336,8 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.4.0'
     implementation "androidx.compose.runtime:runtime-livedata:$composeVersion"
     implementation "com.google.android.material:compose-theme-adapter:$composeVersion"
-    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.0.5'
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$composeVersion"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:$composeVersion"
 }
 
 task copyGoogleServicesExampleFile(type: Copy) {

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -90,6 +90,8 @@ android {
         packagingOptions {
             exclude 'META-INF/gradle/incremental.annotation.processors'
             exclude("META-INF/*.kotlin_module")
+            pickFirst 'META-INF/AL2.0'
+            pickFirst 'META-INF/LGPL2.1'
         }
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.screenshots
 
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.helpers.InitializationRule
@@ -21,12 +22,15 @@ class ScreenshotTest : TestBase() {
     val rule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val initRule = InitializationRule()
+    val composeTestRule = createComposeRule()
 
     @get:Rule(order = 2)
-    val localeTestRule = LocaleTestRule()
+    val initRule = InitializationRule()
 
     @get:Rule(order = 3)
+    val localeTestRule = LocaleTestRule()
+
+    @get:Rule(order = 4)
     var activityRule = ActivityTestRule(MainActivity::class.java)
 
     @Test
@@ -34,7 +38,7 @@ class ScreenshotTest : TestBase() {
         Screengrab.setDefaultScreenshotStrategy(UiAutomatorScreenshotStrategy())
 
         WelcomeScreen
-            .logoutIfNeeded()
+            .logoutIfNeeded(composeTestRule)
             .selectLogin()
             // Connect a WooCommerce store by URL
             .proceedWith(BuildConfig.SCREENSHOTS_URL)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/TabNavComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/TabNavComponent.kt
@@ -1,21 +1,19 @@
 package com.woocommerce.android.screenshots
 
 import com.woocommerce.android.R
+import com.woocommerce.android.screenshots.moremenu.MoreMenuScreen
 import com.woocommerce.android.screenshots.mystore.MyStoreScreen
 import com.woocommerce.android.screenshots.orders.OrderListScreen
 import com.woocommerce.android.screenshots.products.ProductListScreen
-import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
 import com.woocommerce.android.screenshots.util.Screen
 
-class TabNavComponent : Screen {
+class TabNavComponent : Screen(MY_STORE_BUTTON) {
     companion object {
         const val MY_STORE_BUTTON = R.id.dashboard
         const val ORDERS_BUTTON = R.id.orders
         const val PRODUCTS_BUTTON = R.id.products
-        const val REVIEWS_BUTTON = R.id.reviews
+        const val MORE_MENU_BUTTON = R.id.moreMenu
     }
-
-    constructor() : super(MY_STORE_BUTTON)
 
     fun gotoMyStoreScreen(): MyStoreScreen {
         clickOn(MY_STORE_BUTTON)
@@ -27,13 +25,13 @@ class TabNavComponent : Screen {
         return OrderListScreen()
     }
 
-    fun gotoReviewsScreen(): ReviewsListScreen {
-        clickOn(REVIEWS_BUTTON)
-        return ReviewsListScreen()
-    }
-
     fun gotoProductsScreen(): ProductListScreen {
         clickOn(PRODUCTS_BUTTON)
         return ProductListScreen()
+    }
+
+    fun gotoMoreMenuScreen(): MoreMenuScreen {
+        clickOn(MORE_MENU_BUTTON)
+        return MoreMenuScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/login/WelcomeScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/login/WelcomeScreen.kt
@@ -1,7 +1,8 @@
 package com.woocommerce.android.screenshots.login
 
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import com.woocommerce.android.R
-import com.woocommerce.android.screenshots.mystore.MyStoreScreen
+import com.woocommerce.android.screenshots.TabNavComponent
 import com.woocommerce.android.screenshots.util.Screen
 
 class WelcomeScreen : Screen {
@@ -9,9 +10,12 @@ class WelcomeScreen : Screen {
         const val LOGIN_BUTTON = R.id.button_login_store
         const val WPCOM_LOGIN_BUTTON = R.id.button_login_wpcom
 
-        fun logoutIfNeeded(): WelcomeScreen {
+        fun logoutIfNeeded(composeTestRule: ComposeContentTestRule): WelcomeScreen {
             if (isElementDisplayed(R.id.dashboard)) {
-                MyStoreScreen().openSettingsPane().logOut()
+                TabNavComponent()
+                    .gotoMoreMenuScreen()
+                    .openSettings(composeTestRule)
+                    .logOut()
             }
 
             Thread.sleep(1000)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/moremenu/MoreMenuScreen.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.screenshots.moremenu
+
+import android.content.res.Resources
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.woocommerce.android.R
+import com.woocommerce.android.screenshots.mystore.settings.SettingsScreen
+import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
+import com.woocommerce.android.screenshots.util.Screen
+
+class MoreMenuScreen : Screen(MORE_MENU_VIEW) {
+    companion object {
+        const val MORE_MENU_VIEW = R.id.menu
+    }
+
+    private val resources: Resources = InstrumentationRegistry.getInstrumentation().targetContext.resources
+
+    fun openReviewsListScreen(composeTestRule: ComposeTestRule): ReviewsListScreen {
+        composeTestRule.onNodeWithText(
+            resources.getString(R.string.more_menu_button_reviews)
+        ).performClick()
+        return ReviewsListScreen()
+    }
+
+    fun openSettings(composeTestRule: ComposeTestRule): SettingsScreen {
+        composeTestRule.onNodeWithContentDescription(
+            resources.getString(R.string.settings)
+        ).performClick()
+        return SettingsScreen()
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/moremenu/MoreMenuScreen.kt
@@ -1,11 +1,9 @@
 package com.woocommerce.android.screenshots.moremenu
 
-import android.content.res.Resources
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.platform.app.InstrumentationRegistry
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.mystore.settings.SettingsScreen
 import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
@@ -16,18 +14,16 @@ class MoreMenuScreen : Screen(MORE_MENU_VIEW) {
         const val MORE_MENU_VIEW = R.id.menu
     }
 
-    private val resources: Resources = InstrumentationRegistry.getInstrumentation().targetContext.resources
-
     fun openReviewsListScreen(composeTestRule: ComposeTestRule): ReviewsListScreen {
         composeTestRule.onNodeWithText(
-            resources.getString(R.string.more_menu_button_reviews)
+            getTranslatedString(R.string.more_menu_button_reviews)
         ).performClick()
         return ReviewsListScreen()
     }
 
     fun openSettings(composeTestRule: ComposeTestRule): SettingsScreen {
         composeTestRule.onNodeWithContentDescription(
-            resources.getString(R.string.settings)
+            getTranslatedString(R.string.settings)
         ).performClick()
         return SettingsScreen()
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/MyStoreScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/MyStoreScreen.kt
@@ -1,27 +1,12 @@
 package com.woocommerce.android.screenshots.mystore
 
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.woocommerce.android.R
-import com.woocommerce.android.screenshots.TabNavComponent
-import com.woocommerce.android.screenshots.mystore.settings.SettingsScreen
 import com.woocommerce.android.screenshots.util.Screen
 
-class MyStoreScreen : Screen {
+class MyStoreScreen : Screen(MY_STORE) {
     companion object {
         const val MY_STORE = R.id.my_store_refresh_layout
-        const val SETTINGS_BUTTON = R.id.menu_settings
     }
 
-    val tabBar = TabNavComponent()
     val stats = StatsComponent()
-
-    constructor() : super(MY_STORE)
-
-    fun openSettingsPane(): SettingsScreen {
-        onView(withId(SETTINGS_BUTTON)).perform(click())
-
-        return SettingsScreen()
-    }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/reviews/ReviewsListScreen.kt
@@ -4,22 +4,15 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import com.woocommerce.android.R
-import com.woocommerce.android.screenshots.TabNavComponent
 import com.woocommerce.android.screenshots.util.CustomMatchers
 import com.woocommerce.android.screenshots.util.ReviewData
 import com.woocommerce.android.screenshots.util.Screen
 import org.hamcrest.Matchers
 
-class ReviewsListScreen : Screen {
+class ReviewsListScreen : Screen(LIST_VIEW) {
     companion object {
         const val LIST_VIEW = R.id.reviewsList
-
-        const val REVIEW_ICON = R.id.notif_icon
     }
-
-    val tabBar = TabNavComponent()
-
-    constructor() : super(LIST_VIEW)
 
     fun selectReviewByTitle(reviewTitle: String): SingleReviewScreen {
         selectListItem(reviewTitle, LIST_VIEW)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/Screen.kt
@@ -4,13 +4,10 @@ import android.app.Activity
 import android.content.res.Configuration
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
+import androidx.test.espresso.*
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
-import androidx.test.espresso.UiController
-import androidx.test.espresso.ViewAction
-import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -18,12 +15,7 @@ import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
-import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
-import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage.RESUMED
@@ -332,7 +324,7 @@ open class Screen {
         return mCurrentActivity
     }
 
-    private fun getTranslatedString(resourceID: Int): String {
+    protected fun getTranslatedString(resourceID: Int): String {
         return getCurrentActivity()!!.resources.getString(resourceID)
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ProductsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ProductsUITest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.main
 
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.helpers.InitializationRule
@@ -23,15 +24,18 @@ class ProductsUITest : TestBase() {
     val rule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val initRule = InitializationRule()
+    val composeTestRule = createComposeRule()
 
     @get:Rule(order = 2)
+    val initRule = InitializationRule()
+
+    @get:Rule(order = 3)
     var activityRule = ActivityTestRule(MainActivity::class.java)
 
     @Before
     fun setUp() {
         WelcomeScreen
-            .logoutIfNeeded()
+            .logoutIfNeeded(composeTestRule)
             .selectLogin()
             .proceedWith(BuildConfig.SCREENSHOTS_URL)
             .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.main
 
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.helpers.InitializationRule
@@ -22,28 +23,31 @@ class ReviewsUITest : TestBase() {
     val rule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val initRule = InitializationRule()
+    val composeTestRule = createComposeRule()
 
     @get:Rule(order = 2)
+    val initRule = InitializationRule()
+
+    @get:Rule(order = 3)
     var activityRule = ActivityTestRule(MainActivity::class.java)
 
     @Before
     fun setUp() {
         WelcomeScreen
-            .logoutIfNeeded()
+            .logoutIfNeeded(composeTestRule)
             .selectLogin()
             .proceedWith(BuildConfig.SCREENSHOTS_URL)
             .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)
             .proceedWith(BuildConfig.SCREENSHOTS_PASSWORD)
 
-        TabNavComponent().gotoReviewsScreen()
+        TabNavComponent().gotoMoreMenuScreen().openReviewsListScreen(composeTestRule)
     }
 
     @Test
     fun reviewListShowsAllReviews() {
         val reviewsJSONArray = MocksReader().readAllReviewsToArray()
 
-        for (review in reviewsJSONArray.iterator()) {
+        reviewsJSONArray.iterator().forEach { review ->
             val currentReview = ReviewData(
                 review.getInt("product_id"),
                 review.getString("status"),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5764 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We've recently added a new screen to the app: More Menu. This has several implications over the app navigation that break the screenshots and UI tests: 
-  This screen is a new tab in the bottom nav bar that replaces ReviewListScreen tab.
- Settings screen is now accessed from MoreMenuScreen instead of MyStoreScreen
- New MoreMenuScreen uses Android Jetpack Compose to display the UI. This means we need a new `composeTestRule` inside Espresso tests to be able to "click" or "match" UI components in compose

Here is a demo of the `ReviewsUITest` running locally with fixes. 

https://user-images.githubusercontent.com/2663464/152830903-6b137511-b74c-4427-bc6e-b82f635bd6f2.mp4
