### PR TITLE
Fix crash during logout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandler.kt
@@ -15,15 +15,17 @@ import javax.inject.Singleton
 class UnseenReviewsCountHandler @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val notificationStore: NotificationStore,
-    private val selectedSite: SelectedSite
+    selectedSite: SelectedSite
 ) {
     private val unseenReviewsCount: SharedFlow<Int> =
-        selectedSite.observe().flatMapLatest {
-            notificationStore.observeNotificationsForSite(
-                site = selectedSite.get(),
-                filterBySubtype = listOf(STORE_REVIEW.toString())
-            )
-        }
+        selectedSite.observe()
+            .filterNotNull()
+            .flatMapLatest { site ->
+                notificationStore.observeNotificationsForSite(
+                    site = site,
+                    filterBySubtype = listOf(STORE_REVIEW.toString())
+                )
+            }
             .map { it.count { notification -> !notification.read } }
             .distinctUntilChanged()
             .shareIn(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandler.kt
@@ -19,12 +19,15 @@ class UnseenReviewsCountHandler @Inject constructor(
 ) {
     private val unseenReviewsCount: SharedFlow<Int> =
         selectedSite.observe()
-            .filterNotNull()
             .flatMapLatest { site ->
-                notificationStore.observeNotificationsForSite(
-                    site = site,
-                    filterBySubtype = listOf(STORE_REVIEW.toString())
-                )
+                if (site != null) {
+                    notificationStore.observeNotificationsForSite(
+                        site = site,
+                        filterBySubtype = listOf(STORE_REVIEW.toString())
+                    )
+                } else {
+                    flowOf(emptyList())
+                }
             }
             .map { it.count { notification -> !notification.read } }
             .distinctUntilChanged()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandlerTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandlerTests.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.push
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.NotificationStore
+
+// TODO add more test cases
+@ExperimentalCoroutinesApi
+class UnseenReviewsCountHandlerTests : BaseUnitTest() {
+    private lateinit var handler: UnseenReviewsCountHandler
+    private val notificationStore: NotificationStore = mock()
+    private val selectedSite: SelectedSite = mock()
+
+    fun setup(prepareMocks: () -> Unit) {
+        prepareMocks()
+        handler = UnseenReviewsCountHandler(
+            appCoroutineScope = TestCoroutineScope(coroutinesTestRule.testDispatcher),
+            notificationStore = notificationStore,
+            selectedSite = selectedSite
+        )
+    }
+
+    @Test
+    fun `when we get a null site, then emit 0 as count of unread reviews`() = testBlocking {
+        setup {
+            whenever(selectedSite.observe()).thenReturn(flowOf(null))
+        }
+
+        val unseenReviewsCount = handler.observeUnseenCount().first()
+
+        assertThat(unseenReviewsCount).isEqualTo(0)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandlerTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandlerTests.kt
@@ -5,12 +5,9 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.store.NotificationStore


### PR DESCRIPTION
Closes: #5946

### Description
This PR just makes sure `null` values are ignored in the Flow returned from `selectedSite.observe()`, to avoid crashing the app on logout.

@jkmassel we need a new beta release to include this fix, if we are not already planning for one.

### Testing instructions

1. Go to More sectoin
2. Click on App settings
3. Click on "Logout"
4. Confirm the app doesn't crash

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
