### PR TITLE
[Order Creation] refactor the payment section layout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -187,7 +187,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
 
     private fun bindPaymentSection(paymentSection: OrderCreationPaymentSectionBinding, newOrderData: Order) {
         paymentSection.root.isVisible = newOrderData.items.isNotEmpty()
-        paymentSection.taxGroup.isVisible = FeatureFlag.ORDER_CREATION_M2.isEnabled()
+        paymentSection.taxLayout.isVisible = FeatureFlag.ORDER_CREATION_M2.isEnabled()
         paymentSection.taxCalculationHint.isVisible = !FeatureFlag.ORDER_CREATION_M2.isEnabled()
 
         paymentSection.productsTotalValue.text = bigDecimalFormatter(newOrderData.productsTotal)

--- a/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
@@ -115,7 +115,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_100"
             android:layout_marginBottom="@dimen/major_100"
             android:text="@string/order_creation_payment_tax_hint"
             android:textAppearance="?attr/textAppearanceCaption"

--- a/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
@@ -6,116 +6,121 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/major_100">
+        android:orientation="vertical">
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/header_label"
-            android:layout_width="0dp"
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/order_creation_payment"
-            android:textAppearance="?attr/textAppearanceHeadline6"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:gravity="center"
+            android:minHeight="@dimen/major_300"
+            android:orientation="horizontal"
+            android:paddingHorizontal="@dimen/major_100">
 
-        <ProgressBar
-            android:id="@+id/loading_progress"
-            android:layout_width="@dimen/major_200"
-            android:layout_height="@dimen/major_200"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/header_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/order_creation_payment"
+                android:textAppearance="?attr/textAppearanceHeadline6" />
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/products_total_label"
-            android:layout_width="0dp"
+            <ProgressBar
+                android:id="@+id/loading_progress"
+                android:layout_width="@dimen/major_200"
+                android:layout_height="@dimen/major_200"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            android:text="@string/order_creation_payment_products_total"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            app:layout_constraintEnd_toStartOf="@id/products_total_value"
-            app:layout_constraintHorizontal_chainStyle="spread_inside"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/header_label" />
+            android:gravity="center"
+            android:minHeight="@dimen/major_300"
+            android:orientation="horizontal"
+            android:paddingHorizontal="@dimen/major_100">
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/products_total_value"
-            android:layout_width="wrap_content"
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/products_total_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/order_creation_payment_products_total"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/products_total_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                tools:text="$20.00" />
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:id="@+id/tax_layout"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintBaseline_toBaselineOf="@id/products_total_label"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/products_total_label"
-            tools:text="$20.00" />
+            android:gravity="center"
+            android:minHeight="@dimen/major_300"
+            android:orientation="horizontal"
+            android:paddingHorizontal="@dimen/major_100">
 
-        <androidx.constraintlayout.widget.Group
-            android:id="@+id/tax_group"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:constraint_referenced_ids="tax_label, tax_value" />
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tax_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/order_creation_payment_tax"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/tax_label"
-            android:layout_width="0dp"
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tax_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                tools:text="$0.00" />
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            android:text="@string/order_creation_payment_tax"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            app:layout_constraintEnd_toStartOf="@id/tax_value"
-            app:layout_constraintHorizontal_chainStyle="spread_inside"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/products_total_label" />
+            android:gravity="center"
+            android:minHeight="@dimen/major_300"
+            android:orientation="horizontal"
+            android:paddingHorizontal="@dimen/major_100">
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/tax_value"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintBaseline_toBaselineOf="@id/tax_label"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/tax_label"
-            tools:text="$0.00" />
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/order_total_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/order_creation_payment_order_total"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                android:textStyle="bold" />
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/order_total_label"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            android:text="@string/order_creation_payment_order_total"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toStartOf="@id/order_total_value"
-            app:layout_constraintHorizontal_chainStyle="spread_inside"
-            app:layout_constraintStart_toStartOf="parent"
-
-            app:layout_constraintTop_toBottomOf="@id/tax_label" />
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/order_total_value"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            android:textStyle="bold"
-            app:layout_constraintBaseline_toBaselineOf="@id/order_total_label"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/products_total_label"
-            app:layout_constraintWidth_default="wrap"
-            tools:text="$20.00" />
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/order_total_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                android:textStyle="bold"
+                tools:text="$20.00" />
+        </androidx.appcompat.widget.LinearLayoutCompat>
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tax_calculation_hint"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
             android:layout_marginTop="@dimen/minor_100"
+            android:layout_marginBottom="@dimen/major_100"
             android:text="@string/order_creation_payment_tax_hint"
             android:textAppearance="?attr/textAppearanceCaption"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/order_total_label" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.appcompat.widget.LinearLayoutCompat>
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
### Description
@ThomazFB as discussed, this is a PR to update the payment section layout to a LinearLayout instead of the ConstraintLayout, each section will specify a minHeight of `48dp`, to match the button's minHeight, and what Figma states for each line.

As you may notice, the `minHeight` is causing more spacing than before, but I think this OK, since it matches what Figma have, and will give a better looking UI when adding the buttons, since all lines will have the same height.

| Before | After |
| ----- | ----- |
| <img width="398" alt="Screen Shot 2022-02-10 at 16 56 03" src="https://user-images.githubusercontent.com/1657201/153445510-491034ca-5acc-4339-b75b-4ebaeb5b9217.png"> | <img width="398" alt="Screen Shot 2022-02-10 at 17 02 47" src="https://user-images.githubusercontent.com/1657201/153446733-6bc1574b-ab36-4ffa-9d3c-1d040c52dce1.png"> |
| <img width="398" alt="Screen Shot 2022-02-10 at 16 55 30" src="https://user-images.githubusercontent.com/1657201/153445692-ecd6ccba-a575-4128-81c2-47d02f46589b.png"> | <img width="398" alt="Screen Shot 2022-02-10 at 16 52 05" src="https://user-images.githubusercontent.com/1657201/153445558-3401f225-5056-48e2-bb36-bc0682d3272b.png"> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
