### PR TITLE
Use a trimmed search query for country/state search filter

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterViewModel.kt
@@ -34,11 +34,12 @@ class SearchFilterViewModel @Inject constructor() : ViewModel() {
     }
 
     fun onSearch(searchQuery: String) {
-        val searchedItems = allSearchFilterItems.filter { it.name.contains(searchQuery, true) }
+        val trimmedQuery = searchQuery.trim()
+        val searchedItems = allSearchFilterItems.filter { it.name.contains(trimmedQuery, true) }
         val state = if (searchedItems.isNotEmpty()) {
             Search(searchedItems)
         } else {
-            Empty(searchQuery)
+            Empty(trimmedQuery)
         }
         _viewStateLiveData.value = state
     }


### PR DESCRIPTION
Fixes #5885 - This tiny PR simply trims the search query prior to searching in the country & state screens used in order creation. To test:

* Start order creation
* Tap to add a customer
* Ensure that searching in the country & state screens uses a trimmed version of the search query