### PR TITLE
Remove existing product type from the Product Type Bottom Sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -641,6 +641,7 @@ class ProductDetailCardBuilder(
                 }
             )
         }
+
     private fun Product.warning(): ProductProperty? {
         val variations = variationRepository.getProductVariationList(this.remoteId)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -396,7 +396,7 @@ class ProductDetailCardBuilder(
     private fun Product.productType(): ProductProperty {
         val onClickHandler = {
             viewModel.onEditProductCardClicked(
-                ViewProductTypes(false),
+                ViewProductTypes(false, currentProductType = type, isCurrentProductVirtual = isVirtual),
                 Stat.PRODUCT_DETAIL_VIEW_PRODUCT_TYPE_TAPPED
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -68,7 +68,12 @@ sealed class ProductNavigationTarget : Event() {
     object AddProductCategory : ProductNavigationTarget()
     data class ViewProductTags(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductDetailBottomSheet(val productType: ProductType) : ProductNavigationTarget()
-    data class ViewProductTypes(val isAddProduct: Boolean) : ProductNavigationTarget()
+    data class ViewProductTypes(
+        val isAddProduct: Boolean,
+        val currentProductType: String,
+        val isCurrentProductVirtual: Boolean
+    ) : ProductNavigationTarget()
+
     data class ViewProductReviews(val remoteId: Long) : ProductNavigationTarget()
     object ViewProductAdd : ProductNavigationTarget()
     data class ViewGroupedProducts(val remoteId: Long, val groupedProductIds: List<Long>) : ProductNavigationTarget()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -231,7 +231,8 @@ class ProductNavigator @Inject constructor() {
 
             is ViewProductTypes -> {
                 val action = ProductDetailFragmentDirections
-                    .actionProductDetailFragmentToProductTypesBottomSheetFragment(target.isAddProduct)
+                    .actionProductDetailFragmentToProductTypesBottomSheetFragment(target.isAddProduct,
+                        currentProductType = target.currentProductType, isCurrentProductVirtual = target.isCurrentProductVirtual)
                 fragment.findNavController().navigateSafely(action)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -231,8 +231,11 @@ class ProductNavigator @Inject constructor() {
 
             is ViewProductTypes -> {
                 val action = ProductDetailFragmentDirections
-                    .actionProductDetailFragmentToProductTypesBottomSheetFragment(target.isAddProduct,
-                        currentProductType = target.currentProductType, isCurrentProductVirtual = target.isCurrentProductVirtual)
+                    .actionProductDetailFragmentToProductTypesBottomSheetFragment(
+                        target.isAddProduct,
+                        currentProductType = target.currentProductType,
+                        isCurrentProductVirtual = target.isCurrentProductVirtual
+                    )
                 fragment.findNavController().navigateSafely(action)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
@@ -29,7 +29,6 @@ class ProductTypeBottomSheetBuilder {
                 titleResource = string.product_type_variable_title,
                 descResource = string.product_type_variable_desc,
                 iconResource = drawable.ic_gridicons_types,
-                isEnabledForAddFlow = true
             ),
             ProductTypesBottomSheetUiItem(
                 type = GROUPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
@@ -7,8 +7,9 @@ import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
+import javax.inject.Inject
 
-class ProductTypeBottomSheetBuilder {
+class ProductTypeBottomSheetBuilder @Inject constructor() {
     fun buildBottomSheetList(): List<ProductTypesBottomSheetUiItem> {
         return listOf(
             ProductTypesBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -25,8 +25,7 @@ class ProductTypesBottomSheetFragment : BottomSheetDialogFragment() {
         const val KEY_PRODUCT_TYPE_RESULT = "key_product_type_result"
     }
 
-    @Inject
-    internal lateinit var navigator: ProductNavigator
+    @Inject internal lateinit var navigator: ProductNavigator
     val viewModel: ProductTypesBottomSheetViewModel by viewModels()
 
     private lateinit var productTypesBottomSheetAdapter: ProductTypesBottomSheetAdapter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -25,7 +25,8 @@ class ProductTypesBottomSheetFragment : BottomSheetDialogFragment() {
         const val KEY_PRODUCT_TYPE_RESULT = "key_product_type_result"
     }
 
-    @Inject internal lateinit var navigator: ProductNavigator
+    @Inject
+    internal lateinit var navigator: ProductNavigator
     val viewModel: ProductTypesBottomSheetViewModel by viewModels()
 
     private lateinit var productTypesBottomSheetAdapter: ProductTypesBottomSheetAdapter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -25,7 +25,8 @@ import javax.inject.Inject
 @HiltViewModel
 class ProductTypesBottomSheetViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    private val prefs: AppPrefs
+    private val prefs: AppPrefs,
+    private val productTypeBottomSheetBuilder: ProductTypeBottomSheetBuilder
 ) : ScopedViewModel(savedState) {
     private val navArgs: ProductTypesBottomSheetFragmentArgs by savedState.navArgs()
 
@@ -34,9 +35,9 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
 
     fun loadProductTypes() {
         _productTypesBottomSheetList.value = if (navArgs.isAddProduct) {
-            ProductTypeBottomSheetBuilder().buildBottomSheetList()
+            productTypeBottomSheetBuilder.buildBottomSheetList()
         } else {
-            ProductTypeBottomSheetBuilder().buildBottomSheetList()
+            productTypeBottomSheetBuilder.buildBottomSheetList()
                 .filter {
                     !(it.type == navArgs.currentProductType?.let { nonNullProductType ->
                         ProductType.fromString(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -37,6 +37,9 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
             ProductTypeBottomSheetBuilder().buildBottomSheetList()
         } else {
             ProductTypeBottomSheetBuilder().buildBottomSheetList()
+                .filter { !(it.type == navArgs.currentProductType?.let{nonNullProductType -> ProductType.fromString(nonNullProductType)} &&
+                    it.isVirtual == navArgs.isCurrentProductVirtual)
+                }
         }
     }
 
@@ -74,7 +77,6 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
         @StringRes val titleResource: Int,
         @StringRes val descResource: Int,
         @DrawableRes val iconResource: Int,
-        val isEnabledForAddFlow: Boolean = true,
         val isVirtual: Boolean = false
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -39,12 +39,9 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
         } else {
             productTypeBottomSheetBuilder.buildBottomSheetList()
                 .filter {
-                    !(it.type == navArgs.currentProductType?.let { nonNullProductType ->
-                        ProductType.fromString(
-                            nonNullProductType
-                        )
-                    } &&
-                        it.isVirtual == navArgs.isCurrentProductVirtual)
+                    val currentProductType = navArgs.currentProductType
+                        ?.let { nonNullProductType -> ProductType.fromString(nonNullProductType) }
+                    !(it.type == currentProductType && it.isVirtual == navArgs.isCurrentProductVirtual)
                 }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -37,8 +37,13 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
             ProductTypeBottomSheetBuilder().buildBottomSheetList()
         } else {
             ProductTypeBottomSheetBuilder().buildBottomSheetList()
-                .filter { !(it.type == navArgs.currentProductType?.let{nonNullProductType -> ProductType.fromString(nonNullProductType)} &&
-                    it.isVirtual == navArgs.isCurrentProductVirtual)
+                .filter {
+                    !(it.type == navArgs.currentProductType?.let { nonNullProductType ->
+                        ProductType.fromString(
+                            nonNullProductType
+                        )
+                    } &&
+                        it.isVirtual == navArgs.isCurrentProductVirtual)
                 }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -50,7 +50,7 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
 
     fun onProductTypeSelected(productTypeUiItem: ProductTypesBottomSheetUiItem) {
         if (navArgs.isAddProduct) {
-            val properties = mapOf("product_type" to productTypeUiItem.type.value.toLowerCase(ROOT))
+            val properties = mapOf("product_type" to productTypeUiItem.type.value.lowercase(ROOT))
             AnalyticsTracker.track(Stat.ADD_PRODUCT_PRODUCT_TYPE_SELECTED, properties)
 
             saveUserSelection(productTypeUiItem)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -35,7 +35,6 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
     fun loadProductTypes() {
         _productTypesBottomSheetList.value = if (navArgs.isAddProduct) {
             ProductTypeBottomSheetBuilder().buildBottomSheetList()
-                .filter { it.isEnabledForAddFlow }
         } else {
             ProductTypeBottomSheetBuilder().buildBottomSheetList()
         }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -332,6 +332,17 @@
             android:name="isAddProduct"
             android:defaultValue="false"
             app:argType="boolean" />
+        <argument
+            android:name="currentProductType"
+            android:defaultValue="null"
+            app:nullable="true"
+            app:argType="string"
+            />
+        <argument
+            android:name="isCurrentProductVirtual"
+            android:defaultValue="false"
+            app:argType="boolean"
+            />
     </dialog>
     <dialog
         android:id="@+id/featureAnnouncementDialogFragmentOnMain"

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -364,6 +364,17 @@
             android:name="isAddProduct"
             android:defaultValue="false"
             app:argType="boolean" />
+        <argument
+            android:name="currentProductType"
+            android:defaultValue="null"
+            app:nullable="true"
+            app:argType="string"
+            />
+        <argument
+            android:name="isCurrentProductVirtual"
+            android:defaultValue="false"
+            app:argType="boolean"
+            />
     </dialog>
     <fragment
         android:id="@+id/productReviewsFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-
 class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: ProductTypesBottomSheetViewModel
     private val appPrefs: AppPrefs = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
@@ -1,0 +1,86 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.initSavedStateHandle
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+
+class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: ProductTypesBottomSheetViewModel
+    private val appPrefs: AppPrefs = mock()
+    private val bottomSheetBuilder: ProductTypeBottomSheetBuilder = mock()
+
+    @Test
+    fun `given is Add Product flow, when loading product types, then product types not filtered`() {
+        viewModel = ProductTypesBottomSheetViewModel(
+            ProductTypesBottomSheetFragmentArgs(isAddProduct = true).initSavedStateHandle(),
+            appPrefs, bottomSheetBuilder
+        )
+        whenever(bottomSheetBuilder.buildBottomSheetList()).thenReturn(uiItems)
+
+        viewModel.loadProductTypes()
+
+        assertThat(viewModel.productTypesBottomSheetList.value).isEqualTo(uiItems)
+    }
+
+    @Test
+    fun `given is not Add Product flow, when loading product types, then product types is filtered`() {
+        viewModel = ProductTypesBottomSheetViewModel(
+            ProductTypesBottomSheetFragmentArgs(
+                isAddProduct = false,
+                currentProductType = "simple",
+                isCurrentProductVirtual = false
+            ).initSavedStateHandle(),
+            appPrefs, bottomSheetBuilder
+        )
+        whenever(bottomSheetBuilder.buildBottomSheetList()).thenReturn(uiItems)
+
+        viewModel.loadProductTypes()
+
+        assertThat(viewModel.productTypesBottomSheetList.value!!.size).isEqualTo(uiItems.size - 1)
+    }
+
+    @Test
+    fun `when loading product types, then product types is filtered`() {
+        viewModel = ProductTypesBottomSheetViewModel(
+            ProductTypesBottomSheetFragmentArgs(
+                isAddProduct = false,
+                currentProductType = "simple",
+                isCurrentProductVirtual = true
+            ).initSavedStateHandle(),
+            appPrefs, bottomSheetBuilder
+        )
+        whenever(bottomSheetBuilder.buildBottomSheetList()).thenReturn(uiItems)
+
+        viewModel.loadProductTypes()
+
+        assertThat(viewModel.productTypesBottomSheetList.value!!.size).isEqualTo(uiItems.size - 1)
+        assertThat(viewModel.productTypesBottomSheetList.value!![0].isVirtual).isFalse
+    }
+
+    private val uiItems: List<ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem> = listOf(
+        ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem(
+            type = ProductType.SIMPLE,
+            titleResource = 0,
+            descResource = 0,
+            iconResource = 0
+        ),
+        ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem(
+            type = ProductType.SIMPLE,
+            titleResource = 0,
+            descResource = 0,
+            iconResource = 0,
+            isVirtual = true
+        ),
+        ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem(
+            type = ProductType.GROUPED,
+            titleResource = 0,
+            descResource = 0,
+            iconResource = 0
+        )
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
@@ -44,7 +44,7 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when loading product types, then product types is filtered`() {
+    fun `given current type is virtual, when loading product types, then only virtual type is filtered out`() {
         viewModel = ProductTypesBottomSheetViewModel(
             ProductTypesBottomSheetFragmentArgs(
                 isAddProduct = false,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3904
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Instead of removing the change confirmation dialogue when the user taps on a product type that is already set for that product, to match what we have on iOS, this PR removes the current product type from the productTypeBottomSheet. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the product screen
- Tap on one of the existing products to display the Product detail screen
- Tap on the Product type
- note the current product type is not displayed in the product type bottom sheet

Also

- Go to the Products Screen
- tap to add a brand new product
- Check if the Product Type bottom sheet display all the product type options


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/156436788-5ee94204-a6cb-4982-8aea-c33959d972a9.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/156431035-254bedb0-6fd8-4c5c-8a63-96cc271a3906.gif" width="350"/> |

- [ x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
