### PR TITLE
Fix build speed issue

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -166,12 +166,6 @@ android {
 }
 
 dependencies {
-    kotlinCompilerClasspath("org.jetbrains.kotlin:kotlin-compiler-embeddable") {
-        version {
-            strictly gradle.ext.kotlinVersion
-        }
-    }
-
     implementation("org.wordpress:libaddressinput.common:$libaddressinputVersion") {
         exclude group: "org.json", module: "json"
         exclude group: "com.google.guava", module: "guava"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
     id 'com.android.application' apply false
     id 'org.jetbrains.kotlin.android' apply false
     id 'dagger.hilt.android.plugin' apply false
-    id 'androidx.navigation.safeargs.kotlin' apply false
     id 'com.google.gms.google-services' apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'io.github.wzieba.tracks.plugin'
     id 'io.sentry.android.gradle'
     id 'com.android.application' apply false
+    id 'org.jetbrains.kotlin.android' apply false
     id 'dagger.hilt.android.plugin' apply false
     id 'androidx.navigation.safeargs.kotlin' apply false
     id 'com.google.gms.google-services' apply false

--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.library'
-    id 'kotlin-android'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {


### PR DESCRIPTION
⚠️ Please don't merge until #6086 is merged

### Description
Since a long time (#5521), we were under the impression that the `safeargs` plugin is enforcing its own version of the kotlin-compiler, and that needed some workarounds to stop this.
After some investigations, it turns out that this is happening because of some misconfiguration on our side:
1. We weren't declaring the `kotlin-gradle-plugin` in the root `gradle.build`
2. The cardReader module was using the id `kotlin-android`, which meant it was bringing it from the `safeargs`, and not from our own `pluginManagement` block, as this id is not known when using it.

This PR fixes the above issues and removes the `safeargs` from the root `gradle.plugin` (this is not needed, but I think it's a better approach, as the confusion this caused made us lose a lot of time)

I removed also the `kotlinCompilerClasspath` version rule that was added in #6086, since it's not needed.

### Testing instructions
Run `gradlew assembleWasabiDebug --rerun-tasks` in this branch and on `trunk`, and confirm the improvements to the build speed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
