### PR TITLE
Fix plugin in test mode with live account tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTracker.kt
@@ -78,7 +78,8 @@ class CardReaderTracker @Inject constructor(
             is CardReaderOnboardingState.StripeAccountRejected -> "account_rejected"
             is CardReaderOnboardingState.StripeAccountUnderReview -> "account_under_review"
             is CardReaderOnboardingState.StripeAccountCountryNotSupported -> "account_country_not_supported"
-            is CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount -> "wcpay_in_test_mode_with_live_account"
+            is CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount ->
+                "${getPluginNameReasonPrefix(state.preferredPlugin)}_in_test_mode_with_live_account"
             is CardReaderOnboardingState.WcpayNotActivated -> "wcpay_not_activated"
             is CardReaderOnboardingState.WcpayNotInstalled -> "wcpay_not_installed"
             is CardReaderOnboardingState.SetupNotCompleted ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -91,7 +91,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                             )
                     }
                 is CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount ->
-                    viewState.value = OnboardingViewState.StripeAcountError.WCPayInTestModeWithLiveAccountState(
+                    viewState.value = OnboardingViewState.StripeAcountError.PluginInTestModeWithLiveAccountState(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
                     )
@@ -327,7 +327,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_account_overdue_requirements_hint)
             )
 
-            data class WCPayInTestModeWithLiveAccountState(
+            data class PluginInTestModeWithLiveAccountState(
                 override val onContactSupportActionClicked: () -> Unit,
                 override val onLearnMoreActionClicked: () -> Unit
             ) : StripeAcountError(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
@@ -220,7 +220,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when onboarding PluginInTestModeWithLiveStripeAccount, then reason=wcpay_in_test_mode_with_live_account`() =
+    fun `when wcpay in test mode with live account, then wcpay_in_test_mode_with_live_account`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             cardReaderTracker
                 .trackOnboardingState(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(mock()))
@@ -228,6 +228,18 @@ class CardReaderTrackerTest : BaseUnitTest() {
             verify(trackerWrapper).track(
                 eq(CARD_PRESENT_ONBOARDING_NOT_COMPLETED),
                 check { assertThat(it["reason"]).isEqualTo("wcpay_in_test_mode_with_live_account") }
+            )
+        }
+
+    @Test
+    fun `when stripe in test mode with live account, then stripe_extension_in_test_mode_with_live_account`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            cardReaderTracker
+                .trackOnboardingState(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(mock()))
+
+            verify(trackerWrapper).track(
+                eq(CARD_PRESENT_ONBOARDING_NOT_COMPLETED),
+                check { assertThat(it["reason"]).isEqualTo("stripe_extension_in_test_mode_with_live_account") }
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
@@ -223,7 +223,9 @@ class CardReaderTrackerTest : BaseUnitTest() {
     fun `when wcpay in test mode with live account, then wcpay_in_test_mode_with_live_account`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             cardReaderTracker
-                .trackOnboardingState(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(mock()))
+                .trackOnboardingState(
+                    CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(WOOCOMMERCE_PAYMENTS)
+                )
 
             verify(trackerWrapper).track(
                 eq(CARD_PRESENT_ONBOARDING_NOT_COMPLETED),
@@ -235,7 +237,9 @@ class CardReaderTrackerTest : BaseUnitTest() {
     fun `when stripe in test mode with live account, then stripe_extension_in_test_mode_with_live_account`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             cardReaderTracker
-                .trackOnboardingState(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(mock()))
+                .trackOnboardingState(
+                    CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(STRIPE_EXTENSION_GATEWAY)
+                )
 
             verify(trackerWrapper).track(
                 eq(CARD_PRESENT_ONBOARDING_NOT_COMPLETED),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -234,7 +234,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
-                StripeAcountError.WCPayInTestModeWithLiveAccountState::class.java
+                StripeAcountError.PluginInTestModeWithLiveAccountState::class.java
             )
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates `wcpay_in_test_mode_with_live_account` attribute so it includes either `wcpay` or `stripe_extension` prefix depending on the used plugin. The app already does this for some of the other events, eg:
```
is CardReaderOnboardingState.SetupNotCompleted ->
    "${getPluginNameReasonPrefix(state.preferredPlugin)}_not_setup"
is CardReaderOnboardingState.PluginUnsupportedVersion ->
    "${getPluginNameReasonPrefix(state.preferredPlugin)}_unsupported_version"
```

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Running the unit tests should be enough. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No user facing changes.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
