### PR TITLE
Issue/5803 simple payments tracks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -158,6 +158,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         // -- Simple Payments
         SIMPLE_PAYMENTS_FLOW_STARTED,
         SIMPLE_PAYMENTS_FLOW_COMPLETED,
+        SIMPLE_PAYMENTS_FLOW_COLLECT,
         SIMPLE_PAYMENTS_FLOW_FAILED,
         SIMPLE_PAYMENTS_FLOW_CANCELED,
         SIMPLE_PAYMENTS_FLOW_NOTE_ADDED,
@@ -758,6 +759,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_SOFTWARE_UPDATE_TYPE = "software_update_type"
         const val KEY_SUBJECT = "subject"
         const val KEY_DATE_RANGE = "date_range"
+        const val KEY_SOURCE = "source"
 
         const val KEY_SORT_ORDER = "order"
         const val VALUE_SORT_NAME_ASC = "name,ascending"
@@ -822,6 +824,11 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_STATE_OFF = "off"
 
         const val VALUE_SIMPLE_PAYMENTS_FEEDBACK = "simple_payments"
+        const val VALUE_SIMPLE_PAYMENTS_COLLECT_CARD = "card"
+        const val VALUE_SIMPLE_PAYMENTS_COLLECT_CASH = "cash"
+        const val VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT = "amount"
+        const val VALUE_SIMPLE_PAYMENTS_SOURCE_SUMMARY = "summary"
+        const val VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD = "payment_method"
 
         // -- Downloadable Files
         const val KEY_DOWNLOADABLE_FILE_ACTION = "action"
@@ -865,6 +872,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_REFUND_TYPE = "method"
         const val KEY_REFUND_METHOD = "gateway"
         const val KEY_AMOUNT = "amount"
+
+        const val KEY_PAYMENT_METHOD = "payment_method"
 
         const val KEY_IS_JETPACK_CP_CONNECTED = "is_jetpack_cp_conntected"
         const val KEY_ACTIVE_JETPACK_CONNECTION_PLUGINS = "active_jetpack_connection_plugins"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -160,6 +160,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         SIMPLE_PAYMENTS_FLOW_COMPLETED,
         SIMPLE_PAYMENTS_FLOW_FAILED,
         SIMPLE_PAYMENTS_FLOW_CANCELED,
+        SIMPLE_PAYMENTS_FLOW_NOTE_ADDED,
+        SIMPLE_PAYMENTS_FLOW_TAXES_TOGGLED,
         SETTINGS_BETA_FEATURES_SIMPLE_PAYMENTS_TOGGLED,
 
         // -- Order Detail
@@ -816,6 +818,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_PRODUCTS_VARIATIONS_FEEDBACK = "products_variations"
         const val VALUE_SHIPPING_LABELS_M4_FEEDBACK = "shipping_labels_m4"
         const val VALUE_PRODUCT_ADDONS_FEEDBACK = "product_addons"
+        const val VALUE_STATE_ON = "on"
+        const val VALUE_STATE_OFF = "off"
 
         const val VALUE_SIMPLE_PAYMENTS_FEEDBACK = "simple_payments"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
@@ -4,10 +4,10 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
-import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
@@ -50,7 +50,8 @@ class SimplePaymentsDialogViewModel @Inject constructor(
 
     private fun createSimplePaymentsOrder() {
         if (!networkStatus.isConnected()) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED)
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED,
+            mapOf(KEY_SOURCE))
             triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
             return
         }
