### PR TITLE
Remove update-gradle-memory command from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ jobs:
       - android/restore-gradle-cache:
           cache-prefix: tests-cache-v1
       - copy-gradle-properties
-      - update-gradle-memory
       - run:
           # The instrumentation tests are not currently used and do tend to get
           # out of date when the UI changes, failing to build.


### PR DESCRIPTION
I missed one of the `update-gradle-memory` commands in https://github.com/woocommerce/woocommerce-android/pull/5898. This PR fixes that.