### PR TITLE
Save as Draft behavior as in IOs.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -293,9 +293,9 @@ class ProductDetailFragment :
             binding.imageGallery.showProductImages(product.images, this)
         }
 
-        // show status badge for draft products
+        // show status badge for unpublished products
         product.status?.let { status ->
-            if (status == ProductStatus.DRAFT) {
+            if (status != ProductStatus.PUBLISH) {
                 binding.frameStatusBadge.show()
                 binding.textStatusBadge.text = status.toLocalizedString(requireActivity())
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -295,7 +295,7 @@ class ProductDetailFragment :
 
         // show status badge for unpublished products
         product.status?.let { status ->
-            if (status != ProductStatus.PUBLISH && viewModel.isAddFlowEntryPoint.not()) {
+            if (status != ProductStatus.PUBLISH) {
                 binding.frameStatusBadge.show()
                 binding.textStatusBadge.text = status.toLocalizedString(requireActivity())
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -295,7 +295,7 @@ class ProductDetailFragment :
 
         // show status badge for unpublished products
         product.status?.let { status ->
-            if (status != ProductStatus.PUBLISH) {
+            if (status == ProductStatus.DRAFT) {
                 binding.frameStatusBadge.show()
                 binding.textStatusBadge.text = status.toLocalizedString(requireActivity())
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -293,7 +293,7 @@ class ProductDetailFragment :
             binding.imageGallery.showProductImages(product.images, this)
         }
 
-        // show status badge for unpublished products
+        // show status badge for draft products
         product.status?.let { status ->
             if (status == ProductStatus.DRAFT) {
                 binding.frameStatusBadge.show()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -169,8 +169,11 @@ class ProductDetailViewModel @Inject constructor(
     private val isProductPublishedOrPrivate: Boolean
         get() = viewState.productDraft?.let { it.status == PUBLISH || it.status == PRIVATE } ?: false
 
+    private val isDraftUnderCreation:Boolean
+        get() = isProductUnderCreation && viewState.productDraft?.status == DRAFT
+
     val isSaveOptionNeeded: Boolean
-        get() = hasChanges() && ((isProductUnderCreation && viewState.productDraft?.status == DRAFT) || !isProductUnderCreation)
+        get() = hasChanges() && (isDraftUnderCreation || !isProductUnderCreation)
 
     val isPublishOptionNeeded: Boolean
         get() = isProductPublishedOrPrivate.not() or (isAddFlowEntryPoint and isProductUnderCreation)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -170,7 +170,7 @@ class ProductDetailViewModel @Inject constructor(
         get() = viewState.productDraft?.let { it.status == PUBLISH || it.status == PRIVATE } ?: false
 
     val isSaveOptionNeeded: Boolean
-        get() = hasChanges() and (isAddFlowEntryPoint and isProductUnderCreation).not()
+        get() = hasChanges() && ((isProductUnderCreation && viewState.productDraft?.status == DRAFT) || !isProductUnderCreation)
 
     val isPublishOptionNeeded: Boolean
         get() = isProductPublishedOrPrivate.not() or (isAddFlowEntryPoint and isProductUnderCreation)
@@ -662,7 +662,10 @@ class ProductDetailViewModel @Inject constructor(
         }
     }
 
-    private fun startPublishProduct(productStatus: ProductStatus = PUBLISH, exitWhenDone: Boolean = false) {
+    private fun startPublishProduct(
+        productStatus: ProductStatus = viewState.productDraft?.status ?: PUBLISH,
+        exitWhenDone: Boolean = false
+    ) {
         viewState.productDraft?.let {
             val product = it.copy(status = productStatus)
             trackPublishing(product)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -169,11 +169,14 @@ class ProductDetailViewModel @Inject constructor(
     private val isProductPublishedOrPrivate: Boolean
         get() = viewState.productDraft?.let { it.status == PUBLISH || it.status == PRIVATE } ?: false
 
-    private val isDraftUnderCreation: Boolean
-        get() = isProductUnderCreation && viewState.productDraft?.status == DRAFT
+    /**
+     * Returns a boolean to check if the product status is not PUBLISH and the product is under creation
+     */
+    private val isNotPublishUnderCreation: Boolean
+        get() = isProductUnderCreation && viewState.productDraft?.status != PUBLISH
 
     val isSaveOptionNeeded: Boolean
-        get() = hasChanges() && (isDraftUnderCreation || !isProductUnderCreation)
+        get() = hasChanges() && (isNotPublishUnderCreation || !isProductUnderCreation)
 
     val isPublishOptionNeeded: Boolean
         get() = isProductPublishedOrPrivate.not() or (isAddFlowEntryPoint and isProductUnderCreation)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -169,7 +169,7 @@ class ProductDetailViewModel @Inject constructor(
     private val isProductPublishedOrPrivate: Boolean
         get() = viewState.productDraft?.let { it.status == PUBLISH || it.status == PRIVATE } ?: false
 
-    private val isDraftUnderCreation:Boolean
+    private val isDraftUnderCreation: Boolean
         get() = isProductUnderCreation && viewState.productDraft?.status == DRAFT
 
     val isSaveOptionNeeded: Boolean


### PR DESCRIPTION
Closes: #4373 

### Description
This PR aims for cross-platform consistency on the **Save as Draft** feature when the product's status is Draft. It does that by updating the isSaveOptionNeeded flag on ProductDetailViewModel.

### Testing instructions

1. Go to Products > Add new product ("+" at the bottom right).
2. Add a title, description, and price.
3. Check that the **Save as Draft** option is available under the **more** menu option ( three dots ... ) 
4. Change the status to a draft by going to More > Product settings > Status > Draft.
5. Check that the **Publish** option is changed to **Save**, the **Publish**  action is moved into the **more** menu option, and the **Save as Draft** is not available anymore.
6. Save the changes and check that **Publish** appears as the main menu option again.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/18119390/158714568-8f4e3f37-9f7b-4b60-b710-428665eba3dd.mp4