### PR TITLE
[Order creation] Validate billing email when Done button tapped

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.creation.views.bindEditFields
 import com.woocommerce.android.ui.orders.creation.views.update
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
@@ -27,7 +28,9 @@ import com.woocommerce.android.ui.orders.details.editing.address.AddressViewMode
 import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel.AddressType.SHIPPING
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation_edit_customer_address) {
@@ -46,6 +49,8 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
     private var billingBinding: LayoutAddressFormBinding? = null
     private var showShippingAddressFormSwitch: LayoutAddressSwitchBinding? = null
     private var doneMenuItem: MenuItem? = null
+
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -105,6 +110,7 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
             when (event) {
                 is ShowStateSelector -> showStateSearchScreen(event.type, event.states)
                 is ShowCountrySelector -> showCountrySearchScreen(event.type, event.countries)
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> {
                     sharedViewModel.onCustomerAddressEdited(
                         billingAddress = event.addresses.getValue(BILLING),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -176,7 +176,7 @@ class AddressViewModel @Inject constructor(
     }
 
     fun onDoneSelected(addDifferentShippingChecked: Boolean? = null) {
-        // order creation/update will fail if email address is invalid
+        // order creation/editing will fail if billing email address is invalid
         viewState.addressSelectionStates.get(AddressType.BILLING)?.address?.email?.let { billingEmail ->
             if (billingEmail.isNotEmpty() && !StringUtils.isValidEmail(billingEmail)) {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.email_invalid))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.map
+import com.woocommerce.android.R
 import com.woocommerce.android.model.*
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel.StateSpinnerStatus.*
+import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -174,6 +176,14 @@ class AddressViewModel @Inject constructor(
     }
 
     fun onDoneSelected(addDifferentShippingChecked: Boolean? = null) {
+        // order creation/update will fail if email address is invalid
+        viewState.addressSelectionStates.get(AddressType.BILLING)?.address?.email?.let { billingEmail ->
+            if (billingEmail.isNotEmpty() && !StringUtils.isValidEmail(billingEmail)) {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.email_invalid))
+                return
+            }
+        }
+
         triggerEvent(
             Exit(
                 viewState.addressSelectionStates.mapValues { statePair ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.details.editing.BaseOrderEditingFragment
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import com.woocommerce.android.util.UiHelpers.getPxOfUiDimen
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.combineWith
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
@@ -179,6 +180,9 @@ abstract class BaseAddressEditingFragment :
             when (event) {
                 is AddressViewModel.ShowStateSelector -> showStateSearchScreen(event.states)
                 is AddressViewModel.ShowCountrySelector -> showCountrySearchScreen(event.countries)
+                is MultiLiveEvent.Event.ShowSnackbar -> {
+                    uiMessageResolver.showSnack(event.message)
+                }
                 is AddressViewModel.Exit -> {
                     saveChanges()
                     navigateUp()


### PR DESCRIPTION
Closes #6010 - This PR adds customer billing email address validation to order creation & order editing. This is necessary because if an invalid email is passed to the backend, the order will fail to be created.

To test:

* Create a new order
* Tap to add customer details
* Enter some information but leave the email blank
* Tap Done
* Verify no invalid email snackbar appears
* Tap again to edit the customer details
* Enter an invalid email address
* Tap Done
* Verify that an invalid email snackbar appears
* Enter a valid email address
* Tap done
* Verify no invalid email snackbar appears

Note that the customer address form is also used by order editing, so the same steps should be tested in the order detail screen.