### PR TITLE
Increase default Gradle memory to 8G

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,9 @@ commands:
       - run:
           name: Enable build time reporting
           command: sed -i "s/tracksEnabled = false/tracksEnabled = true/" gradle.properties
-  update-gradle-memory:
-      parameters:
-        jvmargs:
-          type: string
-          default: "Xmx2048m"
-      steps:
-        - run:
-            name: Update memory setting
-            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-<< parameters.jvmargs >>/" gradle.properties
+      - run:
+          name: Update default gradle memory
+          command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx2048m/" gradle.properties
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
@@ -126,8 +120,6 @@ jobs:
       - git/shallow-checkout
       - android/restore-gradle-cache
       - copy-gradle-properties
-      - update-gradle-memory:
-          jvmargs: "Xmx2048m"
       - run:
           name: Build
           command: ./gradlew WooCommerce:assembleVanillaDebug --stacktrace
@@ -172,7 +164,6 @@ jobs:
       - run:
           name: Copy Secrets
           command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run configure_apply
-      - update-gradle-memory
       - android/restore-gradle-cache
       - run:
           name: Build APK
@@ -206,7 +197,6 @@ jobs:
       - run:
           name: Copy Secrets
           command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run configure_apply
-      - update-gradle-memory
       - android/restore-gradle-cache
       - run:
           name: Build APK

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx8g
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
It also update CircleCI memory to `2048m` and removes the extra logic for updating gradle memory settings because it's not necessary anymore.