### PR TITLE
Shipping Labels: fix crash issue of the payment method Webview

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
@@ -74,7 +74,7 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview), UrlI
 
     override fun onLoadUrl(url: String) {
         navArgs.urlToTriggerExit?.let {
-            if (url.contains(it)) {
+            if (isAdded && url.contains(it)) {
                 navigateBackWithNotice(WEBVIEW_RESULT)
             }
         }


### PR DESCRIPTION
### Description
@astralbodies identified a bug with the current implementation of the authenticated WebView used for adding payment methods in the shipping labels form, the app would crash when clicking the "<- back" button (it does crash also when adding a new payment method 😱)
The cause of this is that we are listening to URL changes to detect when the user navigates away from current page, we do so by checking against the URL: "me/payment-methods", this was working fine, but it seems that there has been a change to WordPress.com that resulted in loading the URL two times, which triggered two navigation events.

### Testing instructions
1. Make sure you have an order that's eligible for shipping label creation (check p91TBi-3xD-p2 for more information)
2. Open the Order details, and click on "create shipping label"
3. Complete all steps.
4. Click on "Add payment method" or the "edit" button in the payment step.
5. Click on "Add a/other credit card" button.
6. Click on "<- back" button and confirm the webview is closed and the app doesn't crash.
7. Click on "Add a/other credit card" button.
8. Enter valid card details and save it.
9. Confirm the webview is closed and the app behaves correctly.
10. Optional: remove the card from your account 😄 

* Regarding step 9, the new credit card may not appear in the app after adding it, this would happen if you configure your store to target the staging connect-server, as the app's webview won't know, and will add the card to the production server.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->