@@ -71,11 +72,6 @@ class SimplePaymentsDialogViewModel @Inject constructor(
                     AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED)
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.simple_payments_creation_error))
                 } else {
-                    // TODO nbradbury - move to after card/cash payment is completed
-                    AnalyticsTracker.track(
-                        AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_COMPLETED,
-                        mapOf(AnalyticsTracker.KEY_AMOUNT to viewState.currentPrice.toString())
-                    )
                     viewState = viewState.copy(createdOrder = orderMapper.toAppModel(result.order!!))
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
@@ -71,7 +71,7 @@ class SimplePaymentsDialogViewModel @Inject constructor(
                     AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED)
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.simple_payments_creation_error))
                 } else {
-                    // TODO nbradbury - verify this is still the correct place to track this event
+                    // TODO nbradbury - move to after card/cash payment is completed
                     AnalyticsTracker.track(
                         AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_COMPLETED,
                         mapOf(AnalyticsTracker.KEY_AMOUNT to viewState.currentPrice.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
@@ -50,8 +51,6 @@ class SimplePaymentsDialogViewModel @Inject constructor(
 
     private fun createSimplePaymentsOrder() {
         if (!networkStatus.isConnected()) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED,
-            mapOf(KEY_SOURCE))
             triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
             return
         }
@@ -69,7 +68,10 @@ class SimplePaymentsDialogViewModel @Inject constructor(
                 viewState = viewState.copy(isProgressShowing = false, isDoneButtonEnabled = true)
                 if (result.isError) {
                     WooLog.e(WooLog.T.ORDERS, "${result.error.type.name}: ${result.error.message}")
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED)
+                    AnalyticsTracker.track(
+                        AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED,
+                        mapOf(KEY_SOURCE to VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT)
+                    )
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.simple_payments_creation_error))
                 } else {
                     viewState = viewState.copy(createdOrder = orderMapper.toAppModel(result.order!!))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -146,11 +146,14 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     }
 
     private suspend fun Flow<UpdateOrderResult>.collectUpdate() {
-        // TODO nbradbury tracks
         collect { result ->
             when (result) {
                 is OptimisticUpdateResult -> {
                     if (result.event.isError) {
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED,
+                            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_SUMMARY)
+                        )
                         result.event.error?.let {
                             WooLog.e(WooLog.T.ORDERS, "Simple payment optimistic update failed with ${it.message}")
                         }
@@ -162,6 +165,10 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
                 }
                 is UpdateOrderResult.RemoteUpdateResult -> {
                     if (result.event.isError) {
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED,
+                            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT)
+                        )
                         result.event.error?.let {
                             WooLog.e(WooLog.T.ORDERS, "Simple payment remote update failed with ${it.message}")
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -4,6 +4,9 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STATE_OFF
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STATE_ON
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.NetworkStatus
@@ -94,6 +97,12 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     }
 
     fun onChargeTaxesChanged(chargeTaxes: Boolean) {
+        val properties = if (chargeTaxes) {
+            mapOf(KEY_STATE to VALUE_STATE_ON)
+        } else {
+            mapOf(KEY_STATE to VALUE_STATE_OFF)
+        }
+        AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_TAXES_TOGGLED, properties)
         updateViewState(chargeTaxes = chargeTaxes)
     }
 
@@ -102,6 +111,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     }
 
     fun onCustomerNoteChanged(customerNote: String) {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_NOTE_ADDED)
         viewState = viewState.copy(customerNote = customerNote)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentViewModel.kt
@@ -150,7 +150,10 @@ class TakePaymentViewModel @Inject constructor(
                         triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.order_error_update_general))
                         AnalyticsTracker.track(
                             AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED,
-                            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD)
+                            mapOf(
+                                AnalyticsTracker.KEY_SOURCE to
+                                    AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD
+                            )
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentViewModel.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.orders.simplepayments
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CARD
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CASH
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
@@ -43,6 +46,12 @@ class TakePaymentViewModel @Inject constructor(
         get() = order.total
 
     fun onCashPaymentClicked() {
+        AnalyticsTracker.track(
+            AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_COLLECT,
+            mapOf(
+                AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_CASH
+            )
+        )
         triggerEvent(
             MultiLiveEvent.Event.ShowDialog(
                 titleId = R.string.simple_payments_cash_dlg_title,
@@ -62,6 +71,13 @@ class TakePaymentViewModel @Inject constructor(
     fun onCashPaymentConfirmed() {
         if (networkStatus.isConnected()) {
             launch {
+                AnalyticsTracker.track(
+                    AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_COMPLETED,
+                    mapOf(
+                        AnalyticsTracker.KEY_AMOUNT to orderTotal.toString(),
+                        AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_CASH
+                    )
+                )
                 markOrderCompleted()
             }
         } else {
@@ -70,6 +86,12 @@ class TakePaymentViewModel @Inject constructor(
     }
 
     fun onCardPaymentClicked() {
+        AnalyticsTracker.track(
+            AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_COLLECT,
+            mapOf(
+                AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_CARD
+            )
+        )
         if (cardReaderManager.readerStatus.value is CardReaderStatus.Connected) {
             triggerEvent(OrderNavigationTarget.StartCardReaderPaymentFlow(order.id))
         } else {
@@ -90,6 +112,13 @@ class TakePaymentViewModel @Inject constructor(
 
     fun onCardReaderPaymentCompleted() {
         triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.card_reader_payment_completed_payment_header))
+        AnalyticsTracker.track(
+            AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_COMPLETED,
+            mapOf(
+                AnalyticsTracker.KEY_AMOUNT to orderTotal.toString(),
+                AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_CARD
+            )
+        )
         launch {
             delay(DELAY_MS)
             triggerEvent(MultiLiveEvent.Event.Exit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentViewModel.kt
@@ -106,6 +106,11 @@ class TakePaymentViewModel @Inject constructor(
             delay(DELAY_MS)
             if (connected) {
                 triggerEvent(OrderNavigationTarget.StartCardReaderPaymentFlow(order.id))
+            } else {
+                AnalyticsTracker.track(
+                    AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED,
+                    mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD)
+                )
             }
         }
     }
@@ -143,6 +148,10 @@ class TakePaymentViewModel @Inject constructor(
                 is WCOrderStore.UpdateOrderResult.RemoteUpdateResult -> {
                     if (result.event.isError) {
                         triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.order_error_update_general))
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SIMPLE_PAYMENTS_FLOW_FAILED,
+                            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD)
+                        )
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2270-71a5610c5ac6978030882b99662248e72c72b0a4'
+    fluxCVersion = '2270-71a5610c5ac6978030882b99662248e72c72b0a4' // TODO
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2270-71a5610c5ac6978030882b99662248e72c72b0a4' // TODO
+    fluxCVersion = 'trunk-7ca6940c4083ac900696eb46b7d5958a485e1177'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'


### PR DESCRIPTION
Resolves #5803 - This PR adds these missing simple payments tracks events:

- SIMPLE_PAYMENTS_FLOW_NOTE_ADDED
- SIMPLE_PAYMENTS_FLOW_COLLECT
- SIMPLE_PAYMENTS_FLOW_TAXES_TOGGLED 

It also updates SIMPLE_PAYMENTS_FLOW_FAILED to pass the source of failure, which is one of:

- VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT - failure happened on the initial payment amount screen
- VALUE_SIMPLE_PAYMENTS_SOURCE_SUMMARY - failure happened on the subsequent screen (order note, customer email, etc.)
- VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD - failure happened when collecting payment


