### PR TITLE
Support review moderation in product details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 8.9
 -----
-
+- [*] Added support for moderating reviews of specific products from the Product Details screen. [https://github.com/woocommerce/woocommerce-android/pull/6070]
 
 8.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -761,7 +761,7 @@ class MainActivity :
                     )
                 }
                 is ViewReviewDetail -> {
-                    showReviewDetail(event.uniqueId, launchedFromNotification = true, enableModeration = true)
+                    showReviewDetail(event.uniqueId, launchedFromNotification = true)
                 }
                 is ViewReviewList -> showReviewList()
                 is RestartActivityForNotification -> {
@@ -827,7 +827,6 @@ class MainActivity :
     override fun showReviewDetail(
         remoteReviewId: Long,
         launchedFromNotification: Boolean,
-        enableModeration: Boolean,
         tempStatus: String?
     ) {
         if (launchedFromNotification) {
@@ -838,8 +837,7 @@ class MainActivity :
         val action = NavGraphMainDirections.actionGlobalReviewDetailFragment(
             remoteReviewId = remoteReviewId,
             tempStatus = tempStatus,
-            launchedFromNotification = launchedFromNotification,
-            enableModeration = enableModeration
+            launchedFromNotification = launchedFromNotification
         )
         navController.navigateSafely(action)
     }
@@ -847,7 +845,6 @@ class MainActivity :
     override fun showReviewDetailWithSharedTransition(
         remoteReviewId: Long,
         launchedFromNotification: Boolean,
-        enableModeration: Boolean,
         sharedView: View,
         tempStatus: String?
     ) {
@@ -856,8 +853,7 @@ class MainActivity :
         val action = ReviewListFragmentDirections.actionReviewListFragmentToReviewDetailFragment(
             remoteReviewId = remoteReviewId,
             tempStatus = tempStatus,
-            launchedFromNotification = launchedFromNotification,
-            enableModeration = enableModeration
+            launchedFromNotification = launchedFromNotification
         )
         navController.navigateSafely(directions = action, extras = extras)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -30,13 +30,11 @@ interface MainNavigationRouter {
     fun showReviewDetail(
         remoteReviewId: Long,
         launchedFromNotification: Boolean,
-        enableModeration: Boolean,
         tempStatus: String? = null
     )
     fun showReviewDetailWithSharedTransition(
         remoteReviewId: Long,
         launchedFromNotification: Boolean,
-        enableModeration: Boolean,
         sharedView: View,
         tempStatus: String? = null
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
+import com.woocommerce.android.ui.products.reviews.ProductReviewsFragment
 import com.woocommerce.android.ui.products.variations.VariationListFragment
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.VariationListData
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -215,6 +216,10 @@ class ProductDetailFragment :
 
         handleResult<VariationListData>(VariationListFragment.KEY_VARIATION_LIST_RESULT) { data ->
             data.currentVariationAmount?.let { viewModel.onVariationAmountReceived(it) }
+        }
+
+        handleNotice(ProductReviewsFragment.PRODUCT_REVIEWS_MODIFIED) {
+            viewModel.refreshProduct()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1003,6 +1003,12 @@ class ProductDetailViewModel @Inject constructor(
         }
     }
 
+    fun refreshProduct() {
+        launch {
+            fetchProduct(viewState.productDraft?.remoteId ?: navArgs.remoteProductId)
+        }
+    }
+
     private fun loadRemoteProduct(remoteProductId: Long) {
         // Pre-load current site's tax class list for use in the product pricing screen
         launch(dispatchers.main) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -155,8 +155,7 @@ class ProductReviewsFragment :
     override fun onReviewClick(review: ProductReview, sharedView: View?) {
         (activity as? MainNavigationRouter)?.showReviewDetail(
             review.remoteId,
-            launchedFromNotification = false,
-            enableModeration = true
+            launchedFromNotification = false
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -51,6 +51,7 @@ class ProductReviewsFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentReviewsListBinding.bind(view)
+        setupViews()
         setupObservers()
     }
 
@@ -61,9 +62,7 @@ class ProductReviewsFragment :
         _binding = null
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-
+    private fun setupViews() {
         _reviewsAdapter = ReviewListAdapter(this)
 
         binding.reviewsList.apply {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -18,6 +18,9 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.reviews.ReviewListAdapter
+import com.woocommerce.android.ui.reviews.ReviewModerationUi
+import com.woocommerce.android.ui.reviews.observeModerationStatus
+import com.woocommerce.android.ui.reviews.reviewList
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
@@ -28,7 +31,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ProductReviewsFragment :
     BaseFragment(R.layout.fragment_reviews_list),
-    ReviewListAdapter.OnReviewClickListener {
+    ReviewListAdapter.OnReviewClickListener,
+    ReviewModerationUi {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     val viewModel: ProductReviewsViewModel by viewModels()
@@ -114,6 +118,11 @@ class ProductReviewsFragment :
                 showReviewList(it)
             }
         )
+
+        observeModerationStatus(
+            reviewModerationConsumer = viewModel,
+            uiMessageResolver = uiMessageResolver
+        )
     }
 
     private fun showReviewList(reviews: List<ProductReview>) {
@@ -148,7 +157,7 @@ class ProductReviewsFragment :
         (activity as? MainNavigationRouter)?.showReviewDetail(
             review.remoteId,
             launchedFromNotification = false,
-            enableModeration = false
+            enableModeration = true
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsRepository.kt
@@ -3,8 +3,10 @@ package com.woocommerce.android.ui.products.reviews
 import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.REVIEWS
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductReviewChanged
@@ -12,7 +14,8 @@ import javax.inject.Inject
 
 class ProductReviewsRepository @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val productStore: WCProductStore
+    private val productStore: WCProductStore,
+    private val coroutineDispatchers: CoroutineDispatchers
 ) {
     companion object {
         private const val PRODUCT_REVIEW_STATUS_APPROVED = "approved"
@@ -55,10 +58,11 @@ class ProductReviewsRepository @Inject constructor(
     /**
      * Returns all product reviews for the current site and product from the local database
      */
-    fun getProductReviewsFromDB(remoteProductId: Long): List<ProductReview> {
-        return productStore.getProductReviewsForProductAndSiteId(
-            localSiteId = selectedSite.get().id,
-            remoteProductId = remoteProductId
-        ).map { it.toAppModel() }
-    }
+    suspend fun getProductReviewsFromDB(remoteProductId: Long): List<ProductReview> =
+        withContext(coroutineDispatchers.io) {
+            productStore.getProductReviewsForProductAndSiteId(
+                localSiteId = selectedSite.get().id,
+                remoteProductId = remoteProductId
+            ).map { it.toAppModel() }
+        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsRepository.kt
@@ -18,7 +18,6 @@ class ProductReviewsRepository @Inject constructor(
     private val coroutineDispatchers: CoroutineDispatchers
 ) {
     companion object {
-        private const val PRODUCT_REVIEW_STATUS_APPROVED = "approved"
         private const val PAGE_SIZE = WCProductStore.NUM_REVIEWS_PER_FETCH
     }
 
@@ -38,8 +37,7 @@ class ProductReviewsRepository @Inject constructor(
 
         val payload = FetchProductReviewsPayload(
             selectedSite.get(), newOffset,
-            productIds = listOf(remoteProductId),
-            filterByStatus = listOf(PRODUCT_REVIEW_STATUS_APPROVED)
+            productIds = listOf(remoteProductId)
         )
         val result = productStore.fetchProductReviews(payload)
         if (result.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
@@ -85,6 +85,9 @@ class ProductReviewsViewModel @Inject constructor(
     private fun reloadReviewsFromCache() {
         launch {
             _reviewList.value = reviewsRepository.getProductReviewsFromDB(navArgs.remoteProductId)
+            productReviewsViewState = productReviewsViewState.copy(
+                isEmptyViewVisible = _reviewList.value?.isEmpty() == true
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
@@ -67,7 +67,20 @@ class ProductReviewsViewModel @Inject constructor(
         launch { fetchProductReviews(remoteProductId = navArgs.remoteProductId, loadMore = true) }
     }
 
-    override fun ReviewModerationConsumer.reloadReviewsFromCache() {
+    override fun ReviewModerationConsumer.onReviewModerationSuccess() {
+        reloadReviewsFromCache()
+        hasModifiedReviews = true
+    }
+
+    fun onBackButtonClicked() {
+        if (hasModifiedReviews) {
+            triggerEvent(ExitWithResult(Unit))
+        } else {
+            triggerEvent(Exit)
+        }
+    }
+
+    private fun reloadReviewsFromCache() {
         launch {
             _reviewList.value = reviewsRepository.getProductReviewsFromDB(navArgs.remoteProductId)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
@@ -57,7 +57,7 @@ class ProductReviewsViewModel @Inject constructor(
         launch { fetchProductReviews(remoteProductId = navArgs.remoteProductId, loadMore = true) }
     }
 
-    private fun loadProductReviews() {
+    private fun loadProductReviews() = launch {
         // Initial load. Get and show reviewList from the db if any
         val reviewsInDb = reviewsRepository.getProductReviewsFromDB(navArgs.remoteProductId)
         if (reviewsInDb.isNotEmpty()) {
@@ -67,7 +67,7 @@ class ProductReviewsViewModel @Inject constructor(
             productReviewsViewState = productReviewsViewState.copy(isSkeletonShown = true)
         }
 
-        launch { fetchProductReviews(navArgs.remoteProductId, loadMore = false) }
+        fetchProductReviews(navArgs.remoteProductId, loadMore = false)
     }
 
     private suspend fun fetchProductReviews(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.ui.reviews.observeModerationEvents
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.PRODUCTS
 import com.woocommerce.android.viewmodel.LiveDataDelegate
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -44,6 +44,8 @@ class ProductReviewsViewModel @Inject constructor(
     private var productReviewsViewState by productReviewsViewStateData
 
     private val navArgs: ProductReviewsFragmentArgs by savedState.navArgs()
+
+    private var hasModifiedReviews: Boolean = false
 
     init {
         if (_reviewList.value == null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -229,37 +229,30 @@ class ReviewDetailFragment :
     }
 
     private fun configureModerationButtons(status: ProductReviewStatus) {
-        val visibility = if (navArgs.enableModeration) View.VISIBLE else View.GONE
-        binding.reviewApprove.visibility = visibility
-        binding.reviewSpam.visibility = visibility
-        binding.reviewTrash.visibility = visibility
+        binding.reviewApprove.setOnCheckedChangeListener(null)
 
-        if (navArgs.enableModeration) {
-            binding.reviewApprove.setOnCheckedChangeListener(null)
+        // Use the status override if present,else new status
+        when (val newStatus = navArgs.tempStatus?.let { ProductReviewStatus.fromString(it) } ?: status) {
+            APPROVED -> binding.reviewApprove.isChecked = true
+            HOLD -> binding.reviewApprove.isChecked = false
+            else -> WooLog.w(REVIEWS, "Unable to process Review with a status of $newStatus")
+        }
 
-            // Use the status override if present,else new status
-            when (val newStatus = navArgs.tempStatus?.let { ProductReviewStatus.fromString(it) } ?: status) {
-                APPROVED -> binding.reviewApprove.isChecked = true
-                HOLD -> binding.reviewApprove.isChecked = false
-                else -> WooLog.w(REVIEWS, "Unable to process Review with a status of $newStatus")
-            }
+        // Configure the moderate button
+        binding.reviewApprove.setOnCheckedChangeListener(moderateListener)
 
-            // Configure the moderate button
-            binding.reviewApprove.setOnCheckedChangeListener(moderateListener)
+        // Configure the spam button
+        binding.reviewSpam.setOnClickListener {
+            AnalyticsTracker.track(AnalyticsEvent.REVIEW_DETAIL_SPAM_BUTTON_TAPPED)
 
-            // Configure the spam button
-            binding.reviewSpam.setOnClickListener {
-                AnalyticsTracker.track(AnalyticsEvent.REVIEW_DETAIL_SPAM_BUTTON_TAPPED)
+            processReviewModeration(SPAM)
+        }
 
-                processReviewModeration(SPAM)
-            }
+        // Configure the trash button
+        binding.reviewTrash.setOnClickListener {
+            AnalyticsTracker.track(AnalyticsEvent.REVIEW_DETAIL_TRASH_BUTTON_TAPPED)
 
-            // Configure the trash button
-            binding.reviewTrash.setOnClickListener {
-                AnalyticsTracker.track(AnalyticsEvent.REVIEW_DETAIL_TRASH_BUTTON_TAPPED)
-
-                processReviewModeration(TRASH)
-            }
+            processReviewModeration(TRASH)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -250,14 +250,12 @@ class ReviewListFragment :
                 router.showReviewDetail(
                     review.remoteId,
                     launchedFromNotification = false,
-                    enableModeration = true,
                     tempStatus = review.status
                 )
             } else {
                 router.showReviewDetailWithSharedTransition(
                     review.remoteId,
                     launchedFromNotification = false,
-                    enableModeration = true,
                     tempStatus = review.status,
                     sharedView = sharedView
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -92,7 +92,11 @@ class ReviewListViewModel @Inject constructor(
         }
     }
 
-    override fun ReviewModerationConsumer.reloadReviewsFromCache() {
+    override fun ReviewModerationConsumer.onReviewModerationSuccess() {
+        reloadReviewsFromCache()
+    }
+
+    private fun reloadReviewsFromCache() {
         launch {
             _reviewList.value = reviewRepository.getCachedProductReviews()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewModerationConsumer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewModerationConsumer.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.filter
 interface ReviewModerationConsumer {
     val ReviewModerationConsumer.reviewModerationHandler: ReviewModerationHandler
     val ReviewModerationConsumer.rawReviewList: LiveData<List<ProductReview>>
-    fun ReviewModerationConsumer.reloadReviewsFromCache()
+    fun ReviewModerationConsumer.onReviewModerationSuccess()
 }
 
 val ReviewModerationConsumer.pendingReviewModerationStatus
@@ -35,7 +35,7 @@ val ReviewModerationConsumer.reviewList
 suspend fun ReviewModerationConsumer.observeModerationEvents() {
     reviewModerationHandler.pendingModerationStatus
         .filter { statuses -> statuses.any { it.actionStatus == ActionStatus.SUCCESS } }
-        .collect { reloadReviewsFromCache() }
+        .collect { onReviewModerationSuccess() }
 }
 
 fun ReviewModerationConsumer.undoModerationRequest(review: ProductReview) {

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -227,9 +227,6 @@
         <argument
             android:name="launchedFromNotification"
             app:argType="boolean" />
-        <argument
-            android:name="enableModeration"
-            app:argType="boolean" />
     </action>
     <fragment
         android:id="@+id/reviewDetailFragment"
@@ -246,9 +243,6 @@
             app:nullable="true" />
         <argument
             android:name="launchedFromNotification"
-            app:argType="boolean" />
-        <argument
-            android:name="enableModeration"
             app:argType="boolean" />
         <action
             android:id="@+id/action_reviewDetailFromNotification_to_reviewListFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -160,9 +160,6 @@
             android:id="@+id/action_moreMenu_to_settingsActivity"
             app:destination="@id/appSettingsActivity" />
         <action
-            android:id="@+id/action_moreMenuFragment_to_reviewDetailFragment"
-            app:destination="@id/reviewDetailFragment" />
-        <action
             android:id="@+id/action_moreMenuFragment_to_inboxFragment"
             app:destination="@id/inboxFragment" />
         <action
@@ -214,20 +211,7 @@
     </action>
     <action
         android:id="@+id/action_global_reviewDetailFragment"
-        app:destination="@id/reviewDetailFragment">
-        <argument
-            android:name="remoteReviewId"
-            android:defaultValue="0L"
-            app:argType="long" />
-        <argument
-            android:name="tempStatus"
-            android:defaultValue="null"
-            app:argType="string"
-            app:nullable="true" />
-        <argument
-            android:name="launchedFromNotification"
-            app:argType="boolean" />
-    </action>
+        app:destination="@id/reviewDetailFragment" />
     <fragment
         android:id="@+id/reviewDetailFragment"
         android:name="com.woocommerce.android.ui.reviews.ReviewDetailFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1233,9 +1233,9 @@
     <string name="product_no_shipping_class">No shipping class</string>
     <string name="product_shipping_settings">Shipping settings</string>
     <string name="product_total_orders">Total orders</string>
-    <string name="product_ratings_count">\u2022  rated %d times</string>
-    <string name="product_ratings_count_one">\u2022  rated once</string>
-    <string name="product_ratings_count_zero">\u2022  no ratings</string>
+    <string name="product_ratings_count">\u2022  %d approved reviews</string>
+    <string name="product_ratings_count_one">\u2022  one approved review</string>
+    <string name="product_ratings_count_zero">\u2022  no approved reviews</string>
     <string name="product_reviews">Reviews</string>
     <string name="product_downloads">Downloads</string>
     <string name="product_downloadable_files">Downloadable files</string>


### PR DESCRIPTION
Closes: #6060

### Description
This PR just builds on the changes done in #6037 and #6052 to add support for review moderation in product details.

Changes:
1. Adds support for moderation in product details.
2. Removes the unused argument: `enableModeration`
3. Show unapproved reviews in the reviews list, internal discussion: p1647951251512099-slack-CGPNUU63E
4. Updates the wording from `rated %d times` to `%d approved reviews` (same discussion above)
5. Adds logic to refresh product if a review change is detected (due to a moderation).

Regarding the last point, we won't refresh the product if the user leaves the screen without waiting for the change to be submitted (I mean while the undo snackbar is shown), this is an edge case, and we can't really do anything about it, as even if we refresh the list, the change won't be reflected on the server yet.

### Testing instructions
1. Add some reviews to one of the products.
2. Open the product details in the app.
3. Click on Reviews.
4. Test some moderation requests, and make sure everything works as expected.
5. Confirm the number of "approved reviews" is refreshed after performing a moderation.

### Images/gif
https://user-images.githubusercontent.com/1657201/159481841-b8f3dc3e-d5a9-4e64-a82b-381771ad58b4.mov

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.