### PR TITLE
Modify the logic of the currency selection to support Canada

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -4,22 +4,16 @@ import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.extensions.WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
-import com.woocommerce.android.ui.prefs.cardreader.InPersonPaymentsCanadaFeatureFlag
 import java.math.BigDecimal
 import javax.inject.Inject
 
 class CardReaderPaymentCollectibilityChecker @Inject constructor(
     private val orderDetailRepository: OrderDetailRepository,
-    private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
+    private val cardReaderPaymentCurrencySupportedChecker: CardReaderPaymentCurrencySupportedChecker,
 ) {
-    fun isCollectable(order: Order): Boolean {
-        val currencyList = if (inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
-            listOf("usd", "cad")
-        } else {
-            listOf("usd")
-        }
+    suspend fun isCollectable(order: Order): Boolean {
         return with(order) {
-            currency.lowercase() in currencyList &&
+            cardReaderPaymentCurrencySupportedChecker.isCurrencySupported(currency) &&
                 (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&
                 !isOrderPaid &&
                 order.total.compareTo(BigDecimal.ZERO) == 1 &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -4,15 +4,22 @@ import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.extensions.WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.prefs.cardreader.InPersonPaymentsCanadaFeatureFlag
 import java.math.BigDecimal
 import javax.inject.Inject
 
 class CardReaderPaymentCollectibilityChecker @Inject constructor(
-    private val orderDetailRepository: OrderDetailRepository
+    private val orderDetailRepository: OrderDetailRepository,
+    private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
 ) {
     fun isCollectable(order: Order): Boolean {
+        val currencyList = if (inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
+            listOf("usd", "cad")
+        } else {
+            listOf("usd")
+        }
         return with(order) {
-            currency.equals("USD", ignoreCase = true) &&
+            currency.lowercase() in currencyList &&
                 (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&
                 !isOrderPaid &&
                 order.total.compareTo(BigDecimal.ZERO) == 1 &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedChecker.kt
@@ -4,9 +4,9 @@ import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactor
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
-import javax.inject.Inject
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
 
 class CardReaderPaymentCurrencySupportedChecker @Inject constructor(
     private val dispatchers: CoroutineDispatchers,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedChecker.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+class CardReaderPaymentCurrencySupportedChecker @Inject constructor(
+    private val dispatchers: CoroutineDispatchers,
+    private val wooStore: WooCommerceStore,
+    private val selectedSite: SelectedSite,
+    private val cardReaderConfigFactory: CardReaderConfigFactory,
+) {
+    suspend fun isCurrencySupported(currency: String): Boolean {
+        return cardReaderConfigFactory.getCardReaderConfigFor(getStoreCountryCode()).currency == currency
+    }
+
+    private suspend fun getStoreCountryCode(): String? {
+        return withContext(dispatchers.io) {
+            wooStore.getStoreCountryCode(selectedSite.get()) ?: null.also {
+                WooLog.e(WooLog.T.CARD_READER, "Store's country code not found.")
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -51,7 +52,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.Optimist
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.utils.sumBy
 import javax.inject.Inject
-import kotlinx.coroutines.withContext
 
 @OpenClassOnDebug
 @HiltViewModel
@@ -498,7 +498,8 @@ final class OrderDetailViewModel @Inject constructor(
                     orderInfo = OrderInfo(
                         order = order,
                         isPaymentCollectableWithCardReader = isPaymentCollectable,
-                        isReceiptButtonsVisible = FeatureFlag.CARD_READER.isEnabled() && !loadReceiptUrl().isNullOrEmpty()
+                        isReceiptButtonsVisible = FeatureFlag.CARD_READER.isEnabled() &&
+                            !loadReceiptUrl().isNullOrEmpty()
                     ),
                     orderStatus = orderStatus,
                     toolbarTitle = resourceProvider.getString(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -118,6 +118,9 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
         doReturn(site).whenever(selectedSite).getIfExists()
         doReturn(site).whenever(selectedSite).get()
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
+        }
 
         viewModel = spy(
             OrderDetailViewModel(
@@ -155,6 +158,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         val nonRefundedOrder = order.copy(refundTotal = BigDecimal.ZERO)
 
         val expectedViewState = orderWithParameters.copy(orderInfo = orderInfo.copy(order = nonRefundedOrder))
+
+        doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
 
         doReturn(nonRefundedOrder).whenever(repository).getOrderById(any())
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.cardreader
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
-import com.woocommerce.android.ui.prefs.cardreader.InPersonPaymentsCanadaFeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -126,7 +126,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given Canada flag is disabled, when order in Canada, then it is not collectable`() =
+    fun `given Canada IPP flag is disabled, when order in Canada, then it is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             val order = getOrder(currency = "CAD")
             whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
@@ -6,8 +6,6 @@ import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUnSupportedCountry
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
@@ -15,6 +13,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CardReaderPaymentCurrencySupportedCheckerTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.cardreader
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForCanada
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUnSupportedCountry
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlin.test.assertFalse
@@ -84,6 +85,19 @@ class CardReaderPaymentCurrencySupportedCheckerTest : BaseUnitTest() {
             ).thenReturn(CardReaderConfigForUSA)
 
             val isCurrencySupported = cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("CAD")
+
+            assertFalse(isCurrencySupported)
+        }
+
+    @Test
+    fun `given usd currency, when store location in unsupported country, then isCurrencySupported returns false`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn("IN")
+            whenever(
+                cardReaderConfigFactory.getCardReaderConfigFor("IN")
+            ).thenReturn(CardReaderConfigForUnSupportedCountry)
+
+            val isCurrencySupported = cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("USD")
 
             assertFalse(isCurrencySupported)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
@@ -1,0 +1,90 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForCanada
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+class CardReaderPaymentCurrencySupportedCheckerTest : BaseUnitTest() {
+    private val selectedSite: SelectedSite = mock()
+    private val wooStore: WooCommerceStore = mock()
+    private val cardReaderConfigFactory: CardReaderConfigFactory = mock()
+
+    private val site = SiteModel()
+    private val countryCode = "US"
+
+    private val cardReaderPaymentCurrencySupportedChecker = CardReaderPaymentCurrencySupportedChecker(
+        coroutinesTestRule.testDispatchers,
+        wooStore,
+        selectedSite,
+        cardReaderConfigFactory
+    )
+
+    @Before
+    fun setUp() {
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn(countryCode)
+    }
+
+    @Test
+    fun `given usd currency, when store location in USA, then isCurrencySupported returns true`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn("US")
+            whenever(
+                cardReaderConfigFactory.getCardReaderConfigFor("US")
+            ).thenReturn(CardReaderConfigForUSA)
+
+            val isCurrencySupported = cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("USD")
+
+            assertTrue(isCurrencySupported)
+        }
+
+    @Test
+    fun `given usd currency, when store location in Canada, then isCurrencySupported returns false`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
+            whenever(
+                cardReaderConfigFactory.getCardReaderConfigFor("CA")
+            ).thenReturn(CardReaderConfigForCanada)
+
+            val isCurrencySupported = cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("USD")
+
+            assertFalse(isCurrencySupported)
+        }
+
+    @Test
+    fun `given cad currency, when store location in Canada, then isCurrencySupported returns true`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
+            whenever(
+                cardReaderConfigFactory.getCardReaderConfigFor("CA")
+            ).thenReturn(CardReaderConfigForCanada)
+
+            val isCurrencySupported = cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("CAD")
+
+            assertTrue(isCurrencySupported)
+        }
+
+    @Test
+    fun `given cad currency, when store location in USA, then isCurrencySupported returns false`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn("US")
+            whenever(
+                cardReaderConfigFactory.getCardReaderConfigFor("US")
+            ).thenReturn(CardReaderConfigForUSA)
+
+            val isCurrencySupported = cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("CAD")
+
+            assertFalse(isCurrencySupported)
+        }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -324,18 +324,19 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when payment not collectable, then flow terminated and snackbar shown`() {
-        whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(false)
-        val events = mutableListOf<Event>()
-        viewModel.event.observeForever {
-            events.add(it)
-        }
+    fun `when payment not collectable, then flow terminated and snackbar shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(false)
+            val events = mutableListOf<Event>()
+            viewModel.event.observeForever {
+                events.add(it)
+            }
 
-        viewModel.start()
+            viewModel.start()
 
-        assertThat((events[0] as ShowSnackbar).message)
-            .isEqualTo(R.string.card_reader_payment_order_paid_payment_cancelled)
-        assertThat(events[1]).isInstanceOf(Exit::class.java)
+            assertThat((events[0] as ShowSnackbar).message)
+                .isEqualTo(R.string.card_reader_payment_order_paid_payment_cancelled)
+            assertThat(events[1]).isInstanceOf(Exit::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -334,10 +334,13 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             viewModel.start()
 
-            assertThat((events[0] as ShowSnackbar).message)
-                .isEqualTo(R.string.card_reader_payment_order_paid_payment_cancelled)
+            assertThat(
+                (events[0] as ShowSnackbar).message
+            ).isEqualTo(
+                R.string.card_reader_payment_order_paid_payment_cancelled
+            )
             assertThat(events[1]).isInstanceOf(Exit::class.java)
-    }
+        }
 
     @Test
     fun `when flow started, then correct payment description is propagated to CardReaderManager`() =

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -56,6 +56,7 @@ object CardReaderManagerFactory {
                 CancelPaymentAction(terminal),
                 PaymentUtils(),
                 PaymentErrorMapper(),
+                CardReaderConfigFactory()
             ),
             ConnectionManager(
                 terminal,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactory.kt
@@ -10,7 +10,7 @@ class CardReaderConfigFactory {
                 CardReaderConfigForCanada
             }
             else -> {
-                throw IllegalStateException("Invalid country code")
+                CardReaderConfigForUnSupportedCountry
             }
         }
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUnSupportedCountry.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUnSupportedCountry.kt
@@ -9,9 +9,9 @@ object CardReaderConfigForUnSupportedCountry : CardReaderConfig {
     override val countryCode: String
         get() = "N/A"
     override val supportedReaders: List<SpecificReader>
-        get() = listOf()
+        get() = emptyList()
     override val paymentMethodType: List<PaymentMethodType>
-        get() = listOf()
+        get() = emptyList()
     override val isStripeExtensionSupported: Boolean
         get() = false
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUnSupportedCountry.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUnSupportedCountry.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.cardreader.internal.config
+
+import com.stripe.stripeterminal.external.models.PaymentMethodType
+import com.woocommerce.android.cardreader.connection.SpecificReader
+
+object CardReaderConfigForUnSupportedCountry : CardReaderConfig {
+    override val currency: String
+        get() = "NA"
+    override val countryCode: String
+        get() = "NA"
+    override val supportedReaders: List<SpecificReader>
+        get() = listOf()
+    override val paymentMethodType: List<PaymentMethodType>
+        get() = listOf()
+    override val isStripeExtensionSupported: Boolean
+        get() = false
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUnSupportedCountry.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUnSupportedCountry.kt
@@ -5,9 +5,9 @@ import com.woocommerce.android.cardreader.connection.SpecificReader
 
 object CardReaderConfigForUnSupportedCountry : CardReaderConfig {
     override val currency: String
-        get() = "NA"
+        get() = "N/A"
     override val countryCode: String
-        get() = "NA"
+        get() = "N/A"
     override val supportedReaders: List<SpecificReader>
         get() = listOf()
     override val paymentMethodType: List<PaymentMethodType>

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -5,6 +5,7 @@ import com.stripe.stripeterminal.external.models.PaymentIntentStatus
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.CANCELED
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.internal.payments.actions.CancelPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus
@@ -150,7 +151,10 @@ internal class PaymentManager(
 
     private suspend fun FlowCollector<CardPaymentStatus>.isInvalidState(paymentInfo: PaymentInfo) =
         when {
-            !paymentUtils.isSupportedCurrency(paymentInfo.currency) -> {
+            !paymentUtils.isSupportedCurrency(
+                paymentInfo.currency,
+                CardReaderConfigFactory().getCardReaderConfigFor(paymentInfo.countryCode)
+            ) -> {
                 emit(errorMapper.mapError(errorMessage = "Unsupported currency: $paymentInfo.currency"))
                 true
             }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -35,6 +35,7 @@ internal class PaymentManager(
     private val cancelPaymentAction: CancelPaymentAction,
     private val paymentUtils: PaymentUtils,
     private val errorMapper: PaymentErrorMapper,
+    private val cardReaderConfigFactory: CardReaderConfigFactory,
 ) {
     suspend fun acceptPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus> = flow {
         if (isInvalidState(paymentInfo)) return@flow
@@ -153,7 +154,7 @@ internal class PaymentManager(
         when {
             !paymentUtils.isSupportedCurrency(
                 paymentInfo.currency,
-                CardReaderConfigFactory().getCardReaderConfigFor(paymentInfo.countryCode)
+                cardReaderConfigFactory.getCardReaderConfigFor(paymentInfo.countryCode)
             ) -> {
                 emit(errorMapper.mapError(errorMessage = "Unsupported currency: $paymentInfo.currency"))
                 true

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtils.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtils.kt
@@ -1,9 +1,9 @@
 package com.woocommerce.android.cardreader.internal.payments
 
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfig
 import java.math.BigDecimal
 import java.math.RoundingMode
 
-private const val USD_CURRENCY = "usd"
 internal const val USD_TO_CENTS_DECIMAL_PLACES = 2
 
 internal class PaymentUtils {
@@ -17,6 +17,10 @@ internal class PaymentUtils {
             .longValueExact()
     }
 
-    // TODO Add Support for other currencies
-    fun isSupportedCurrency(currency: String): Boolean = currency.equals(USD_CURRENCY, ignoreCase = true)
+    fun isSupportedCurrency(
+        currency: String,
+        cardReaderConfig: CardReaderConfig
+    ): Boolean = currency.equals(
+        cardReaderConfig.currency, ignoreCase = true
+    )
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
@@ -35,10 +35,13 @@ class CardReaderConfigFactoryTest {
         assertThat(cardReaderConfig).isInstanceOf(expectedCardReaderConfig::class.java)
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun `given invalid country code, then exception is thrown`() {
+    @Test
+    fun `given unsupported country code, then unsupported country card reader config is returned`() {
         val countryCode = "invalid country code"
+        val expectedCardReaderConfig = CardReaderConfigForUnSupportedCountry
 
-        cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
+        val cardReaderConfig = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
+
+        assertThat(cardReaderConfig).isInstanceOf(expectedCardReaderConfig::class.java)
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -120,13 +120,13 @@ class PaymentManagerTest {
             .thenReturn(PaymentFailed(CardPaymentStatusErrorType.Generic, null, ""))
         whenever(paymentErrorMapper.mapError(anyOrNull(), anyOrNull()))
             .thenReturn(PaymentFailed(CardPaymentStatusErrorType.Generic, null, ""))
-        whenever(paymentUtils.isSupportedCurrency(any())).thenReturn(true)
+        whenever(paymentUtils.isSupportedCurrency(any(), any())).thenReturn(true)
     }
 
     // BEGIN - Arguments validation and conversion
     @Test
     fun `when currency not supported, then error emitted`() = runBlockingTest {
-        whenever(paymentUtils.isSupportedCurrency(any())).thenReturn(false)
+        whenever(paymentUtils.isSupportedCurrency(any(), any())).thenReturn(false)
         val result = manager.acceptPayment(createPaymentInfo(currency = NONE_USD_CURRENCY)).single()
 
         assertThat(result).isInstanceOf(PaymentFailed::class.java)
@@ -134,7 +134,7 @@ class PaymentManagerTest {
 
     @Test
     fun `when currency supported, then flow initiated`() = runBlockingTest {
-        whenever(paymentUtils.isSupportedCurrency(any())).thenReturn(true)
+        whenever(paymentUtils.isSupportedCurrency(any(), any())).thenReturn(true)
         val result = manager.acceptPayment(createPaymentInfo())
             .takeUntil(InitializingPayment::class).toList()
 
@@ -534,6 +534,7 @@ class PaymentManagerTest {
         customerId: String? = null,
         orderKey: String? = null,
         statementDescriptor: String? = null,
+        countryCode: String = "US"
     ): PaymentInfo =
         PaymentInfo(
             paymentDescription = paymentDescription,
@@ -547,5 +548,6 @@ class PaymentManagerTest {
             customerId = customerId,
             orderKey = orderKey,
             statementDescriptor = statementDescriptor,
+            countryCode = countryCode,
         )
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -10,6 +10,8 @@ import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_PA
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.internal.payments.actions.CancelPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus
@@ -77,6 +79,7 @@ class PaymentManagerTest {
     private val cancelPaymentAction: CancelPaymentAction = mock()
     private val paymentErrorMapper: PaymentErrorMapper = mock()
     private val paymentUtils: PaymentUtils = mock()
+    private val cardReaderConfigFactory: CardReaderConfigFactory = mock()
 
     private val expectedSequence = listOf(
         InitializingPayment::class,
@@ -97,6 +100,7 @@ class PaymentManagerTest {
             cancelPaymentAction,
             paymentUtils,
             paymentErrorMapper,
+            cardReaderConfigFactory,
         )
         whenever(terminalWrapper.isInitialized()).thenReturn(true)
         whenever(createPaymentAction.createPaymentIntent(any()))
@@ -120,6 +124,7 @@ class PaymentManagerTest {
             .thenReturn(PaymentFailed(CardPaymentStatusErrorType.Generic, null, ""))
         whenever(paymentErrorMapper.mapError(anyOrNull(), anyOrNull()))
             .thenReturn(PaymentFailed(CardPaymentStatusErrorType.Generic, null, ""))
+        whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForUSA)
         whenever(paymentUtils.isSupportedCurrency(any(), any())).thenReturn(true)
     }
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtilsTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtilsTest.kt
@@ -1,5 +1,9 @@
 package com.woocommerce.android.cardreader.internal.payments
 
+import com.stripe.stripeterminal.external.models.PaymentMethodType
+import com.woocommerce.android.cardreader.connection.SpecificReader
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfig
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -15,15 +19,27 @@ class PaymentUtilsTest {
     private val paymentUtils = PaymentUtils()
 
     @Test
-    fun `given currency not USD, when is currency supported invoked, then false returned`() = runBlockingTest {
-        val result = paymentUtils.isSupportedCurrency(NONE_USD_CURRENCY)
+    fun `given not supported country, when is currency supported invoked, then false returned`() = runBlockingTest {
+        val nonSupportedCountry = object : CardReaderConfig {
+            override val currency: String
+                get() = ""
+            override val countryCode: String
+                get() = ""
+            override val supportedReaders: List<SpecificReader>
+                get() = listOf()
+            override val paymentMethodType: List<PaymentMethodType>
+                get() = listOf()
+            override val isStripeExtensionSupported: Boolean
+                get() = false
+        }
+        val result = paymentUtils.isSupportedCurrency(NONE_USD_CURRENCY, nonSupportedCountry)
 
         assertThat(result).isFalse()
     }
 
     @Test
-    fun `given currency USD, when is currency supported invoked, then true returned`() = runBlockingTest {
-        val result = paymentUtils.isSupportedCurrency(USD_CURRENCY)
+    fun `given supported country, when is currency supported invoked, then true returned`() = runBlockingTest {
+        val result = paymentUtils.isSupportedCurrency(USD_CURRENCY, CardReaderConfigForUSA)
 
         assertThat(result).isTrue()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5841 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR Modifies the logic of the currency selection to support Canada wherever necessary in our project. Right now the currency is hardcoded to USD in the below files.

- `PaymentUtils.kt`
- `CardReaderPaymentCollectibilityChecker.kt`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Smoke test In-Person Payments with the US store and make sure payment succeeds


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
