### PR TITLE
Issue/5962 product detail bottom sheet exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
@@ -36,12 +36,7 @@ class ProductDetailBottomSheetAdapter(
     override fun getItemCount() = options.size
 
     fun setProductDetailBottomSheetOptions(optionList: List<ProductDetailBottomSheetUiItem>) {
-        if (optionList == options) {
-            return
-        } else if (options.isEmpty()) {
-            options.addAll(optionList)
-            notifyDataSetChanged()
-        } else {
+        if (optionList != options) {
             val diffResult =
                 DiffUtil.calculateDiff(
                     ProductDetailBottomSheetItemDiffUtil(options, optionList)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
@@ -36,15 +36,13 @@ class ProductDetailBottomSheetAdapter(
     override fun getItemCount() = options.size
 
     fun setProductDetailBottomSheetOptions(optionList: List<ProductDetailBottomSheetUiItem>) {
-        if (optionList != options) {
-            val diffResult =
-                DiffUtil.calculateDiff(
-                    ProductDetailBottomSheetItemDiffUtil(options, optionList)
-                )
-            options.clear()
-            options.addAll(optionList)
-            diffResult.dispatchUpdatesTo(this)
-        }
+        val diffResult =
+            DiffUtil.calculateDiff(
+                ProductDetailBottomSheetItemDiffUtil(options, optionList)
+            )
+        options.clear()
+        options.addAll(optionList)
+        diffResult.dispatchUpdatesTo(this)
     }
 
     class ProductDetailBottomSheetViewHolder(private val viewBinding: ProductDetailBottomSheetListItemBinding) :

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
@@ -36,7 +36,9 @@ class ProductDetailBottomSheetAdapter(
     override fun getItemCount() = options.size
 
     fun setProductDetailBottomSheetOptions(optionList: List<ProductDetailBottomSheetUiItem>) {
-        if (options.isEmpty()) {
+        if (optionList == options) {
+            return
+        } else if (options.isEmpty()) {
             options.addAll(optionList)
             notifyDataSetChanged()
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
@@ -53,7 +53,6 @@ class ProductDetailBottomSheetFragment : BottomSheetDialogFragment() {
         }
 
         setupObservers()
-        viewModel.fetchBottomSheetList()
     }
 
     private fun setupObservers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -953,7 +953,7 @@ class ProductDetailViewModel @Inject constructor(
         fetchBottomSheetList()
     }
 
-    fun fetchBottomSheetList() {
+    private fun fetchBottomSheetList() {
         viewState.productDraft?.let {
             launch(dispatchers.computation) {
                 val detailList = productDetailBottomSheetBuilder.buildBottomSheetList(it)


### PR DESCRIPTION
Possible fix for #5962 - as with similar RecyclerView issues, I wasn't able to reproduce the crash but eyeballing the code I could see what the problem might be.

`ProductDetailBottomSheetAdapter.setProductDetailBottomSheetOptions()` was being called twice in quick succession, which can cause this crash. A simple check of whether the list has changed avoids this problem.

I wanted to avoid the problem of that function being called twice, and I believe I can do that by removing the call to `fetchBottomSheetList` [here](https://github.com/woocommerce/woocommerce-android/blob/0a85b39af97b2232000ca33fbd2e22b4f59ecabf/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt#L56). That call is unnecessary since `ProductDetailFragment` already calls that, and it updates the list when the product type is changed. However, that's a larger change so I opted for the simple solution. If the reviewer thinks this change should be made, I'm happy to do it.

