### PR TITLE
IPP Canada: Make IPP work for Interac payments

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -93,8 +93,6 @@ internal class PaymentManager(
             retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
                 capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntent)
             }
-        } else {
-            return@flow
         }
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -93,7 +93,7 @@ internal class PaymentManager(
 
     private fun isInteracPayment(paymentIntent: PaymentIntent): Boolean {
         return !paymentIntent.getCharges().isNullOrEmpty() &&
-            paymentIntent.getCharges()[0].paymentMethodDetails?.interacPresentDetails != null
+            paymentIntent.getCharges().getOrNull(0)?.paymentMethodDetails?.interacPresentDetails != null
     }
 
     private fun interacPaymentSuccessful(paymentIntent: PaymentIntent): Boolean {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -76,6 +76,19 @@ internal class PaymentManager(
             paymentIntent = processPayment(paymentIntent)
         }
 
+        /*
+            At this point,
+
+            if this was an Interac payment. The payment has already been captured successfully
+            in the previous step (Processing step). In the next capture step, we will inform the backend about
+            the successful Interac payment transaction that has already happened and it's not the success/failure
+            of the actual Interac payment itself.
+
+            If this was a non-Interac payment. We expect the payment intent's status to be REQUIRES_CAPTURE and in
+            the next step we capture the payment in the backend. Here, the success/failure of the capture step defines
+            the success/failure of the actual payment.
+         */
+
         if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE || isInteracPaymentSuccessful(paymentIntent)) {
             retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
                 capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntent)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -77,12 +77,21 @@ internal class PaymentManager(
         }
         if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CONFIRMATION) {
             paymentIntent = processPayment(paymentIntent)
-            if (paymentIntent.status != PaymentIntentStatus.REQUIRES_CAPTURE) {
+            if (
+                paymentIntent.status != PaymentIntentStatus.REQUIRES_CAPTURE &&
+                (!paymentIntent.getCharges().isNullOrEmpty() &&
+                    paymentIntent.getCharges()[0].paymentMethodDetails?.interacPresentDetails == null)
+            ) {
                 return@flow
             }
         }
 
-        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE) {
+        if (
+            paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE ||
+            (paymentIntent.status == PaymentIntentStatus.SUCCEEDED &&
+                !paymentIntent.getCharges().isNullOrEmpty() &&
+                paymentIntent.getCharges()[0].paymentMethodDetails?.interacPresentDetails != null)
+        ) {
             retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
                 capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntent)
             }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -71,23 +71,17 @@ internal class PaymentManager(
 
         if (paymentIntent.status == PaymentIntentStatus.REQUIRES_PAYMENT_METHOD) {
             paymentIntent = collectPayment(paymentIntent)
-            if (paymentIntent.status != PaymentIntentStatus.REQUIRES_CONFIRMATION) {
-                return@flow
-            }
         }
         if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CONFIRMATION) {
             paymentIntent = processPayment(paymentIntent)
-            if (
-                paymentIntent.status != PaymentIntentStatus.REQUIRES_CAPTURE && !isInteracPayment(paymentIntent)
-            ) {
-                return@flow
-            }
         }
 
         if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE || interacPaymentSuccessful(paymentIntent)) {
             retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
                 capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntent)
             }
+        } else {
+            return@flow
         }
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -78,28 +78,26 @@ internal class PaymentManager(
         if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CONFIRMATION) {
             paymentIntent = processPayment(paymentIntent)
             if (
-                paymentIntent.status != PaymentIntentStatus.REQUIRES_CAPTURE && isNotInteracPayment(paymentIntent)
+                paymentIntent.status != PaymentIntentStatus.REQUIRES_CAPTURE && !isInteracPayment(paymentIntent)
             ) {
                 return@flow
             }
         }
 
-        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE || interacPaymentSucceeded(paymentIntent)) {
+        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE || interacPaymentSuccessful(paymentIntent)) {
             retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
                 capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntent)
             }
         }
     }
 
