### PR TITLE
Issue/5980 no such element product list filter

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.FilterListItemBinding
-import com.woocommerce.android.extensions.areSameAs
 import com.woocommerce.android.ui.products.ProductFilterListAdapter.ProductFilterViewHolder
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterListItemUiModel
 
@@ -48,9 +47,6 @@ class ProductFilterListAdapter(
     override fun getItemId(position: Int) = position.toLong()
 
     override fun getItemCount() = filterList.size
-
-    private fun isSameList(newList: List<FilterListItemUiModel>) =
-        filterList.areSameAs(newList) { this.isSameFilter(it) }
 
     class ProductFilterViewHolder(val viewBinding: FilterListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListAdapter.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.FilterListItemBinding
 import com.woocommerce.android.extensions.areSameAs
@@ -13,10 +14,10 @@ class ProductFilterListAdapter(
 ) : RecyclerView.Adapter<ProductFilterViewHolder>() {
     var filterList = listOf<FilterListItemUiModel>()
         set(value) {
-            if (!isSameList(value)) {
-                field = value
-                notifyDataSetChanged()
-            }
+            val diffResult =
+                DiffUtil.calculateDiff(ProductFilterDiffUtil(field, value))
+            field = value
+            diffResult.dispatchUpdatesTo(this)
         }
 
     interface OnProductFilterClickListener {
@@ -57,6 +58,22 @@ class ProductFilterListAdapter(
             viewBinding.filterItemName.text = filter.filterItemName
             viewBinding.filterItemSelection.text =
                 filter.filterOptionListItems.first { it.isSelected }.filterOptionItemName
+        }
+    }
+
+    private class ProductFilterDiffUtil(
+        val oldList: List<FilterListItemUiModel>,
+        val newList: List<FilterListItemUiModel>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+            oldList[oldItemPosition].filterItemKey == newList[newItemPosition].filterItemKey
+
+        override fun getOldListSize(): Int = oldList.size
+
+        override fun getNewListSize(): Int = newList.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition] == newList[newItemPosition]
         }
     }
 }


### PR DESCRIPTION
This is a potential - albeit unlikely - fix for #5980. This is somewhat similar to #5963 in that it's a mysterious `RecyclerView` crash, and our attempt to solve that was to rely entirely on `DiffUtils` when populating the adapter. So this PR does the same thing for the `ProductListFilterAdapter`

To test:

* Switch to the product list
* Tap "Filters"
* Ensure the filters screen works as expected