### PR TITLE
origin/issue/5962-product-detail-bottom-sheet-exception-take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
@@ -11,10 +11,6 @@ import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.Produ
 class ProductDetailBottomSheetAdapter(
     private val onItemClicked: (bottomSheetUiItem: ProductDetailBottomSheetUiItem) -> Unit
 ) : RecyclerView.Adapter<ProductDetailBottomSheetViewHolder>() {
-    init {
-        setHasStableIds(true)
-    }
-
     var options: List<ProductDetailBottomSheetUiItem> = emptyList()
         set(value) {
             val diffResult = DiffUtil.calculateDiff(
@@ -40,8 +36,6 @@ class ProductDetailBottomSheetAdapter(
     override fun onBindViewHolder(holder: ProductDetailBottomSheetViewHolder, position: Int) {
         holder.bind(options[position], onItemClicked)
     }
-
-    override fun getItemId(position: Int) = options[position].type.ordinal.toLong()
 
     override fun getItemCount() = options.size
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.Produ
 class ProductDetailBottomSheetAdapter(
     private val onItemClicked: (bottomSheetUiItem: ProductDetailBottomSheetUiItem) -> Unit
 ) : RecyclerView.Adapter<ProductDetailBottomSheetViewHolder>() {
-
     init {
         setHasStableIds(true)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
@@ -11,11 +11,22 @@ import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.Produ
 class ProductDetailBottomSheetAdapter(
     private val onItemClicked: (bottomSheetUiItem: ProductDetailBottomSheetUiItem) -> Unit
 ) : RecyclerView.Adapter<ProductDetailBottomSheetViewHolder>() {
-    private val options = ArrayList<ProductDetailBottomSheetUiItem>()
 
     init {
         setHasStableIds(true)
     }
+
+    var options: List<ProductDetailBottomSheetUiItem> = emptyList()
+        set(value) {
+            val diffResult = DiffUtil.calculateDiff(
+                ProductDetailBottomSheetItemDiffUtil(
+                    field,
+                    value
+                )
+            )
+            field = value
+            diffResult.dispatchUpdatesTo(this)
+        }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductDetailBottomSheetViewHolder {
         return ProductDetailBottomSheetViewHolder(
@@ -31,19 +42,9 @@ class ProductDetailBottomSheetAdapter(
         holder.bind(options[position], onItemClicked)
     }
 
-    override fun getItemId(position: Int) = position.toLong()
+    override fun getItemId(position: Int) = options[position].type.id
 
     override fun getItemCount() = options.size
-
-    fun setProductDetailBottomSheetOptions(optionList: List<ProductDetailBottomSheetUiItem>) {
-        val diffResult =
-            DiffUtil.calculateDiff(
-                ProductDetailBottomSheetItemDiffUtil(options, optionList)
-            )
-        options.clear()
-        options.addAll(optionList)
-        diffResult.dispatchUpdatesTo(this)
-    }
 
     class ProductDetailBottomSheetViewHolder(private val viewBinding: ProductDetailBottomSheetListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
@@ -64,7 +65,7 @@ class ProductDetailBottomSheetAdapter(
         val result: List<ProductDetailBottomSheetUiItem>
     ) : DiffUtil.Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-            items[oldItemPosition].type == result[newItemPosition].type
+            items[oldItemPosition].type.id == result[newItemPosition].type.id
 
         override fun getOldListSize(): Int = items.size
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetAdapter.kt
@@ -41,7 +41,7 @@ class ProductDetailBottomSheetAdapter(
         holder.bind(options[position], onItemClicked)
     }
 
-    override fun getItemId(position: Int) = options[position].type.id
+    override fun getItemId(position: Int) = options[position].type.ordinal.toLong()
 
     override fun getItemCount() = options.size
 
@@ -64,7 +64,7 @@ class ProductDetailBottomSheetAdapter(
         val result: List<ProductDetailBottomSheetUiItem>
     ) : DiffUtil.Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-            items[oldItemPosition].type.id == result[newItemPosition].type.id
+            items[oldItemPosition].type.ordinal == result[newItemPosition].type.ordinal
 
         override fun getOldListSize(): Int = items.size
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -31,7 +31,6 @@ class ProductDetailBottomSheetBuilder(
         SHORT_DESCRIPTION(string.product_short_description, string.bottom_sheet_short_description_desc),
         LINKED_PRODUCTS(string.product_detail_linked_products, string.bottom_sheet_linked_products_desc),
         PRODUCT_DOWNLOADS(string.product_downloadable_files, string.bottom_sheet_downloadable_files_desc)
-
     }
 
     data class ProductDetailBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -22,15 +22,16 @@ class ProductDetailBottomSheetBuilder(
     private val resources: ResourceProvider
 ) {
     enum class ProductDetailBottomSheetType(
+        val id: Long,
         @StringRes val titleResource: Int,
         @StringRes val descResource: Int
     ) {
-        PRODUCT_SHIPPING(string.product_shipping, string.bottom_sheet_shipping_desc),
-        PRODUCT_CATEGORIES(string.product_categories, string.bottom_sheet_categories_desc),
-        PRODUCT_TAGS(string.product_tags, string.bottom_sheet_tags_desc),
-        SHORT_DESCRIPTION(string.product_short_description, string.bottom_sheet_short_description_desc),
-        LINKED_PRODUCTS(string.product_detail_linked_products, string.bottom_sheet_linked_products_desc),
-        PRODUCT_DOWNLOADS(string.product_downloadable_files, string.bottom_sheet_downloadable_files_desc)
+        PRODUCT_SHIPPING(1L, string.product_shipping, string.bottom_sheet_shipping_desc),
+        PRODUCT_CATEGORIES(2L, string.product_categories, string.bottom_sheet_categories_desc),
+        PRODUCT_TAGS(3L, string.product_tags, string.bottom_sheet_tags_desc),
+        SHORT_DESCRIPTION(4L, string.product_short_description, string.bottom_sheet_short_description_desc),
+        LINKED_PRODUCTS(5L, string.product_detail_linked_products, string.bottom_sheet_linked_products_desc),
+        PRODUCT_DOWNLOADS(6L, string.product_downloadable_files, string.bottom_sheet_downloadable_files_desc)
     }
 
     data class ProductDetailBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -22,16 +22,16 @@ class ProductDetailBottomSheetBuilder(
     private val resources: ResourceProvider
 ) {
     enum class ProductDetailBottomSheetType(
-        val id: Long,
         @StringRes val titleResource: Int,
         @StringRes val descResource: Int
     ) {
-        PRODUCT_SHIPPING(1L, string.product_shipping, string.bottom_sheet_shipping_desc),
-        PRODUCT_CATEGORIES(2L, string.product_categories, string.bottom_sheet_categories_desc),
-        PRODUCT_TAGS(3L, string.product_tags, string.bottom_sheet_tags_desc),
-        SHORT_DESCRIPTION(4L, string.product_short_description, string.bottom_sheet_short_description_desc),
-        LINKED_PRODUCTS(5L, string.product_detail_linked_products, string.bottom_sheet_linked_products_desc),
-        PRODUCT_DOWNLOADS(6L, string.product_downloadable_files, string.bottom_sheet_downloadable_files_desc)
+        PRODUCT_SHIPPING(string.product_shipping, string.bottom_sheet_shipping_desc),
+        PRODUCT_CATEGORIES(string.product_categories, string.bottom_sheet_categories_desc),
+        PRODUCT_TAGS(string.product_tags, string.bottom_sheet_tags_desc),
+        SHORT_DESCRIPTION(string.product_short_description, string.bottom_sheet_short_description_desc),
+        LINKED_PRODUCTS(string.product_detail_linked_products, string.bottom_sheet_linked_products_desc),
+        PRODUCT_DOWNLOADS(string.product_downloadable_files, string.bottom_sheet_downloadable_files_desc)
+
     }
 
     data class ProductDetailBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
@@ -79,6 +79,6 @@ class ProductDetailBottomSheetFragment : BottomSheetDialogFragment() {
     private fun showProductDetailBottomSheetOptions(
         productDetailBottomSheetOptions: List<ProductDetailBottomSheetUiItem>
     ) {
-        productDetailBottomSheetAdapter.setProductDetailBottomSheetOptions(productDetailBottomSheetOptions)
+        productDetailBottomSheetAdapter.options = productDetailBottomSheetOptions
     }
 }


### PR DESCRIPTION
This is the second attempt to fix #5962, a mystery crash in `ProductDetailBottomSheetAdapter`. I noticed that rather than return a unique ID in that adapter's `getItemId()`, we return `position.toLong()`. We do that in many places in WCAndroid, but ideally if an adapter has stable IDs we should provide a unique ID instead of the position.

So, this PR updates the adapter to use a unique ID for each item. I also slightly modified the way the list is populated, but that was for clarity rather than an attempt to fix this problem.

If we continue to see these crashes after this PR is in a release, I recommend the next step is to try not using unique IDs for the adapter.

To test:
 * Open product detail
 * Tap the "Add more details button"
 * Ensure the bottom sheet works as expected