### PR TITLE
Navigation: remove the NavArgs workaround

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
@@ -1,42 +1,15 @@
 package com.woocommerce.android.viewmodel
 
 import android.annotation.SuppressLint
-import android.os.Bundle
-import android.os.Parcelable
 import androidx.annotation.MainThread
 import androidx.collection.ArrayMap
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavArgs
-import com.woocommerce.android.util.PackageUtils
-import java.io.Serializable
 import java.lang.reflect.Method
 import kotlin.reflect.KClass
-import androidx.navigation.NavArgsLazy as CompatNavArgsLazy
 
-/**
- * The current implementation of `fromSavedStateHandle` can't restore Parcelable[] properly
- * So we'll keep using the old implementation temporarily when not running tests.
- * TODO go back to using `fromSavedStateHandle` when the issue is fixed https://issuetracker.google.com/issues/207315994
- */
 @MainThread
-inline fun <reified Args : NavArgs> SavedStateHandle.navArgs(): Lazy<Args> {
-    return if (PackageUtils.isTesting()) {
-        NavArgsLazy(Args::class, this)
-    } else {
-        CompatNavArgsLazy(Args::class) {
-            val bundle = Bundle()
-            keys().forEach {
-                val value = get<Any>(it)
-                if (value is Serializable?) {
-                    bundle.putSerializable(it, value)
-                } else if (value is Parcelable?) {
-                    bundle.putParcelable(it, value)
-                }
-            }
-            bundle
-        }
-    }
-}
+inline fun <reified Args : NavArgs> SavedStateHandle.navArgs() = NavArgsLazy(Args::class, this)
 
 /** cache the methods for [NavArgsLazy] to avoid depending on reflection for all invocations **/
 // TODO investigate the usage of [ConcurrentHashMap] to avoid getting ConcurrentModificationException when accessing


### PR DESCRIPTION
### Description
The beta version of navigation had a bug that prevented restoring custom Parcelables from the saved state, which resulted in using a https://github.com/woocommerce/woocommerce-android/pull/5307 to prevent the crash.
Now, that we updated the navigation to 2.4.1 which contains Google's fix for the [bug](https://issuetracker.google.com/issues/207315994) we reported, we can safely remove the workaround.

### Testing instructions
Confirm the previous bug is fixed:

1. Enable "Don't keep activities" from the developer options.
2. Open Product Images screen of one of the products.
3. Navigate to another app, then re-open the app.
4. Confirm that the app doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
