### PR TITLE
Add support for IPP for booking orders requiring confirmation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 8.7
 -----
-
+- [*] In-Person Payments: Add support for accepting payments on bookable products
 
 8.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCOrderModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCOrderModelExt.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.store.WCProductStore
 
 internal const val CASH_ON_DELIVERY_PAYMENT_TYPE = "cod"
 internal const val WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE = "woocommerce_payments"
+internal const val WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE = "wc-booking-gateway"
 
 val CASH_PAYMENTS = listOf(CASH_ON_DELIVERY_PAYMENT_TYPE, "bacs", "cheque")
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.cardreader
 
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
+import com.woocommerce.android.extensions.WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
 import com.woocommerce.android.extensions.WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
@@ -23,7 +24,8 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
                 (
                     paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE ||
                         paymentMethod.isEmpty() ||
-                        paymentMethod == WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE
+                        paymentMethod == WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE ||
+                        paymentMethod == WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
                     ) &&
                 !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -276,10 +276,36 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when order has "woocommerce_payments" payment method then it is collectable`() =
+    fun `when order has "woocommerce_payments" payment method, then it is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val order = getOrder(paymentMethod = "woocommerce_payments")
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order)
+
+            // THEN
+            assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order has "wc-booking-gateway" payment method, then it is collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentMethod = "wc-booking-gateway")
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order)
+
+            // THEN
+            assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `given bookings order requires confirmation, when checking collectibility, then it is collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentMethod = "wc-booking-gateway")
 
             // WHEN
             val isCollectable = checker.isCollectable(order)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -301,6 +301,9 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             assertThat(isCollectable).isTrue()
         }
 
+    /**
+     * This test is a clone of the previous test (except of the name) and was added just for the documentation purposes.
+     */
     @Test
     fun `given bookings order requires confirmation, when checking collectibility, then it is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5978 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds support for accepting IPP on booking orders that require confirmation. Such orders have `paymentMethod` set to `wc-booking-gateway` and this PR whitelists this paymentMethod for IPP.

Video with walkthrough can be found on p2-pdfdoF-x7

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Install [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/?utm_source=google&utm_medium=cpc&utm_campaign=marketplace_search_brand_row&utm_content=woocommerce_+bookings&gclid=CjwKCAiAyPyQBhB6EiwAFUuakmqSfoqQhXllPTswn-b_XK6M1kJG51Er64uHd0LYC4vpGDQClhpXERoC23wQAvD_BwE) extension on your store 
2. Create a product in WPAdmin
3. Set it's ProductType to "Bookable Product"
4. Check `Requires confirmation?` checkbox
5. Create an order and add this product to the cart
6. Proceed to checkout and select "Cash/Pay on delivery"
7. Open the order in the app
8. Collect IPP for this order




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
