### PR TITLE
Issue/5850 sp truncated customer note

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_simple_payments.xml
+++ b/WooCommerce/src/main/res/layout/fragment_simple_payments.xml
@@ -8,8 +8,9 @@
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginBottom="@dimen/major_100">
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/containerButton"
+        app:layout_constraintTop_toTopOf="parent">
 
         <LinearLayout
             android:id="@+id/container"
@@ -217,6 +218,7 @@
     </ScrollView>
 
     <FrameLayout
+        android:id="@+id/containerButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/color_surface"

--- a/WooCommerce/src/main/res/layout/fragment_simple_payments.xml
+++ b/WooCommerce/src/main/res/layout/fragment_simple_payments.xml
@@ -8,7 +8,8 @@
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_marginBottom="@dimen/major_100">
 
         <LinearLayout
             android:id="@+id/container"


### PR DESCRIPTION
Closes #5850 - prior to this fix, long customer notes in simple payments could be cut off. Using @shiki's sample text below, copy & paste it into a simple payment customer note in `trunk`:

```
Alpha

Bravo

Charlie

Delta

Echo

Foxtrot

Golf

Hotel

Juliett
```

Then note how the text is cut off, like this:

![before](https://user-images.githubusercontent.com/3903757/154353253-48773a60-f6ce-4965-8419-a08ea275c2d8.png)

Next switch to this branch, do the same thing, and note the text is no longer cut off:

![after](https://user-images.githubusercontent.com/3903757/154353311-c82d4649-bc89-4dbb-8dcf-39b1f9f68298.png)


