### PR TITLE
Issue/6003 order creation customer exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
@@ -241,7 +241,7 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done).apply {
-            isVisible = addressViewModel.isAnyAddressEdited.value ?: false
+            isVisible = addressViewModel.shouldShowDoneButton.value ?: false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -49,7 +49,8 @@ class AddressViewModel @Inject constructor(
     private var initialState = emptyMap<AddressType, Address>()
 
     val isAnyAddressEdited: LiveData<Boolean> = viewStateData.liveData.map { viewState ->
-        viewState.addressSelectionStates.mapValues { it.value.address } != initialState
+        viewState.addressSelectionStates.isNotEmpty() &&
+            viewState.addressSelectionStates.mapValues { it.value.address } != initialState
     }
 
     private val _isDifferentShippingAddressChecked = MutableLiveData<Boolean>()
@@ -62,7 +63,7 @@ class AddressViewModel @Inject constructor(
         val isDifferentShippingAddressDisabled =
             isDifferentShippingAddressChecked == false && (shippingAddress != Address.EMPTY)
 
-        (isAnyAddressEdited == true || isDifferentShippingAddressDisabled) && !viewState.isLoading
+        isAnyAddressEdited == true || isDifferentShippingAddressDisabled
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -62,7 +62,7 @@ class AddressViewModel @Inject constructor(
         val isDifferentShippingAddressDisabled =
             isDifferentShippingAddressChecked == false && (shippingAddress != Address.EMPTY)
 
-        isAnyAddressEdited == true || isDifferentShippingAddressDisabled
+        (isAnyAddressEdited == true || isDifferentShippingAddressDisabled) && !viewState.isLoading
     }
 
     /**


### PR DESCRIPTION
Fixes #6003 - The crash itself occurs when the user taps Done while country data is being loaded, and the view model exits [here](https://github.com/woocommerce/woocommerce-android/blob/cc6eb7fcceada359e924a9ac6cfa4452494ffc59/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt#L179) with an empty `addressSelectionStates` resulting in the crash [here](https://github.com/woocommerce/woocommerce-android/blob/39a9fea84b9a292959dc5c9d0fcc9e43cca48bdf/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt#L109)

That may be something we want to address, but this PR corrects another issue, which is that `isAnyAddressEdited` would return true when `addressSelectionStates` is empty, resulting in the Done button appearing during the initial load even though the user made no changes.

To test, change [getCountries](https://github.com/woocommerce/woocommerce-android/blob/cc6eb7fcceada359e924a9ac6cfa4452494ffc59/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt#L34) to return an `emptyList()` so countries are always fetched when entering the customer details fragment and ensure the Done button doesn't appear.