### PR TITLE
[Order Creation] display variation attributes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -69,15 +69,19 @@ class OrderCreationProductsAdapter(
             }
 
             binding.productAttributes.text = buildString {
-                if (productModel.isStockManaged) {
-                    append(
-                        context.getString(
-                            R.string.order_creation_product_stock_quantity,
-                            productModel.stockQuantity.formatToString()
-                        )
-                    )
+                if (productModel.item.isVariation && productModel.item.attributesDescription.isNotEmpty()) {
+                    append(productModel.item.attributesDescription)
                 } else {
-                    append(context.getString(R.string.order_creation_product_instock))
+                    if (productModel.isStockManaged) {
+                        append(
+                            context.getString(
+                                R.string.order_creation_product_stock_quantity,
+                                productModel.stockQuantity.formatToString()
+                            )
+                        )
+                    } else {
+                        append(context.getString(R.string.order_creation_product_instock))
+                    }
                 }
                 append(" • ")
                 append(currencyFormatter(productModel.item.total))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -84,7 +84,7 @@ class OrderCreationProductsAdapter(
                     }
                 }
                 append(" • ")
-                append(currencyFormatter(productModel.item.total))
+                append(currencyFormatter(productModel.item.total).replace(" ", "\u00A0"))
             }
 
             binding.productSku.text =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -43,7 +43,7 @@ class OrderCreationProductsAdapter(
     inner class ProductViewHolder(private val binding: OrderCreationProductItemBinding) : ViewHolder(binding.root) {
         private val context = binding.root.context
         private val safePosition: Int?
-            get() = adapterPosition.takeIf { it != NO_POSITION }
+            get() = bindingAdapterPosition.takeIf { it != NO_POSITION }
 
         init {
             binding.root.setOnClickListener {


### PR DESCRIPTION
Closes: #5766 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the product list in the order creation form to display the attributes of variations.
**A question**: when a variation doesn't have any attributes (I mean all attributes are set to `Any`) should we continue to show the stock status the same as I did on this PR, or should we just hide it? cc @shiki @adamzelinski @rachelmcr (for iOS comparison)

### Testing instructions
1. Open the order creation form.
2. Click on Add product.
3. Select a variable product, and pick a variation.
4. Confirm the variation attributes are displayed.

### Images/gif
This shows a variation with attributes and a variation without attributes:
<img width=400 src="https://user-images.githubusercontent.com/1657201/154096341-cf1946b1-47fe-4b3a-97f5-7afd671f3645.png"/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
