### PR TITLE
Fix `JaCoCo` integration

### DIFF
--- a/config/gradle/jacoco.gradle
+++ b/config/gradle/jacoco.gradle
@@ -7,7 +7,8 @@ jacoco {
 }
 
 rootProject.afterEvaluate {
-    tasks.create(name: "jacocoTestReport", type: JacocoReport, dependsOn: [':WooCommerce:testWasabiDebugUnitTest', ':libs:cardreader:testDebugUnitTest']) {
+    tasks.register("jacocoTestReport", JacocoReport) {
+        dependsOn(':WooCommerce:testWasabiDebugUnitTest', ':libs:cardreader:testDebugUnitTest')
 
         group = "Reporting"
         description = "Generate Jacoco coverage reports for WasabiDebug variant"

--- a/config/gradle/jacoco.gradle
+++ b/config/gradle/jacoco.gradle
@@ -56,12 +56,9 @@ rootProject.afterEvaluate {
         sourceDirectories.setFrom(files([sources]))
         classDirectories.from = files([kotlinClasses])
 
-        def executions = rootProject.subprojects.findAll { proj ->
-            def path = "${proj.buildDir}/jacoco/testWasabiDebugUnitTest.exec"
-            (new File(path)).exists()
-        }.collect { proj ->
-            "${proj.buildDir}/jacoco/testWasabiDebugUnitTest.exec"
-        }
-        executionData.from = files(executions)
+        executionData.from = files([
+                "WooCommerce/build/jacoco/testWasabiDebugUnitTest.exec",
+                "libs/cardreader/build/jacoco/testDebugUnitTest.exec"
+        ])
     }
 }

--- a/config/gradle/jacoco.gradle
+++ b/config/gradle/jacoco.gradle
@@ -1,4 +1,6 @@
-apply plugin: JacocoPlugin
+allprojects {
+    apply plugin: JacocoPlugin
+}
 
 jacoco {
     toolVersion = "0.8.7"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6048
<!-- Id number of the GitHub issue this PR addresses. -->

Fixes JaCoCo introduced in #6049 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes issues regarding JaCoCo plugin, that made it more difficult to work with the plugin (double execution needed). See details in PR comments.

#### Known issue
Executing task logs ` Classes in bundle 'woocommerce-android' do not match with execution data. For report generation the same class files must be used as at runtime.` warning. I'm aware of it but at it is related to only a few classes (3 of them related to logging only) I think it's okay to go ahead with this PR and investigate those issues later.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Run `./gradlew clean` to clean all JaCoCo artifacts (`*.exec` files)
2. Run `./gradlew jacocoTestReport --console=plain --rerun-tasks`
3. Assert that report at `WooCommerce/build/reports/jacoco/wasabiDebug/index.html` has been generated
4. Assert that there's a test coverage for `com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel`
5. Assert that there's a test coverage for `com.woocommerce.android.cardreader.internal.payments.PaymentErrorMapper`


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
