### PR TITLE
[Order Creation] Show a discard dialog when leaving the form, and delete draft order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -26,6 +26,8 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.dialog.WooDialog
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigator
@@ -37,13 +39,15 @@ import com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusVie
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_form) {
+class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_form), BackPressListener {
     private val viewModel by hiltNavGraphViewModels<OrderCreationViewModel>(R.id.nav_graph_order_creations)
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter
@@ -273,6 +277,8 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                         orderStatusList = event.orderStatusList
                     ).let { findNavController().navigateSafely(it) }
             is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+            is ShowDialog -> event.showDialog()
+            is Exit -> findNavController().navigateUp()
         }
     }
 
@@ -312,4 +318,9 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
     }
 
     override fun getFragmentTitle() = getString(R.string.order_creation_fragment_title)
+
+    override fun onRequestAllowBackPress(): Boolean {
+        viewModel.onBackButtonClicked()
+        return false
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -91,6 +91,7 @@ class OrderCreationRepository @Inject constructor(
     }
 
     suspend fun deleteDraftOrder(order: Order) {
+        // Make sure the request is not cancelled after leaving the screen
         withContext(NonCancellable) {
             orderUpdateStore.deleteOrder(
                 site = selectedSite.get(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.LineItem
@@ -86,6 +87,16 @@ class OrderCreationRepository @Inject constructor(
         return when {
             result.isError -> Result.failure(WooException(result.error))
             else -> Result.success(orderMapper.toAppModel(result.model!!))
+        }
+    }
+
+    suspend fun deleteDraftOrder(order: Order) {
+        withContext(NonCancellable) {
+            orderUpdateStore.deleteOrder(
+                site = selectedSite.get(),
+                orderId = order.id,
+                trash = false
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -6,6 +6,8 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -93,11 +95,17 @@ class OrderCreationRepository @Inject constructor(
     suspend fun deleteDraftOrder(order: Order) {
         // Make sure the request is not cancelled after leaving the screen
         withContext(NonCancellable) {
+            WooLog.d(T.ORDERS, "Send a request to delete draft order")
             orderUpdateStore.deleteOrder(
                 site = selectedSite.get(),
                 orderId = order.id,
                 trash = false
-            )
+            ).let {
+                when {
+                    it.isError -> WooLog.w(T.ORDERS, "Deleting the order draft failed, error: ${it.error.message}")
+                    else -> WooLog.d(T.ORDERS, "Draft order deleted successfully")
+                }
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -227,6 +227,10 @@ class OrderCreationViewModel @Inject constructor(
         }
         triggerEvent(ShowDialog.buildDiscardDialogEvent(
             positiveBtnAction = { _, _ ->
+                val draft = _orderDraft.value
+                if (draft.id != 0L) {
+                    launch { orderCreationRepository.deleteDraftOrder(draft) }
+                }
                 triggerEvent(Exit)
             }
         ))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -31,6 +31,8 @@ import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -216,6 +218,18 @@ class OrderCreationViewModel @Inject constructor(
                 }
             )
         }
+    }
+
+    fun onBackButtonClicked() {
+        if (_orderDraft.value.copy(currency = "") == Order.EMPTY) {
+            triggerEvent(Exit)
+            return
+        }
+        triggerEvent(ShowDialog.buildDiscardDialogEvent(
+            positiveBtnAction = { _, _ ->
+                triggerEvent(Exit)
+            }
+        ))
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -225,15 +225,17 @@ class OrderCreationViewModel @Inject constructor(
             triggerEvent(Exit)
             return
         }
-        triggerEvent(ShowDialog.buildDiscardDialogEvent(
-            positiveBtnAction = { _, _ ->
-                val draft = _orderDraft.value
-                if (draft.id != 0L) {
-                    launch { orderCreationRepository.deleteDraftOrder(draft) }
+        triggerEvent(
+            ShowDialog.buildDiscardDialogEvent(
+                positiveBtnAction = { _, _ ->
+                    val draft = _orderDraft.value
+                    if (draft.id != 0L) {
+                        launch { orderCreationRepository.deleteDraftOrder(draft) }
+                    }
+                    triggerEvent(Exit)
                 }
-                triggerEvent(Exit)
-            }
-        ))
+            )
+        )
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-40cd7df149ce5c032fe9408728ea76c8f8b0af6d'
+    fluxCVersion = '2275-3f3c74d7cf1174a9bfccc8f68267f130c12ec466'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2275-3f3c74d7cf1174a9bfccc8f68267f130c12ec466'
+    fluxCVersion = 'trunk-a81137c2be455b236db013c03686cafe0ef84c2c'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5823 
Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2275

### Description
This PR handles the discard dialog when leaving the order creation form, and makes sure the draft order is deleted from the site if it was created to calculate prices.

### Testing instructions
##### Case 1: M1
1. Make sure `ORDER_CREATION_M2` is set to false.
2. Open order creation form.
3. Make some changes.
4. Click on back button.
5. Confirm that a discard dialog is shown, and that you can either stay on form or leave it.

##### Case 2: M2
1. Make sure `ORDER_CREATION_M2` is set to true.
2. Open order creation form.
3. Add some products to the order, and wait for the draft to be created.
4. Click on back button.
5. Confirm that a discard dialog is shown.
6. Click on "Discard".
7. Confirm that you see the following messages on logcat: `Send a request to delete draft order` followed by `Draft order deleted successfully`.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
