### PR TITLE
Issue/5852 fix crash on initial order creation customer edit

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
@@ -40,6 +41,7 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
     private val addressViewModel: AddressViewModel by viewModels()
     private val sharedViewModel by hiltNavGraphViewModels<OrderCreationViewModel>(R.id.nav_graph_order_creations)
 
+    private var fragmentViewBinding: FragmentCreationEditCustomerAddressBinding? = null
     private var shippingBinding: LayoutAddressFormBinding? = null
     private var billingBinding: LayoutAddressFormBinding? = null
     private var showShippingAddressFormSwitch: LayoutAddressSwitchBinding? = null
@@ -75,6 +77,8 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
 
     private fun observeViewState() {
         addressViewModel.viewStateData.observe(viewLifecycleOwner) { _, new ->
+            fragmentViewBinding?.progressIndicator?.isVisible = new.isLoading
+
             val newBilling = new.addressSelectionStates[BILLING]
             val newShipping = new.addressSelectionStates[SHIPPING]
 
@@ -136,10 +140,13 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
 
         showShippingAddressFormSwitch = LayoutAddressSwitchBinding.inflate(layoutInflater)
 
-        FragmentCreationEditCustomerAddressBinding.bind(view).container.apply {
-            addView(billingBinding?.root)
-            addView(showShippingAddressFormSwitch?.root)
-            addView(shippingBinding?.root)
+        fragmentViewBinding = FragmentCreationEditCustomerAddressBinding.bind(view)
+        fragmentViewBinding?.container.apply {
+            if (this != null) {
+                addView(billingBinding?.root)
+                addView(showShippingAddressFormSwitch?.root)
+                addView(shippingBinding?.root)
+            }
         }
 
         updateShippingBindingVisibility(showShippingAddressFormSwitch?.addressSwitch?.isChecked ?: false)
@@ -254,6 +261,7 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
 
     override fun onDestroyView() {
         super.onDestroyView()
+        fragmentViewBinding = null
         shippingBinding = null
         billingBinding = null
         showShippingAddressFormSwitch = null

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -15,11 +14,19 @@
 
     </ScrollView>
 
-    <ProgressBar
+    <FrameLayout
         android:id="@+id/progressBar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/grey_c_30"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+    </FrameLayout>
+
 </FrameLayout>

--- a/WooCommerce/src/main/res/layout/fragment_creation_edit_customer_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_creation_edit_customer_address.xml
@@ -1,12 +1,30 @@
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/scroll"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
-    <LinearLayout
-        android:id="@+id/container"
+    <ScrollView
+        android:id="@+id/scroll"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical" />
+        android:layout_height="match_parent">
 
-</ScrollView>
+        <LinearLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </ScrollView>
+
+    <FrameLayout
+        android:id="@+id/progress_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/grey_c_30"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+    </FrameLayout>
+</FrameLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5852 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a hotfix for reproduction scenario described in #5852.

Ideally, as `Location` is now integral part of `Order` (aggregation happens there), we should really make sure that correct `Location` is assigned to `Order` in a moment of mapping. So we should fetch `Location`s if needed then, not in `AddressViewModel`.

But for now, this is a quick fix for an issue that can happen for clients.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Fresh install app or remove `WCLocations` data from database `DELETE FROM WCLocations`
2. Open order creation customer edit *or* order details address edit
3. Try to edit any field imidiatelly
4. **Assert there's progressbar and you can't edit text while it's visible**

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5845095/153721528-20ddd769-ec85-4d03-97c4-15d8cc2fbfd3.mov


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
