### PR TITLE
Issue/5967 email sent note

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
@@ -103,6 +103,7 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
                 UiHelpers.setTextOrHide(binding.primaryActionBtn, viewState.primaryActionLabel)
                 UiHelpers.setTextOrHide(binding.secondaryActionBtn, viewState.secondaryActionLabel)
                 UiHelpers.setTextOrHide(binding.tertiaryActionBtn, viewState.tertiaryActionLabel)
+                UiHelpers.setTextOrHide(binding.receiptSentLabel, viewState.receiptSentAutomaticallyHint)
                 UiHelpers.updateVisibility(binding.progressBarWrapper, viewState.isProgressVisible)
                 binding.primaryActionBtn.setOnClickListener {
                     viewState.onPrimaryActionClicked?.invoke()
@@ -130,7 +131,9 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
 
     private fun announceForAccessibility(binding: CardReaderPaymentDialogBinding, viewState: ViewState) {
         with(binding) {
-            if (viewState is ViewState.PaymentSuccessfulState) {
+            if (viewState is ViewState.PaymentSuccessfulState ||
+                viewState is ViewState.PaymentSuccessfulReceiptSentAutomaticallyState
+            ) {
                 viewState.headerLabel?.let {
                     headerLabel.announceForAccessibility(getString(it) + viewState.amountWithCurrencyLabel)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewState.kt
@@ -4,11 +4,13 @@ import androidx.annotation.DimenRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 
 sealed class ViewState(
     @StringRes open val hintLabel: Int? = null,
     @StringRes open val headerLabel: Int? = null,
     @StringRes val paymentStateLabel: Int? = null,
+    open val receiptSentAutomaticallyHint: UiString? = null,
     @DimenRes val paymentStateLabelTopMargin: Int = R.dimen.major_275,
     @DrawableRes val illustration: Int? = null,
     open val isProgressVisible: Boolean = false,
@@ -76,6 +78,18 @@ sealed class ViewState(
         illustration = R.drawable.img_celebration,
         primaryActionLabel = R.string.card_reader_payment_print_receipt,
         secondaryActionLabel = R.string.card_reader_payment_send_receipt,
+        tertiaryActionLabel = R.string.card_reader_payment_save_for_later,
+    )
+
+    data class PaymentSuccessfulReceiptSentAutomaticallyState(
+        override val amountWithCurrencyLabel: String,
+        override val receiptSentAutomaticallyHint: UiString,
+        override val onPrimaryActionClicked: (() -> Unit),
+        override val onTertiaryActionClicked: (() -> Unit)
+    ) : ViewState(
+        headerLabel = R.string.card_reader_payment_completed_payment_header,
+        illustration = R.drawable.img_celebration,
+        primaryActionLabel = R.string.card_reader_payment_print_receipt,
         tertiaryActionLabel = R.string.card_reader_payment_save_for_later,
     )
 

--- a/WooCommerce/src/main/res/layout/card_reader_payment_dialog.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_payment_dialog.xml
@@ -10,7 +10,7 @@
         android:layout_height="@dimen/payments_dialog_height"
         android:background="@color/color_surface_elevated"
         android:paddingTop="@dimen/major_150"
-        android:paddingBottom="@dimen/major_150">
+        android:paddingBottom="@dimen/major_75">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/header_label"
@@ -99,6 +99,19 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/payment_state_label"
             tools:text="Tap or insert to pay" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/receipt_sent_label"
+            style="@style/Woo.TextView.Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_125"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:gravity="center_horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/content_group"
+            tools:text="A receipt has been emailed to xyz" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/primary_action_btn"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -978,6 +978,7 @@
     <string name="card_reader_refetching_order_failed">Error fetching order. Order state in the app might be outdated.</string>
     <string name="card_reader_payment_order_paid_payment_cancelled">The order is already paid</string>
     <string name="card_reader_payment_reader_not_connected">Please make sure that the card reader is connected.</string>
+    <string name="card_reader_payment_reader_receipt_sent">A receipt has been sent to &lt;strong&gt;%s&lt;/strong&gt;</string>
 
     <string name="card_reader_welcome_dialog_header">Collect payments with a card reader</string>
     <string name="card_reader_welcome_dialog_text">Congrats, you are now able to accept debit and credit card payments with WooCommerce Payments!</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -438,7 +438,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given billing not email, when payment completed, then ui updated to payment successful receipt sent state`() =
+    fun `given billing not empty, when payment completed, then ui updated to payment successful receipt sent state`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(mockedAddress.email).thenReturn("nonemptyemail")
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -59,6 +59,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: CardReaderPaymentViewModel
     private val cardReaderManager: CardReaderManager = mock()
     private val orderRepository: OrderDetailRepository = mock()
+    private val mockedOrder = mock<Order>()
+    private val mockedAddress = mock<Address>()
     private var resourceProvider: ResourceProvider = mock()
     private val selectedSite: SelectedSite = mock()
     private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker = mock()
@@ -98,17 +100,15 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             dispatchers = coroutinesTestRule.testDispatchers
         )
 
-        val mockedOrder = mock<Order>()
         whenever(orderRepository.getOrderById(any())).thenReturn(mockedOrder)
         whenever(mockedOrder.total).thenReturn(DUMMY_TOTAL)
         whenever(mockedOrder.currency).thenReturn("GBP")
         whenever(currencyFormatter.formatAmountWithCurrency("GBP", DUMMY_TOTAL.toDouble()))
             .thenReturn("$DUMMY_CURRENCY_SYMBOL$DUMMY_TOTAL")
-        val address = mock<Address>()
-        whenever(mockedOrder.billingAddress).thenReturn(address)
-        whenever(address.email).thenReturn("test@test.test")
-        whenever(address.firstName).thenReturn("Tester")
-        whenever(address.lastName).thenReturn("Test")
+        whenever(mockedOrder.billingAddress).thenReturn(mockedAddress)
+        whenever(mockedAddress.email).thenReturn("")
+        whenever(mockedAddress.firstName).thenReturn("Tester")
+        whenever(mockedAddress.lastName).thenReturn("Test")
         whenever(mockedOrder.orderKey).thenReturn("wc_order_j0LMK3bFhalEL")
         whenever(mockedOrder.number).thenReturn(DUMMY_ORDER_NUMBER)
         whenever(mockedOrder.id).thenReturn(ORDER_ID)
@@ -426,7 +426,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when payment completed, then ui updated to payment successful state`() =
+    fun `given billing email empty, when payment completed, then ui updated to payment successful state`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -435,6 +435,21 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(PaymentSuccessfulState::class.java)
+        }
+
+    @Test
+    fun `given billing not email, when payment completed, then ui updated to payment successful receipt sent state`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(mockedAddress.email).thenReturn("nonemptyemail")
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+
+            viewModel.start()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(
+                PaymentSuccessfulReceiptSentAutomaticallyState::class.java
+            )
         }
 
     @Test
@@ -1022,7 +1037,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when user clicks on print receipt button, then PrintReceipt event emitted`() =
+    fun `given billing email empty, when user clicks on print receipt button, then PrintReceipt event emitted`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1035,7 +1050,22 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when user clicks on print receipt button, then printing receipt state shown`() =
+    fun `given billing email not empty, when user clicks on print receipt button, then PrintReceipt event emitted`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(mockedAddress.email).thenReturn("nonemptyemail")
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+            viewModel.start()
+
+            (viewModel.viewStateData.value as PaymentSuccessfulReceiptSentAutomaticallyState)
+                .onPrimaryActionClicked.invoke()
+
+            assertThat(viewModel.event.value).isInstanceOf(PrintReceipt::class.java)
+        }
+
+    @Test
+    fun `given billing email empty, when user clicks on print receipt button, then printing receipt state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1049,7 +1079,23 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when print result received, then payment successful state shown`() =
+    fun `given billing email not empty, when user clicks on print receipt button, then printing receipt state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(mockedAddress.email).thenReturn("nonemptyemail")
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+            viewModel.start()
+
+            (viewModel.viewStateData.value as PaymentSuccessfulReceiptSentAutomaticallyState)
+                .onPrimaryActionClicked.invoke()
+
+            assertThat(viewModel.viewStateData.value)
+                .isInstanceOf(PrintingReceiptState::class.java)
+        }
+
+    @Test
+    fun `given billing email empty, when print result received, then payment successful state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1060,6 +1106,23 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             viewModel.onPrintResult(CANCELLED)
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(PaymentSuccessfulState::class.java)
+        }
+
+    @Test
+    fun `given billing email not empty, when print result received, then payment success receipt sent state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(mockedAddress.email).thenReturn("nonemptyemail")
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+            viewModel.start()
+            (viewModel.viewStateData.value as PaymentSuccessfulReceiptSentAutomaticallyState)
+                .onPrimaryActionClicked.invoke()
+
+            viewModel.onPrintResult(CANCELLED)
+
+            assertThat(viewModel.viewStateData.value)
+                .isInstanceOf(PaymentSuccessfulReceiptSentAutomaticallyState::class.java)
         }
 
     @Test
@@ -1092,7 +1155,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when user clicks on print receipt button, then event tracked`() =
+    fun `given billing email empty, when user clicks on print receipt button, then event tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1100,6 +1163,21 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             (viewModel.viewStateData.value as PaymentSuccessfulState).onPrimaryActionClicked.invoke()
+
+            verify(tracker).trackPrintReceiptTapped()
+        }
+
+    @Test
+    fun `given billing email not empty, when user clicks on print receipt button, then event tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(mockedAddress.email).thenReturn("nonemptyemail")
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+            viewModel.start()
+
+            (viewModel.viewStateData.value as PaymentSuccessfulReceiptSentAutomaticallyState)
+                .onPrimaryActionClicked.invoke()
 
             verify(tracker).trackPrintReceiptTapped()
         }
@@ -1152,7 +1230,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when user clicks on save for later button, then Exit event emitted`() =
+    fun `given billing email empty, when user clicks on save for later button, then Exit event emitted`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1160,6 +1238,21 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             (viewModel.viewStateData.value as PaymentSuccessfulState).onTertiaryActionClicked.invoke()
+
+            assertThat(viewModel.event.value).isInstanceOf(Exit::class.java)
+        }
+
+    @Test
+    fun `given billing email not empty, when user clicks on save for later button, then Exit event emitted`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(mockedAddress.email).thenReturn("nonemptyemail")
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+            viewModel.start()
+
+            (viewModel.viewStateData.value as PaymentSuccessfulReceiptSentAutomaticallyState)
+                .onTertiaryActionClicked.invoke()
 
             assertThat(viewModel.event.value).isInstanceOf(Exit::class.java)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5967
<!-- Id number of the GitHub issue this PR addresses. -->

Not urgent, can be merged into 8.7 or 8.8.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates Payment Successful screen
- when billing email is empty a dialog with "Print receipt and Send receipt" is shown
- when billing email is not empty a dialog with "Print receipt and Email has been sent" is shown

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create an order and leave the billing email empty
2. Collect payment for this order
3. Notice the payment successful screen looks as it looked before - except of a minor change in bottom margin
--------------
1. Create an order and enter a billing email
2. Collect payment for this order
3. Notice the payment successful screen contains "A receipt has been sent to xyz@xyz.xyz" and Print Receipt button
4. Tap on Print receipt and wait until the printing UI is shown
5. Go back and notice the payment successful screen contains "A receipt has been sent to xyz@xyz.xyz" and Print Receipt button


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

cc @adamzelinski 
| Before | After |
| --- | --- |
| ![Screenshot_1646314175](https://user-images.githubusercontent.com/2261188/156574487-871ebc8b-dff8-4eb1-8f36-1368263554ab.png) | ![Screenshot_1646289504](https://user-images.githubusercontent.com/2261188/156574682-31c8d071-04b5-47dc-90f9-f17a80b9ca2a.png) |
| ![Screenshot_1646314177](https://user-images.githubusercontent.com/2261188/156574489-4696ce57-8fd8-443f-8459-827c9a6fd4df.png) | ![Screenshot_1646289506](https://user-images.githubusercontent.com/2261188/156574679-71318632-6249-487f-83d7-3279a85b2c8f.png) |
| ![Screenshot_1646314145](https://user-images.githubusercontent.com/2261188/156574469-ef6bcfd0-430e-454e-9cd1-fa78b36d5679.png) | ![Screenshot_1646289510](https://user-images.githubusercontent.com/2261188/156574675-c7473c5f-611e-43e8-8905-e8d4540093b1.png) |
| ![Screenshot_1646314148](https://user-images.githubusercontent.com/2261188/156574486-1cb8e3a1-9eb3-490a-918e-7ee753d93eba.png) | ![Screenshot_1646289512](https://user-images.githubusercontent.com/2261188/156574672-55dcaa7f-b4b8-4cdb-ae0f-58d1a3f7250b.png) |
| ![Screenshot_1646314153](https://user-images.githubusercontent.com/2261188/156574494-8efc619f-254d-471d-87ee-076cdfbfbffd.png) | ![Screenshot_1646291045](https://user-images.githubusercontent.com/2261188/156574664-a9f94afb-7f64-4ed2-a800-a2c4299dce87.png) |
| N/A | ![Screenshot_1646292282](https://user-images.githubusercontent.com/2261188/156574651-2b154000-8dca-405c-8e25-65c18f096b25.png) |



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
