### PR TITLE
issue/5819-order-creation-no-pauses-in-address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -305,13 +305,22 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                 val view = LayoutOrderCreationCustomerInfoBinding.inflate(layoutInflater)
                 view.name.text = "${order.billingAddress.firstName} ${order.billingAddress.lastName}"
                 view.email.text = order.billingAddress.email
-                view.shippingAddressDetails.text =
+
+                val shippingAddressDetails =
                     if (order.shippingAddress != Address.EMPTY) {
                         order.formatShippingInformationForDisplay()
                     } else {
                         order.formatBillingInformationForDisplay()
                     }
-                view.billingAddressDetails.text = order.formatBillingInformationForDisplay()
+                view.shippingAddressDetails.text = shippingAddressDetails
+                view.shippingAddressDetails.contentDescription =
+                    shippingAddressDetails.replace("\n", ". ")
+
+                val billingAddressDetails = order.formatBillingInformationForDisplay()
+                view.billingAddressDetails.text = billingAddressDetails
+                view.billingAddressDetails.contentDescription =
+                    billingAddressDetails.replace("\n", ". ")
+
                 view.customerInfoViewMoreButtonTitle.setOnClickListener {
                     view.changeState()
                 }


### PR DESCRIPTION
Fixes #5819 - prior to this PR, tapping the order creation shipping or billing address with TalkBack enabled would cause them to be read as a single sentence, with no pauses between lines. This PR resolves this by setting the content description to the address with periods between sentences.