### PR TITLE
Enable Stripe Extension feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 8.6
 -----
-
+- [**] In-Person Payments: Add support for Stripe by WooCommerce extension
 
 8.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 const val SUPPORTED_WCPAY_VERSION = "3.2.1"
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-const val SUPPORTED_STRIPE_EXTENSION_VERSION = "5.8.1"
+const val SUPPORTED_STRIPE_EXTENSION_VERSION = "6.2.0"
 
 class CardReaderOnboardingChecker @Inject constructor(
     private val selectedSite: SelectedSite,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -23,7 +23,7 @@ enum class FeatureFlag {
             ORDER_CREATION_M2 -> false
             JETPACK_CP,
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
-            PAYMENTS_STRIPE_EXTENSION -> false
+            PAYMENTS_STRIPE_EXTENSION -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
             ORDER_FILTERS,
             ANALYTICS_HUB,
             IN_PERSON_PAYMENTS_CANADA -> PackageUtils.isDebugBuild()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -23,7 +23,8 @@ enum class FeatureFlag {
             ORDER_CREATION_M2 -> false
             JETPACK_CP,
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
-            PAYMENTS_STRIPE_EXTENSION -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
+            // Keeping the flag for a few sprints so we can quickly disable the feature if needed
+            PAYMENTS_STRIPE_EXTENSION -> true
             ORDER_FILTERS,
             ANALYTICS_HUB,
             IN_PERSON_PAYMENTS_CANADA -> PackageUtils.isDebugBuild()


### PR DESCRIPTION
Closes #5504
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables support for IPP via Stripe Extension for all users. It also bumps the minimum required version of Stripe Extension to 6.2.0.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Verify "outdated plugin" screen is shown for versions < 6.2.0
2. Verify "outdated plugin" screen is NOT shown for version 6.2.0 - [woocommerce-gateway-stripe.zip](https://github.com/woocommerce/woocommerce-android/files/8080759/woocommerce-gateway-stripe.zip)

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
