### PR TITLE
Adjust Decreasing operation to account for the VariationID presence

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -102,7 +102,7 @@ class OrderCreationViewModel @Inject constructor(
 
     fun onDecreaseProductsQuantity(id: Long) {
         _orderDraft.value.items
-            .find { it.productId == id }
+            .find { it.productId == id || it.variationId == id }
             ?.takeIf { it.quantity == 1F }
             ?.let { onProductClicked(it) }
             ?: _orderDraft.update { it.adjustProductQuantity(id, -1) }


### PR DESCRIPTION
Summary
==========
Fixes issue #6007 by making the Product quantity minus button click event to account for the VariationID when searching which product was hit with the `minus` operation, making it possible for the decision of opening the complete Product view or decreasing the item quantity to work for Variable Products.

Screenshots
==========
## Before
https://user-images.githubusercontent.com/5920403/157421160-7971bef1-6bb2-4b08-894d-44a0d3cf095f.mp4

## After
https://user-images.githubusercontent.com/5920403/157421194-64719689-6d4d-4a3c-a206-622f5fd9f56a.mp4



How to Test
==========
1. Make sure the Order Creation experimental toggle is activated inside the App Settings
2. Go to the Order list and enter the Order Creation flow through the FAB
3. Add a Variable Product inside the Product section
4. Try to decrease the product quantity to less than 1, verify that the complete Product view is opened immediately making room to remove the Variation from the Order draft

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
