### PR TITLE
Navigate to Stripe.com on Purchase Reader clicked with Stripe ext

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -42,6 +42,7 @@ object AppUrls {
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
 
     const val WOOCOMMERCE_M2_PURCHASE_CARD_READER = "https://woocommerce.com/products/m2-card-reader/"
+    const val STRIPE_M2_PURCHASE_CARD_READER = "https://stripe.com/terminal/stripe-reader"
     const val WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY = "https://woocommerce.com/products/hardware/"
 
     const val BBPOS_MANUAL_CARD_READER =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
@@ -4,10 +4,14 @@ import androidx.annotation.DrawableRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.InPersonPaymentsCanadaFeatureFlag
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -19,6 +23,8 @@ import javax.inject.Inject
 class CardReaderHubViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val selectedSite: SelectedSite,
 ) : ScopedViewModel(savedState) {
     private val arguments: CardReaderHubFragmentArgs by savedState.navArgs()
 
@@ -27,7 +33,15 @@ class CardReaderHubViewModel @Inject constructor(
             // todo fix the URL when decided
             "${AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY}${arguments.storeCountryCode}"
         } else {
-            AppUrls.WOOCOMMERCE_M2_PURCHASE_CARD_READER
+            val preferredPlugin = appPrefsWrapper.getCardReaderPreferredPlugin(
+                selectedSite.get().id,
+                selectedSite.get().siteId,
+                selectedSite.get().selfHostedSiteId
+            )
+            when (preferredPlugin) {
+                STRIPE_EXTENSION_GATEWAY -> AppUrls.STRIPE_M2_PURCHASE_CARD_READER
+                WOOCOMMERCE_PAYMENTS, null -> AppUrls.WOOCOMMERCE_M2_PURCHASE_CARD_READER
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5891
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR navigates the user to https://stripe.com/terminal/stripe-reader when they click on "Purchase Reader" row on a store which is using Stripe Extension. If the store is using WCPay it still navigates to the original https://woocommerce.com/products/m2-card-reader/.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
**Make sure `IN_PERSON_PAYMENTS_CANADA` is disabled.**
1. Select a store with WCPay setup
2. Tap on Settings -> In Person Payments -> Purchase Card Reader
3. Notice you are navigated to woocommerce.com
-----
1. Select a store with Stripe Extension setup
2. Tap on Settings -> In Person Payments -> Purchase Card Reader
3. Notice you are navigated to stripe.com


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
