### PR TITLE
Subtracting last product quantity to zero in Order Creation calls full product view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapItemToProductUiModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapItemToProductUiModel.kt
@@ -28,7 +28,7 @@ class MapItemToProductUiModel @Inject constructor(
                 imageUrl = imageUrl.orEmpty(),
                 isStockManaged = isStockManaged ?: false,
                 stockQuantity = stockQuantity ?: 0.0,
-                canDecreaseQuantity = quantity >= 2
+                canDecreaseQuantity = quantity > 0
                 // TODO check if we need to disable the plus button depending on stock quantity
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapItemToProductUiModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapItemToProductUiModel.kt
@@ -27,8 +27,7 @@ class MapItemToProductUiModel @Inject constructor(
                 item = this,
                 imageUrl = imageUrl.orEmpty(),
                 isStockManaged = isStockManaged ?: false,
-                stockQuantity = stockQuantity ?: 0.0,
-                canDecreaseQuantity = quantity > 0
+                stockQuantity = stockQuantity ?: 0.0
                 // TODO check if we need to disable the plus button depending on stock quantity
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -65,7 +65,6 @@ class OrderCreationProductsAdapter(
             binding.productName.text = productModel.item.name
             binding.stepperView.apply {
                 value = productModel.item.quantity.toInt()
-                isMinusButtonEnabled = productModel.canDecreaseQuantity
             }
 
             binding.productAttributes.text = buildString {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -346,6 +346,5 @@ data class ProductUIModel(
     val item: Order.Item,
     val imageUrl: String,
     val isStockManaged: Boolean,
-    val stockQuantity: Double,
-    val canDecreaseQuantity: Boolean
+    val stockQuantity: Double
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -99,7 +99,13 @@ class OrderCreationViewModel @Inject constructor(
 
     fun onIncreaseProductsQuantity(id: Long) = _orderDraft.update { it.adjustProductQuantity(id, +1) }
 
-    fun onDecreaseProductsQuantity(id: Long) = _orderDraft.update { it.adjustProductQuantity(id, -1) }
+    fun onDecreaseProductsQuantity(id: Long) {
+        _orderDraft.value.items
+            .find { it.productId == id }
+            ?.takeIf { it.quantity == 1F }
+            ?.let { onProductClicked(it) }
+            ?: _orderDraft.update { it.adjustProductQuantity(id, -1) }
+    }
 
     fun onOrderStatusChanged(status: Order.Status) {
         AnalyticsTracker.track(


### PR DESCRIPTION
Summary
==========
Fixes issue #5957 by changing the Product item decrease button behavior when the quantity is `1`. For this scenario, now we redirect to the full product view instead of disabling the decrease button, making it easier to remove the Product and still avoid removing it by accident.

Screenshots
==========
https://user-images.githubusercontent.com/5920403/156472905-9aa094c6-f2b9-4177-8e34-20a0edb66955.mp4

How to Test
==========
1. Make sure the feature flag ORDER_CREATION_M2 is enabled
2. Open the Order Creation form
3. Add a Product
4. Increase the product quantity at will
5. Decrease the product quantity until it is reduced to one
6. Verify that the full Product view is now called when hitting the decrease button again, instead of disabling it

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
