### PR TITLE
issue/5850-sp-disappearing-customer-note

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -74,7 +74,6 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
         }
 
     init {
-        viewState = viewState.copy(customerNote = order.customerNote)
         val hasTaxes = order.totalTax > BigDecimal.ZERO
         updateViewState(hasTaxes)
     }


### PR DESCRIPTION
Fixes [this sub-issue](https://github.com/woocommerce/woocommerce-android/issues/5850#issuecomment-1042004054) of #5850. To test,

- Make sure "Don't keep activities" is enabled
- Switch to `trunk`
- Go to the order list
- Press the FAB and choose to create a simple payment
- Enter an amount
- In the next screen, add a customer note
- Background the app
- Notice the customer note is lost when you return to the app

Next, switch to this branch and confirm the note is retained.