### PR TITLE
Update <error_generic> string from "An error occurred" to "Something went wrong" 

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1664,7 +1664,7 @@
     <string name="checking_email">Checking email</string>
     <string name="email_invalid">Enter a valid email address</string>
     <string name="forgot_password">Lost your password?</string>
-    <string name="error_generic">An error occurred</string>
+    <string name="error_generic">Something went wrong</string>
     <string name="no_site_error">The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.</string>
     <string name="invalid_site_url_message">Check that the site URL entered is valid</string>
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes: #4449 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The original issue mentioned the need to replace the string "An unexpected error occurred" showing in some errors with "Something went wrong". Searching the codebase for the string "An unexpected error occurred", nothing returned. However, discussing this with @malinajirka it was noticed that the string "An error occurred" was still there. So for the sake of consistency, I'm updating it to match the "Something went wrong" string used throughout the app.

So this is updating the <string name="error_generic"> from " An error occurred" to **"Something went wrong"** to keep it consistent with the rest of the error messages in the app.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
