### PR TITLE
Remove selected store setting

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/settings/SettingsScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/settings/SettingsScreen.kt
@@ -11,14 +11,14 @@ import com.woocommerce.android.screenshots.util.Screen
 
 class SettingsScreen : Screen {
     companion object {
-        const val SELECTED_STORE = R.id.option_store
+        const val HELP_BUTTON = R.id.option_help_and_support
         const val BETA_FEATURES_BUTTON = R.id.option_beta_features
         const val LOG_OUT_BUTTON = R.id.btn_option_logout
     }
 
-    // Using SELECTED_STORE even if we don't need to interact with it because for some reason Espresso can't find
+    // Using HELP_BUTTON even if we don't need to interact with it because for some reason Espresso can't find
     // LOG_OUT_BUTTON
-    constructor() : super(SELECTED_STORE)
+    constructor() : super(HELP_BUTTON)
 
     fun openBetaFeatures(): BetaFeaturesScreen {
         clickOn(BETA_FEATURES_BUTTON)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/RequestCodes.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/RequestCodes.kt
@@ -8,7 +8,6 @@ object RequestCodes {
 
     const val ADD_ACCOUNT = BASE_REQUEST_CODE + 0
     const val SETTINGS = BASE_REQUEST_CODE + 1
-    const val SITE_PICKER = BASE_REQUEST_CODE + 2
     const val IN_APP_UPDATE = BASE_REQUEST_CODE + 3
 
     const val CAMERA_PERMISSION = BASE_REQUEST_CODE + 10

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -7,7 +7,10 @@ import android.content.Intent
 import android.content.res.Resources.Theme
 import android.net.Uri
 import android.os.Bundle
-import android.view.*
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.WindowManager
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -30,7 +33,10 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivityMainBinding
-import com.woocommerce.android.extensions.*
+import com.woocommerce.android.extensions.active
+import com.woocommerce.android.extensions.collapse
+import com.woocommerce.android.extensions.expand
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -560,12 +566,6 @@ class MainActivity :
                 return
             }
             RequestCodes.SETTINGS -> {
-                // restart the activity if the user returned from settings and they switched sites
-                if (resultCode == AppSettingsActivity.RESULT_CODE_SITE_CHANGED) {
-                    presenter.selectedSiteChanged(selectedSite.get())
-                    restart()
-                }
-
                 // beta features have changed. Restart activity for changes to take effect
                 if (resultCode == AppSettingsActivity.RESULT_CODE_BETA_OPTIONS_CHANGED) {
                     restart()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -10,6 +10,8 @@ import com.woocommerce.android.push.NotificationChannelType.NEW_ORDER
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SelectedSite.SelectedSiteChangedEvent
+import com.woocommerce.android.ui.orders.cardreader.ClearCardReaderData
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -43,6 +45,7 @@ class MainPresenter @Inject constructor(
     private val productImageMap: ProductImageMap,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val wcOrderStore: WCOrderStore,
+    private val clearCardReaderData: ClearCardReaderData
 ) : MainContract.Presenter {
     private var mainView: MainContract.View? = null
 
@@ -100,6 +103,9 @@ class MainPresenter @Inject constructor(
             WCOrderActionBuilder
                 .newFetchOrderStatusOptionsAction(FetchOrderStatusOptionsPayload(site))
         )
+        if (FeatureFlag.CARD_READER.isEnabled()) {
+            coroutineScope.launch { clearCardReaderData() }
+        }
     }
 
     override fun fetchUnfilledOrderCount() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/ClearCardReaderData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/ClearCardReaderData.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import com.woocommerce.android.cardreader.CardReaderManager
+import javax.inject.Inject
+
+class ClearCardReaderData @Inject constructor(
+    private val cardReaderManager: CardReaderManager
+) {
+    suspend operator fun invoke() {
+        if (cardReaderManager.initialized) {
+            cardReaderManager.disconnectReader()
+            cardReaderManager.clearCachedCredentials()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -18,11 +18,10 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PreferencesWrapper
 import dagger.android.DispatchingAndroidInjector
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -31,8 +30,6 @@ class AppSettingsActivity :
     AppSettingsListener,
     AppSettingsContract.View {
     companion object {
-        private const val KEY_SITE_CHANGED = "key_site_changed"
-        const val RESULT_CODE_SITE_CHANGED = Activity.RESULT_FIRST_USER
         const val RESULT_CODE_BETA_OPTIONS_CHANGED = 2
         const val KEY_BETA_OPTION_CHANGED = "key_beta_option_changed"
     }
@@ -44,7 +41,6 @@ class AppSettingsActivity :
     @Inject lateinit var notificationMessageHandler: NotificationMessageHandler
 
     private val sharedPreferences by lazy { PreferenceManager.getDefaultSharedPreferences(this) }
-    private var siteChanged = false
     private var isBetaOptionChanged = false
 
     private lateinit var binding: ActivityAppSettingsBinding
@@ -63,13 +59,9 @@ class AppSettingsActivity :
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         savedInstanceState?.let {
-            siteChanged = it.getBoolean(KEY_SITE_CHANGED)
             isBetaOptionChanged = it.getBoolean(KEY_BETA_OPTION_CHANGED)
         }
 
-        if (siteChanged) {
-            setResult(RESULT_CODE_SITE_CHANGED)
-        }
         if (isBetaOptionChanged) {
             setResult(RESULT_CODE_BETA_OPTIONS_CHANGED)
         }
@@ -86,7 +78,6 @@ class AppSettingsActivity :
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putBoolean(KEY_SITE_CHANGED, siteChanged)
         outState.putBoolean(KEY_BETA_OPTION_CHANGED, isBetaOptionChanged)
         super.onSaveInstanceState(outState)
     }
@@ -100,18 +91,6 @@ class AppSettingsActivity :
             finish()
             true
         }
-    }
-
-    /**
-     * User switched sites from the main settings fragment, set the result code so the calling activity
-     * will know the site changed
-     */
-    override fun onSiteChanged() {
-        if (FeatureFlag.CARD_READER.isEnabled()) presenter.clearCardReaderData()
-        siteChanged = true
-        setResult(RESULT_CODE_SITE_CHANGED)
-
-        prefs.resetSitePreferences()
     }
 
     override fun onRequestLogout() {
@@ -165,7 +144,6 @@ class AppSettingsActivity :
                     )
                 )
 
-                if (FeatureFlag.CARD_READER.isEnabled()) presenter.clearCardReaderData()
                 presenter.logout()
             }
             .setNegativeButton(R.string.back) { _, _ ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsContract.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.ui.base.BaseView
 interface AppSettingsContract {
     interface Presenter : BasePresenter<View> {
         fun logout()
-        fun clearCardReaderData()
         fun userIsLoggedIn(): Boolean
         fun getAccountDisplayName(): String
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -19,7 +19,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
 import com.woocommerce.android.databinding.FragmentSettingsMainBinding
-import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.FeatureAnnouncement
@@ -68,8 +67,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         } else {
             throw ClassCastException(context.toString() + " must implement AppSettingsListener")
         }
-
-        updateStoreViews()
 
         binding.btnOptionLogout.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_LOGOUT_BUTTON_TAPPED)
@@ -173,27 +170,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_licensesFragment)
         }
 
-        /*
-        Hide "Switch Store" option in Settings, because it is moved to the "More" screen.
-        We temporarily comment out the code instead of deleting, because we might want to restore it later,
-        based on merchants feedbacks.
-
-        TODO: Maybe restore "Switch Store" option in Settings, depending on merchants feedbacks.
-        For more context: https://github.com/woocommerce/woocommerce-android/issues/5586
-
-        if (presenter.hasMultipleStores()) {
-            val storeClickListener = View.OnClickListener {
-                AnalyticsTracker.track(SETTINGS_SELECTED_SITE_TAPPED)
-                SitePickerActivity.showSitePickerForResult(this)
-            }
-            binding.optionStore.setOnClickListener(storeClickListener)
-            binding.optionSwitchStore.setOnClickListener(storeClickListener)
-        } else {
-            binding.optionSwitchStore.hide()
-        }
-        */
-        binding.optionSwitchStore.hide()
-
         binding.optionTheme.optionValue = getString(AppPrefs.getAppTheme().label)
         binding.optionTheme.setOnClickListener {
             // FIXME AMANDA tracks event
@@ -223,7 +199,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         // if we're returning from the site picker, make sure the new store is shown and the activity
         // knows it has changed
         if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK) {
-            updateStoreViews()
             updateStoreSettings()
             settingsListener.onSiteChanged()
             presenter.setupJetpackInstallOption()
@@ -274,11 +249,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                     )
                 )
         }
