### PR TITLE
Update Kotlin to 1.6.10 & Compose to 1.1.1

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -166,6 +166,11 @@ android {
 }
 
 dependencies {
+    kotlinCompilerClasspath("org.jetbrains.kotlin:kotlin-compiler-embeddable") {
+        version {
+            strictly gradle.ext.kotlinVersion
+        }
+    }
 
     implementation("org.wordpress:libaddressinput.common:$libaddressinputVersion") {
         exclude group: "org.json", module: "json"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -58,6 +58,7 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
         super.postValue(value)
     }
 
+    @Suppress("UnnecessaryAbstractClass")
     abstract class Event(var isHandled: Boolean = false) {
         data class ShowSnackbar(
             @StringRes val message: Int,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/viewmodel/BaseUnitTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/viewmodel/BaseUnitTest.kt
@@ -9,6 +9,7 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 
+@Suppress("UnnecessaryAbstractClass")
 @RunWith(MockitoJUnitRunner::class)
 abstract class BaseUnitTest {
     @Rule @JvmField

--- a/build.gradle
+++ b/build.gradle
@@ -110,9 +110,9 @@ ext {
     aboutAutomatticVersion = '0.0.4'
 
     // Compose and its module versions need to be consistent with each other (for example 'compose-theme-adapter')
-    composeVersion = "1.1.0-rc01"
-    lifecycleViewmodelComposeVersion = "2.4.0"
-    composeThemeAdapterVersion = "1.1.2"
+    composeVersion = "1.1.1"
+    lifecycleViewmodelComposeVersion = "2.4.1"
+    composeThemeAdapterVersion = "1.1.6"
 }
 
 // Onboarding and dev env setup tasks

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     gradle.ext.agpVersion = '7.1.1'
     gradle.ext.daggerVersion = '2.40.5'
     gradle.ext.detektVersion = '1.19.0'
-    gradle.ext.kotlinVersion = '1.5.31'
+    gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.navigationVersion = '2.4.1'
 
     repositories {


### PR DESCRIPTION
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR upgrades Kotlin to `1.6.10` and Compose to `1.1.1`.

It includes the following:
- Forces kotlin version through strict `KotlinCompilerClasspath` version (see [commit](https://github.com/woocommerce/woocommerce-android/commit/a87e236e477e3519e55dc3e5dafd0e0f9611ffa2) and [previous set of discussions here](https://github.com/woocommerce/woocommerce-android/pull/5755#issuecomment-1047165088)).
- Suppresses the `UnnecessaryAbstractClass` warnings on a couple of classes (see [commit](https://github.com/woocommerce/woocommerce-android/commit/d95ab72a64d714c4099ffc233667c69ec12e29a6)).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Smoke test the app.
- Test for build time increases (local & CI).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
