### PR TITLE
issue/5820-order-creation-show-billing-not-accessible

### DIFF
--- a/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
@@ -99,7 +99,6 @@
         android:layout_height="wrap_content"
         android:clickable="true"
         android:focusable="true"
-        android:importantForAccessibility="no"
         android:text="@string/orderdetail_show_billing"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes #5820 - the "Show billing" button in the order creation form was marked with `android:importantForAccessibility="no"` which made it inaccessible to TalkBack navigation. This PR corrects that problem.


https://user-images.githubusercontent.com/3903757/158782411-b22421fd-c9bb-432a-b604-1de1cb3dd691.mp4

 