### PR TITLE
Use "Menu" instead of "More" on bottom tab option.

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
     <string name="product_attributes_error_saving">Error while saving your attributes</string>
     <string name="product_attribute_remove">Remove this attribute?</string>
     <string name="review_notifications">Reviews</string>
-    <string name="more_menu">More</string>
+    <string name="more_menu">Menu</string>
     <string name="more_menu_button_woo_admin">WooCommerce Admin</string>
     <string name="more_menu_button_payments">Payments</string>
     <string name="more_menu_button_analytics">Analytics</string>


### PR DESCRIPTION
I've only just noticed that the bottom navigation tab says "Menu" in the design, instead of "More" like in the current state of the app.

<img width="697" alt="Screen Shot 2022-02-21 at 16 08 35" src="https://user-images.githubusercontent.com/266376/154928607-32df72a7-7b24-44b5-8a13-7c047767edba.png">

To test this PR:

Run app, check and make sure the last bottom tab item says "Menu".