### PR TITLE
Remove order creation experimental toggle

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Fixed an issue to update the product price to zero, if required. [https://github.com/woocommerce/woocommerce-android/pull/6039]
 - [*] Added support for moderating reviews of specific products from the Product Details screen. [https://github.com/woocommerce/woocommerce-android/pull/6070]
 - [*] In-Person Payments: Removed collecting L2/L3 data. [https://github.com/woocommerce/woocommerce-android/pull/6084]
+- [***] Order Creation is now available for the general public making possible to fully create custom orders directly from the app
 
 8.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [*] Fixed an issue to update the product price to zero, if required. [https://github.com/woocommerce/woocommerce-android/pull/6039]
 - [*] Added support for moderating reviews of specific products from the Product Details screen. [https://github.com/woocommerce/woocommerce-android/pull/6070]
 - [*] In-Person Payments: Removed collecting L2/L3 data. [https://github.com/woocommerce/woocommerce-android/pull/6084]
-- [***] Order Creation is now available for the general public making possible to fully create custom orders directly from the app
+- [***] Order Creation is now available for the general public making possible to fully create custom orders directly from the app [https://github.com/woocommerce/woocommerce-android/pull/6092]
 
 8.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -41,7 +41,6 @@ object AppPrefs {
         DATABASE_DOWNGRADED,
         IS_PRODUCTS_FEATURE_ENABLED,
         IS_PRODUCT_ADDONS_ENABLED,
-        IS_ORDER_CREATION_ENABLED,
         LOGIN_USER_BYPASSED_JETPACK_REQUIRED,
         SELECTED_ORDER_LIST_TAB_POSITION,
         IMAGE_OPTIMIZE_ENABLED,
@@ -151,10 +150,6 @@ object AppPrefs {
     var isProductAddonsEnabled: Boolean
         get() = getBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, false)
         set(value) = setBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, value)
-
-    var isOrderCreationEnabled: Boolean
-        get() = getBoolean(DeletablePrefKey.IS_ORDER_CREATION_ENABLED, false)
-        set(value) = setBoolean(DeletablePrefKey.IS_ORDER_CREATION_ENABLED, value)
 
     fun getLastAppVersionCode(): Int {
         return getDeletableInt(UndeletablePrefKey.LAST_APP_VERSION_CODE)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -31,6 +31,8 @@ object AppUrls {
 
     const val SIMPLE_PAYMENTS_SURVEY = "https://automattic.survey.fm/woo-app-quick-order-production"
 
+    const val ORDER_CREATION_SURVEY = "https://automattic.survey.fm/woo-app-order-creation-production"
+
     const val COUPONS_SURVEY_DEBUG = "https://automattic.survey.fm/woo-app-coupon-management-testing"
     const val COUPONS_SURVEY = "https://automattic.survey.fm/woo-app-coupon-management-production"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -21,6 +21,7 @@ data class FeatureFeedbackSettings(
         PRODUCTS_VARIATIONS("products_variations"),
         PRODUCT_ADDONS("product_addons"),
         SIMPLE_PAYMENTS("simple_payments"),
+        SIMPLE_PAYMENTS_AND_ORDER_CREATION("simple_payments_and_order_creation"),
         COUPONS("coupons")
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -9,6 +9,7 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
     SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY, 4),
     SIMPLE_PAYMENTS(AppUrls.SIMPLE_PAYMENTS_SURVEY, 1),
+    ORDER_CREATION(AppUrls.ORDER_CREATION_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
     COUPONS(
         if (FeatureFlag.MORE_MENU_COUPONS.isEnabled()) { AppUrls.COUPONS_SURVEY_DEBUG } else { AppUrls.COUPONS_SURVEY }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -209,13 +209,7 @@ class OrderListFragment :
     }
 
     private fun initCreateOrderFAB(fabButton: FloatingActionButton) {
-        fabButton.setOnClickListener {
-            if (AppPrefs.isOrderCreationEnabled) {
-                showOrderCreationBottomSheet()
-            } else {
-                showSimplePaymentsDialog()
-            }
-        }
+        fabButton.setOnClickListener { showOrderCreationBottomSheet() }
         pinFabAboveBottomNavigationBar(fabButton)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -24,6 +24,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.FeatureFeedbackSettings
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS_AND_ORDER_CREATION
+import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -90,7 +92,7 @@ class OrderListFragment :
         get() = binding.orderListView.emptyView
 
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)?.state ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)?.state ?: FeedbackState.UNANSWERED
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -511,10 +513,7 @@ class OrderListFragment :
     }
 
     private fun displaySimplePaymentsWIPCard(show: Boolean) {
-        if (!show ||
-            feedbackState == FeatureFeedbackSettings.FeedbackState.DISMISSED ||
-            !viewModel.isCardReaderOnboardingCompleted()
-        ) {
+        if (!show || feedbackState == FeedbackState.DISMISSED) {
             binding.simplePaymentsWIPcard.isVisible = false
             return
         }
@@ -537,7 +536,7 @@ class OrderListFragment :
                 AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
             )
         )
-        registerFeedbackSetting(FeatureFeedbackSettings.FeedbackState.GIVEN)
+        registerFeedbackSetting(FeedbackState.GIVEN)
         NavGraphMainDirections
             .actionGlobalFeedbackSurveyFragment(SurveyType.SIMPLE_PAYMENTS)
             .apply { findNavController().navigateSafely(this) }
@@ -551,13 +550,13 @@ class OrderListFragment :
                 AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
             )
         )
-        registerFeedbackSetting(FeatureFeedbackSettings.FeedbackState.DISMISSED)
+        registerFeedbackSetting(FeedbackState.DISMISSED)
         displaySimplePaymentsWIPCard(false)
     }
 
-    private fun registerFeedbackSetting(state: FeatureFeedbackSettings.FeedbackState) {
+    private fun registerFeedbackSetting(state: FeedbackState) {
         FeatureFeedbackSettings(
-            FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS.name,
+            SIMPLE_PAYMENTS_AND_ORDER_CREATION.name,
             state
         ).registerItselfWith(TAG)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -539,7 +539,7 @@ class OrderListFragment :
         )
         registerFeedbackSetting(FeedbackState.GIVEN)
         NavGraphMainDirections
-            .actionGlobalFeedbackSurveyFragment(SurveyType.SIMPLE_PAYMENTS)
+            .actionGlobalFeedbackSurveyFragment(SurveyType.ORDER_CREATION)
             .apply { findNavController().navigateSafely(this) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -105,14 +105,6 @@ class AppSettingsActivity :
         }
     }
 
-    override fun onOrderCreationOptionChanged(enabled: Boolean) {
-        if (AppPrefs.isOrderCreationEnabled != enabled) {
-            isBetaOptionChanged = true
-            AppPrefs.isOrderCreationEnabled = enabled
-            setResult(RESULT_CODE_BETA_OPTIONS_CHANGED)
-        }
-    }
-
     override fun finishLogout() {
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -28,7 +28,6 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
 
         with(FragmentSettingsBetaBinding.bind(view)) {
             bindProductAddonsToggle()
-            bindOrderCreationToggle()
         }
     }
 
@@ -44,16 +43,6 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
             )
 
             settingsListener?.onProductAddonsOptionChanged(isChecked)
-                ?: handleToggleChangeFailure(switch, isChecked)
-        }
-    }
-
-    private fun FragmentSettingsBetaBinding.bindOrderCreationToggle() {
-        switchOrderCreationToggle.isChecked = AppPrefs.isOrderCreationEnabled
-        switchOrderCreationToggle.setOnCheckedChangeListener { switch, isChecked ->
-            // trigger order creation tracks
-
-            settingsListener?.onOrderCreationOptionChanged(isChecked)
                 ?: handleToggleChangeFailure(switch, isChecked)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -248,7 +248,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     private fun generateBetaFeaturesTitleList() =
         mutableListOf<String>().apply {
             add(getString(R.string.beta_features_add_ons))
-            add(getString(R.string.beta_features_order_creation))
         }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -46,7 +46,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     interface AppSettingsListener {
         fun onRequestLogout()
         fun onProductAddonsOptionChanged(enabled: Boolean)
-        fun onOrderCreationOptionChanged(enabled: Boolean)
     }
 
     private lateinit var settingsListener: AppSettingsListener

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -16,11 +16,4 @@
 
     <View style="@style/Woo.Divider" />
 
-    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-        android:id="@+id/switchOrderCreationToggle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:toggleOptionDesc="@string/settings_enable_order_creation_teaser_message"
-        app:toggleOptionTitle="@string/settings_enable_order_creation_teaser_title" />
-
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1485,7 +1485,6 @@
     <string name="beta_features">Beta features</string>
     <string name="beta_features_add_ons">View Add-ons</string>
     <string name="beta_features_simple_payments">Simple payments</string>
-    <string name="beta_features_order_creation">Order creation</string>
     <string name="settings_signout">Log out</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -306,8 +306,8 @@
     <string name="orderlist_loading">Looking up your orders…</string>
     <string name="orderlist_no_filters_title">All Orders</string>
     <string name="orderlist_filters_title">Filtered Orders</string>
-    <string name="orderlist_simple_payments_wip_title">Take payments from your device!</string>
-    <string name="orderlist_simple_payments_wip_message_enabled">We are working on making it easier for you to take payments from your device! For now, tap the "+" button and you\'ll be able to create an order with the amount you want to collect.</string>
+    <string name="orderlist_simple_payments_wip_title">Create orders &amp; take payments!</string>
+    <string name="orderlist_simple_payments_wip_message_enabled">We\'ve been working on making it possible to create orders and take payments from your device! You can try these features out by tapping on the "+" button</string>
     <string name="orderlist_simple_payments_menu">Simple payment</string>
     <string name="order_card_transition_name">order_card_%1$s</string>
     <string name="order_card_detail_transition_name">order_card_detail</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="settings_enable_product_adding_teaser_message">Test out the new simple, linked and grouped product creation as we get ready to launch</string>
     <string name="settings_enable_product_addons_teaser_title">View Add-ons</string>
     <string name="settings_enable_product_addons_teaser_message">Test out viewing Order Add-ons as we get ready to launch</string>
-    <string name="settings_enable_order_creation_teaser_title">Order Creation</string>
-    <string name="settings_enable_order_creation_teaser_message">Test out creating orders with full details as we get ready to launch</string>
     <string name="settings_enable_product_teaser_title">Product editing</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>


### PR DESCRIPTION
Summary
==========
Fix issues #6091 and #5861 by completely removing the Order Creation feature of the Experimental toggle protection and updating the Order list to display the Order Creation feedback request and survey.

How to Test
==========
### ⚠️ Since this is the final step before releasing Order Creation to the general public, the testing steps for this PR includes our test plan.

## Testing by screen
Here’s what we need to verify on each affected or new screen:

### Order List:
- Tapping “+” brings up bottom-sheet with Create Order and Simple Payment.
- Choosing “Create Order” creates new order, loads New Order screen.
- New Order appears in Order List after being created.
- New Order appears in Order List in wp-admin after being created.
- All Order details are correctly reflected in the associated Order Details screen after the Order is created.
- All Order details are correctly reflected in wp-admin after Order is created.

### New Order:
- Edit order status, add product, add shipping, add fee, and add customer details appear.
- Order status should show the selected status. It should never show “auto-draft”.
- Create button appears. Button can be tapped once. When tapped, Order is created and appears in Order List. Order - appears in wp-admin once created.
- Orders do not appear in wp-admin before the Create button is tapped. Exception: stores running below WooCommerce version 6.3 will see draft orders with the status “pending”.
- When <button is tapped, Order is not created, and “discard changes” confirmation dialogue appears. Order does not appear in Order List if changes are discarded. Order does not appear in wp-admin if changes are discarded.
- Each + button brings up the associated screen. After adding/editing data (product, customer, status, shipping, fee), it appears correctly.
- Once products are added, + and - buttons change product quantity. Quantity cannot be less than 1. Pressing - once the quantity is at 1 brings up the single product screen with “remove” button.
- Once products are added, payment details (automatically calculated) appear.
- Taxes are automatically calculated and displayed. The tax amount is the same as for the same total in wp-admin.
- Products total and Order total are automatically calculated and displayed.
- Loading indicator is displayed while updating the order (e.g. after adding more products) or creating the order.

### Order Status:
- Can change order status to any status (including custom statuses).
- Close button doesn’t save changes.
- Done button saves changes.

### Add Product:
- Can add existing products (simple, grouped, and external) as well as product variations.
- Can search for existing products.
- Close button closes list.
- When a product is added, New Order screen appears with the product listed.
- Can remove products by tapping “remove”.

### Add Customer Details:
- Add customer Details, Billing Address, and Different Shipping Address toggle appear.
- Different Shipping Address toggle opens a second set of fields.
- Country opens country list. State opens state list, if a country with states is selected.
- Customer data can be added, and appears on New Order after entering.
- Customer data can be edited after it’s been added.
- International addresses and other customer data are accepted.
- Valid email address is required. If invalid email address is entered, “invalid email” snackbar appears.

### Add Shipping:
- Amount can be added, and can be negative.
- Custom shipping rate name can be added. Existing shipping methods cannot be selected.
- Tapping “done” closes add shipping and shows New Order again, with the shipping amount added
- After shipping has been added, it can be removed by tapping “remove shipping from order”

### Add Fee:
- Amount can be added, and can be negative.
- Can toggle between “%” and “$”
- Tapping “done” closes add fee and shows New Order again, with the fee amount added
- After fee has been added, it can be removed by tapping “remove fee from order”

## Testing globally
Here are things we need check everywhere, in addition to some stress testing. We’ll do this sort of testing at the end during full-flow testing, in addition to testing on new screens as we introduce them during each milestone. Here I’ve listed the items that apply to M1 specifically, and what to check.

### Accessibility: VoiceOver/TalkBack, Font Size
- plus button on Order List
- Everything on New Order screen and every screen that opens from it
- Large font sizes, especially on a filled-out New Order screen

### Device: Screen sizes, dark/light, orientation, backgrounding
- Test on a tablet if you have one
- UI should align with designs on both large and small screens
- Dark and Light mode, switching between dark and light mode mid-flow
- Try the flow in each screen orientation, as well as switching orientation mid-flow. On iOS, try landscape mode in both directions, to see if the notch causes problems.
- Background the screen mid-flow in several places. Switch apps, go to the home screen, pull down settings, turn off the screen. See how the app reacts, whether data is retained, and whether your place in the flow is saved.

### Languages/Locales: RTL, entering extended-latin characters
- Entering non-latin and extended-latin characters is especially important in the Add Customer screen.
- Try the flow in a language you’re familiar with. Check that untranslated strings are being addressed.
- Try the flow in an RTL language. Also try with the Store language set to RTL.
- In any of the languages you try, make sure entering non-latin and extended-latin characters works in all fields including search fields (and gets appropriate results).
- Set your store settings to use a currency other than USD.

### Try to break it: Large orders, long strings, and sync issues
- Try adding an unseemly number of individual products to an order.
- Try adding an unseemly number of a particular product to an order.
- In the Customer section, try out long names and addresses. Make sure the fields react appropriately, then head back to - New Order to check that they are displayed correctly.
- Check how especially long product names are displayed in New Order as well as the Product List in Add Product.
- Try adding a stupidly expensive item (i.e., a long price) to an order. Check that taxes and percent-based fees are calculated correctly and prices are displayed properly.
- Simulate sync issues by testing on a sketchy network, while transitioning between networks, or by turning off wifi in the midst of syncing changes.

### User roles:
- Shop Manager can use + to Create order, Add Products, Add Customer.
- Confirm that other roles (Customer, non-Admin WP roles like Editor) cannot interact with Order Creation.

### Site Types:
- Test on Atomic
- Test on Self-hosted with Jetpack

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
