### PR TITLE
issue/5807-order-creation-headings 

### DIFF
--- a/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
@@ -24,6 +24,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:accessibilityHeading="true"
                 android:text="@string/order_creation_payment"
                 android:textAppearance="?attr/textAppearanceHeadline6" />
 

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -11,6 +11,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginTop="@dimen/major_75"
+        android:accessibilityHeading="true"
         android:textAppearance="?attr/textAppearanceHeadline6"
         app:layout_constraintEnd_toStartOf="@id/edit_button"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Closes #5807 by adding `android:accessibilityHeading="true"` to order creation form headers in order to enable [heading navigation](https://developer.android.com/guide/topics/ui/accessibility/principles#headings_within_text). Note that this is only supported on API 28+ but the app runs fine on older APIs.

To test, simply enable TalkBack and ensure that when focusing a heading, TalkBack includes the word "heading" at the end.