### PR TITLE
Issue/5806 order creation status accessibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.details.views
 
 import android.content.Context
-import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
@@ -15,7 +14,6 @@ import com.woocommerce.android.extensions.isToday
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.ui.orders.OrderStatusTag
-import com.woocommerce.android.widgets.tags.TagView
 
 typealias EditStatusClickListener = (View) -> Unit
 
@@ -29,8 +27,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     private var mode: Mode = Mode.OrderEdit
 
     fun updateStatus(orderStatus: OrderStatus) {
-        binding.orderStatusOrderTags.removeAllViews()
-        binding.orderStatusOrderTags.addView(getTagView(orderStatus))
+        binding.orderStatusOrderTags.tag = OrderStatusTag(orderStatus)
     }
 
     fun updateOrder(order: Order) {
@@ -64,18 +61,6 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
         }
     }
 
-    private fun getTagView(orderStatus: OrderStatus): TagView {
-        val orderTag = OrderStatusTag(orderStatus)
-        val tagView = TagView(context)
-        tagView.tag = orderTag
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            tagView.isFocusableInTouchMode = false
-        } else {
-            tagView.focusable = View.NOT_FOCUSABLE
-        }
-        return tagView
-    }
-
     fun initView(mode: Mode, editOrderStatusClickListener: EditStatusClickListener) {
         this.mode = mode
         when (mode) {
@@ -93,7 +78,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
                 with(binding.orderStatusEditButton) {
                     isVisible = true
                     text = context.getString(R.string.edit)
-                    setOnClickListener(editOrderStatusClickListener)
+                    // setOnClickListener(editOrderStatusClickListener)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -69,9 +69,9 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
         val tagView = TagView(context)
         tagView.tag = orderTag
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            tagView.isFocusableInTouchMode = true
+            tagView.isFocusableInTouchMode = false
         } else {
-            tagView.focusable = View.FOCUSABLE
+            tagView.focusable = View.NOT_FOCUSABLE
         }
         return tagView
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -67,7 +67,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
             Mode.OrderEdit -> {
                 binding.orderStatusEditButton.isVisible = false
                 binding.orderStatusEditImage.isVisible = true
-                with(binding.orderStatusEdit) {
+                with(binding.orderStatusContainer) {
                     isClickable = true
                     isFocusable = true
                     setOnClickListener(editOrderStatusClickListener)
@@ -78,7 +78,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
                 with(binding.orderStatusEditButton) {
                     isVisible = true
                     text = context.getString(R.string.edit)
-                    // setOnClickListener(editOrderStatusClickListener)
+                    setOnClickListener(editOrderStatusClickListener)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -27,6 +27,8 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     private var mode: Mode = Mode.OrderEdit
 
     fun updateStatus(orderStatus: OrderStatus) {
+        binding.orderStatusOrderTags.contentDescription =
+            context.getString(R.string.orderstatus_contentDesc_withStatus, orderStatus.label)
         binding.orderStatusOrderTags.tag = OrderStatusTag(orderStatus)
     }
 
@@ -77,7 +79,6 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
                 binding.orderStatusEditImage.isVisible = false
                 with(binding.orderStatusEditButton) {
                     isVisible = true
-                    text = context.getString(R.string.edit)
                     setOnClickListener(editOrderStatusClickListener)
                 }
             }

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -26,8 +27,8 @@
             android:layout_marginBottom="@dimen/minor_00"
             tools:text="George Carlin" />
 
-        <LinearLayout
-            android:id="@+id/orderStatus_edit"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/orderStatus_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:focusable="true"
@@ -37,11 +38,13 @@
             <com.woocommerce.android.widgets.tags.TagView
                 android:id="@+id/orderStatus_orderTags"
                 android:layout_width="wrap_content"
-                android:focusable="false"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
                 android:contentDescription="@string/orderstatus_contentDesc"
-                tools:text="Pending payment"/>
+                android:focusable="false"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/orderStatus_editImage"
@@ -51,16 +54,22 @@
                 android:importantForAccessibility="no"
                 android:paddingHorizontal="@dimen/major_100"
                 android:paddingVertical="@dimen/major_75"
-                android:src="@drawable/ic_edit_pencil" />
+                android:src="@drawable/ic_edit_pencil"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/orderStatus_editButton"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/orderStatus_editButton"
                 style="@style/Woo.Button.TextButton.Secondary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:focusable="false"
                 android:contentDescription="@string/order_creation_status_edit_content_description"
-                android:text="@string/edit" />
-        </LinearLayout>
+                android:focusable="false"
+                android:text="@string/edit"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </LinearLayout>
 </merge>

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -30,16 +30,16 @@
             android:id="@+id/orderStatus_edit"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:focusable="false"
+            android:focusable="true"
             android:gravity="center_vertical"
             android:orientation="horizontal">
 
-            <com.woocommerce.android.widgets.FlowLayout
+            <com.woocommerce.android.widgets.tags.TagView
                 android:id="@+id/orderStatus_orderTags"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
+                android:focusable="false"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
-                android:layout_weight="1"
                 android:contentDescription="@string/orderstatus_contentDesc"
                 tools:text="Pending payment"/>
 
@@ -47,6 +47,7 @@
                 android:id="@+id/orderStatus_editImage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:focusable="false"
                 android:importantForAccessibility="no"
                 android:paddingHorizontal="@dimen/major_100"
                 android:paddingVertical="@dimen/major_75"
@@ -57,6 +58,7 @@
                 style="@style/Woo.Button.TextButton.Secondary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:focusable="false"
                 android:contentDescription="@string/order_creation_status_edit_content_description"
                 android:text="@string/edit" />
         </LinearLayout>

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -30,8 +30,7 @@
             android:id="@+id/orderStatus_edit"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?attr/selectableItemBackground"
-            android:contentDescription="@string/orderdetail_change_order_status"
+            android:focusable="false"
             android:gravity="center_vertical"
             android:orientation="horizontal">
 
@@ -41,7 +40,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_weight="1"
-                android:contentDescription="@string/orderstatus_contentDesc" />
+                android:contentDescription="@string/orderstatus_contentDesc"
+                tools:text="Pending payment"/>
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/orderStatus_editImage"

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -31,7 +31,7 @@
             android:id="@+id/orderStatus_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:focusable="true"
+            android:focusable="false"
             android:gravity="center_vertical"
             android:orientation="horizontal">
 
@@ -40,8 +40,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
-                android:contentDescription="@string/orderstatus_contentDesc"
-                android:focusable="false"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -50,7 +48,6 @@
                 android:id="@+id/orderStatus_editImage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:focusable="false"
                 android:importantForAccessibility="no"
                 android:paddingHorizontal="@dimen/major_100"
                 android:paddingVertical="@dimen/major_75"
@@ -65,7 +62,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/order_creation_status_edit_content_description"
-                android:focusable="false"
                 android:text="@string/edit"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -875,6 +875,7 @@
     <string name="orderstatus_cancelled">Cancelled</string>
     <string name="orderstatus_refunded">Refunded</string>
     <string name="orderstatus_contentDesc">Order status</string>
+    <string name="orderstatus_contentDesc_withStatus">Order status: %s</string>
     <!--
         Add Shipment Tracking Labels
     -->


### PR DESCRIPTION
Closes #5806 - Prior to this PR, the status in the order creation screen didn't work well with TalkBack. TalkBack treated it as multiple views: the status tag, the Edit button, and the containing view.

This PR resolves this, as shown in the video below, by making only the status tag and Edit button focusable. This also involved putting the TagView in the layout instead of inflating it at runtime, and the order status is included in TalkBack when that view is focused.

https://user-images.githubusercontent.com/3903757/158638328-86696160-8fb1-46ce-9cf4-42d4933e25e1.mp4


