### PR TITLE
Grouping Product total, taxes and order total so they can be dictated together during order creation

### DIFF
--- a/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
@@ -41,7 +41,9 @@
             android:gravity="center"
             android:minHeight="@dimen/major_300"
             android:orientation="horizontal"
-            android:paddingHorizontal="@dimen/major_100">
+            android:paddingHorizontal="@dimen/major_100"
+            android:focusable="true"
+            android:focusableInTouchMode="false">
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/products_total_label"
@@ -126,7 +128,9 @@
             android:gravity="center"
             android:minHeight="@dimen/major_300"
             android:orientation="horizontal"
-            android:paddingHorizontal="@dimen/major_100">
+            android:paddingHorizontal="@dimen/major_100"
+            android:focusable="true"
+            android:focusableInTouchMode="false">
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/tax_label"
@@ -150,7 +154,9 @@
             android:gravity="center"
             android:minHeight="@dimen/major_300"
             android:orientation="horizontal"
-            android:paddingHorizontal="@dimen/major_100">
+            android:paddingHorizontal="@dimen/major_100"
+            android:focusable="true"
+            android:focusableInTouchMode="false">
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/order_total_label"
@@ -159,7 +165,8 @@
                 android:layout_weight="1"
                 android:text="@string/order_creation_payment_order_total"
                 android:textAppearance="?attr/textAppearanceSubtitle1"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                />
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/order_total_value"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5812 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the order creation screen, when using TalkBack, the Products total, taxes and order total labels and their respective values are added as two separate entries. This PR changes that to group both each label and its correspondent value so it can be read together via TalkBack without the need to tap on two different fields, reducing the number of elements on the screen.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable TalkBack from the accessibility options
2. Go to the orders screen
3. tap the + button
4. select Create Order
5. Tap on "+ Add Product" under the Products tab
6. Select a product
7. Tap on the Products total, taxes and order total field and check TalkBack reads both fields (label and value) together


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

### Before

https://user-images.githubusercontent.com/30724184/157739405-e17c1913-aacc-4747-8b89-ebf64cc27fcb.mp4

### After

https://user-images.githubusercontent.com/30724184/157738132-803e36e5-00e8-4f23-973f-5329336614c2.mp4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
