### PR TITLE
Grouping customer's name and email to be dictated together in the Order Creation Screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -303,8 +303,8 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
         order.takeIf { it.billingAddress != Address.EMPTY }
             ?.let {
                 val view = LayoutOrderCreationCustomerInfoBinding.inflate(layoutInflater)
-                view.name.text =
-                    "${order.billingAddress.firstName} ${order.billingAddress.lastName}\n${order.billingAddress.email}"
+                view.name.text = "${order.billingAddress.firstName} ${order.billingAddress.lastName}"
+                view.email.text = order.billingAddress.email
                 view.shippingAddressDetails.text =
                     if (order.shippingAddress != Address.EMPTY) {
                         order.formatShippingInformationForDisplay()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -303,8 +303,8 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
         order.takeIf { it.billingAddress != Address.EMPTY }
             ?.let {
                 val view = LayoutOrderCreationCustomerInfoBinding.inflate(layoutInflater)
-                view.name.text = "${order.billingAddress.firstName} ${order.billingAddress.lastName}"
-                view.email.text = order.billingAddress.email
+                view.name.text =
+                    "${order.billingAddress.firstName} ${order.billingAddress.lastName}\n${order.billingAddress.email}"
                 view.shippingAddressDetails.text =
                     if (order.shippingAddress != Address.EMPTY) {
                         order.formatShippingInformationForDisplay()

--- a/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content"
     app:layoutDescription="@xml/layout_order_creation_customer_info_scene">
 
-    <LinearLayout
+    <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/name_email"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -32,7 +32,7 @@
             app:layout_constraintStart_toStartOf="@id/name"
             app:layout_constraintTop_toBottomOf="@id/name"
             tools:text="george@woo.com" />
-    </LinearLayout>
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
     <View
         android:id="@+id/name_divider"

--- a/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
@@ -6,22 +6,41 @@
     android:layout_height="wrap_content"
     app:layoutDescription="@xml/layout_order_creation_customer_info_scene">
 
-    <TextView
-        android:id="@+id/name"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/name_email"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="George Costanza \n george@woo.com" />
+        android:focusable="true"
+        android:focusableInTouchMode="false"
+        android:orientation="vertical"
+        android:layout_marginStart="@dimen/major_100">
+
+        <TextView
+            android:id="@+id/name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="George Costanza" />
+
+        <TextView
+            android:id="@+id/email"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody2"
+            app:layout_constraintStart_toStartOf="@id/name"
+            app:layout_constraintTop_toBottomOf="@id/name"
+            tools:text="george@woo.com" />
+    </LinearLayout>
+
     <View
         android:id="@+id/name_divider"
         style="@style/Woo.Divider"
         android:layout_width="0dp"
         android:layout_marginTop="@dimen/minor_100"
-        app:layout_constraintStart_toStartOf="@id/name"
-        app:layout_constraintTop_toBottomOf="@id/name" />
+        app:layout_constraintStart_toStartOf="@id/name_email"
+        app:layout_constraintTop_toBottomOf="@id/name_email" />
 
     <TextView
         android:id="@+id/shipping_header"

--- a/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
@@ -14,24 +14,14 @@
         android:textAppearance="?attr/textAppearanceSubtitle1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="George Costanza" />
-
-    <TextView
-        android:id="@+id/email"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceBody2"
-        app:layout_constraintStart_toStartOf="@id/name"
-        app:layout_constraintTop_toBottomOf="@id/name"
-        tools:text="george@woo.com" />
-
+        tools:text="George Costanza \n george@woo.com" />
     <View
         android:id="@+id/name_divider"
         style="@style/Woo.Divider"
         android:layout_width="0dp"
         android:layout_marginTop="@dimen/minor_100"
-        app:layout_constraintStart_toStartOf="@id/email"
-        app:layout_constraintTop_toBottomOf="@id/email" />
+        app:layout_constraintStart_toStartOf="@id/name"
+        app:layout_constraintTop_toBottomOf="@id/name" />
 
     <TextView
         android:id="@+id/shipping_header"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5818 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the order creation screen, when using TalkBack, the customer's name/last name and email are added as two separate entries. This PR changes that to group both the name and the email address so it can be read together via TalkBack without the need to tap on two different fields, reducing the number of elements on the screen.
 
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable TalkBack from the accessibility options
2. Go to the orders screen
3. tap the + button 
4. select Create Order
5. Tap on "+ Add Customer Details" under the Customer tab
6. Add a Name, Last Name and Address and tap on Done
7. Tap on the Customer info field and check TalkBack reads both fields (name and email) together

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
**Before:**

(it's a little hard to tap on each individual line)
 
https://user-images.githubusercontent.com/30724184/157340029-e2c7c1c3-513e-4d0f-b195-7970e86803e0.mp4


**After:**

https://user-images.githubusercontent.com/30724184/157339333-e28ab872-6e30-4c64-bc55-1ecb8b9c0258.mp4


- [ x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
