### PR TITLE
Navigate to wcpay vs stripe docs depending on preferred plugin

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -40,6 +40,8 @@ object AppUrls {
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
+    const val STRIPE_LEARN_MORE_ABOUT_PAYMENTS =
+        "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/"
 
     const val WOOCOMMERCE_M2_PURCHASE_CARD_READER = "https://woocommerce.com/products/m2-card-reader/"
     const val WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY = "https://woocommerce.com/products/hardware/"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
-import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -19,6 +18,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.setDrawableColor
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.CardReaderDetailEvent.CopyReadersNameToClipboard
+import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.CardReaderDetailEvent.NavigateToUrlInGenericWebView
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.NavigationTarget.CardReaderConnectScreen
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.NavigationTarget.CardReaderUpdateScreen
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState
@@ -44,12 +44,6 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentCardReaderDetailBinding.bind(view)
-
-        val learnMoreListener = View.OnClickListener {
-            ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
-        }
-        binding.readerConnectedState.cardReaderDetailLearnMoreTv.learnMore.setOnClickListener(learnMoreListener)
-        binding.readerDisconnectedState.cardReaderDetailLearnMoreTv.learnMore.setOnClickListener(learnMoreListener)
 
         observeEvents(binding)
         observeViewState(binding)
@@ -91,6 +85,8 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                         binding.readerConnectedState.primaryActionBtn.announceForAccessibility(
                             getString(event.accessibilityConnectedText)
                         )
+                    is NavigateToUrlInGenericWebView ->
+                        ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                     else -> event.isHandled = false
                 }
             }
@@ -126,6 +122,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                             with(cardReaderDetailLearnMoreTv.root) {
                                 movementMethod = LinkMovementMethod.getInstance()
                                 UiHelpers.setTextOrHide(this, state.learnMoreLabel)
+                                setOnClickListener { state.onLearnMoreClicked.invoke() }
                             }
                         }
                     }
@@ -144,6 +141,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                             with(cardReaderDetailLearnMoreTv.root) {
                                 movementMethod = LinkMovementMethod.getInstance()
                                 UiHelpers.setTextOrHide(this, state.learnMoreLabel)
+                                setOnClickListener { state.onLearnMoreClicked.invoke() }
                             }
                         }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.LayoutRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.exhaustive
@@ -16,6 +17,8 @@ import com.woocommerce.android.ui.prefs.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingEvent.NavigateToUrlInGenericWebView
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingEvent.NavigateToUrlInWPComWebView
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.WcPayAndStripeInstalledState
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
@@ -35,6 +38,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
     private val cardReaderTracker: CardReaderTracker,
     private val userEligibilityFetcher: UserEligibilityFetcher,
     private val selectedSite: SelectedSite,
+    private val appPrefsWrapper: AppPrefsWrapper,
 ) : ScopedViewModel(savedState) {
     override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event
@@ -176,7 +180,16 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private fun onLearnMoreClicked() {
         cardReaderTracker.trackOnboardingLearnMoreTapped()
-        triggerEvent(NavigateToUrlInGenericWebView(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS))
+        val preferredPlugin = appPrefsWrapper.getCardReaderPreferredPlugin(
+            selectedSite.get().id,
+            selectedSite.get().siteId,
+            selectedSite.get().selfHostedSiteId
+        )
+        val learnMoreUrl = when (preferredPlugin) {
+            STRIPE_EXTENSION_GATEWAY -> AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS
+            WOOCOMMERCE_PAYMENTS, null -> AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS
+        }
+        triggerEvent(NavigateToUrlInGenericWebView(learnMoreUrl))
     }
 
     private fun onSkipPendingRequirementsClicked(storeCountryCode: String) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -174,7 +174,6 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
         }
 
-
     @Test
     fun `given account country not supported, when learn more clicked, then app shows learn more section`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
@@ -16,6 +17,8 @@ import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardi
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.StripeExtensionError
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.UnsupportedCountryState
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.WCPayError
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -37,7 +40,10 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         whenever(model.getUserRoles()).thenReturn(arrayListOf(WCUserRole.ADMINISTRATOR))
         onBlocking { it.fetchUserInfo() } doReturn model
     }
-    private val selectedSite: SelectedSite = mock()
+    private val selectedSite: SelectedSite = mock {
+        on(it.get()).thenReturn(SiteModel())
+    }
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val countryCode = "US"
 
     @Test
