### PR TITLE
Fix issue of disappearing notification badges when the app is restored

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.main
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.MenuItem
 import android.view.View
@@ -72,23 +71,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
                     }
                 }
             })
-    }
-
-    /**
-     * HACK alert! The bottom nav's presenter stores the badges in its saved state and recreates them
-     * in onRestoreInstanceState, which should be fine but instead it ends up creating duplicates
-     * of our badges. To work around this we remove the badges before state is saved and recreate
-     * them ourselves when state is restored.
-     */
-    override fun onSaveInstanceState(): Parcelable {
-        removeBadge(R.id.orders)
-        removeBadge(R.id.reviews)
-        return super.onSaveInstanceState()
-    }
-
-    override fun onRestoreInstanceState(state: Parcelable?) {
-        super.onRestoreInstanceState(state)
-        createBadges()
     }
 
     private fun createBadges() {


### PR DESCRIPTION
Closes: #5069
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The cause of the issue is the override of `onSaveInstanceState`/`onRestoreInstanceState` we had in our BottomNavigationView class, these overridden functions were useful as a temporary solution for the issue https://github.com/material-components/material-components-android/issues/1247, but since this issue has been fixed since the version `1.3.0` of the material library, and we are currently using `1.4.0` we don't need them anymore.

### Testing instructions

1. Open app
2. Assert you can see badge on the Orders bottom navigation icon
3. Go to phone launcher / lock screen
4. Go back to app
5. Confirm the badge is still visible on the orders' bottom navigation icon


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
