### PR TITLE
Issue/5800 update play task dep

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     }
 
     implementation 'com.google.firebase:firebase-messaging-ktx:23.0.0'
-    implementation 'com.google.android.gms:play-services-auth:20.0.0'
+    implementation 'com.google.android.gms:play-services-auth:20.1.0'
 
     // Support library
     implementation "androidx.legacy:legacy-support-v4:1.0.0"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5800 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We have transitive dependencies on `play-services-tasks v18.0.0` which apparently have a potential nullpointer issue. From Google:

>play-services-tasks v18.0.0 has known issues that can lead to runtime NPEs (NullPointerException) when handling Task<Void> results in Kotlin code. We strongly recommend that you avoid using this version. This also impacts the SDKs listed in the December 9, 2021 release, because they all depend on play-services-tasks. A fix for this issue is included in play-services-tasks v18.0.1. See https://developers.google.com/android/guides/releases#december_16_2021

So I've updated the dependency that was causing us to use `play-services-tasks v18.0.0`. With this change we now rely on `play-services-tasks:18.0.1`

```
+--- com.google.android.gms:play-services-auth:20.1.0
|    +--- androidx.fragment:fragment:1.0.0 -> 1.4.0 (*)
|    +--- androidx.loader:loader:1.0.0 (*)
|    +--- com.google.android.gms:play-services-auth-api-phone:18.0.1
|    |    +--- com.google.android.gms:play-services-base:18.0.1
|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
|    |    |    +--- androidx.core:core:1.2.0 -> 1.7.0 (*)
|    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.4.0 (*)
|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
|    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
|    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
|    +--- com.google.android.gms:play-services-auth-base:18.0.1
|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
|    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
|    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
|    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
|    +--- com.google.android.gms:play-services-base:18.0.1 (*)
|    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
|    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
```

and from `com.google.firebase:firebase-common:20.0.0`

```
|    +--- com.google.firebase:firebase-common:20.0.0
|    |    +--- com.google.android.gms:play-services-basement:17.0.0 -> 18.0.0 (*)
|    |    +--- com.google.android.gms:play-services-tasks:17.0.0 -> 18.0.1
...
```

### Testing instructions
Run `./gradlew :WooCommerce:dependencies --configuration vanillaReleaseRuntimeClasspath` and check that there are no usages of `play-services-tasks v18.0.0`

