### PR TITLE
State list hides last item

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <FrameLayout
         android:id="@+id/searchViewContainer"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/color_surface"
-        app:layout_constraintBottom_toTopOf="@+id/searchItemsList"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:background="@color/color_surface">
 
         <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/searchEditText"
@@ -34,19 +30,12 @@
         android:layout_height="0dp"
         android:layout_marginTop="@dimen/major_100"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/searchViewContainer"
         tools:visibility="visible" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/searchItemsList"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/color_surface"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/searchViewContainer" />
+        android:background="@color/color_surface"/>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <FrameLayout
         android:id="@+id/searchViewContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/color_surface">
+        android:background="@color/color_surface"
+        android:layout_alignParentTop="true">
 
         <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/searchEditText"
@@ -27,15 +27,17 @@
     <com.woocommerce.android.widgets.WCEmptyView
         android:id="@+id/emptyView"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
         android:visibility="gone"
-        tools:visibility="visible" />
+        tools:visibility="visible"
+        android:layout_below="@id/searchViewContainer"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/searchItemsList"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/color_surface"/>
+        android:background="@color/color_surface"
+        android:layout_below="@id/searchViewContainer"/>
 
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
Summary
==========
Fixes issue #5840 by doing a reconfiguration of the SearchFilterFragment XML layout file, placing the list correctly in the view, and avoiding the navigation bar overlapping the list last item.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20220311_200618](https://user-images.githubusercontent.com/5920403/157986808-d8da9350-4e60-4eec-ab4c-4899ca0097c5.png) | ![Screenshot_20220311_200132](https://user-images.githubusercontent.com/5920403/157986796-07ef3ef2-673b-4491-a884-16c99a42aee2.png) |

How to Test
==========
1. Make sure the Order Creation experimental toggle is activated inside the App Settings
2. Go to the Order list and enter the Order Creation flow through the FAB
3. Go to the Customer details section
4. Select a country that contains a defined list of states
5. Go to the State selector
6. Verify that the last item shows correctly


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
