### PR TITLE
Restart MainActivity on site switch

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.*
 import android.view.animation.AccelerateDecelerateInterpolator
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
@@ -88,10 +89,14 @@ class MainActivity :
         }
     }
 
-    @Inject lateinit var presenter: MainContract.Presenter
-    @Inject lateinit var loginAnalyticsListener: LoginAnalyticsListener
-    @Inject lateinit var selectedSite: SelectedSite
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var presenter: MainContract.Presenter
+    @Inject
+    lateinit var loginAnalyticsListener: LoginAnalyticsListener
+    @Inject
+    lateinit var selectedSite: SelectedSite
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel: MainActivityViewModel by viewModels()
 
@@ -111,7 +116,7 @@ class MainActivity :
     private lateinit var toolbar: Toolbar
 
     private val sitePickerLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        handleSitePickerResult()
+        handleSitePickerResult(it)
     }
 
     private val appBarOffsetListener by lazy {
@@ -625,9 +630,11 @@ class MainActivity :
         sitePickerLauncher.launch(sitePickerIntent)
     }
 
-    private fun handleSitePickerResult() {
-        presenter.selectedSiteChanged(selectedSite.get())
-        restart()
+    private fun handleSitePickerResult(activityResult: ActivityResult) {
+        if (activityResult.resultCode == RESULT_OK) {
+            presenter.selectedSiteChanged(selectedSite.get())
+            restart()
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -89,14 +89,10 @@ class MainActivity :
         }
     }
 
-    @Inject
-    lateinit var presenter: MainContract.Presenter
-    @Inject
-    lateinit var loginAnalyticsListener: LoginAnalyticsListener
-    @Inject
-    lateinit var selectedSite: SelectedSite
-    @Inject
-    lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var presenter: MainContract.Presenter
+    @Inject lateinit var loginAnalyticsListener: LoginAnalyticsListener
+    @Inject lateinit var selectedSite: SelectedSite
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel: MainActivityViewModel by viewModels()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.*
 import android.view.animation.AccelerateDecelerateInterpolator
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
@@ -108,6 +109,10 @@ class MainActivity :
 
     private lateinit var binding: ActivityMainBinding
     private lateinit var toolbar: Toolbar
+
+    private val sitePickerLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        handleSitePickerResult()
+    }
 
     private val appBarOffsetListener by lazy {
         AppBarLayout.OnOffsetChangedListener { appBarLayout, verticalOffset ->
@@ -613,6 +618,16 @@ class MainActivity :
         // Complete UI initialization
         binding.bottomNav.init(navController, this)
         initFragment(null)
+    }
+
+    fun startSitePicker() {
+        val sitePickerIntent = Intent(this, SitePickerActivity::class.java)
+        sitePickerLauncher.launch(sitePickerIntent)
+    }
+
+    private fun handleSitePickerResult() {
+        presenter.selectedSiteChanged(selectedSite.get())
+        restart()
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.moremenu
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -15,8 +14,8 @@ import com.woocommerce.android.databinding.FragmentMoreMenuBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.*
-import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -91,8 +90,7 @@ class MoreMenuFragment : TopLevelFragment(R.layout.fragment_more_menu) {
     }
 
     private fun startSitePicker() {
-        val sitePickerIntent = Intent(context, SitePickerActivity::class.java)
-        requireActivity().startActivity(sitePickerIntent)
+        (requireActivity() as MainActivity).startSitePicker()
     }
 
     private fun openInBrowser(url: String) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the user switches stores the Order List doesn't get updated and shows data for the originally selected store. This PR fixes this issue by restarting the MainActivity when a store is switched. [That's how the app behaved before](https://github.com/woocommerce/woocommerce-android/blob/6662e1bd88a78c815abdc6f9aa9c96fbef42112b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt#L557-L561) the move of "Switch Store" button from App Settings to More section of the app.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open Order list and notice the items
2. Open More section of the app
3. Tap on "Switch store" button
4. Select a different store
5. Open Order List and notice the items correspond to the currently selected store

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @jkmassel This PR is targeting the release branch. Could you please release a new beta when this PR is merged? Thanks!
