### PR TITLE
Add Buildkite Installable Builds

### DIFF
--- a/.buildkite/commands/installable-build.sh
+++ b/.buildkite/commands/installable-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :hammer_and_wrench: Building"
+bundle exec fastlane build_and_upload_installable_build

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.5.0
+    - automattic/bash-cache#2.1.0
 
 steps:
   - label: "checkstyle"
@@ -51,4 +51,9 @@ steps:
       echo "--- ⚒️ Building"
       cp gradle.properties-example gradle.properties
       ./gradlew assembleVanillaDebugAndroidTest
+    plugins: *common_plugins
+
+  - label: "🛠 Installable Build"
+    command: ".buildkite/commands/installable-build.sh"
+    if: "build.pull_request.id != null || build.pull_request.draft"
     plugins: *common_plugins

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,6 @@ workflows:
       - Lint
       - Dependency Tree Diff
       - Test
-      - Installable Build
       - Ensure Screenshots Tests Build
       - Connected Tests:
           name: UI Tests (Pixel 2 | API 28)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,29 @@
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: 2bc269ecada46f8f1abcd8e23cdd410cd5c1d9aa
+  branch: add/s3-binary-upload
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (3.0.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      buildkit (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (5.2.6)
+    activesupport (5.2.6.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -30,6 +50,8 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     bigdecimal (1.4.4)
+    buildkit (1.4.5)
+      sawyer (>= 0.6)
     chroma (0.2.0)
     claide (1.1.0)
     colored (1.2)
@@ -114,21 +136,8 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (2.3.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
-    git (1.9.1)
+    git (1.10.2)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.16.0)
       google-apis-core (>= 0.4, < 2.a)
@@ -172,7 +181,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.11)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jmespath (1.5.0)
     json (2.6.1)
@@ -183,19 +192,19 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.7.1)
     minitest (5.15.0)
     multi_json (1.15.0)
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
-    octokit (4.21.0)
+    octokit (4.22.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.13.10)
+    oj (3.13.11)
     optimist (3.0.1)
     options (2.3.2)
     optparse (0.1.1)
@@ -208,7 +217,7 @@ GEM
     public_suffix (4.0.6)
     racc (1.6.0)
     rake (13.0.6)
-    rake-compiler (1.1.6)
+    rake-compiler (1.1.9)
       rake
     rchardet (1.8.0)
     representable (3.1.1)
@@ -267,7 +276,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 2)
+  fastlane-plugin-wpmreleasetoolkit!
   nokogiri
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 2bc269ecada46f8f1abcd8e23cdd410cd5c1d9aa
-  branch: add/s3-binary-upload
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (3.0.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      buildkit (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -136,6 +116,20 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-wpmreleasetoolkit (3.1.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      buildkit (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
     git (1.10.2)
       rchardet (~> 1.8)
@@ -276,7 +270,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 3.1)
   nokogiri
 
 BUNDLED WITH

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,18 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_086"
+msgid ""
+"8.6:\n"
+"This release contains a helpful feature for merchants looking to record a quick monetary transaction that we call simple payments. Quickly take an in-person credit card payment or send your customer a payment link to your site!\n"
+"\n"
+"You’ll also see we changed the tabs a bit and added a “More” tab. Store settings and a few other things were moved there to prepare for more features!\n"
+msgstr ""
+
 msgctxt "release_note_085"
 msgid ""
 "8.5:\n"
 "You’ve been asking to create orders in the app. We’re happy to say we have a sneak peek ready if you want to help us test it out! Head over to settings in the app and turn on the beta feature for Order Creation. Right now, you can add products, notes, and addresses, and future releases will have additional functionality.\n"
-msgstr ""
-
-msgctxt "release_note_084"
-msgid ""
-"8.4:\n"
-"We’re in the process of refreshing the look of the app! You’ll notice some nice visual changes to the sales graph in My Store and a new conversion calculation. We’re also no longer rounding the sales totals to provide greater clarity. This isn’t the last of it – more updates to come in the next few weeks!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,3 @@
-You’ve been asking to create orders in the app. We’re happy to say we have a sneak peek ready if you want to help us test it out! Head over to settings in the app and turn on the beta feature for Order Creation. Right now, you can add products, notes, and addresses, and future releases will have additional functionality.
+This release contains a helpful feature for merchants looking to record a quick monetary transaction that we call simple payments. Quickly take an in-person credit card payment or send your customer a payment link to your site!
+
+You’ll also see we changed the tabs a bit and added a “More” tab. Store settings and a few other things were moved there to prepare for more features!

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -589,6 +589,7 @@ platform :android do
       )
     )    
   end
+
   #####################################################################################
   # build_apk
   # -----------------------------------------------------------------------------------
@@ -616,7 +617,7 @@ platform :android do
 
     install_url = "#{INSTALLABLE_BUILD_DOMAIN}/#{upload_path}"
     qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{URI::encode( install_url )}&choe=UTF-8"
-    comment_body = "You can test the changes on this Pull Request by <a href='#{install_url}'>downloading an installable build</a>, or scanning this QR code: <a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a>"
+    comment_body = "You can test the changes on this Pull Request by <a href='#{install_url}'>downloading an installable build</a>, or scanning this QR code:<br><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a>"
 
     comment_on_pr(
       project: 'woocommerce/woocommerce-android',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,6 +16,7 @@ end
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
 INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
+RELEASE_NOTES_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata', 'release_notes.txt')
 
 ########################################################################
 # Environment
@@ -78,9 +79,11 @@ platform :android do
     android_bump_version_release()
     new_version = android_get_app_version()
 
-    extract_release_notes_for_version(version: new_version,
+    extract_release_notes_for_version(
+      version: new_version,
       release_notes_file_path:"#{PROJECT_ROOT_FOLDER}/RELEASE-NOTES.txt",
-      extracted_notes_file_path:release_notes_path)
+      extracted_notes_file_path:RELEASE_NOTES_PATH
+    )
     android_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
@@ -666,7 +669,7 @@ platform :android do
     create_release(
       repository: GHHELPER_REPO,
       version: version["name"],
-      release_notes_file_path: release_notes_path,
+      release_notes_file_path: RELEASE_NOTES_PATH,
       prerelease: prerelease,
       release_assets: release_assets.join(',')
     )
@@ -681,10 +684,6 @@ platform :android do
   #####################################################################################
   # Utils
   #####################################################################################
-  def release_notes_path
-    "#{PROJECT_ROOT_FOLDER}/WooCommerce/metadata/release_notes.txt"
-  end
-
   def aab_file_name(version)
     "wcandroid-#{version["name"]}.aab"
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,13 @@ before_all do |lane|
 end
 
 ########################################################################
+# Constants
+########################################################################
+PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
+BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
+INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
+
+########################################################################
 # Environment
 ########################################################################
 Dotenv.load('~/.wcandroid-env.default')
@@ -72,7 +79,7 @@ platform :android do
     new_version = android_get_app_version()
 
     extract_release_notes_for_version(version: new_version,
-      release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt",
+      release_notes_file_path:"#{PROJECT_ROOT_FOLDER}/RELEASE-NOTES.txt",
       extracted_notes_file_path:release_notes_path)
     android_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
@@ -284,8 +291,7 @@ platform :android do
     version = android_get_release_version()
     build_bundle(version: version, flavor:"Vanilla")
 
-    project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
-    aab_file_path = File.join(project_root, "artifacts", aab_file_name(version))
+    aab_file_path = File.join(PROJECT_ROOT_FOLDER, "artifacts", aab_file_name(version))
 
     UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
 
@@ -327,9 +333,7 @@ platform :android do
     version = android_get_release_version()
     build_bundle(version: version, flavor:"Vanilla")
 
-    project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
-    aab_file_path = File.join(project_root, "artifacts", aab_file_name(version))
-
+    aab_file_path = File.join(PROJECT_ROOT_FOLDER, "artifacts", aab_file_name(version))
     UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
 
     upload_to_play_store(
@@ -586,6 +590,43 @@ platform :android do
     )    
   end
   #####################################################################################
+  # build_apk
+  # -----------------------------------------------------------------------------------
+  # This lane builds an apk
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_apk
+  #####################################################################################
+  desc "Builds an APK"
+  lane :build_and_upload_installable_build do | options |
+
+    UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
+
+    gradle(
+      task: "assemble",
+      flavor: "Jalapeno",
+      build_type: "Release"
+    )
+
+    upload_path = upload_to_s3(
+      bucket: 'a8c-apps-public-artifacts',
+      key: "woocommerce-installable-build-#{generate_installable_build_number}.apk",
+      file: lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+    )
+
+    install_url = "#{INSTALLABLE_BUILD_DOMAIN}/#{upload_path}"
+    qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{URI::encode( install_url )}&choe=UTF-8"
+    comment_body = "You can test the changes on this Pull Request by <a href='#{install_url}'>downloading an installable build</a>, or scanning this QR code: <a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a>"
+
+    comment_on_pr(
+      project: 'woocommerce/woocommerce-android',
+      pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
+      reuse_identifier: 'installable-build-link',
+      body: comment_body
+    ) unless ENV['BUILDKITE_PULL_REQUEST'].nil?
+  end
+
+  #####################################################################################
   # Private lanes
   #####################################################################################
   private_lane :delete_old_changelogs do | options |
@@ -615,12 +656,10 @@ platform :android do
     version = options[:version]
     prerelease = options[:prerelease] || false
 
-    project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
-
     # APKs built on CI are not signed with master key, which means Google Sign-In won't work with those.
     # So don't attach them to the release, as this ends up being confusing for beta-testers.
-    apk_file_path = File.join(project_root, 'artifacts', universal_apk_name(version)) unless is_ci
-    aab_file_path = File.join(project_root, 'artifacts', aab_file_name(version))
+    apk_file_path = File.join(PROJECT_ROOT_FOLDER, 'artifacts', universal_apk_name(version)) unless is_ci
+    aab_file_path = File.join(PROJECT_ROOT_FOLDER, 'artifacts', aab_file_name(version))
     release_assets = [apk_file_path, aab_file_path].compact
 
     create_release(
@@ -642,7 +681,7 @@ platform :android do
   # Utils
   #####################################################################################
   def release_notes_path
-    "#{ENV["PROJECT_ROOT_FOLDER"]}WooCommerce/metadata/release_notes.txt"
+    "#{PROJECT_ROOT_FOLDER}/WooCommerce/metadata/release_notes.txt"
   end
 
   def aab_file_name(version)
@@ -651,5 +690,23 @@ platform :android do
 
   def universal_apk_name(version)
     "wcandroid-#{version["name"]}-universal.apk"
+  end
+
+  # This function is Buildkite-specific
+  def generate_installable_build_number
+
+    if ENV['BUILDKITE']
+      commit = ENV['BUILDKITE_COMMIT'][0,7]
+      branch = ENV['BUILDKITE_BRANCH'].parameterize
+      pr_num = ENV['BUILDKITE_PULL_REQUEST']
+
+      return pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"
+    else
+      repo = Git.open(PROJECT_ROOT_FOLDER)
+      commit = repo.current_branch.parameterize
+      branch = repo.revparse('HEAD')[0, 7]
+
+      return "#{branch}-#{commit}"
+    end
   end
 end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 2'
+#gem 'fastlane-plugin-wpmreleasetoolkit', '~> 2'
+#gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'add/s3-binary-upload'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,6 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-#gem 'fastlane-plugin-wpmreleasetoolkit', '~> 2'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 3.1'
 #gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'add/s3-binary-upload'
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'add/s3-binary-upload'


### PR DESCRIPTION
Adds Installable Build Support on each PR (including the nice QR-code-to-download functionality).

This PR depends on these changes, and will need fixes before it can be merged:
https://github.com/Automattic/bash-cache-buildkite-plugin/pull/18/files
https://github.com/wordpress-mobile/release-toolkit/pull/339

**To Test:**
- Verify that the installable build task is successful.
- Verify that the installable build link downloads the APK file.
- Verify that the QR code works on an Android device, and that the app can be downloaded and run.
- Verify that CircleCI doesn't offer the option for an installable build in this PR.