@@ -119,6 +125,55 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             assertThat(viewModel.event.value)
                 .isInstanceOf(OnboardingEvent.NavigateToSupport::class.java)
         }
+
+    @Test
+    fun `given preferred plugin Stripe, when learn more clicked, then app navigates to Stripe docs`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
+            whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
+                .thenReturn(STRIPE_EXTENSION_GATEWAY)
+
+            val viewModel = createVM()
+
+            (viewModel.viewStateData.value as UnsupportedCountryState).onLearnMoreActionClicked.invoke()
+
+            val event = viewModel.event.value as OnboardingEvent.NavigateToUrlInGenericWebView
+            assertThat(event.url).isEqualTo(AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS)
+        }
+
+    @Test
+    fun `given preferred plugin WCPay, when learn more clicked, then app navigates to wcpay docs`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
+            whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
+                .thenReturn(WOOCOMMERCE_PAYMENTS)
+
+            val viewModel = createVM()
+
+            (viewModel.viewStateData.value as UnsupportedCountryState).onLearnMoreActionClicked.invoke()
+
+            val event = viewModel.event.value as OnboardingEvent.NavigateToUrlInGenericWebView
+            assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
+        }
+
+    @Test
+    fun `given preferred plugin null, when learn more clicked, then app navigates to wcpay docs`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
+            whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
+                .thenReturn(null)
+
+            val viewModel = createVM()
+
+            (viewModel.viewStateData.value as UnsupportedCountryState).onLearnMoreActionClicked.invoke()
+
+            val event = viewModel.event.value as OnboardingEvent.NavigateToUrlInGenericWebView
+            assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
+        }
+
 
     @Test
     fun `given account country not supported, when learn more clicked, then app shows learn more section`() =
@@ -588,6 +643,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             onboardingChecker,
             tracker,
             userEligibilityFetcher,
-            selectedSite
+            selectedSite,
+            appPrefsWrapper,
         )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes: #5758 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the "Learn more" URL in the In-Person Payments flows depending on the used plugin - wcpay vs stripe.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Consider whether unit tests are enough or this needs to be tested manually - I tested it manually so I personally think it doesn't require double-testing.

1. Select a site in the app which has outdated version of **Stripe plugin** - any version older than 6.2.0 is considered as out-dated -> you can download it at the bottom of this page https://wordpress.org/plugins/woocommerce-gateway-stripe/advanced/ 
2. Tap on "In Person Payments" in app settings
3. Notice "Outdated plugin version" screen is shown
4. Tap on "learn more" at the bottom and verify you are redirected to IPP in Stripe Extension documentation (the docs are not public yet, so you might see 404 error)
------
1. Select a site in the app which has outdated version of **WCPay plugin** - any version older than 3.2.1 is considered as out-dated -> you can download it at the bottom of this page https://wordpress.org/plugins/woocommerce-payments/advanced/
2. Tap on "In Person Payments" in app settings
3. Notice "Outdated plugin version" screen is shown
4. Tap on "learn more" at the bottom and verify you are redirected to IPP in WCPay Extension documentation
--------
1. Select a site in the app which has **up-to-date** version of **Stripe plugin** - version 6.2.0+
2. Tap on "In Person Payments" in app settings
3. Tap on "Manage Card Reader"
4. Tap on "learn more" at the bottom and verify you are redirected to IPP in Stripe Extension documentation (the docs are not public yet, so you might see 404 error)
--------
1. Select a site in the app which has **up-to-date** version of **WCPay plugin** - version 3.2.1+
2. Tap on "In Person Payments" in app settings
3. Tap on "Manage Card Reader"
4. Tap on "learn more" at the bottom and verify you are redirected to IPP in WCPay Extension documentation

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| WCPay | Stripe |
| --- | --- |
| ![2fdd23a9b75962eaf5d60dd024480197](https://user-images.githubusercontent.com/2261188/154504044-0491586e-4c7a-453e-988f-ac410c33b674.gif) | ![abbc7c2abfea91e778b32ad4af3949eb](https://user-images.githubusercontent.com/2261188/154504190-45d3b76f-b473-419e-9dd7-516e94be0f8f.gif) |
| ![df5055398c8ff14b53532e597de4e59f](https://user-images.githubusercontent.com/2261188/154510302-cda68e99-2eb2-4e9f-859d-63311ecaf3e4.gif) | ![1433d6761a64d00abc31ed4029c106e8](https://user-images.githubusercontent.com/2261188/154510073-751d662f-c900-444b-94aa-40f8449b6cc8.gif) |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