-    }
-
-    private fun updateStoreViews() {
-        binding.optionStore.optionTitle = presenter.getStoreDomainName()
-        binding.optionStore.optionValue = presenter.getUserDisplayName()
     }
 
     private fun updateStoreSettings() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -47,7 +47,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
     interface AppSettingsListener {
         fun onRequestLogout()
-        fun onSiteChanged()
         fun onProductAddonsOptionChanged(enabled: Boolean)
         fun onOrderCreationOptionChanged(enabled: Boolean)
     }
@@ -200,7 +199,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         // knows it has changed
         if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK) {
             updateStoreSettings()
-            settingsListener.onSiteChanged()
             presenter.setupJetpackInstallOption()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.prefs
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.text.Spannable
@@ -14,7 +13,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
-import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.*
@@ -190,17 +188,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         super.onDestroyView()
         _binding = null
         presenter.dropView()
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-
-        // if we're returning from the site picker, make sure the new store is shown and the activity
-        // knows it has changed
-        if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK) {
-            updateStoreSettings()
-            presenter.setupJetpackInstallOption()
-        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -18,13 +18,11 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
-import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
-import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivitySitePickerBinding
@@ -72,12 +70,6 @@ class SitePickerActivity :
             val intent = Intent(context, SitePickerActivity::class.java)
             intent.putExtra(KEY_CALLED_FROM_LOGIN, true)
             context.startActivity(intent)
-        }
-
-        fun showSitePickerForResult(fragment: Fragment) {
-            val intent = Intent(fragment.activity, SitePickerActivity::class.java)
-            intent.putExtra(KEY_CALLED_FROM_LOGIN, false)
-            fragment.startActivityForResult(intent, RequestCodes.SITE_PICKER)
         }
     }
     @Inject lateinit var presenter: SitePickerContract.Presenter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.sitepicker
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
@@ -30,7 +31,8 @@ class SitePickerPresenter
     private val accountStore: AccountStore,
     private val siteStore: SiteStore,
     private val wooCommerceStore: WooCommerceStore,