-    private fun isNotInteracPayment(paymentIntent: PaymentIntent): Boolean {
+    private fun isInteracPayment(paymentIntent: PaymentIntent): Boolean {
         return !paymentIntent.getCharges().isNullOrEmpty() &&
-            paymentIntent.getCharges()[0].paymentMethodDetails?.interacPresentDetails == null
+            paymentIntent.getCharges()[0].paymentMethodDetails?.interacPresentDetails != null
     }
 
-    private fun interacPaymentSucceeded(paymentIntent: PaymentIntent): Boolean {
-        return paymentIntent.status == PaymentIntentStatus.SUCCEEDED &&
-            !paymentIntent.getCharges().isNullOrEmpty() &&
-            paymentIntent.getCharges()[0].paymentMethodDetails?.interacPresentDetails != null
+    private fun interacPaymentSuccessful(paymentIntent: PaymentIntent): Boolean {
+        return isInteracPayment(paymentIntent) && paymentIntent.status == PaymentIntentStatus.SUCCEEDED
     }
 
     private suspend fun FlowCollector<CardPaymentStatus>.retrieveReceiptUrl(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -76,7 +76,7 @@ internal class PaymentManager(
             paymentIntent = processPayment(paymentIntent)
         }
 
-        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE || interacPaymentSuccessful(paymentIntent)) {
+        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE || isInteracPaymentSuccessful(paymentIntent)) {
             retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
                 capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntent)
             }
@@ -90,7 +90,7 @@ internal class PaymentManager(
             paymentIntent.getCharges().getOrNull(0)?.paymentMethodDetails?.interacPresentDetails != null
     }
 
-    private fun interacPaymentSuccessful(paymentIntent: PaymentIntent): Boolean {
+    private fun isInteracPaymentSuccessful(paymentIntent: PaymentIntent): Boolean {
         return isInteracPayment(paymentIntent) && paymentIntent.status == PaymentIntentStatus.SUCCEEDED
     }
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -336,10 +336,10 @@ class PaymentManagerTest {
                     }
                 )
 
-            manager
-                .acceptPayment(createPaymentInfo()).toList()
+            val result = manager
+                .acceptPayment(createPaymentInfo()).takeUntil(CapturingPayment::class).toList()
 
-            verify(cardReaderStore).capturePaymentIntent(any(), anyString())
+            assertThat(result.last()).isInstanceOf(CapturingPayment::class.java)
         }
 
     @Test
@@ -364,26 +364,6 @@ class PaymentManagerTest {
 
             assertThat(result).isNotNull // verify the flow did not timeout
             verify(cardReaderStore, never()).capturePaymentIntent(any(), anyString())
-        }
-
-    @Test
-    fun `given non-interac payment, when processing payment finishes successfully, then capture payment is emitted`() =
-        runBlockingTest {
-            whenever(processPaymentAction.processPayment(anyOrNull()))
-                .thenReturn(
-                    flow {
-                        emit(
-                            ProcessPaymentStatus.Success(
-                                createPaymentIntent(REQUIRES_CAPTURE)
-                            )
-                        )
-                    }
-                )
-
-            manager
-                .acceptPayment(createPaymentInfo()).toList()
-
-            verify(cardReaderStore).capturePaymentIntent(any(), anyString())
         }
 
     // END - Processing Payment

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.payments
 
+import com.stripe.stripeterminal.external.models.CardPresentDetails
 import com.stripe.stripeterminal.external.models.Charge
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus
@@ -7,6 +8,7 @@ import com.stripe.stripeterminal.external.models.PaymentIntentStatus.CANCELED
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CAPTURE
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CONFIRMATION
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_PAYMENT_METHOD
+import com.stripe.stripeterminal.external.models.PaymentIntentStatus.SUCCEEDED
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
@@ -320,6 +322,70 @@ class PaymentManagerTest {
             verify(cardReaderStore, never()).capturePaymentIntent(any(), anyString())
         }
 
