### PR TITLE
Open ReviewDetail From ProductReviewFragment 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -810,10 +810,13 @@ class MainActivity :
             binding.bottomNav.active(MORE.position)
         }
 
-        val query = "?remoteReviewId=$remoteReviewId&tempStatus=$tempStatus" +
-            "&launchedFromNotification=$launchedFromNotification&enableModeration=$enableModeration"
-        val deeplink = "wcandroid://reviewDetail$query"
-        navController.navigate(Uri.parse(deeplink))
+        val action = NavGraphMainDirections.actionGlobalReviewDetailFragment(
+            remoteReviewId = remoteReviewId,
+            tempStatus = tempStatus,
+            launchedFromNotification = launchedFromNotification,
+            enableModeration = enableModeration
+        )
+        navController.navigate(action)
     }
 
     override fun showReviewDetailWithSharedTransition(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -810,13 +810,10 @@ class MainActivity :
             binding.bottomNav.active(MORE.position)
         }
 
-        val action = MoreMenuFragmentDirections.actionMoreMenuFragmentToReviewDetailFragment(
-            remoteReviewId = remoteReviewId,
-            tempStatus = tempStatus,
-            launchedFromNotification = launchedFromNotification,
-            enableModeration = enableModeration
-        )
-        navController.navigateSafely(action)
+        val query = "?remoteReviewId=$remoteReviewId&tempStatus=$tempStatus" +
+            "&launchedFromNotification=$launchedFromNotification&enableModeration=$enableModeration"
+        val deeplink = "wcandroid://reviewDetail$query"
+        navController.navigate(Uri.parse(deeplink))
     }
 
     override fun showReviewDetailWithSharedTransition(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -816,7 +816,7 @@ class MainActivity :
             launchedFromNotification = launchedFromNotification,
             enableModeration = enableModeration
         )
-        navController.navigate(action)
+        navController.navigateSafely(action)
     }
 
     override fun showReviewDetailWithSharedTransition(

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -229,6 +229,7 @@
             android:id="@+id/action_reviewDetailFromNotification_to_reviewListFragment"
             app:destination="@id/reviews"
             app:popUpTo="@+id/moreMenu" />
+        <deepLink app:uri="wcandroid://reviewDetail?remoteReviewId={remoteReviewId}&amp;tempStatus={tempStatus}&amp;launchedFromNotification={launchedFromNotification}&amp;enableModeration={enableModeration}" />
     </fragment>
 
     <include app:graph="@navigation/nav_graph_orders" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -206,6 +206,25 @@
             android:defaultValue="false"
             app:argType="boolean" />
     </action>
+    <action
+        android:id="@+id/action_global_reviewDetailFragment"
+        app:destination="@id/reviewDetailFragment">
+        <argument
+            android:name="remoteReviewId"
+            android:defaultValue="0L"
+            app:argType="long" />
+        <argument
+            android:name="tempStatus"
+            android:defaultValue="null"
+            app:argType="string"
+            app:nullable="true" />
+        <argument
+            android:name="launchedFromNotification"
+            app:argType="boolean" />
+        <argument
+            android:name="enableModeration"
+            app:argType="boolean" />
+    </action>
     <fragment
         android:id="@+id/reviewDetailFragment"
         android:name="com.woocommerce.android.ui.reviews.ReviewDetailFragment"
@@ -229,7 +248,6 @@
             android:id="@+id/action_reviewDetailFromNotification_to_reviewListFragment"
             app:destination="@id/reviews"
             app:popUpTo="@+id/moreMenu" />
-        <deepLink app:uri="wcandroid://reviewDetail?remoteReviewId={remoteReviewId}&amp;tempStatus={tempStatus}&amp;launchedFromNotification={launchedFromNotification}&amp;enableModeration={enableModeration}" />
     </fragment>
 
     <include app:graph="@navigation/nav_graph_orders" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5210
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Go to Product List
Open detail of a product with reviews
Open list of product reviews for that product
Tap on one of the reviews and notice nothing happens


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Go to Product List
Open detail of a product with reviews
Open list of product reviews for that product
Tap on one of the reviews , the review detail for it will open


### Root Cause 
The product review fragment and the review detail fragment are part of two different graphs.
This cannot be reached via direct action as was done in the code via ViewMoreFragment 

### Fix
There are 3 ways to reach a destination in a different graph
1) Launch a graph which contains  the destination as the start destination
2) Connect via global action 
3) Use deep link 

I went with deep link for this as Detail Review Fragment is opened in context of a Review before it , so deep link seemed better.

Changed to Global action after review.


### Images/gif

https://user-images.githubusercontent.com/20752243/155175964-1870cac0-2a85-4ccb-b765-383918049c94.mp4




- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
