### PR TITLE
Issue/5813 order creation disable done button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationCustomerAddFragment.kt
@@ -97,8 +97,8 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
                 }
             }
         }
-        addressViewModel.shouldShowDoneButton.observe(viewLifecycleOwner) { shouldShowDoneButton: Boolean ->
-            doneMenuItem?.isVisible = shouldShowDoneButton
+        addressViewModel.shouldEnableDoneButton.observe(viewLifecycleOwner) { shouldShowDoneButton: Boolean ->
+            doneMenuItem?.isEnabled = shouldShowDoneButton
         }
         addressViewModel.isDifferentShippingAddressChecked.observe(viewLifecycleOwner) { checked ->
             updateShippingBindingVisibility(checked)
@@ -247,7 +247,7 @@ class OrderCreationCustomerAddFragment : BaseFragment(R.layout.fragment_creation
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done).apply {
-            isVisible = addressViewModel.shouldShowDoneButton.value ?: false
+            isEnabled = addressViewModel.shouldEnableDoneButton.value ?: false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -58,7 +58,7 @@ class AddressViewModel @Inject constructor(
     private val _isDifferentShippingAddressChecked = MutableLiveData<Boolean>()
     val isDifferentShippingAddressChecked: LiveData<Boolean> = _isDifferentShippingAddressChecked
 
-    val shouldShowDoneButton = isAnyAddressEdited.combineWith(
+    val shouldEnableDoneButton = isAnyAddressEdited.combineWith(
         isDifferentShippingAddressChecked,
         viewStateData.liveData.map { it.addressSelectionStates[AddressType.SHIPPING]?.address }
     ) { isAnyAddressEdited, isDifferentShippingAddressChecked, shippingAddress ->

--- a/WooCommerce/src/main/res/color/action_menu_fg_selector.xml
+++ b/WooCommerce/src/main/res/color/action_menu_fg_selector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:state_enabled="false"
+        android:color="@color/color_on_surface_disabled"/>
+    <item
+        android:color="@color/woo_pink_50"/>
+</selector>
+
+

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -20,7 +20,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:background">@color/color_toolbar</item>
     </style>
     <style name="Widget.Woo.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
-        <item name="actionMenuTextColor">@color/woo_pink_50</item>
+        <item name="actionMenuTextColor">@color/action_menu_fg_selector</item>
         <item name="colorControlNormal">@color/woo_pink_50</item>
     </style>
     <style name="TextAppearance.Woo.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -42,7 +42,7 @@
         <item name="android:textColorLink">@color/color_secondary</item>
 
         <item name="minTouchTargetSize">@dimen/min_tap_target</item>
-        <item name="actionMenuTextColor">?attr/colorSecondary</item>
+        <item name="actionMenuTextColor">@color/action_menu_fg_selector</item>
 
         <!-- Shapes -->
         <item name="shapeAppearanceSmallComponent">@style/ShapeAppearance.Theme.Woo.SmallComponent</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -61,7 +61,7 @@ class AddressViewModelTest : BaseUnitTest() {
     @Before
     fun setup() {
         addressViewModel.viewStateData.liveData.observeForever(viewStateObserver)
-        addressViewModel.shouldShowDoneButton.observeForever(mock())
+        addressViewModel.shouldEnableDoneButton.observeForever(mock())
     }
 
     @Test
@@ -250,18 +250,18 @@ class AddressViewModelTest : BaseUnitTest() {
     fun `Should show done button if billing address has been edited`() {
         addressViewModel.start(mapOf(SHIPPING to shippingAddress, BILLING to shippingAddress))
 
-        assertThat(addressViewModel.shouldShowDoneButton.value).isFalse
+        assertThat(addressViewModel.shouldEnableDoneButton.value).isFalse
         addressViewModel.onFieldEdited(BILLING, Field.FirstName, "new first name")
-        assertThat(addressViewModel.shouldShowDoneButton.value).isTrue
+        assertThat(addressViewModel.shouldEnableDoneButton.value).isTrue
     }
 
     @Test
     fun `Should show done button if shipping address has been edited`() {
         addressViewModel.start(mapOf(SHIPPING to shippingAddress, BILLING to shippingAddress))
 
-        assertThat(addressViewModel.shouldShowDoneButton.value).isFalse
+        assertThat(addressViewModel.shouldEnableDoneButton.value).isFalse
         addressViewModel.onFieldEdited(SHIPPING, Field.FirstName, "new first name")
-        assertThat(addressViewModel.shouldShowDoneButton.value).isTrue
+        assertThat(addressViewModel.shouldEnableDoneButton.value).isTrue
     }
 
     @Test
@@ -273,8 +273,8 @@ class AddressViewModelTest : BaseUnitTest() {
             )
         )
 
-        assertThat(addressViewModel.shouldShowDoneButton.value).isFalse
+        assertThat(addressViewModel.shouldEnableDoneButton.value).isFalse
         addressViewModel.onDifferentShippingAddressChecked(false)
-        assertThat(addressViewModel.shouldShowDoneButton.value).isTrue
+        assertThat(addressViewModel.shouldEnableDoneButton.value).isTrue
     }
 }


### PR DESCRIPTION
Closes #5813 - This PR disables rather than hides the Done button in the order creation customer address screen. This required updating our `actionMenuTextColor` style to use a selector in order to provide a disabled color to the button.