### PR TITLE
Show skeletons when loading review list for the first time after login

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.reviews
 
 import android.os.Parcelable
-import androidx.lifecycle.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -66,7 +69,6 @@ class ReviewListViewModel @Inject constructor(
     init {
         EventBus.getDefault().register(this)
         dispatcher.register(this)
-        observeReviewUpdates()
     }
 
     override fun onCleared() {
@@ -92,6 +94,7 @@ class ReviewListViewModel @Inject constructor(
             }
             fetchReviewList(loadMore = false)
         }
+        observeReviewUpdates()
     }
 
     /**
@@ -214,7 +217,9 @@ class ReviewListViewModel @Inject constructor(
     private fun observeReviewUpdates() {
         viewModelScope.launch {
             unseenReviewsCountHandler.observeUnseenCount()
-                .collect { forceRefreshReviews() }
+                .collect { unseenCount ->
+                    if (unseenCount != 0) forceRefreshReviews()
+                }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -93,8 +93,8 @@ class ReviewListViewModel @Inject constructor(
                 viewState = viewState.copy(isSkeletonShown = true)
             }
             fetchReviewList(loadMore = false)
+            observeReviewUpdates()
         }
-        observeReviewUpdates()
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -29,7 +29,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.EventBus
@@ -217,9 +217,7 @@ class ReviewListViewModel @Inject constructor(
     private fun observeReviewUpdates() {
         viewModelScope.launch {
             unseenReviewsCountHandler.observeUnseenCount()
-                .collect { unseenCount ->
-                    if (unseenCount != 0) forceRefreshReviews()
-                }
+                .collectLatest { forceRefreshReviews() }
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5948 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
On a fresh install of the app, when clicking on the Reviews icon, the empty view is first displayed for a few seconds before the Reviews list is displayed. We should display skeletons while loading instead. 

Trickier bug than it looks. 
The reason for the bug is this code I added recently to observe updates on unseen reviews: 
```kotlin 
    private fun observeReviewUpdates() {
        viewModelScope.launch {
            unseenReviewsCountHandler.observeUnseenCount()
                .collect { unseenCount ->
                   forceRefreshReviews()
                }
        }
    }
```
That code was triggering a `forceRefresh()` always when we open the screen and right after the `start()` function was called. Both of these functions concurrently updated the state of the skeleton overriding the expected behavior and setting skeleton visibility to false before the review list was fully fetched. 
Two small changes in this PR: 
- Ensure we subscribe to unseenReviews count right after the first fetching of reviews list is done. This way we avoid any potential race condition with the loading states. 
- Minor improvement to reduce the amount of forceRefresh calls when there are many subsequent unseen reviews count updates. For this we will use collectLatest instead of collect.  From docs: 
>The crucial difference from collect is that when the original flow emits a new value then the action block for the previous value is cancelled.


## Test instructions

1. Make a fresh install of the app 
2. Open review list from more menu
3. Check that skeletons are displayed before review list or empty case
4. Switch site and repeat

Repeat that flow  having unread reviews. 





