### PR TITLE
Enable Gradle Build Scans on CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,3 +173,15 @@ tasks.register("configureApply") {
         println("Done")
     }
 }
+
+buildScan {
+    // Always run Gradle scan on CI builds
+    if (System.getenv('CI')) {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+        tag 'CI'
+        publishAlways()
+        // Otherwise CI might shut down before it's uploaded
+        uploadInBackground = false
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,6 +41,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id 'com.gradle.enterprise' version '3.8.1'
+}
+
 include ':libs:cardreader'
 include ':WooCommerce'
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5886
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR enables build scans for CI only PRs.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please go to Buildkite's logs and look for link just under `Publishing build scan` caption. Check if link works opens build scan.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