+    @Test
+    fun `given interac payment, when processing payment finishes successfully, then capture payment is emitted`() =
+        runBlockingTest {
+            whenever(processPaymentAction.processPayment(anyOrNull()))
+                .thenReturn(
+                    flow {
+                        emit(
+                            ProcessPaymentStatus.Success(
+                                createPaymentIntent(SUCCEEDED, interacPresentDetails = mock())
+                            )
+                        )
+                    }
+                )
+
+            manager
+                .acceptPayment(createPaymentInfo()).toList()
+
+            verify(cardReaderStore).capturePaymentIntent(any(), anyString())
+        }
+
+    @Test
+    fun `given interac payment, when processing payment finishes with canceled status, then flow terminates`() =
+        runBlockingTest {
+            whenever(processPaymentAction.processPayment(anyOrNull()))
+                .thenReturn(
+                    flow {
+                        emit(
+                            ProcessPaymentStatus.Success(
+                                createPaymentIntent(CANCELED, interacPresentDetails = mock())
+                            )
+                        )
+                    }
+                )
+
+            val result = withTimeoutOrNull(TIMEOUT) {
+                manager
+                    .acceptPayment(createPaymentInfo())
+                    .toList()
+            }
+
+            assertThat(result).isNotNull // verify the flow did not timeout
+            verify(cardReaderStore, never()).capturePaymentIntent(any(), anyString())
+        }
+
+    @Test
+    fun `given non-interac payment, when processing payment finishes successfully, then capture payment is emitted`() =
+        runBlockingTest {
+            whenever(processPaymentAction.processPayment(anyOrNull()))
+                .thenReturn(
+                    flow {
+                        emit(
+                            ProcessPaymentStatus.Success(
+                                createPaymentIntent(REQUIRES_CAPTURE)
+                            )
+                        )
+                    }
+                )
+
+            manager
+                .acceptPayment(createPaymentInfo()).toList()
+
+            verify(cardReaderStore).capturePaymentIntent(any(), anyString())
+        }
+
     // END - Processing Payment
     // BEGIN - Capturing Payment
     @Test
@@ -504,12 +570,18 @@ class PaymentManagerTest {
         }
     // END - Cancel
 
-    private fun createPaymentIntent(status: PaymentIntentStatus, receiptUrl: String? = "test url"): PaymentIntent =
+    private fun createPaymentIntent(
+        status: PaymentIntentStatus,
+        receiptUrl: String? = "test url",
+        interacPresentDetails: CardPresentDetails? = null
+    ): PaymentIntent =
         mock<PaymentIntent>().also {
             whenever(it.status).thenReturn(status)
             whenever(it.id).thenReturn("dummyId")
             val charge = mock<Charge>()
             whenever(charge.receiptUrl).thenReturn(receiptUrl)
+            whenever(charge.paymentMethodDetails).thenReturn(mock())
+            whenever(charge.paymentMethodDetails?.interacPresentDetails).thenReturn(interacPresentDetails)
             whenever(it.getCharges()).thenReturn(listOf(charge))
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5708 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds support for doing IPP using the [Interac](https://stripe.com/docs/terminal/payments/regional?integration-country=CA#interac-payments) cards. 
>Interac payments are authorized and captured in a single step

This PR makes necessary changes to accommodate this ☝️ 

### 🗒️ Note to reviewer
Proper error handling for Interac payment needs to be done. It will be part of a separate PR

### ⚠️ Wisepad 3 device
You need to have a physical Wisepad 3 card reader and a test Interac card in order to test this PR.

### 🧪 Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure you have your store set up in Canada
2. Navigate to the order detail screen
3. Click on the `Collect payment` button
4. Use your test Interac card for the payment
5. Make sure the payment succeeds without any error
6. Repeat steps 2 to 3. Use Stripe test card instead if Interac card and make sure the payment succeeds for non-Interac payments as well


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