-    private val userEligibilityFetcher: UserEligibilityFetcher
+    private val userEligibilityFetcher: UserEligibilityFetcher,
+    private val appPrefs: AppPrefs
 ) : SitePickerContract.Presenter {
     private var view: SitePickerContract.View? = null
 
@@ -142,6 +144,7 @@ class SitePickerPresenter
     }
 
     override fun updateWooSiteSettings(site: SiteModel) {
+        appPrefs.resetSitePreferences()
         dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(site))
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -10,28 +10,6 @@
     <View style="@style/Woo.Divider" />
 
     <!--
-        Primary store
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/settings_selected_store" />
-
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_store"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:optionTitle="testwooshop.mystagingwebsite.com"
-        tools:optionValue="Woo Tester" />
-
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_switch_store"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/settings_switch_store" />
-
-    <View style="@style/Woo.Divider" />
-    <!--
         Help & support
     -->
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainPresenterTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.orders.cardreader.ClearCardReaderData
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,6 +49,7 @@ class MainPresenterTest : BaseUnitTest() {
     }
     private val productImageMap: ProductImageMap = mock()
     private val appPrefs: AppPrefsWrapper = mock()
+    private val clearCardReaderData: ClearCardReaderData = mock()
 
     private val wcOrderStore: WCOrderStore = mock {
         on { observeOrdersForSite(any(), any()) } doReturn emptyFlow()
@@ -67,7 +69,8 @@ class MainPresenterTest : BaseUnitTest() {
                 selectedSite,
                 productImageMap,
                 appPrefs,
-                wcOrderStore
+                wcOrderStore,
+                clearCardReaderData
             )
         )
         actionCaptor = argumentCaptor()
