### PR TITLE
Fix wrongly translated string in Dutch that is generating a crash

### DIFF
--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -16,7 +16,7 @@ Language: nl
     <string name="order_creation_payment_order_total">Besteltotaal</string>
     <string name="order_creation_payment_products_total">Totaalaantal producten</string>
     <string name="order_creation_payment">Betaling</string>
-    <string name="dashboard_top_performers_net_sales">Netto verkoop: %@ %s</string>
+    <string name="dashboard_top_performers_net_sales">Netto verkoop: %s</string>
     <string name="dashboard_top_performers_items_sold">Verkochte artikelen</string>
     <string name="dashboard_stats_conversion">Conversie</string>
     <string name="create">Aanmaken</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5822

### Description
A string token has been wrongly translated to Dutch. A crash will happen for all users that have the device language to Dutch and open the app. The problem is this string:
<string name="dashboard_top_performers_net_sales">Netto verkoop: %@ %s</string>
It should be:
<string name="dashboard_top_performers_net_sales">Netto verkoop: %s</string>
That extra %@ is causing the crash.

### Testing instructions
- Set the device to Dutch
- Open My Store tab and let the Top Performers section load. This section must not be empty in order for the crash to happen. 
