### PR TITLE
[Order Creation] support of negative shipping and fees

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_order_creation_fee.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_fee.xml
@@ -33,7 +33,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/fee_type_switch"
                 app:supportsEmptyState="false"
-                app:supportsNegativeValues="false" />
+                app:supportsNegativeValues="true" />
 
             <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
                 android:id="@+id/fee_percentage_edit_text"
@@ -42,7 +42,7 @@
                 android:layout_marginTop="@dimen/major_75"
                 android:hint="@string/order_creation_fee_percentage_hint"
                 android:visibility="gone"
-                android:inputType="numberDecimal"
+                android:inputType="numberDecimal|numberSigned"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/fee_type_switch" />

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_shipping.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_shipping.xml
@@ -21,7 +21,7 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/order_creation_shipping_amount"
                 app:supportsEmptyState="false"
-                app:supportsNegativeValues="false" />
+                app:supportsNegativeValues="true" />
 
             <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
                 android:id="@+id/nameEditText"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5974
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This simply enables the negative support that was added to the CurrencyEditText in #5929 for the shipping and fee screens.
For percentage fees, it worked also out of the box after enabling negative values, nice work on there @ThomazFB 👏 

### Testing instructions
Test adding and editing negative fees (both by value and percentage) and shipping rates in the Order Creation form.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
