### PR TITLE
Merge 8.8 code freeze to trunk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (5.2.6.2)
+    activesupport (5.2.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -30,7 +30,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     bigdecimal (1.4.4)
-    buildkit (1.4.5)
+    buildkit (1.5.0)
       sawyer (>= 0.6)
     chroma (0.2.0)
     claide (1.1.0)
@@ -116,7 +116,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (3.1.0)
+    fastlane-plugin-wpmreleasetoolkit (4.0.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.4)
@@ -203,7 +203,7 @@ GEM
     options (2.3.2)
     optparse (0.1.1)
     os (1.1.4)
-    parallel (1.21.0)
+    parallel (1.22.0)
     plist (3.6.0)
     progress_bar (1.3.3)
       highline (>= 1.6, < 3)
@@ -270,8 +270,8 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 3.1)
+  fastlane-plugin-wpmreleasetoolkit (~> 4.0)
   nokogiri
 
 BUNDLED WITH
-   2.2.33
+   2.3.8

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+8.9
+-----
+
+
 8.8
 -----
 

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -69,9 +69,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "8.7"
+            versionName "8.8-rc-1"
         }
-        versionCode 286
+        versionCode 287
 
         minSdkVersion 21
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,3 +1,2 @@
-Did you know we’ve released a beta feature for creating orders? Head to the Menu tab, tap the settings icon, and scroll to beta features. We just added fees and shipping costs!
 
-We fixed a rare issue where sometimes the notes for an order appeared incorrectly. Thanks for letting us know!
+

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-10108ee9af6d98e2861843b19d379a22df8473e4'
+    fluxCVersion = '1.38.0'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,6 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 3.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 4.0'
 #gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 #gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'add/s3-binary-upload'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="more_menu_button_analytics">Analytics</string>
     <string name="more_menu_button_inbox">Inbox</string>
     <string name="more_menu_button_store">View Store</string>
+    <string name="more_menu_button_coupons">Coupons</string>
     <string name="more_menu_button_reviews">Reviews</string>
     <string name="more_menu_avatar">User profile picture</string>
     <string name="version_with_name_param">Version %s</string>
@@ -131,12 +132,14 @@
     <string name="generic_string" translatable="false">%s</string>
     <string name="error_required_field">Required field</string>
     <string name="analytics">Analytics</string>
-    <string name="minus">Minus</string>
-    <string name="plus">Plus</string>
+    <string name="minus_one">Minus one</string>
+    <string name="plus_one">Plus one</string>
     <string name="card">Card</string>
     <string name="cash">Cash</string>
     <string name="create">Create</string>
     <string name="exclusive_or">or</string>
+    <string name="count">Count: %s</string>
+    <string name="no_sku">No SKU</string>
 
     <!--
         Date/Time Labels
@@ -875,6 +878,7 @@
     <string name="orderstatus_cancelled">Cancelled</string>
     <string name="orderstatus_refunded">Refunded</string>
     <string name="orderstatus_contentDesc">Order status</string>
+    <string name="orderstatus_contentDesc_withStatus">Order status: %s</string>
     <!--
         Add Shipment Tracking Labels
     -->
@@ -1853,6 +1857,8 @@
 
     <!-- Inbox -->
     <string name="dismiss_inbox_note">Dismiss</string>
+    <string name="empty_inbox_title">Congrats, you’ve read everything!</string>
+    <string name="empty_inbox_description">Come back soon for more tips and insights on growing your store</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>


### PR DESCRIPTION
Besides the usual changes made by `fastlane`:
* Updates release toolkit to `4.0`
* Updates FluxC to `1.38.0` which points to the same commit hash as `trunk-10108ee9af6d98e2861843b19d379a22df8473e4`.