@@ -194,6 +197,15 @@ class MainPresenterTest : BaseUnitTest() {
             mainPresenter.fetchSitesAfterDowngrade()
             verify(mainContractView).showProgressDialog(any())
             verify(mainContractView).updateSelectedSite()
+        }
+    }
+
+    @Test
+    fun `When selected site changes, then card reader data is cleared`() = testBlocking {
+        if (FeatureFlag.CARD_READER.isEnabled()) {
+            mainPresenter.selectedSiteChanged(site = selectedSite.get())
+
+            verify(clearCardReaderData).invoke()
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ClearCardReaderDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ClearCardReaderDataTest.kt
@@ -1,0 +1,51 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+
+import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class ClearCardReaderDataTest : BaseUnitTest() {
+
+    private val cardReaderManager: CardReaderManager = mock()
+
+    private val sut = ClearCardReaderData(cardReaderManager)
+
+    @Test
+    fun `Given card reader is initialised, when clearing card reader data, cache is cleared`() =
+        testBlocking {
+            whenever(cardReaderManager.initialized).thenReturn(true)
+
+            sut.invoke()
+
+            verify(cardReaderManager).clearCachedCredentials()
+            verify(cardReaderManager).disconnectReader()
+        }
+
+    @Test
+    fun `Given card reader is initialised, when clearing card reader data, card reader is disconnected`() =
+        testBlocking {
+            whenever(cardReaderManager.initialized).thenReturn(true)
+
+            sut.invoke()
+
+            verify(cardReaderManager).disconnectReader()
+        }
+
+
+    @Test
+    fun `Given card reader not initialised, when clearing card reader data, nothing happens`() = testBlocking {
+        whenever(cardReaderManager.initialized).thenReturn(false)
+
+        sut.invoke()
+
+        verify(cardReaderManager, never()).clearCachedCredentials()
+        verify(cardReaderManager, never()).disconnectReader()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ClearCardReaderDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ClearCardReaderDataTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.cardreader
 
-
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -37,7 +36,6 @@ class ClearCardReaderDataTest : BaseUnitTest() {
 
             verify(cardReaderManager).disconnectReader()
         }
-
 
     @Test
     fun `Given card reader not initialised, when clearing card reader data, nothing happens`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ClearCardReaderDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ClearCardReaderDataTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 class ClearCardReaderDataTest : BaseUnitTest() {
-
     private val cardReaderManager: CardReaderManager = mock()
 
     private val sut = ClearCardReaderData(cardReaderManager)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -1,20 +1,14 @@
 package com.woocommerce.android.ui.prefs
 
-import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.ui.orders.cardreader.ClearCardReaderData
 import com.woocommerce.android.util.CoroutineTestRule
+import com.woocommerce.android.util.FeatureFlag
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.KArgumentCaptor
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.NotificationAction
@@ -34,7 +28,7 @@ class AppSettingsPresenterTest {
 
     private val dispatcher: Dispatcher = mock()
     private val accountStore: AccountStore = mock()
-    private val cardReaderManager: CardReaderManager = mock()
+    private val clearCardReaderData: ClearCardReaderData = mock()
 
     private lateinit var appSettingsPresenter: AppSettingsPresenter
 
@@ -42,7 +36,12 @@ class AppSettingsPresenterTest {
 
     @Before
     fun setup() {
-        appSettingsPresenter = AppSettingsPresenter(dispatcher, accountStore, cardReaderManager, mock())
+        appSettingsPresenter = AppSettingsPresenter(
+            dispatcher,
+            accountStore,
+            mock(),
+            clearCardReaderData
+        )
         appSettingsPresenter.takeView(appSettingsContractView)
 
         actionCaptor = argumentCaptor()
@@ -74,30 +73,13 @@ class AppSettingsPresenterTest {
 
     @Test
     fun `cleanPaymentsData with initialized manager should disconnect reader`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            whenever(cardReaderManager.initialized).thenReturn(true)
+        if (FeatureFlag.CARD_READER.isEnabled()) {
 
-            // WHEN
-            appSettingsPresenter.clearCardReaderData()
+            coroutinesTestRule.testDispatcher.runBlockingTest {
+                appSettingsPresenter.logout()
 
-            // THEN
-            verify(cardReaderManager).clearCachedCredentials()
-            verify(cardReaderManager).disconnectReader()
+                verify(clearCardReaderData).invoke()
+            }
         }
     }
-
-    @Test
-    fun `cleanPaymentsData with not initialized manager should not disconnect reader`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            whenever(cardReaderManager.initialized).thenReturn(false)
-
-            // WHEN
-            appSettingsPresenter.clearCardReaderData()
-
-            // THEN
-            verify(cardReaderManager, never()).clearCachedCredentials()
-            verify(cardReaderManager, never()).disconnectReader()
-        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -74,7 +74,6 @@ class AppSettingsPresenterTest {
     @Test
     fun `cleanPaymentsData with initialized manager should disconnect reader`() {
         if (FeatureFlag.CARD_READER.isEnabled()) {
-
             coroutinesTestRule.testDispatcher.runBlockingTest {
                 appSettingsPresenter.logout()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part 1 from: #5927 

Part 2 is not urgent to merge and will be merged on `trunk` here #5939
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
After enabling the new more menu tab, users can see store details and switch store directly from the more menu. So in order to avoid any possible confusion, we are removing the setting with the site details. This should be released in `release/8.6` so after merging this PR we should generate new betas versions. cc: @jkmassel 

### Testing instructions
Open settings (from More Menu now) and check that row with the site details is not visible anymore: 


| Before  | After|
| ------------- | ------------- |
| <img width="300"  src="https://user-images.githubusercontent.com/2663464/155796185-5b16b8bb-cc0c-497d-9256-993df6a1fb07.png"> | <img width="300"  src="https://user-images.githubusercontent.com/2663464/155798999-02c7787a-7e1d-47b6-a1dc-5eda8804cf75.png"> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


