### PR TITLE
Issue/5988 Save country to a track keeper for Simple Payments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
@@ -43,7 +43,7 @@ class SimplePaymentsDialogViewModel @Inject constructor(
 
     init {
         launch(Dispatchers.IO) {
-            setCountryToTracking()
+            saveCountryForTracking()
         }
     }
 
@@ -91,7 +91,7 @@ class SimplePaymentsDialogViewModel @Inject constructor(
         }
     }
 
-    private suspend fun setCountryToTracking() {
+    private suspend fun saveCountryForTracking() {
         cardReaderTrackingInfoKeeper.setCountry(wooStore.getStoreCountryCode(selectedSite.get()))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsDialogViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.prefs.cardreader.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -22,6 +23,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.OrderUpdateStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import javax.inject.Inject
 
@@ -32,10 +34,18 @@ class SimplePaymentsDialogViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val orderUpdateStore: OrderUpdateStore,
     private val networkStatus: NetworkStatus,
-    private val orderMapper: OrderMapper
+    private val orderMapper: OrderMapper,
+    private val wooStore: WooCommerceStore,
+    private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper,
 ) : ScopedViewModel(savedState) {
     final val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
     internal var viewState by viewStateLiveData
+
+    init {
+        launch(Dispatchers.IO) {
+            setCountryToTracking()
+        }
+    }
 
     var currentPrice: BigDecimal
         get() = viewState.currentPrice
@@ -79,6 +89,10 @@ class SimplePaymentsDialogViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun setCountryToTracking() {
+        cardReaderTrackingInfoKeeper.setCountry(wooStore.getStoreCountryCode(selectedSite.get()))
     }
 
     @Parcelize


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5988 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Simple Payments doesn't use Onboarding checker that's why we need (hopefully temporarily) to store country code for the tracking needs directly

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Use Simple Payments
* Try to collect a payment
* Notice country parameter in LogCat for IPP events

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
