### PR TITLE
Add stripe sdk to licenses

### DIFF
--- a/WooCommerce/src/main/res/raw/licenses.html
+++ b/WooCommerce/src/main/res/raw/licenses.html
@@ -35,6 +35,11 @@
         <li><a href="https://github.com/Tinder/StateMachine">StateMachine</a>: Copyright 2018, Match Group, LLC</li>
     </ul>
 
+    <p>The following libraries are licensed under <a href="https://opensource.org/licenses/MIT">MIT</a>:</p>
+    <ul>
+      <li><a href="https://github.com/stripe/stripe-android">Stripe Android SDK</a>: Copyright (c) 2011- Stripe, Inc.</li>
+    </ul>
+
     <p>Additional credits:</p>
     <ul>
       <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Cash register sound</a> ("cha-ching") by CapsLok remixed for extra depth by Zott820</li>

--- a/WooCommerce/src/main/res/raw/licenses.html
+++ b/WooCommerce/src/main/res/raw/licenses.html
@@ -37,7 +37,7 @@
 
     <p>The following libraries are licensed under <a href="https://opensource.org/licenses/MIT">MIT</a>:</p>
     <ul>
-      <li><a href="https://github.com/stripe/stripe-android">Stripe Android SDK</a>: Copyright (c) 2011- Stripe, Inc.</li>
+      <li><a href="https://github.com/stripe/stripe-terminal-android">Stripe Terminal Android</a>: Copyright (c) 2018- Stripe, Inc. (<a href="https://stripe.com">https://stripe.com</a>)</li>
     </ul>
 
     <p>Additional credits:</p>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5283
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds mention about Stripe SDK for Android to our licenses page.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open App settings
2. Tap on "Open Source Licenses"
3. Notice Stripe SDK is mentioned and both MIT link and Stripe SDK links work as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/2261188/155986442-003e0f5b-23d6-4153-b5cc-7ad6dd121066.png" width="250px" />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
