### PR TITLE
Update wording of both plugins activated screen

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1076,12 +1076,12 @@
     <string name="card_reader_onboarding_wcpay_in_test_mode_with_live_account_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_wcpay_in_test_mode_with_live_account_hint">In-Person Payments isn\’t available in Test Mode. Please turn it off to continue.</string>
 
-    <string name="card_reader_onboarding_both_plugins_activated_header">Multiple payment providers detected</string>
-    <string name="card_reader_onboarding_both_plugins_activated_hint_admin">In-Person Payments will only work with one provider activated. Please deactivate one of these to continue:</string>
-    <string name="card_reader_onboarding_both_plugins_activated_hint_store_owner">In-Person Payments will only work with one provider activated. Please contact a site administrator to deactivate one of these to continue:</string>
+    <string name="card_reader_onboarding_both_plugins_activated_header">Conflicting payment plugins detected</string>
+    <string name="card_reader_onboarding_both_plugins_activated_hint_admin">In-Person Payments will only work with one of following plugins activated. Please deactivate one of these plugins to continue:</string>
+    <string name="card_reader_onboarding_both_plugins_activated_hint_store_owner">In-Person Payments will only work with one of following plugins activated. Please contact a site administrator to deactivate one of these plugins to continue:</string>
     <string name="card_reader_onboarding_both_plugins_activated_hint_plugin_one">WooCommerce Stripe Gateway</string>
     <string name="card_reader_onboarding_both_plugins_activated_hint_plugin_two">WooCommerce Payments</string>
-    <string name="card_reader_onboarding_both_plugins_activated_open_store_admin_label">Go to Plugin Admin</string>
+    <string name="card_reader_onboarding_both_plugins_activated_open_store_admin_label">Manage Plugins</string>
     <string name="card_reader_onboarding_both_plugins_activated_refresh_button">Refresh after updating</string>
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Updates wording of "Both plugins activated" screen as per https://github.com/woocommerce/woocommerce-ios/issues/6010#issuecomment-1029501686.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Verify the strings don't contain typos.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Admin | Shop Manager |
| ---- | ---- |
| ![Screenshot_1644227610](https://user-images.githubusercontent.com/2261188/152765832-b769c194-88bd-4138-95da-0759322be653.png) | ![Screenshot_1644227792](https://user-images.githubusercontent.com/2261188/152765846-8953f377-edd7-4f3c-afd7-6c6e79422825.png) |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
