### PR TITLE
Issue/5808 order creation image dictated

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -65,6 +65,7 @@ class OrderCreationProductsAdapter(
             binding.productName.text = productModel.item.name
             binding.stepperView.apply {
                 value = productModel.item.quantity.toInt()
+                contentDescription = context.getString(R.string.count, value.toString())
             }
 
             binding.productAttributes.text = buildString {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -87,8 +87,14 @@ class OrderCreationProductsAdapter(
                 append(currencyFormatter(productModel.item.total).replace(" ", "\u00A0"))
             }
 
-            binding.productSku.text =
-                context.getString(R.string.orderdetail_product_lineitem_sku_value, productModel.item.sku)
+            binding.productSku.apply {
+                text = context.getString(R.string.orderdetail_product_lineitem_sku_value, productModel.item.sku)
+                contentDescription = if (productModel.item.sku.isNotEmpty()) {
+                    text
+                } else {
+                    context.getString(R.string.no_sku)
+                }
+            }
 
             val imageSize = context.resources.getDimensionPixelSize(R.dimen.image_major_50)
             PhotonUtils.getPhotonImageUrl(productModel.imageUrl, imageSize, imageSize)?.let { imageUrl ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -87,13 +87,10 @@ class OrderCreationProductsAdapter(
                 append(currencyFormatter(productModel.item.total).replace(" ", "\u00A0"))
             }
 
-            binding.productSku.apply {
-                text = context.getString(R.string.orderdetail_product_lineitem_sku_value, productModel.item.sku)
-                contentDescription = if (productModel.item.sku.isNotEmpty()) {
-                    text
-                } else {
-                    context.getString(R.string.no_sku)
-                }
+            binding.productSku.text = if (productModel.item.sku.isNotEmpty()) {
+                context.getString(R.string.orderdetail_product_lineitem_sku_value, productModel.item.sku)
+            } else {
+                context.getString(R.string.no_sku)
             }
 
             val imageSize = context.resources.getDimensionPixelSize(R.dimen.image_major_50)

--- a/WooCommerce/src/main/res/layout/order_creation_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_product_item.xml
@@ -13,7 +13,7 @@
         android:layout_gravity="center"
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginTop="@dimen/minor_100"
-        android:contentDescription="@string/orderdetail_product_image_contentdesc"
+        android:importantForAccessibility="no"
         android:scaleType="centerCrop"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/WooCommerce/src/main/res/layout/product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_list_item.xml
@@ -26,7 +26,7 @@
             android:layout_height="@dimen/image_minor_100"
             android:layout_gravity="center"
             android:background="@drawable/picture_corners"
-            android:contentDescription="@string/product_image_content_description"
+            android:importantForAccessibility="no"
             android:scaleType="centerCrop"
             tools:src="@drawable/ic_product" />
     </FrameLayout>

--- a/WooCommerce/src/main/res/layout/view_stepper.xml
+++ b/WooCommerce/src/main/res/layout/view_stepper.xml
@@ -14,7 +14,7 @@
         style="@style/Woo.Button.Icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/minus"
+        android:contentDescription="@string/minus_one"
         app:icon="@drawable/ic_gridicons_minus" />
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -33,6 +33,6 @@
         style="@style/Woo.Button.Icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/plus"
+        android:contentDescription="@string/plus_one"
         app:icon="@drawable/ic_add" />
 </merge>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -131,8 +131,8 @@
     <string name="generic_string" translatable="false">%s</string>
     <string name="error_required_field">Required field</string>
     <string name="analytics">Analytics</string>
-    <string name="minus">Minus</string>
-    <string name="plus">Plus</string>
+    <string name="minus_one">Minus one</string>
+    <string name="plus_one">Plus one</string>
     <string name="card">Card</string>
     <string name="cash">Cash</string>
     <string name="create">Create</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="create">Create</string>
     <string name="exclusive_or">or</string>
     <string name="count">Count: %s</string>
+    <string name="no_sku">No SKU</string>
 
     <!--
         Date/Time Labels

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -137,6 +137,7 @@
     <string name="cash">Cash</string>
     <string name="create">Create</string>
     <string name="exclusive_or">or</string>
+    <string name="count">Count: %s</string>
 
     <!--
         Date/Time Labels


### PR DESCRIPTION
Closes #5808 - previously TalkBack would say "product image" when a product was focused in order creation. This occurred in both the dedicated order creation product list and the main product list. This PR marks the images as "not important for accessibility" to resolve this.

In addition, this PR closes #5810 and improves the dictation when tapping a product in the order creation product list . Instead of just saying the number of items, it prefixes it with "Count" (so "Count: 1" instead of just "1"). And if the SKU is empty, instead of just saying "SKU" it says (and reads) "No SKU."

Last but not least, this PR partially addresses #5811 by saying "Plus one" and "Minus one" when the stepper view's +/- buttons are tapped. The second part of that issue is addressed in #6041..

![dude](https://user-images.githubusercontent.com/3903757/158656716-e1a98b1a-6eeb-452d-ac60-f25b933ea838.png)

