### PR TITLE
Issue/5922  Show tax breakdown

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -178,6 +178,7 @@ data class Order(
     @Parcelize
     data class TaxLine(
         val id: Long,
+        val label:String,
         val compound: Boolean,
         val taxTotal: String,
         val ratePercent: Float

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -178,7 +178,7 @@ data class Order(
     @Parcelize
     data class TaxLine(
         val id: Long,
-        val label:String,
+        val label: String,
         val compound: Boolean,
         val taxTotal: String,
         val ratePercent: Float

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -82,6 +82,7 @@ class OrderMapper @Inject constructor(private val getLocations: GetLocations) {
     private fun List<TaxLine>.mapTaxLines(): List<Order.TaxLine> = map {
         Order.TaxLine(
             id = it.id!!,
+            label = it.label!!,
             compound = it.compound ?: false,
             taxTotal = it.taxTotal ?: StringUtils.EMPTY,
             ratePercent = it.ratePercent ?: 0f

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
@@ -86,22 +86,19 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
     }
 
     private fun setupObservers(binding: FragmentSimplePaymentsBinding) {
-        viewModel.event.observe(
-            viewLifecycleOwner,
-            { event ->
-                when (event) {
-                    is MultiLiveEvent.Event.ShowSnackbar -> {
-                        uiMessageResolver.showSnack(event.message)
-                    }
-                    is SimplePaymentsFragmentViewModel.ShowCustomerNoteEditor -> {
-                        showCustomerNoteEditor()
-                    }
-                    is SimplePaymentsFragmentViewModel.ShowTakePaymentScreen -> {
-                        showTakePaymentScreen()
-                    }
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ShowSnackbar -> {
+                    uiMessageResolver.showSnack(event.message)
+                }
+                is SimplePaymentsFragmentViewModel.ShowCustomerNoteEditor -> {
+                    showCustomerNoteEditor()
+                }
+                is SimplePaymentsFragmentViewModel.ShowTakePaymentScreen -> {
+                    showTakePaymentScreen()
                 }
             }
-        )
+        }
 
         viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.orderSubtotal.takeIfNotEqualTo(old?.orderSubtotal) { subtotal ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
@@ -8,6 +8,7 @@ import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.textview.MaterialTextView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -18,6 +19,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
+import com.woocommerce.android.ui.orders.taxes.OrderTaxesAdapter
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,11 +31,16 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
     private val sharedViewModel by hiltNavGraphViewModels<SimplePaymentsSharedViewModel>(R.id.nav_graph_main)
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+
     @Inject lateinit var currencyFormatter: CurrencyFormatter
+
+    private var _orderTaxesAdapter: OrderTaxesAdapter? = null
+    private val orderTaxesAdapter: OrderTaxesAdapter
+        get() = _orderTaxesAdapter!!
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         val binding = FragmentSimplePaymentsBinding.bind(view)
         binding.buttonDone.setOnClickListener {
             viewModel.onDoneButtonClicked()
@@ -63,6 +70,13 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
         )
         binding.notesSection.setOnEditButtonClicked {
             viewModel.onCustomerNoteClicked()
+        }
+
+        _orderTaxesAdapter = OrderTaxesAdapter(currencyFormatter, sharedViewModel.currencyCode)
+        binding.listTaxes.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = orderTaxesAdapter
+            isNestedScrollingEnabled = false
         }
     }
 
@@ -95,9 +109,8 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
                 binding.textCustomAmount.text = subTotalStr
                 binding.textSubtotal.text = subTotalStr
             }
-            new.orderTotalTax.takeIfNotEqualTo(old?.orderTotalTax) { totalTax ->
-                val taxStr = currencyFormatter.formatCurrency(totalTax, sharedViewModel.currencyCode)
-                binding.textTax.text = taxStr
+            new.orderTaxes.takeIfNotEqualTo(old?.orderTaxes) { taxes ->
+                orderTaxesAdapter.updateTaxes(taxes)
             }
             new.orderTotal.takeIfNotEqualTo(old?.orderTotal) { total ->
                 val totalStr = currencyFormatter.formatCurrency(total, sharedViewModel.currencyCode)
@@ -107,12 +120,10 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
             new.chargeTaxes.takeIfNotEqualTo(old?.chargeTaxes) { chargeTaxes ->
                 binding.switchChargeTaxes.isChecked = chargeTaxes
                 if (chargeTaxes) {
-                    binding.containerTaxes.isVisible = true
+                    binding.listTaxes.isVisible = true
                     binding.textTaxMessage.isVisible = true
-                    binding.textTaxLabel.text =
-                        getString(R.string.simple_payments_tax_with_percent, viewModel.taxRatePercent)
                 } else {
-                    binding.containerTaxes.isVisible = false
+                    binding.listTaxes.isVisible = false
                     binding.textTaxMessage.isVisible = false
                 }
             }
@@ -161,4 +172,9 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
     }
 
     override fun getFragmentTitle() = getString(R.string.simple_payments_title)
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _orderTaxesAdapter = null
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragment.kt
@@ -38,7 +38,6 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments) {
     private val orderTaxesAdapter: OrderTaxesAdapter
         get() = _orderTaxesAdapter!!
 
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentSimplePaymentsBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -181,8 +181,4 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
 
     object ShowCustomerNoteEditor : MultiLiveEvent.Event()
     object ShowTakePaymentScreen : MultiLiveEvent.Event()
-
-    companion object {
-        const val EMPTY_TAX_RATE = "0.00"
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -126,7 +126,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
         launch {
             simplePaymentsRepository.updateSimplePayment(
                 order.id,
-                viewState.orderTotal.toString(),
+                order.feesTotal.toString(),
                 viewState.customerNote,
                 viewState.billingEmail,
                 viewState.chargeTaxes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -55,7 +55,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     // check for an empty list here to simplify our test. note the single fee line is the only way to get the price w/o
     // taxes, and FluxC sets the tax status to "taxable" so when the order is created core automatically sets the total
     // tax if the store has taxes enabled.
-    val feeLineTotal
+    val feeLineTotal:BigDecimal
         get() = if (order.feesLines.isNotEmpty()) {
             order.feesLines[0].total
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -54,7 +54,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     // check for an empty list here to simplify our test. note the single fee line is the only way to get the price w/o
     // taxes, and FluxC sets the tax status to "taxable" so when the order is created core automatically sets the total
     // tax if the store has taxes enabled.
-    val feeLineTotal:BigDecimal
+    val feeLineTotal: BigDecimal
         get() = if (order.feesLines.isNotEmpty()) {
             order.feesLines[0].total
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -47,21 +47,9 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     val orderDraft
         get() = order.copy(
             total = viewState.orderTotal,
-            totalTax = viewState.orderTotalTax,
+            taxLines = viewState.orderTaxes,
             customerNote = viewState.customerNote
         )
-
-    // it was decided that both Android and iOS would determine the tax rate by looking at the
-    // first tax line item because there was nowhere else to get the tax rate, and we didn't
-    // want to calculate the tax percentage on the client. although it's possible that there will
-    // be multiple tax lines, the team assumed the first rate would be the one to show (this may
-    // be revisited)
-    val taxRatePercent
-        get() = if (order.taxLines.isNotEmpty() && viewState.chargeTaxes) {
-            order.taxLines[0].ratePercent.toString()
-        } else {
-            EMPTY_TAX_RATE
-        }
 
     // accessing feesLines[0] should be safe to do since a fee line is passed by FluxC when creating the order, but we
     // check for an empty list here to simplify our test. note the single fee line is the only way to get the price w/o
@@ -84,14 +72,14 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
             viewState = viewState.copy(
                 chargeTaxes = true,
                 orderSubtotal = feeLineTotal,
-                orderTotalTax = order.totalTax,
+                orderTaxes = order.taxLines,
                 orderTotal = order.total
             )
         } else {
             viewState = viewState.copy(
                 chargeTaxes = false,
                 orderSubtotal = feeLineTotal,
-                orderTotalTax = BigDecimal.ZERO,
+                orderTaxes = emptyList(),
                 orderTotal = feeLineTotal
             )
         }
@@ -186,7 +174,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     data class ViewState(
         val chargeTaxes: Boolean = false,
         val orderSubtotal: BigDecimal = BigDecimal.ZERO,
-        val orderTotalTax: BigDecimal = BigDecimal.ZERO,
+        val orderTaxes: List<Order.TaxLine> = emptyList(),
         val orderTotal: BigDecimal = BigDecimal.ZERO,
         val customerNote: String = "",
         val billingEmail: String = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -47,7 +47,6 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     val orderDraft
         get() = order.copy(
             total = viewState.orderTotal,
-            taxLines = viewState.orderTaxes,
             customerNote = viewState.customerNote
         )
 
@@ -68,18 +67,17 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     }
 
     private fun updateViewState(chargeTaxes: Boolean) {
-        if (chargeTaxes) {
-            viewState = viewState.copy(
+        viewState = if (chargeTaxes) {
+            viewState.copy(
                 chargeTaxes = true,
                 orderSubtotal = feeLineTotal,
                 orderTaxes = order.taxLines,
                 orderTotal = order.total
             )
         } else {
-            viewState = viewState.copy(
+            viewState.copy(
                 chargeTaxes = false,
                 orderSubtotal = feeLineTotal,
-                orderTaxes = emptyList(),
                 orderTotal = feeLineTotal
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/taxes/OrderTaxesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/taxes/OrderTaxesAdapter.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.databinding.OrderTaxItemBinding
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.util.CurrencyFormatter
 
-
 class OrderTaxesAdapter(
     private val currencyFormatter: CurrencyFormatter,
     private val currencyCode: String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/taxes/OrderTaxesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/taxes/OrderTaxesAdapter.kt
@@ -15,6 +15,10 @@ class OrderTaxesAdapter(
 ) : RecyclerView.Adapter<OrderTaxesAdapter.ViewHolder>() {
     private var taxes: List<Order.TaxLine> = emptyList()
 
+    init {
+        setHasStableIds(true)
+    }
+
     @SuppressLint("NotifyDataSetChanged")
     fun updateTaxes(newTaxes: List<Order.TaxLine>) {
         taxes = newTaxes
@@ -36,6 +40,8 @@ class OrderTaxesAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.bind(taxes[position])
     }
+
+    override fun getItemId(position: Int): Long = taxes[position].id
 
     override fun getItemCount(): Int = taxes.size
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/taxes/OrderTaxesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/taxes/OrderTaxesAdapter.kt
@@ -1,0 +1,55 @@
+package com.woocommerce.android.ui.orders.taxes
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.OrderTaxItemBinding
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.util.CurrencyFormatter
+
+
+class OrderTaxesAdapter(
+    private val currencyFormatter: CurrencyFormatter,
+    private val currencyCode: String
+) : RecyclerView.Adapter<OrderTaxesAdapter.ViewHolder>() {
+    private var taxes: List<Order.TaxLine> = emptyList()
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateTaxes(newTaxes: List<Order.TaxLine>) {
+        taxes = newTaxes
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            OrderTaxItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            ),
+            currencyFormatter,
+            currencyCode
+        )
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(taxes[position])
+    }
+
+    override fun getItemCount(): Int = taxes.size
+
+    class ViewHolder(
+        private val viewBinding: OrderTaxItemBinding,
+        private val currencyFormatter: CurrencyFormatter,
+        private val currencyCode: String
+    ) : RecyclerView.ViewHolder(viewBinding.root) {
+        fun bind(tax: Order.TaxLine) {
+            val context = viewBinding.root.context
+            viewBinding.taxLabel.text =
+                String.format(context.getString(R.string.tax_name_with_tax_percent), tax.label, tax.ratePercent)
+            viewBinding.taxValue.text = currencyFormatter.formatCurrency(tax.taxTotal, currencyCode)
+        }
+    }
+}

--- a/WooCommerce/src/main/res/layout/fragment_simple_payments.xml
+++ b/WooCommerce/src/main/res/layout/fragment_simple_payments.xml
@@ -139,31 +139,13 @@
                 android:layout_height="wrap_content"
                 android:text="@string/simple_payments_charge_taxes" />
 
-            <!-- Tax -->
-            <LinearLayout
-                android:id="@+id/containerTaxes"
+            <!-- Taxes -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/listTaxes"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:layout_height="wrap_content">
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/textTaxLabel"
-                    style="@style/Woo.Card.Body.High"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:text="@string/tax" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/textTax"
-                    style="@style/Woo.Card.Body.High"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    tools:text="$4.00" />
-            </LinearLayout>
+            </androidx.recyclerview.widget.RecyclerView>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/textTaxMessage"

--- a/WooCommerce/src/main/res/layout/order_tax_item.xml
+++ b/WooCommerce/src/main/res/layout/order_tax_item.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/minor_100"
+    android:focusable="true"
+    android:orientation="horizontal">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tax_label"
+        style="@style/Woo.Card.Body.High"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="@string/tax" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tax_value"
+        style="@style/Woo.Card.Body.High"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="$7.00"/>
+</LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -337,6 +337,10 @@
     <string name="simple_payments_cash_dlg_message">This will create your order and mark it as paid if you received payment outside of WooCommerce</string>
     <string name="simple_payments_cash_dlg_button">Mark as paid</string>
     <!--
+         Taxes
+    -->
+    <string name="tax_name_with_tax_percent">%1$s (%2$s%%)</string>
+    <!--
          Order Creation
     -->
     <string name="orderlist_create_order_button_description">Create order</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModelTests.kt
@@ -46,18 +46,18 @@ class SimplePaymentsFragmentViewModelTests : BaseUnitTest() {
     }
 
     @Test
-    fun `when charging taxes is enabled, then taxLines is taken from the order`() =
+    fun `when charging taxes is enabled, then taxes are applied to the total amount of the order`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             initViewModel()
             viewModel.onChargeTaxesChanged(chargeTaxes = true)
-            assertThat(viewModel.orderDraft.taxLines).isEqualTo(testOrder.taxLines)
+            assertThat(viewModel.orderDraft.total).isGreaterThan(viewModel.orderDraft.feesTotal)
         }
 
     @Test
-    fun `when charging taxes is NOT enabled, then taxLines is empty`() =
+    fun `when charging taxes is NOT enabled, then total amount is equal to the total fee`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             initViewModel()
             viewModel.onChargeTaxesChanged(chargeTaxes = false)
-            assertThat(viewModel.orderDraft.taxLines.size).isEqualTo(0)
+            assertThat(viewModel.orderDraft.total).isEqualTo(viewModel.orderDraft.feesTotal)
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModelTests.kt
@@ -26,6 +26,7 @@ class SimplePaymentsFragmentViewModelTests : BaseUnitTest() {
                 it.add(
                     Order.TaxLine(
                         id = TAX_LINE_ID,
+                        label = "Test Tax",
                         compound = false,
                         taxTotal = "10.00",
                         ratePercent = TAX_LINE_TAX_RATE
@@ -45,18 +46,18 @@ class SimplePaymentsFragmentViewModelTests : BaseUnitTest() {
     }
 
     @Test
-    fun `when charging taxes is enabled, then tax rate is taken from first tax line`() =
+    fun `when charging taxes is enabled, then taxLines is taken from the order`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             initViewModel()
             viewModel.onChargeTaxesChanged(chargeTaxes = true)
-            assertThat(viewModel.taxRatePercent).isEqualTo(TAX_LINE_TAX_RATE.toString())
+            assertThat(viewModel.orderDraft.taxLines).isEqualTo(testOrder.taxLines)
         }
 
     @Test
-    fun `when charging taxes is NOT enabled, then tax rate is zero`() =
+    fun `when charging taxes is NOT enabled, then taxLines is empty`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             initViewModel()
             viewModel.onChargeTaxesChanged(chargeTaxes = false)
-            assertThat(viewModel.taxRatePercent).isEqualTo(SimplePaymentsFragmentViewModel.EMPTY_TAX_RATE)
+            assertThat(viewModel.orderDraft.taxLines.size).isEqualTo(0)
         }
 }


### PR DESCRIPTION
Closes: #5922

### Description
This PR changes how the app displays the tax amount on the summary screen. Now it gives more information to the user by listing all the taxes charged ( when the charge tax option is enabled ). It also fixes charging the taxes twice by using the order's fees instead of the order total when calling `simplePaymentsRepository.updateSimplePayment`.

### Testing instructions
My Store -> Orders -> (+) Simple Payments
Enter an amount (for example 10.00)
When the **charge tax** option is enabled, -> shows the taxes applied to the order. 
When the **charge tax** option is disabled -> hide the taxes applied to the order 
Press take payment -> Cash -> Mark as paid
See the total amount is the order's amount + taxes.

### Images/gif
https://user-images.githubusercontent.com/18119390/159366877-ed9e0510-0a41-4a68-b1c4-e8cb2cd51b39.mp4

### Small fix
I also noticed that after payment was taken, the app displayed an incorrect amount in the order. It did that because calling `simplePaymentsRepository.updateSimplePayment` with charge tax enabled updated the amount passed to the total amount including taxes, and not the total amount of the order.
#### Bug testing instructions
My Store -> Orders -> (+) Simple Payments
Enter an amount of 10.00
Press take payment -> Cash -> Mark as paid
See that the order amount is now 10.00 + taxes, and taxes are applied on this new amount.
Expected result: order amount total is 10.00 + taxes

https://user-images.githubusercontent.com/18119390/159367918-332f3441-0542-48d9-a6fa-760a420f09f7.mp4

![Screenshot](https://user-images.githubusercontent.com/18119390/159368443-569e7860-25da-4788-b1df-eb882ce69f93.png)



