### PR TITLE
Remove duplicated simple payments destinations

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -13,31 +13,6 @@
             android:id="@+id/action_myStore_to_jetpackBenefitsDialog"
             app:destination="@id/nav_graph_jetpack_install" />
     </fragment>
-    <dialog
-        android:id="@+id/simplePaymentsDialog"
-        android:name="com.woocommerce.android.ui.orders.simplepayments.SimplePaymentsDialog"
-        android:label="SimplePaymentsDialog" />
-    <fragment
-        android:id="@+id/simplePaymentsFragment"
-        android:name="com.woocommerce.android.ui.orders.simplepayments.SimplePaymentsFragment"
-        android:label="SimplePaymentsFragment">
-        <argument
-            android:name="order"
-            app:argType="com.woocommerce.android.model.Order"
-            app:nullable="false" />
-        <action
-            android:id="@+id/action_simplePaymentsFragment_to_simplePaymentsCustomerNoteFragment"
-            app:destination="@id/simplePaymentsCustomerNoteFragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/simplePaymentsCustomerNoteFragment"
-        android:name="com.woocommerce.android.ui.orders.simplepayments.SimplePaymentsCustomerNoteFragment"
-        android:label="SimplePaymentsCustomerNoteFragment">
-        <argument
-            android:name="customerNote"
-            android:defaultValue='""'
-            app:argType="string" />
-    </fragment>
     <fragment
         android:id="@+id/orders"
         android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"


### PR DESCRIPTION
### Description
@hafizrahman reported an intermittent build issue on Slack (p1644651121416469-slack-CGPNUU63E), after digging on the root cause, it turned out the simple payment destinations were duplicated, as they were deleted in this [PR](https://github.com/woocommerce/woocommerce-android/pull/5633), but they were brought back after a conflict fix in this [PR](https://github.com/woocommerce/woocommerce-android/pull/5373).

### Testing instructions
The removal of those destinations seems to not enforce generating the Directions/NavArgs code, so to confirm this works as expected, please follow these steps:
1. Checkout this branch.
2. Run the command `./gradlew :WooCommerce:generateSafeArgsWasabiDebug --rerun-tasks` (replace Wasabi with the flavor you are using) to force re-generating the navigation classes.
3. Run the app.
4. Open the simple payments flow, and confirm everything works as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->