### PR TITLE
Track plugin slug in all IPP events

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -119,7 +119,7 @@ class AppPrefsTest {
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            status = CARD_READER_ONBOARDING_PENDING,
+            status = CARD_READER_ONBOARDING_COMPLETED,
             preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
         )
 
@@ -254,7 +254,7 @@ class AppPrefsTest {
                 remoteSiteId = 0L,
                 selfHostedSiteId = 0L
             )
-        ).isTrue
+        ).isFalse
     }
 
     @Test

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -1,7 +1,8 @@
 package com.woocommerce.android
 
 import androidx.test.platform.app.InstrumentationRegistry
-import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus
+import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus
+import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.*
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -34,96 +35,179 @@ class AppPrefsTest {
 
     @Test
     fun whenCardReaderOnboardingCompletedWithStripeExtThenCorrectOnboardingStatusIsStored() {
-        AppPrefs.setCardReaderOnboardingCompleted(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.STRIPE_EXTENSION_GATEWAY
+            status = CARD_READER_ONBOARDING_COMPLETED,
+            preferredPlugin = PluginType.STRIPE_EXTENSION_GATEWAY,
         )
 
         assertThat(
-            AppPrefs.getCardReaderOnboardingCompletedStatus(
+            AppPrefs.getCardReaderOnboardingStatus(
                 localSiteId = 0,
                 remoteSiteId = 0L,
                 selfHostedSiteId = 0L
             )
-        ).isEqualTo(CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION)
+        ).isEqualTo(CardReaderOnboardingStatus.CARD_READER_ONBOARDING_COMPLETED)
+    }
+
+    @Test
+    fun whenCardReaderOnboardingCompletedWithStripeExtThenCorrectPreferredPluginIsStored() {
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            status = CARD_READER_ONBOARDING_COMPLETED,
+            preferredPlugin = PluginType.STRIPE_EXTENSION_GATEWAY,
+        )
+
+        assertThat(
+            AppPrefs.getCardReaderPreferredPlugin(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isEqualTo(PluginType.STRIPE_EXTENSION_GATEWAY)
     }
 
     @Test
     fun whenCardReaderOnboardingPendingRequirementWithStripeExtThenCorrectOnboardingStatusIsStored() {
-        AppPrefs.setCardReaderOnboardingPending(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.STRIPE_EXTENSION_GATEWAY
+            status = CARD_READER_ONBOARDING_PENDING,
+            preferredPlugin = PluginType.STRIPE_EXTENSION_GATEWAY,
         )
 
         assertThat(
-            AppPrefs.getCardReaderOnboardingCompletedStatus(
+            AppPrefs.getCardReaderOnboardingStatus(
                 localSiteId = 0,
                 remoteSiteId = 0L,
                 selfHostedSiteId = 0L
             )
         ).isEqualTo(
-            CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
+            CardReaderOnboardingStatus.CARD_READER_ONBOARDING_PENDING
+        )
+    }
+
+    @Test
+    fun whenCardReaderOnboardingPendingRequirementWithStripeExtThenCorrectPreferredPluginIsStored() {
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            status = CARD_READER_ONBOARDING_PENDING,
+            preferredPlugin = PluginType.STRIPE_EXTENSION_GATEWAY,
+        )
+
+        assertThat(
+            AppPrefs.getCardReaderPreferredPlugin(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isEqualTo(
+            PluginType.STRIPE_EXTENSION_GATEWAY
         )
     }
 
     @Test
     fun whenCardReaderOnboardingCompletedWithWCPayThenCorrectOnboardingStatusIsStored() {
-        AppPrefs.setCardReaderOnboardingCompleted(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.WOOCOMMERCE_PAYMENTS
+            status = CARD_READER_ONBOARDING_PENDING,
+            preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
         )
 
         assertThat(
-            AppPrefs.getCardReaderOnboardingCompletedStatus(
+            AppPrefs.getCardReaderOnboardingStatus(
                 localSiteId = 0,
                 remoteSiteId = 0L,
                 selfHostedSiteId = 0L
             )
-        ).isEqualTo(CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY)
+        ).isEqualTo(CardReaderOnboardingStatus.CARD_READER_ONBOARDING_COMPLETED)
+    }
+
+    @Test
+    fun whenCardReaderOnboardingCompletedWithWCPayThenCorrectPreferredPluginIsStored() {
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            status = CARD_READER_ONBOARDING_COMPLETED,
+            preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
+        )
+
+        assertThat(
+            AppPrefs.getCardReaderPreferredPlugin(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isEqualTo(PluginType.WOOCOMMERCE_PAYMENTS)
     }
 
     @Test
     fun whenCardReaderOnboardingPendingRequirementsWithWCPayThenCorrectOnboardingStatusIsStored() {
-        AppPrefs.setCardReaderOnboardingPending(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.WOOCOMMERCE_PAYMENTS
+            status = CARD_READER_ONBOARDING_PENDING,
+            preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
         )
 
         assertThat(
-            AppPrefs.getCardReaderOnboardingCompletedStatus(
+            AppPrefs.getCardReaderOnboardingStatus(
                 localSiteId = 0,
                 remoteSiteId = 0L,
                 selfHostedSiteId = 0L
             )
-        ).isEqualTo(CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY)
+        ).isEqualTo(CardReaderOnboardingStatus.CARD_READER_ONBOARDING_PENDING)
+    }
+
+    @Test
+    fun whenCardReaderOnboardingPendingRequirementsWithWCPayThenCorrectPreferredPluginIsStored() {
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            status = CARD_READER_ONBOARDING_PENDING,
+            preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
+        )
+
+        assertThat(
+            AppPrefs.getCardReaderPreferredPlugin(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isEqualTo(PluginType.WOOCOMMERCE_PAYMENTS)
     }
 
     @Test
     fun whenCardReaderOnboardingNotCompletedThenCorrectOnboardingStatusIsStored() {
         assertThat(
-            AppPrefs.getCardReaderOnboardingCompletedStatus(
+            AppPrefs.getCardReaderOnboardingStatus(
                 localSiteId = 1,
                 remoteSiteId = 0L,
                 selfHostedSiteId = 0L
             )
-        ).isEqualTo(CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_NOT_COMPLETED)
+        ).isEqualTo(CardReaderOnboardingStatus.CARD_READER_ONBOARDING_NOT_COMPLETED)
     }
 
     @Test
     fun whenCardReaderOnboardingCompletedWithWCPayThenCorrectOnboardingStatusFlagIsReturned() {
-        AppPrefs.setCardReaderOnboardingCompleted(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.WOOCOMMERCE_PAYMENTS
+            status = CARD_READER_ONBOARDING_COMPLETED,
+            preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
         )
 
         assertThat(
@@ -137,11 +221,12 @@ class AppPrefsTest {
 
     @Test
     fun whenCardReaderOnboardingPendingRequirementsWithWCPayThenCorrectOnboardingStatusFlagIsReturned() {
-        AppPrefs.setCardReaderOnboardingPending(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.WOOCOMMERCE_PAYMENTS
+            status = CARD_READER_ONBOARDING_PENDING,
+            preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
         )
 
         assertThat(
@@ -155,11 +240,12 @@ class AppPrefsTest {
 
     @Test
     fun whenCardReaderOnboardingCompletedWithStripeExtThenCorrectOnboardingStatusFlagIsReturned() {
-        AppPrefs.setCardReaderOnboardingCompleted(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.STRIPE_EXTENSION_GATEWAY
+            status = CARD_READER_ONBOARDING_PENDING,
+            preferredPlugin = PluginType.STRIPE_EXTENSION_GATEWAY,
         )
 
         assertThat(
@@ -173,11 +259,12 @@ class AppPrefsTest {
 
     @Test
     fun whenCardReaderOnboardingPendingRequirementsWithStripeExtThenCorrectOnboardingStatusFlagIsReturned() {
-        AppPrefs.setCardReaderOnboardingPending(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = PluginType.STRIPE_EXTENSION_GATEWAY
+            status = CARD_READER_ONBOARDING_PENDING,
+            preferredPlugin = PluginType.STRIPE_EXTENSION_GATEWAY,
         )
 
         assertThat(
@@ -202,11 +289,12 @@ class AppPrefsTest {
 
     @Test
     fun whenCardReaderOnboardingNotCompletedThenCorrectOnboardingStatusIsReturned() {
-        AppPrefs.setCardReaderOnboardingCompleted(
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = 0,
             remoteSiteId = 0L,
             selfHostedSiteId = 0L,
-            pluginType = null
+            status = CARD_READER_ONBOARDING_NOT_COMPLETED,
+            preferredPlugin = null,
         )
 
         assertThat(
@@ -216,6 +304,25 @@ class AppPrefsTest {
                 selfHostedSiteId = 0L
             )
         ).isFalse
+    }
+
+    @Test
+    fun whenEmptyPreferredPluginSetThenNullReturned() {
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            status = CARD_READER_ONBOARDING_NOT_COMPLETED,
+            preferredPlugin = null,
+        )
+
+        assertThat(
+            AppPrefs.getCardReaderPreferredPlugin(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L
+            )
+        ).isNull()
     }
 
     @Test

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -7,11 +7,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.SharedPreferences.Editor
 import androidx.preference.PreferenceManager
-import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
-import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY
-import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
-import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
-import com.woocommerce.android.AppPrefs.CardReaderOnboardingCompletedStatus.CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY
+import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.*
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.*
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType
@@ -58,7 +54,8 @@ object AppPrefs {
         IS_USER_ELIGIBLE,
         USER_EMAIL,
         RECEIPT_PREFIX,
-        CARD_READER_ONBOARDING_COMPLETED_STATUS,
+        CARD_READER_ONBOARDING_COMPLETED_STATUS_V2,
+        CARD_READER_PREFERRED_PLUGIN,
         CARD_READER_STATEMENT_DESCRIPTOR,
         ORDER_FILTER_PREFIX,
         ORDER_FILTER_CUSTOM_DATE_RANGE_START,
@@ -418,15 +415,15 @@ object AppPrefs {
         setString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW, flow)
     }
 
-    fun getCardReaderOnboardingCompletedStatus(
+    fun getCardReaderOnboardingStatus(
         localSiteId: Int,
         remoteSiteId: Long,
         selfHostedSiteId: Long
-    ): CardReaderOnboardingCompletedStatus {
-        return CardReaderOnboardingCompletedStatus.valueOf(
+    ): CardReaderOnboardingStatus {
+        return CardReaderOnboardingStatus.valueOf(
             PreferenceUtils.getString(
                 getPreferences(),
-                getCardReaderOnboardingCompletedKey(
+                getCardReaderOnboardingKey(
                     localSiteId,
                     remoteSiteId,
                     selfHostedSiteId
@@ -437,70 +434,61 @@ object AppPrefs {
     }
 
     fun isCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long): Boolean {
-        val completedStatus = getCardReaderOnboardingCompletedStatus(
+        val completedStatus = getCardReaderOnboardingStatus(
             localSiteId,
             remoteSiteId,
             selfHostedSiteId
         )
-        return completedStatus == CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY ||
-            completedStatus == CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
+        return completedStatus == CARD_READER_ONBOARDING_COMPLETED
     }
 
-    @Throws(IllegalStateException::class)
-    fun getPaymentPluginType(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long): PluginType {
-        return when (getCardReaderOnboardingCompletedStatus(localSiteId, remoteSiteId, selfHostedSiteId)) {
-            CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY,
-            CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY ->
-                PluginType.WOOCOMMERCE_PAYMENTS
-            CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION,
-            CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION ->
-                PluginType.STRIPE_EXTENSION_GATEWAY
-            CARD_READER_ONBOARDING_NOT_COMPLETED ->
-                throw IllegalStateException("Onboarding not completed. Plugin Type is null")
-        }
-    }
-
-    fun setCardReaderOnboardingCompleted(
-        localSiteId: Int,
-        remoteSiteId: Long,
-        selfHostedSiteId: Long,
-        pluginType: PluginType?
-    ) {
-        val pluginName = when (pluginType) {
-            PluginType.WOOCOMMERCE_PAYMENTS -> CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY
-            PluginType.STRIPE_EXTENSION_GATEWAY -> CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION
-            null -> CARD_READER_ONBOARDING_NOT_COMPLETED
-        }
-        PreferenceUtils.setString(
-            getPreferences(),
-            getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
-            pluginName.name
-        )
-    }
-
-    fun setCardReaderOnboardingPending(
-        localSiteId: Int,
-        remoteSiteId: Long,
-        selfHostedSiteId: Long,
-        pluginType: PluginType?
-    ) {
-        val pluginName = when (pluginType) {
-            PluginType.WOOCOMMERCE_PAYMENTS -> CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY
-            PluginType.STRIPE_EXTENSION_GATEWAY -> CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION
-            null -> CARD_READER_ONBOARDING_NOT_COMPLETED
-        }
-        PreferenceUtils.setString(
-            getPreferences(),
-            getCardReaderOnboardingCompletedKey(localSiteId, remoteSiteId, selfHostedSiteId),
-            pluginName.name
-        )
-    }
-
-    private fun getCardReaderOnboardingCompletedKey(
+    fun getCardReaderPreferredPlugin(
         localSiteId: Int,
         remoteSiteId: Long,
         selfHostedSiteId: Long
-    ) = "$CARD_READER_ONBOARDING_COMPLETED_STATUS:$localSiteId:$remoteSiteId:$selfHostedSiteId"
+    ): PluginType? {
+        val storedValue = PreferenceUtils.getString(
+            getPreferences(),
+            getCardReaderPreferredPluginKey(
+                localSiteId,
+                remoteSiteId,
+                selfHostedSiteId
+            ),
+            null
+        )
+        return storedValue?.let { PluginType.valueOf(it) }
+    }
+
+    fun setCardReaderOnboardingStatusAndPreferredPlugin(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long,
+        status: CardReaderOnboardingStatus,
+        preferredPlugin: PluginType?,
+    ) {
+        PreferenceUtils.setString(
+            getPreferences(),
+            getCardReaderOnboardingKey(localSiteId, remoteSiteId, selfHostedSiteId),
+            status.toString()
+        )
+        PreferenceUtils.setString(
+            getPreferences(),
+            getCardReaderPreferredPluginKey(localSiteId, remoteSiteId, selfHostedSiteId),
+            preferredPlugin?.toString()
+        )
+    }
+
+    private fun getCardReaderOnboardingKey(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = "$CARD_READER_ONBOARDING_COMPLETED_STATUS_V2:$localSiteId:$remoteSiteId:$selfHostedSiteId"
+
+    private fun getCardReaderPreferredPluginKey(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = "$CARD_READER_PREFERRED_PLUGIN:$localSiteId:$remoteSiteId:$selfHostedSiteId"
 
     fun setCardReaderStatementDescriptor(
         statementDescriptor: String?,
@@ -699,11 +687,9 @@ object AppPrefs {
         }
     }
 
-    enum class CardReaderOnboardingCompletedStatus {
-        CARD_READER_ONBOARDING_COMPLETED_WITH_WCPAY,
-        CARD_READER_ONBOARDING_COMPLETED_WITH_STRIPE_EXTENSION,
-        CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_WCPAY,
-        CARD_READER_ONBOARDING_PENDING_REQUIREMENTS_WITH_STRIPE_EXTENSION,
+    enum class CardReaderOnboardingStatus {
+        CARD_READER_ONBOARDING_COMPLETED,
+        CARD_READER_ONBOARDING_PENDING,
         CARD_READER_ONBOARDING_NOT_COMPLETED,
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android
 
+import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType
 import javax.inject.Inject
 
@@ -18,19 +19,27 @@ class AppPrefsWrapper @Inject constructor() {
     fun isCardReaderOnboardingCompleted(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
         AppPrefs.isCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId)
 
-    fun setCardReaderOnboardingCompleted(
+    fun getCardReaderPreferredPlugin(
         localSiteId: Int,
         remoteSiteId: Long,
-        selfHostedSiteId: Long,
-        pluginType: PluginType?
-    ) = AppPrefs.setCardReaderOnboardingCompleted(localSiteId, remoteSiteId, selfHostedSiteId, pluginType)
+        selfHostedSiteId: Long
+    ): PluginType? = AppPrefs.getCardReaderPreferredPlugin(localSiteId, remoteSiteId, selfHostedSiteId)
 
-    fun setCardReaderOnboardingPending(
+    fun setCardReaderOnboardingStatusAndPreferredPlugin(
         localSiteId: Int,
         remoteSiteId: Long,
         selfHostedSiteId: Long,
-        pluginType: PluginType?
-    ) = AppPrefs.setCardReaderOnboardingPending(localSiteId, remoteSiteId, selfHostedSiteId, pluginType)
+        status: CardReaderOnboardingStatus,
+        preferredPlugin: PluginType?,
+    ) {
+        AppPrefs.setCardReaderOnboardingStatusAndPreferredPlugin(
+            localSiteId,
+            remoteSiteId,
+            selfHostedSiteId,
+            status,
+            preferredPlugin
+        )
+    }
 
     fun setCardReaderStatementDescriptor(
         statementDescriptor: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.util.WooLog.T
 import org.json.JSONObject
 import org.wordpress.android.fluxc.model.SiteModel
 import java.util.UUID
+import kotlin.collections.HashMap
 
 class AnalyticsTracker private constructor(private val context: Context) {
     // region Track Event Enums
@@ -919,17 +920,35 @@ class AnalyticsTracker private constructor(private val context: Context) {
          * @param errorDescription The error text or other description.
          */
         fun track(stat: Stat, errorContext: String?, errorType: String?, errorDescription: String?) {
-            val props = HashMap<String, String>()
+            track(stat, mapOf(), errorContext, errorType, errorDescription)
+        }
+
+        /**
+         * A convenience method for logging an error event with some additional meta data.
+         * @param stat The stat to track.
+         * @param properties Map of additional properties
+         * @param errorContext A string providing additional context (if any) about the error.
+         * @param errorType The type of error.
+         * @param errorDescription The error text or other description.
+         */
+        fun track(
+            stat: Stat,
+            properties: Map<String, Any>,
+            errorContext: String?,
+            errorType: String?,
+            errorDescription: String?
+        ) {
+            val mutableProperties = HashMap<String, Any>(properties)
             errorContext?.let {
-                props[KEY_ERROR_CONTEXT] = it
+                mutableProperties[KEY_ERROR_CONTEXT] = it
             }
             errorType?.let {
-                props[KEY_ERROR_TYPE] = it
+                mutableProperties[KEY_ERROR_TYPE] = it
             }
             errorDescription?.let {
-                props[KEY_ERROR_DESC] = it
+                mutableProperties[KEY_ERROR_DESC] = it
             }
-            track(stat, props)
+            track(stat, mutableProperties)
         }
 
         /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTrackerWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTrackerWrapper.kt
@@ -7,11 +7,7 @@ import javax.inject.Inject
 @Reusable
 class AnalyticsTrackerWrapper
 @Inject constructor() {
-    fun track(stat: Stat) {
-        AnalyticsTracker.track(stat)
-    }
-
-    fun track(stat: Stat, properties: Map<String, *>) {
+    fun track(stat: Stat, properties: Map<String, *> = emptyMap<String, Any>()) {
         AnalyticsTracker.track(stat, properties)
     }
 
@@ -24,6 +20,24 @@ class AnalyticsTrackerWrapper
      */
     fun track(stat: Stat, errorContext: String?, errorType: String?, errorDescription: String?) {
         AnalyticsTracker.track(stat, errorContext, errorType, errorDescription)
+    }
+
+    /**
+     * A convenience method for logging an error event with some additional meta data.
+     * @param stat The stat to track.
+     * @param properties Map of additional properties
+     * @param errorContext A string providing additional context (if any) about the error.
+     * @param errorType The type of error.
+     * @param errorDescription The error text or other description.
+     */
+    fun track(
+        stat: Stat,
+        properties: Map<String, Any>,
+        errorContext: String?,
+        errorType: String?,
+        errorDescription: String?
+    ) {
+        AnalyticsTracker.track(stat, properties, errorContext, errorType, errorDescription)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -39,11 +39,11 @@ class CardReaderModule {
     ) = object : CardReaderStore {
         override suspend fun fetchCustomerIdByOrderId(orderId: Long): String? {
             return inPersonPaymentsStore.createCustomerByOrderId(
-                appPrefs.getPaymentPluginType(
+                appPrefs.getCardReaderPreferredPlugin(
                     selectedSite.get().id,
                     selectedSite.get().siteId,
                     selectedSite.get().selfHostedSiteId
-                ).toInPersonPaymentsPluginType(),
+                )!!.toInPersonPaymentsPluginType(),
                 selectedSite.get(),
                 orderId
             ).model?.customerId
@@ -51,11 +51,11 @@ class CardReaderModule {
 
         override suspend fun fetchConnectionToken(): String {
             val result = inPersonPaymentsStore.fetchConnectionToken(
-                appPrefs.getPaymentPluginType(
+                appPrefs.getCardReaderPreferredPlugin(
                     selectedSite.get().id,
                     selectedSite.get().siteId,
                     selectedSite.get().selfHostedSiteId
-                ).toInPersonPaymentsPluginType(),
+                )!!.toInPersonPaymentsPluginType(),
                 selectedSite.get()
             )
             return result.model?.token.orEmpty()
@@ -63,11 +63,11 @@ class CardReaderModule {
 
         override suspend fun capturePaymentIntent(orderId: Long, paymentId: String): CapturePaymentResponse {
             val response = inPersonPaymentsStore.capturePayment(
-                appPrefs.getPaymentPluginType(
+                appPrefs.getCardReaderPreferredPlugin(
                     selectedSite.get().id,
                     selectedSite.get().siteId,
                     selectedSite.get().selfHostedSiteId
-                ).toInPersonPaymentsPluginType(),
+                )!!.toInPersonPaymentsPluginType(),
                 selectedSite.get(),
                 paymentId,
                 orderId

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
@@ -49,21 +49,21 @@ class CardReaderTracker @Inject constructor(
         when (state) {
             is CardReaderOnboardingState.OnboardingCompleted -> null
             is CardReaderOnboardingState.StoreCountryNotSupported -> "country_not_supported"
-            CardReaderOnboardingState.StripeAccountOverdueRequirement -> "account_overdue_requirements"
+            is CardReaderOnboardingState.StripeAccountOverdueRequirement -> "account_overdue_requirements"
             is CardReaderOnboardingState.StripeAccountPendingRequirement -> "account_pending_requirements"
-            CardReaderOnboardingState.StripeAccountRejected -> "account_rejected"
-            CardReaderOnboardingState.StripeAccountUnderReview -> "account_under_review"
+            is CardReaderOnboardingState.StripeAccountRejected -> "account_rejected"
+            is CardReaderOnboardingState.StripeAccountUnderReview -> "account_under_review"
             is CardReaderOnboardingState.StripeAccountCountryNotSupported -> "account_country_not_supported"
-            CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount -> "wcpay_in_test_mode_with_live_account"
-            CardReaderOnboardingState.WcpayNotActivated -> "wcpay_not_activated"
-            CardReaderOnboardingState.WcpayNotInstalled -> "wcpay_not_installed"
+            is CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount -> "wcpay_in_test_mode_with_live_account"
+            is CardReaderOnboardingState.WcpayNotActivated -> "wcpay_not_activated"
+            is CardReaderOnboardingState.WcpayNotInstalled -> "wcpay_not_installed"
             is CardReaderOnboardingState.SetupNotCompleted ->
-                "${getPluginNameReasonPrefix(state.pluginType)}_not_setup"
+                "${getPluginNameReasonPrefix(state.preferredPlugin)}_not_setup"
             is CardReaderOnboardingState.PluginUnsupportedVersion ->
-                "${getPluginNameReasonPrefix(state.pluginType)}_unsupported_version"
-            CardReaderOnboardingState.GenericError -> "generic_error"
-            CardReaderOnboardingState.NoConnectionError -> "no_connection_error"
-            CardReaderOnboardingState.WcpayAndStripeActivated -> "wcpay_and_stripe_installed_and_activated"
+                "${getPluginNameReasonPrefix(state.preferredPlugin)}_unsupported_version"
+            is CardReaderOnboardingState.GenericError -> "generic_error"
+            is CardReaderOnboardingState.NoConnectionError -> "no_connection_error"
+            is CardReaderOnboardingState.WcpayAndStripeActivated -> "wcpay_and_stripe_installed_and_activated"
         }
 
     private fun getPluginNameReasonPrefix(pluginType: PluginType): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
@@ -30,7 +30,7 @@ class CardReaderTracker @Inject constructor(
     ) {
         addPreferredPluginSlugProperty(properties)
 
-        val isError = errorType != null || errorDescription != null
+        val isError = !errorType.isNullOrBlank() || !errorDescription.isNullOrEmpty()
         if (isError) {
             trackerWrapper.track(
                 stat,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs.cardreader
 
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Failed
@@ -13,13 +14,33 @@ import javax.inject.Inject
 class CardReaderTracker @Inject constructor(
     private val trackerWrapper: AnalyticsTrackerWrapper,
 ) {
+    private fun track(
+        stat: Stat,
+        properties: MutableMap<String, Any> = mutableMapOf(),
+        errorType: String? = null,
+        errorDescription: String? = null,
+    ) {
+        val isError = errorType != null || errorDescription != null
+        if (isError) {
+            trackerWrapper.track(
+                stat,
+                properties,
+                this.javaClass.simpleName,
+                errorType,
+                errorDescription
+            )
+        } else {
+            trackerWrapper.track(stat, properties)
+        }
+    }
+
     fun trackOnboardingLearnMoreTapped() {
-        trackerWrapper.track(CARD_PRESENT_ONBOARDING_LEARN_MORE_TAPPED)
+        track(CARD_PRESENT_ONBOARDING_LEARN_MORE_TAPPED)
     }
 
     fun trackOnboardingState(state: CardReaderOnboardingState) {
         getOnboardingNotCompletedReason(state)?.let {
-            trackerWrapper.track(CARD_PRESENT_ONBOARDING_NOT_COMPLETED, mapOf("reason" to it))
+            track(CARD_PRESENT_ONBOARDING_NOT_COMPLETED, mutableMapOf("reason" to it))
         }
     }
 
@@ -57,11 +78,9 @@ class CardReaderTracker @Inject constructor(
     }
 
     fun trackSoftwareUpdateUnknownStatus() {
-        trackerWrapper.track(
+        track(
             CARD_READER_SOFTWARE_UPDATE_FAILED,
-            this.javaClass.simpleName,
-            null,
-            "Unknown software update status"
+            errorDescription = "Unknown software update status"
         )
     }
 
@@ -87,119 +106,112 @@ class CardReaderTracker @Inject constructor(
         errorDescription: String? = null,
     ) {
         val eventPropertiesMap = errorDescription?.let { description ->
-            hashMapOf(
+            hashMapOf<String, Any>(
                 AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to if (requiredUpdate) REQUIRED_UPDATE else OPTIONAL_UPDATE,
                 AnalyticsTracker.KEY_ERROR_CONTEXT to this.javaClass.simpleName,
                 AnalyticsTracker.KEY_ERROR_DESC to description
             )
         } ?: run {
-            hashMapOf(
+            hashMapOf<String, Any>(
                 AnalyticsTracker.KEY_SOFTWARE_UPDATE_TYPE to if (requiredUpdate) REQUIRED_UPDATE else OPTIONAL_UPDATE
             )
         }
-        trackerWrapper.track(
+        track(
             event,
             eventPropertiesMap
         )
     }
 
     fun trackReadersDiscovered(count: Int) {
-        trackerWrapper.track(
-            AnalyticsTracker.Stat.CARD_READER_DISCOVERY_READER_DISCOVERED,
-            mapOf("reader_count" to count)
+        track(
+            CARD_READER_DISCOVERY_READER_DISCOVERED,
+            mutableMapOf("reader_count" to count)
         )
     }
 
     fun trackReaderDiscoveryFailed(errorMessage: String) {
-        trackerWrapper.track(
+        track(
             CARD_READER_DISCOVERY_FAILED,
-            this.javaClass.simpleName,
-            null,
-            errorMessage
+            errorDescription = errorMessage
         )
     }
 
     fun trackAutoConnectionStarted() {
-        trackerWrapper.track(CARD_READER_AUTO_CONNECTION_STARTED)
+        track(CARD_READER_AUTO_CONNECTION_STARTED)
     }
 
     fun trackOnConnectTapped() {
-        trackerWrapper.track(CARD_READER_CONNECTION_TAPPED)
+        track(CARD_READER_CONNECTION_TAPPED)
     }
 
     fun trackFetchingLocationSucceeded() {
-        trackerWrapper.track(CARD_READER_LOCATION_SUCCESS)
+        track(CARD_READER_LOCATION_SUCCESS)
     }
 
     fun trackFetchingLocationFailed(errorDescription: String?) {
-        trackerWrapper.track(
+        track(
             CARD_READER_LOCATION_FAILURE,
-            this.javaClass.simpleName,
-            null,
-            errorDescription,
+            errorDescription = errorDescription,
         )
     }
 
     fun trackMissingLocationTapped() {
-        trackerWrapper.track(CARD_READER_LOCATION_MISSING_TAPPED)
+        track(CARD_READER_LOCATION_MISSING_TAPPED)
     }
 
     fun trackConnectionFailed() {
-        trackerWrapper.track(CARD_READER_CONNECTION_FAILED)
+        track(CARD_READER_CONNECTION_FAILED)
     }
 
     fun trackConnectionSucceeded() {
-        trackerWrapper.track(CARD_READER_CONNECTION_SUCCESS)
+        track(CARD_READER_CONNECTION_SUCCESS)
     }
 
     fun trackPaymentFailed(errorMessage: String, errorType: CardPaymentStatusErrorType = Generic) {
-        trackerWrapper.track(
+        track(
             CARD_PRESENT_COLLECT_PAYMENT_FAILED,
-            this.javaClass.simpleName,
-            errorType.toString(),
-            errorMessage
+            errorType = errorType.toString(),
+            errorDescription = errorMessage
         )
     }
 
     fun trackPaymentSucceeded() {
-        trackerWrapper.track(CARD_PRESENT_COLLECT_PAYMENT_SUCCESS)
+        track(CARD_PRESENT_COLLECT_PAYMENT_SUCCESS)
     }
 
     fun trackPrintReceiptTapped() {
-        trackerWrapper.track(RECEIPT_PRINT_TAPPED)
+        track(RECEIPT_PRINT_TAPPED)
     }
 
     fun trackEmailReceiptTapped() {
-        trackerWrapper.track(RECEIPT_EMAIL_TAPPED)
+        track(RECEIPT_EMAIL_TAPPED)
     }
 
     fun trackEmailReceiptFailed() {
-        trackerWrapper.track(RECEIPT_EMAIL_FAILED)
+        track(RECEIPT_EMAIL_FAILED)
     }
 
     fun trackPrintReceiptCancelled() {
-        trackerWrapper.track(RECEIPT_PRINT_CANCELED)
+        track(RECEIPT_PRINT_CANCELED)
     }
 
     fun trackPrintReceiptFailed() {
-        trackerWrapper.track(RECEIPT_PRINT_FAILED)
+        track(RECEIPT_PRINT_FAILED)
     }
 
     fun trackPrintReceiptSucceeded() {
-        trackerWrapper.track(RECEIPT_PRINT_SUCCESS)
+        track(RECEIPT_PRINT_SUCCESS)
     }
 
     fun trackPaymentCancelled(currentPaymentState: String?) {
-        trackerWrapper.track(
+        track(
             CARD_PRESENT_COLLECT_PAYMENT_CANCELLED,
-            this.javaClass.simpleName,
-            null,
-            "User manually cancelled the payment during state $currentPaymentState"
+            errorDescription = "User manually cancelled the payment during state $currentPaymentState"
         )
     }
 
     fun trackCollectPaymentTapped() {
-        trackerWrapper.track(CARD_PRESENT_COLLECT_PAYMENT_TAPPED)
+        track(CARD_PRESENT_COLLECT_PAYMENT_TAPPED)
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
@@ -136,6 +136,10 @@ class CardReaderTracker @Inject constructor(
         )
     }
 
+    fun trackDiscoveryTapped() {
+        track(CARD_READER_DISCOVERY_TAPPED)
+    }
+
     fun trackAutoConnectionStarted() {
         track(CARD_READER_AUTO_CONNECTION_STARTED)
     }
@@ -212,6 +216,10 @@ class CardReaderTracker @Inject constructor(
 
     fun trackCollectPaymentTapped() {
         track(CARD_PRESENT_COLLECT_PAYMENT_TAPPED)
+    }
+
+    fun trackDisconnectTapped() {
+        track(CARD_READER_DISCONNECT_TAPPED)
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -378,11 +378,11 @@ class CardReaderConnectViewModel @Inject constructor(
         }
     }
 
-    private fun getPaymentPluginType(): PluginType = appPrefs.getPaymentPluginType(
+    private fun getPaymentPluginType(): PluginType = appPrefs.getCardReaderPreferredPlugin(
         selectedSite.get().id,
         selectedSite.get().siteId,
         selectedSite.get().selfHostedSiteId
-    )
+    )!!
 
     private fun handleLocationFetchingError(result: CardReaderLocationRepository.LocationIdFetchingResult.Error) {
         this@CardReaderConnectViewModel.coroutineContext.cancelChildren()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -7,8 +7,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
@@ -19,6 +17,7 @@ import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.ui.prefs.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.NavigationTarget.CardReaderConnectScreen
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.ConnectedState
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.ConnectedState.ButtonState
@@ -42,7 +41,7 @@ private const val PERCENT_100 = 100
 @HiltViewModel
 class CardReaderDetailViewModel @Inject constructor(
     val cardReaderManager: CardReaderManager,
-    private val tracker: AnalyticsTrackerWrapper,
+    private val tracker: CardReaderTracker,
     private val appPrefs: AppPrefs,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
@@ -136,7 +135,7 @@ class CardReaderDetailViewModel @Inject constructor(
     }
 
     private fun onConnectBtnClicked() {
-        tracker.track(AnalyticsTracker.Stat.CARD_READER_DISCOVERY_TAPPED)
+        tracker.trackDiscoveryTapped()
         triggerEvent(CardReaderConnectScreen)
     }
 
@@ -145,7 +144,7 @@ class CardReaderDetailViewModel @Inject constructor(
     }
 
     private fun onDisconnectClicked() {
-        tracker.track(AnalyticsTracker.Stat.CARD_READER_DISCONNECT_TAPPED)
+        tracker.trackDisconnectTapped()
         launch {
             clearLastKnowReader()
             val disconnectionResult = cardReaderManager.disconnectReader()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -232,7 +232,6 @@ enum class PluginType(val minSupportedVersion: String) {
 sealed class CardReaderOnboardingState(
     open val preferredPlugin: PluginType? = null
 ) {
-
     data class OnboardingCompleted(override val preferredPlugin: PluginType, val countryCode: String) :
         CardReaderOnboardingState()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -51,11 +51,14 @@ class CardReaderOnboardingChecker @Inject constructor(
 
         return fetchOnboardingState()
             .also {
-                when (it) {
-                    is OnboardingCompleted -> updateOnboardingCompletedStatus(it.pluginType)
-                    is StripeAccountPendingRequirement -> updateOnboardingPendingStatus(it.pluginType)
-                    else -> updateOnboardingCompletedStatus(null)
-                }
+                updateSharedPreferences(
+                    when (it) {
+                        is OnboardingCompleted -> CARD_READER_ONBOARDING_COMPLETED
+                        is StripeAccountPendingRequirement -> CARD_READER_ONBOARDING_PENDING
+                        else -> CARD_READER_ONBOARDING_NOT_COMPLETED
+                    },
+                    it.preferredPlugin,
+                )
             }
     }
 
@@ -193,23 +196,14 @@ class CardReaderOnboardingChecker @Inject constructor(
     private fun isInUndefinedState(paymentAccount: WCPaymentAccountResult): Boolean =
         paymentAccount.status != COMPLETE
 
-    private fun updateOnboardingCompletedStatus(pluginType: PluginType?) {
+    private fun updateSharedPreferences(status: CardReaderOnboardingStatus, preferredPlugin: PluginType?) {
         val site = selectedSite.get()
-        appPrefsWrapper.setCardReaderOnboardingCompleted(
+        appPrefsWrapper.setCardReaderOnboardingStatusAndPreferredPlugin(
             localSiteId = site.id,
             remoteSiteId = site.siteId,
             selfHostedSiteId = site.selfHostedSiteId,
-            pluginType
-        )
-    }
-
-    private fun updateOnboardingPendingStatus(pluginType: PluginType?) {
-        val site = selectedSite.get()
-        appPrefsWrapper.setCardReaderOnboardingPending(
-            localSiteId = site.id,
-            remoteSiteId = site.siteId,
-            selfHostedSiteId = site.selfHostedSiteId,
-            pluginType
+            status,
+            preferredPlugin,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -65,7 +65,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     viewState.value =
                         OnboardingViewState.WCPayError.WCPayNotInstalledState(::refreshState, ::onLearnMoreClicked)
                 is CardReaderOnboardingState.PluginUnsupportedVersion ->
-                    when (state.pluginType) {
+                    when (state.preferredPlugin) {
                         PluginType.WOOCOMMERCE_PAYMENTS ->
                             viewState.value =
                                 OnboardingViewState.WCPayError.WCPayUnsupportedVersionState(
@@ -82,7 +82,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     viewState.value =
                         OnboardingViewState.WCPayError.WCPayNotActivatedState(::refreshState, ::onLearnMoreClicked)
                 is CardReaderOnboardingState.SetupNotCompleted ->
-                    viewState.value = when (state.pluginType) {
+                    viewState.value = when (state.preferredPlugin) {
                         PluginType.WOOCOMMERCE_PAYMENTS ->
                             OnboardingViewState.WCPayError.WCPayNotSetupState(::refreshState, ::onLearnMoreClicked)
                         PluginType.STRIPE_EXTENSION_GATEWAY ->
@@ -90,12 +90,12 @@ class CardReaderOnboardingViewModel @Inject constructor(
                                 ::refreshState, ::onLearnMoreClicked
                             )
                     }
-                CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount ->
+                is CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount ->
                     viewState.value = OnboardingViewState.StripeAcountError.WCPayInTestModeWithLiveAccountState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
                     )
-                CardReaderOnboardingState.StripeAccountUnderReview ->
+                is CardReaderOnboardingState.StripeAccountUnderReview ->
                     viewState.value = OnboardingViewState.StripeAcountError.StripeAccountUnderReviewState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
@@ -108,12 +108,12 @@ class CardReaderOnboardingViewModel @Inject constructor(
                             onButtonActionClicked = { onSkipPendingRequirementsClicked(state.countryCode) },
                             dueDate = formatDueDate(state)
                         )
-                CardReaderOnboardingState.StripeAccountOverdueRequirement ->
+                is CardReaderOnboardingState.StripeAccountOverdueRequirement ->
                     viewState.value = OnboardingViewState.StripeAcountError.StripeAccountOverdueRequirementsState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
                     )
-                CardReaderOnboardingState.StripeAccountRejected ->
+                is CardReaderOnboardingState.StripeAccountRejected ->
                     viewState.value = OnboardingViewState.StripeAcountError.StripeAccountRejectedState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/PaymentChargeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/PaymentChargeRepository.kt
@@ -13,16 +13,12 @@ class PaymentChargeRepository @Inject constructor(
     private val appPrefs: AppPrefs
 ) {
     private val activePlugin: WCInPersonPaymentsStore.InPersonPaymentsPluginType?
-        get() = try {
-            appPrefs.getPaymentPluginType(
-                selectedSite.get().id,
-                selectedSite.get().siteId,
-                selectedSite.get().selfHostedSiteId
-            ).toInPersonPaymentsPluginType()
-        } catch (e: IllegalStateException) {
-            WooLog.e(WooLog.T.ORDERS, "Active Payment Plugin is not set")
-            null
-        }
+        get() = appPrefs.getCardReaderPreferredPlugin(
+            selectedSite.get().id,
+            selectedSite.get().siteId,
+            selectedSite.get().selfHostedSiteId
+        )?.toInPersonPaymentsPluginType()
+            ?: null.also { WooLog.e(WooLog.T.ORDERS, "Active Payment Plugin is not set") }
 
     suspend fun fetchCardDataUsedForOrderPayment(chargeId: String): CardDataUsedForOrderPaymentResult {
         val plugin = activePlugin

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
@@ -336,7 +336,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
             cardReaderTracker.trackReaderDiscoveryFailed(dummyErrorMgs)
 
             verify(trackerWrapper).track(
-                eq(CARD_READER_DISCOVERY_FAILED), anyOrNull(), anyOrNull(), eq(dummyErrorMgs)
+                eq(CARD_READER_DISCOVERY_FAILED), anyOrNull(), anyOrNull(), anyOrNull(), eq(dummyErrorMgs)
             )
         }
 
@@ -358,6 +358,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
             verify(trackerWrapper).track(
                 CARD_READER_LOCATION_FAILURE,
+                mutableMapOf(),
                 "CardReaderTracker",
                 null,
                 dummyErrorMgs
@@ -379,7 +380,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
             cardReaderTracker.trackPaymentFailed(dummyMessage)
 
             verify(trackerWrapper).track(
-                eq(CARD_PRESENT_COLLECT_PAYMENT_FAILED), anyOrNull(), anyOrNull(), eq(dummyMessage)
+                eq(CARD_PRESENT_COLLECT_PAYMENT_FAILED), anyOrNull(), anyOrNull(), anyOrNull(), eq(dummyMessage)
             )
         }
 
@@ -436,6 +437,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
             verify(trackerWrapper).track(
                 eq(CARD_PRESENT_COLLECT_PAYMENT_CANCELLED),
+                anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
                 eq("User manually cancelled the payment during state $currentPaymentState")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -1395,7 +1395,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
         (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(true)
         (viewModel.event.value as CheckBluetoothEnabled).onBluetoothCheckResult(true)
-        whenever(appPrefs.getPaymentPluginType(any(), any(), any())).thenReturn(
+        whenever(appPrefs.getCardReaderPreferredPlugin(any(), any(), any())).thenReturn(
             PluginType.WOOCOMMERCE_PAYMENTS
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.prefs.cardreader.detail
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
@@ -12,6 +10,7 @@ import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailab
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.ui.prefs.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.CardReaderDetailEvent.CardReaderConnected
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.CardReaderDetailEvent.CardReaderDisconnected
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.CardReaderDetailEvent.CopyReadersNameToClipboard
@@ -38,7 +37,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         onBlocking { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
     }
 
-    private val tracker: AnalyticsTrackerWrapper = mock()
+    private val tracker: CardReaderTracker = mock()
     private val appPrefs: AppPrefs = mock()
 
     @Test
@@ -347,7 +346,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as NotConnectedState).onPrimaryActionClicked.invoke()
 
             // THEN
-            verify(tracker).track(AnalyticsTracker.Stat.CARD_READER_DISCOVERY_TAPPED)
+            verify(tracker).trackDiscoveryTapped()
         }
 
     @Test
@@ -362,7 +361,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as ConnectedState).primaryButtonState!!.onActionClicked()
 
             // THEN
-            verify(tracker).track(AnalyticsTracker.Stat.CARD_READER_DISCONNECT_TAPPED)
+            verify(tracker).trackDisconnectTapped()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
+import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.*
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForCanada
@@ -459,7 +460,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountUnderReview)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountUnderReview::class.java)
         }
 
     @Test
@@ -507,7 +508,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountOverdueRequirement)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountOverdueRequirement::class.java)
         }
 
     @Test
@@ -523,7 +524,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountOverdueRequirement)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountOverdueRequirement::class.java)
         }
 
     @Test
@@ -537,7 +538,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountRejected::class.java)
         }
 
     @Test
@@ -551,7 +552,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountRejected::class.java)
         }
 
     @Test
@@ -565,7 +566,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountRejected::class.java)
         }
 
     @Test
@@ -579,7 +580,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountRejected::class.java)
         }
 
     @Test
@@ -591,7 +592,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount::class.java)
         }
 
     @Test
@@ -603,7 +604,8 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isNotEqualTo(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount)
+            assertThat(result)
+                .isNotInstanceOf(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount::class.java)
         }
 
     @Test
@@ -615,7 +617,8 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isNotEqualTo(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount)
+            assertThat(result)
+                .isNotInstanceOf(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount::class.java)
         }
 
     @Test
@@ -627,7 +630,8 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isNotEqualTo(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount)
+            assertThat(result)
+                .isNotInstanceOf(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount::class.java)
         }
 
     @Test
@@ -639,7 +643,8 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isNotEqualTo(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount)
+            assertThat(result)
+                .isNotInstanceOf(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount::class.java)
         }
 
     @Test
@@ -653,11 +658,12 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.WOOCOMMERCE_PAYMENTS)
+            eq(CARD_READER_ONBOARDING_COMPLETED),
+            anyOrNull(),
         )
     }
 
@@ -678,11 +684,12 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingPending(
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.WOOCOMMERCE_PAYMENTS)
+            eq(CARD_READER_ONBOARDING_PENDING),
+            anyOrNull(),
         )
     }
 
@@ -697,11 +704,12 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.STRIPE_EXTENSION_GATEWAY)
+            eq(CARD_READER_ONBOARDING_COMPLETED),
+            anyOrNull(),
         )
     }
 
@@ -722,11 +730,12 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingPending(
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.STRIPE_EXTENSION_GATEWAY)
+            eq(CARD_READER_ONBOARDING_PENDING),
+            anyOrNull(),
         )
     }
 
@@ -755,16 +764,17 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         )
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper, never()).setCardReaderOnboardingCompleted(
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
             anyInt(),
             anyLong(),
             anyLong(),
+            eq(CARD_READER_ONBOARDING_NOT_COMPLETED),
             any()
         )
     }
 
     @Test
-    fun `when onboarding completed using wcpay, then onboarding completed plugin type saved`() = testBlocking {
+    fun `when onboarding completed using wcpay, then wcpay plugin type saved`() = testBlocking {
         whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
             .thenReturn(null)
@@ -774,11 +784,12 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.WOOCOMMERCE_PAYMENTS)
+            any(),
+            eq(PluginType.WOOCOMMERCE_PAYMENTS),
         )
     }
 
@@ -809,7 +820,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when onboarding completed using stripe, then onboarding completed plugin type saved`() = testBlocking {
+    fun `when onboarding completed using stripe, then onboarding completed saved`() = testBlocking {
         whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
             .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
@@ -819,16 +830,37 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(PluginType.STRIPE_EXTENSION_GATEWAY)
+            eq(CARD_READER_ONBOARDING_COMPLETED),
+            any(),
         )
     }
 
     @Test
-    fun `when onboarding failed due to error, then onboarding completed plugin type is reset`() = testBlocking {
+    fun `when onboarding completed using stripe, then stripe plugin type saved`() = testBlocking {
+        whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+            .thenReturn(null)
+        whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
+
+        checker.getOnboardingState()
+
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            any(),
+            eq(PluginType.STRIPE_EXTENSION_GATEWAY),
+        )
+    }
+
+    @Test
+    fun `when onboarding failed due to error, then onboarding not completed is saved`() = testBlocking {
         whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
             buildPaymentAccountResult(
                 WCPaymentAccountResult.WCPaymentAccountStatus.REJECTED_OTHER,
@@ -837,11 +869,12 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         checker.getOnboardingState()
 
-        verify(appPrefsWrapper).setCardReaderOnboardingCompleted(
+        verify(appPrefsWrapper).setCardReaderOnboardingStatusAndPreferredPlugin(
             anyInt(),
             anyLong(),
             anyLong(),
-            eq(null)
+            eq(CARD_READER_ONBOARDING_NOT_COMPLETED),
+            anyOrNull(),
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -75,7 +75,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account country not supported, then country not supported state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(""))
+                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
 
             val viewModel = createVM()
 
@@ -124,7 +124,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `given account country not supported, when learn more clicked, then app shows learn more section`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(""))
+                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
             val viewModel = createVM()
 
             (viewModel.viewStateData.value as UnsupportedCountryState).onLearnMoreActionClicked.invoke()
@@ -137,7 +137,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `given account country not supported, when contact support clicked, then app navigates to support screen`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(""))
+                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
             val viewModel = createVM()
 
             (viewModel.viewStateData.value as UnsupportedCountryState).onContactSupportActionClicked.invoke()
@@ -229,7 +229,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when wcpay in test mode with live stripe account, then wcpay in test mode state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount)
+                .thenReturn(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(mock()))
 
             val viewModel = createVM()
 
@@ -462,7 +462,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account rejected, then account rejected state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountRejected)
+                .thenReturn(CardReaderOnboardingState.StripeAccountRejected(mock()))
 
             val viewModel = createVM()
 
@@ -512,7 +512,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account overdue requirements, then account overdue requirements state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountOverdueRequirement)
+                .thenReturn(CardReaderOnboardingState.StripeAccountOverdueRequirement(mock()))
 
             val viewModel = createVM()
 
@@ -525,7 +525,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account under review, then account under review state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountUnderReview)
+                .thenReturn(CardReaderOnboardingState.StripeAccountUnderReview(mock()))
 
             val viewModel = createVM()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/PaymentChargeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/PaymentChargeRepositoryTest.kt
@@ -49,7 +49,7 @@ class PaymentChargeRepositoryTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val chargeId = "charge_id"
-            whenever(appPrefs.getPaymentPluginType(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
+            whenever(appPrefs.getCardReaderPreferredPlugin(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
                 .thenReturn(PluginType.STRIPE_EXTENSION_GATEWAY)
             whenever(
                 ippStore.fetchPaymentCharge(
@@ -73,11 +73,11 @@ class PaymentChargeRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given active plugin saved and response notsuccessful when fetching data then error returned`() {
+    fun `given active plugin saved and response not successful when fetching data then error returned`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val chargeId = "charge_id"
-            whenever(appPrefs.getPaymentPluginType(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
+            whenever(appPrefs.getCardReaderPreferredPlugin(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
                 .thenReturn(PluginType.STRIPE_EXTENSION_GATEWAY)
             whenever(
                 ippStore.fetchPaymentCharge(
@@ -102,8 +102,8 @@ class PaymentChargeRepositoryTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val chargeId = "charge_id"
-            whenever(appPrefs.getPaymentPluginType(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
-                .thenThrow(IllegalStateException())
+            whenever(appPrefs.getCardReaderPreferredPlugin(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
+                .thenReturn(null)
 
             // WHEN
             val result = repo.fetchCardDataUsedForOrderPayment(chargeId)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5773 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Don't get scared by the size of the PR - a loot of the changes are done in tests. **I recommend reviewing this PR by commits to better follow my train of thoughts.**

Changes in this PR
1. [Adds support for tracking additional properties to all IPP events.](https://github.com/woocommerce/woocommerce-android/pull/5842/commits/bd056a07d1baa969fcf5c00a898153fc033307d9) Originally, only non-error tracking events could add additional properties. 
2. [Updates the way we store "onboarding completed", "onboarding pending" and "preferred payment plugin". ](https://github.com/woocommerce/woocommerce-android/pull/5842/commits/51a6cd8190093c0d67f8537b39f36e0c39c335de)Originally, we had separate methods for "onboarding completed/onboarding pending" - moreover, preferred plugin type was stored within the same entry in shared prefs. In this commit, both "completed/pending" is stored within the same method. Moreover, preferred plugin type is store still within the same method but into a separate shared prefs entry.
3. [Moves CardReaderDetail tracking events into CardReaderTracked.](https://github.com/woocommerce/woocommerce-android/pull/5842/commits/c5f527b40c0d128e26abcbbd864e7218cdbcc87a) I forgot to update it in the previous PRs, so this is just a left over.
4. [AppPrefs.getCardReaderPreferredPlugin (original getPaymentPluginType) returns `null` instead of IllegalStateException when it's accessed before a preferred plugin is determined.](https://github.com/woocommerce/woocommerce-android/pull/5842/commits/5b5b2167f17ee62a515d81cdcc4eacea380ba5f5) This commit crashes with a NPE if it's accessed from a place where the app expected a plugin to be already set. If the app doesn't expect it to be set, it doesn't crash - this is used in follow up commits where we want to track "plugin_slug=unknown".
5. [This is a follow up for item `2`. This commit updates CardReaderOnboardingChecker](https://github.com/woocommerce/woocommerce-android/pull/5842/commits/ce7e85f93eea4042c61276246f5827e5745fabc5) so it uses a single method for storing `onboarding completed` and `onboarding pending`.
6. [Adds "preferredPlugin" field to all CardReaderOnboardingStates.](https://github.com/woocommerce/woocommerce-android/pull/5842/commits/2fb5ac51f3b1573e4881bb3a86f98950adea61f6) It is set to null if the state doesn't know the preferred plugin because it wasn't determined yet.
7. [The final commits adds "plugin_slug" to all IPP events.](https://github.com/woocommerce/woocommerce-android/pull/5842/commits/6abc524d36851fca6100b2d1c1da36988347373f)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Ideally, carefully review all the unit tests and smoke test a few IPP tracking events -> don't forget testing even some error states, since this PR touches the way errors are tracked in the AnalyticsTracker.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No user facing changes.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
