### PR TITLE
Issue/5884 state country search single line

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -18,6 +18,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/major_100"
             android:layout_marginBottom="@dimen/major_100"
+            android:inputType="textFilter"
             android:drawableStart="@drawable/ic_search_24dp"
             android:drawablePadding="@dimen/major_100"
             android:imeOptions="flagNoExtractUi" />

--- a/WooCommerce/src/main/res/layout/fragment_search_filter.xml
+++ b/WooCommerce/src/main/res/layout/fragment_search_filter.xml
@@ -21,7 +21,7 @@
             android:inputType="textFilter"
             android:drawableStart="@drawable/ic_search_24dp"
             android:drawablePadding="@dimen/major_100"
-            android:imeOptions="flagNoExtractUi" />
+            android:imeOptions="flagNoExtractUi|actionSearch" />
 
     </FrameLayout>
 


### PR DESCRIPTION
Closes #5884 - previously the order creation state/country search enabled entering multiple lines, which isn't typical for search views. This PR addresses this by adding `inputType="textFilter"` to the search field to limit entries to a single line, then adds `actionSearch` to the `imoOptions` so a search icon is shown at the bottom right instead of a return icon.

![search](https://user-images.githubusercontent.com/3903757/158679434-5c267e59-21c4-42d9-b0c6-b17fb4b8067e.png)

