### PR TITLE
Refactor ProductDetailViewModel: reduce size of saved data

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -10,9 +10,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
@@ -31,12 +29,6 @@ abstract class BaseProductFragment : BaseFragment, BackPressListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // if this is the initial creation of this fragment, tell the viewModel to make a copy of the product
-        // as it exists now so we can easily discard changes are determine if any changes were made inside
-        // this fragment
-        if (savedInstanceState == null) {
-            viewModel.updateProductBeforeEnteringFragment()
-        }
 
         setupObservers(viewModel)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -262,12 +262,10 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     private fun initializeStoredProductAfterRestoration() {
-        launch {
-            storedProduct = if (isAddFlowEntryPoint && !isProductStoredAtSite) {
-                createDefaultProductForAddFlow()
-            } else {
-                productRepository.getProduct(viewState.productDraft?.remoteId ?: navArgs.remoteProductId)
-            }
+        storedProduct = if (isAddFlowEntryPoint && !isProductStoredAtSite) {
+            createDefaultProductForAddFlow()
+        } else {
+            productRepository.getProduct(viewState.productDraft?.remoteId ?: navArgs.remoteProductId)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -575,8 +575,8 @@ class ProductDetailViewModel @Inject constructor(
             isUploadingImagesForNonCreatedProduct
         ) {
             val positiveAction = DialogInterface.OnClickListener { _, _ ->
-                // discard changes made to the product and exit product detail
-                discardEditChanges()
+                // Make sure to cancel any remaining image uploads
+                mediaFileUploadHandler.cancelUpload(getRemoteProductId())
                 triggerEvent(ExitProduct)
             }
 
@@ -984,22 +984,6 @@ class ProductDetailViewModel @Inject constructor(
 
     fun onProductDetailBottomSheetItemSelected(uiItem: ProductDetailBottomSheetUiItem) {
         onEditProductCardClicked(uiItem.clickEvent, uiItem.stat)
-    }
-
-    /**
-     * Called when discard is clicked on any of the product screens to restore the product to
-     * the state it was in when the screen was first entered
-     */
-    private fun discardEditChanges() {
-        viewState = viewState.copy(productDraft = storedProduct)
-        _addedProductTags.clearList()
-
-        // Make sure to cancel any remaining image uploads
-        mediaFileUploadHandler.cancelUpload(getRemoteProductId())
-
-        // updates the UPDATE menu button in the product detail screen i.e. the UPDATE menu button
-        // will only be displayed if there are changes made to the Product model.
-        updateProductEditAction()
     }
 
     fun checkConnection(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -321,7 +321,6 @@ class ProductDetailViewModel @Inject constructor(
         viewState.productDraft?.let {
             triggerEvent(ViewProductImageGallery(it.remoteId, it.images))
         }
-        updateProductBeforeEnteringFragment()
     }
 
     /**
@@ -332,7 +331,6 @@ class ProductDetailViewModel @Inject constructor(
         viewState.productDraft?.let {
             triggerEvent(ViewProductImageGallery(it.remoteId, it.images, true))
         }
-        updateProductBeforeEnteringFragment()
     }
 
     fun onAddFirstVariationClicked() {
@@ -354,7 +352,6 @@ class ProductDetailViewModel @Inject constructor(
     fun onEditProductCardClicked(target: ProductNavigationTarget, stat: AnalyticsEvent? = null) {
         stat?.let { AnalyticsTracker.track(it) }
         triggerEvent(target)
-        updateProductBeforeEnteringFragment()
     }
 
     /**
@@ -824,14 +821,6 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     /**
-     * Called before entering any product screen to save of copy of the product prior to the user making any
-     * changes in that specific screen
-     */
-    fun updateProductBeforeEnteringFragment() {
-        viewState.productBeforeEnteringFragment = viewState.productDraft ?: storedProduct
-    }
-
-    /**
      * Update all product fields that are edited by the user
      */
     @Suppress("LongMethod", "ComplexMethod")
@@ -1002,7 +991,7 @@ class ProductDetailViewModel @Inject constructor(
      * the state it was in when the screen was first entered
      */
     private fun discardEditChanges() {
-        viewState = viewState.copy(productDraft = viewState.productBeforeEnteringFragment)
+        viewState = viewState.copy(productDraft = storedProduct)
         _addedProductTags.clearList()
 
         // Make sure to cancel any remaining image uploads
@@ -1543,7 +1532,6 @@ class ProductDetailViewModel @Inject constructor(
             }
             viewState = viewState.copy(
                 productDraft = null,
-                productBeforeEnteringFragment = storedProduct,
                 isProductUpdated = false
             )
             loadRemoteProduct(product.remoteId)
@@ -1567,7 +1555,6 @@ class ProductDetailViewModel @Inject constructor(
         if (isSuccess) {
             viewState = viewState.copy(
                 productDraft = null,
-                productBeforeEnteringFragment = storedProduct,
                 isProductUpdated = false
             )
             loadRemoteProduct(newProductRemoteId)
@@ -1599,12 +1586,6 @@ class ProductDetailViewModel @Inject constructor(
             productDraft = updatedDraft
         )
         storedProduct = productToUpdateFrom
-
-        if (viewState.productBeforeEnteringFragment == null) {
-            viewState = viewState.copy(
-                productBeforeEnteringFragment = updatedDraft
-            )
-        }
     }
 
     private fun loadProductTaxAndShippingClassDependencies(product: Product) {
@@ -2074,16 +2055,10 @@ class ProductDetailViewModel @Inject constructor(
      * When the user first enters the product detail screen, the [productDraft] and [storedProduct] are the same.
      * When a change is made to the product in the UI, the [productDraft] model is updated with whatever change
      * has been made in the UI.
-     *
-     * The [productBeforeEnteringFragment] is a copy of the product before a specific detail fragment is entered.
-     * This is used when the user taps the back button to detect if any changes were made in that fragment, and
-     * if so we ask whether the user wants to discard changes. If they do, then we reset [productDraft] back to
-     * [productBeforeEnteringFragment] to restore it to the state it was when the fragment was entered.
      */
     @Parcelize
     data class ProductDetailViewState(
         val productDraft: Product? = null,
-        var productBeforeEnteringFragment: Product? = null,
         val isSkeletonShown: Boolean? = null,
         val uploadingImageUris: List<Uri>? = null,
         val isProgressDialogShown: Boolean? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -99,6 +99,8 @@ class ProductDetailViewModel @Inject constructor(
     }
     private var viewState by productDetailViewStateData
 
+    private var storedProduct: Product? = null
+
     // view state for the product categories screen
     val productCategoriesViewStateData = LiveDataDelegate(savedState, ProductCategoriesViewState())
     private var productCategoriesViewState by productCategoriesViewStateData
@@ -364,12 +366,12 @@ class ProductDetailViewModel @Inject constructor(
             attributeListViewState = attributeListViewState.copy(isCreatingVariationDialogShown = false)
         }
 
-    fun hasCategoryChanges() = viewState.storedProduct?.hasCategoryChanges(viewState.productDraft) ?: false
+    fun hasCategoryChanges() = storedProduct?.hasCategoryChanges(viewState.productDraft) ?: false
 
-    fun hasTagChanges() = viewState.storedProduct?.hasTagChanges(viewState.productDraft) ?: false
+    fun hasTagChanges() = storedProduct?.hasTagChanges(viewState.productDraft) ?: false
 
     fun hasSettingsChanges(): Boolean {
-        return if (viewState.storedProduct?.hasSettingsChanges(viewState.productDraft) == true) {
+        return if (storedProduct?.hasSettingsChanges(viewState.productDraft) == true) {
             true
         } else {
             viewState.isPasswordChanged
@@ -486,16 +488,16 @@ class ProductDetailViewModel @Inject constructor(
         )
     }
 
-    fun hasExternalLinkChanges() = viewState.storedProduct?.hasExternalLinkChanges(viewState.productDraft) ?: false
+    fun hasExternalLinkChanges() = storedProduct?.hasExternalLinkChanges(viewState.productDraft) ?: false
 
-    fun hasLinkedProductChanges() = viewState.storedProduct?.hasLinkedProductChanges(viewState.productDraft) ?: false
+    fun hasLinkedProductChanges() = storedProduct?.hasLinkedProductChanges(viewState.productDraft) ?: false
 
     fun hasDownloadsChanges(): Boolean {
-        return viewState.storedProduct?.hasDownloadChanges(viewState.productDraft) ?: false
+        return storedProduct?.hasDownloadChanges(viewState.productDraft) ?: false
     }
 
     fun hasDownloadsSettingsChanges(): Boolean {
-        return viewState.storedProduct?.let {
+        return storedProduct?.let {
             it.downloadLimit != viewState.productDraft?.downloadLimit ||
                 it.downloadExpiry != viewState.productDraft?.downloadExpiry ||
                 it.isDownloadable != viewState.productDraft?.isDownloadable
@@ -503,7 +505,7 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     fun hasChanges(): Boolean {
-        return viewState.storedProduct?.let { product ->
+        return storedProduct?.let { product ->
             viewState.productDraft?.isSameProduct(product) == false || viewState.isPasswordChanged
         } ?: false
     }
@@ -730,7 +732,7 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     private fun trackWithProductId(event: AnalyticsEvent) {
-        viewState.storedProduct?.let {
+        storedProduct?.let {
             AnalyticsTracker.track(
                 event,
                 mapOf(AnalyticsTracker.KEY_PRODUCT_ID to it.remoteId)
@@ -810,7 +812,7 @@ class ProductDetailViewModel @Inject constructor(
      * changes in that specific screen
      */
     fun updateProductBeforeEnteringFragment() {
-        viewState.productBeforeEnteringFragment = viewState.productDraft ?: viewState.storedProduct
+        viewState.productBeforeEnteringFragment = viewState.productDraft ?: storedProduct
     }
 
     /**
@@ -915,11 +917,11 @@ class ProductDetailViewModel @Inject constructor(
                 saleEndDateGmt = if (productHasSale(isSaleScheduled, product)) {
                     saleEndDate
                 } else {
-                    viewState.storedProduct?.saleEndDateGmt
+                    storedProduct?.saleEndDateGmt
                 },
                 saleStartDateGmt = if (productHasSale(isSaleScheduled, product)) {
                     saleStartDate ?: product.saleStartDateGmt
-                } else viewState.storedProduct?.saleStartDateGmt,
+                } else storedProduct?.saleStartDateGmt,
                 downloads = downloads ?: product.downloads,
                 downloadLimit = downloadLimit ?: product.downloadLimit,
                 downloadExpiry = downloadExpiry ?: product.downloadExpiry,
@@ -954,7 +956,7 @@ class ProductDetailViewModel @Inject constructor(
     private fun updateCards(product: Product) {
         launch(dispatchers.io) {
             mutex.withLock {
-                val cards = cardBuilder.buildPropertyCards(product, viewState.storedProduct?.sku ?: "")
+                val cards = cardBuilder.buildPropertyCards(product, storedProduct?.sku ?: "")
                 withContext(dispatchers.main) {
                     _productDetailCards.value = cards
                 }
@@ -1063,7 +1065,7 @@ class ProductDetailViewModel @Inject constructor(
      * then the visibility is `PRIVATE`, otherwise it's `PUBLIC`.
      */
     fun getProductVisibility(): ProductVisibility {
-        val status = viewState.productDraft?.status ?: viewState.storedProduct?.status
+        val status = viewState.productDraft?.status ?: storedProduct?.status
         val password = viewState.draftPassword ?: viewState.storedPassword
         return when {
             password?.isNotEmpty() == true -> {
@@ -1119,11 +1121,11 @@ class ProductDetailViewModel @Inject constructor(
     /**
      * Updates the UPDATE menu button in the product detail screen. UPDATE is only displayed
      * when there are changes made to the [Product] model and this can be verified by comparing
-     * the viewState.product with viewState.storedProduct model.
+     * the viewState.product with storedProduct model.
      */
     private fun updateProductEditAction() {
         viewState.productDraft?.let { draft ->
-            val isProductUpdated = viewState.storedProduct?.isSameProduct(draft) == false ||
+            val isProductUpdated = storedProduct?.isSameProduct(draft) == false ||
                 viewState.isPasswordChanged
             viewState = viewState.copy(isProductUpdated = isProductUpdated)
         }
@@ -1418,7 +1420,7 @@ class ProductDetailViewModel @Inject constructor(
         triggerEvent(RenameProductAttribute(attributeName))
     }
 
-    fun hasAttributeChanges() = viewState.storedProduct?.hasAttributeChanges(viewState.productDraft) ?: false
+    fun hasAttributeChanges() = storedProduct?.hasAttributeChanges(viewState.productDraft) ?: false
 
     /**
      * Used by the add attribute screen to fetch the list of store-wide product attributes
@@ -1525,7 +1527,7 @@ class ProductDetailViewModel @Inject constructor(
             }
             viewState = viewState.copy(
                 productDraft = null,
-                productBeforeEnteringFragment = getProduct().storedProduct,
+                productBeforeEnteringFragment = storedProduct,
                 isProductUpdated = false
             )
             loadRemoteProduct(product.remoteId)
@@ -1549,7 +1551,7 @@ class ProductDetailViewModel @Inject constructor(
         if (isSuccess) {
             viewState = viewState.copy(
                 productDraft = null,
-                productBeforeEnteringFragment = getProduct().storedProduct,
+                productBeforeEnteringFragment = storedProduct,
                 isProductUpdated = false
             )
             loadRemoteProduct(newProductRemoteId)
@@ -1568,7 +1570,7 @@ class ProductDetailViewModel @Inject constructor(
 
     private fun updateProductState(productToUpdateFrom: Product) {
         val updatedDraft = viewState.productDraft?.let { currentDraft ->
-            if (viewState.storedProduct?.isSameProduct(currentDraft) == true) {
+            if (storedProduct?.isSameProduct(currentDraft) == true) {
                 productToUpdateFrom
             } else {
                 productToUpdateFrom.mergeProduct(currentDraft)
@@ -1578,9 +1580,9 @@ class ProductDetailViewModel @Inject constructor(
         loadProductTaxAndShippingClassDependencies(updatedDraft)
 
         viewState = viewState.copy(
-            productDraft = updatedDraft,
-            storedProduct = productToUpdateFrom
+            productDraft = updatedDraft
         )
+        storedProduct = productToUpdateFrom
 
         if (viewState.productBeforeEnteringFragment == null) {
             viewState = viewState.copy(
@@ -2064,7 +2066,6 @@ class ProductDetailViewModel @Inject constructor(
      */
     @Parcelize
     data class ProductDetailViewState(
-        var storedProduct: Product? = null,
         val productDraft: Product? = null,
         var productBeforeEnteringFragment: Product? = null,
         val isSkeletonShown: Boolean? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -62,7 +62,7 @@ class ProductSettingsFragment : BaseProductFragment(R.layout.fragment_product_se
             activity?.invalidateOptionsMenu()
         }
 
-        if (viewModel.getProduct().storedProduct?.productType == SIMPLE) {
+        if (viewModel.getProduct().productDraft?.productType == SIMPLE) {
             binding.productIsDownloadable.visibility = View.VISIBLE
             binding.productIsDownloadableDivider.visibility = View.VISIBLE
             binding.productIsDownloadable.setOnCheckedChangeListener { checkbox, isChecked ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -106,7 +106,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     private val productWithParameters = ProductDetailViewState(
         productDraft = product,
-        storedProduct = product,
         productBeforeEnteringFragment = product,
         isSkeletonShown = false,
         uploadingImageUris = emptyList(),
@@ -790,6 +789,17 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         doReturn(true).whenever(viewModel).hasChanges()
         viewModel.start()
         assertThat(viewModel.isSaveOptionNeeded).isFalse()
+    }
+
+    @Test
+    fun `when restoring saved state, then re-fetch stored product to correctly calculate hasChanges`() {
+        // Make sure draft product has different data than draft product
+        doReturn(product.copy(name = product.name + "test")).whenever(productRepository).getProduct(any())
+        savedState.set(ProductDetailViewState::class.java.name, productWithParameters)
+
+        viewModel.start()
+
+        assertThat(viewModel.hasChanges()).isTrue
     }
 
     private val productsDraft

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -106,7 +106,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     private val productWithParameters = ProductDetailViewState(
         productDraft = product,
-        productBeforeEnteringFragment = product,
         isSkeletonShown = false,
         uploadingImageUris = emptyList(),
         showBottomSheetButton = true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5993 

### Description
This is a first part of #5993, with a goal of reducing if not eliminating the `TransactionTooLargeException`s that occur on product details screens.
On this part I removed two copies of the `Product` instance from the ViewState:
1. `storedProduct` is now a regular property of the ViewModel, it gets initiated as it was before when the ViewModel is created, and when we restore instance, there is a logic to re-initiate it.
2. `productBeforeEnteringFragment` is not needed anymore, so I removed it. This property was used only for the logic of discard changes dialog in subscreens, but since we don't show this dialog anymore, it's not needed.

### Testing instructions
#### Confirm you can reproduce `TransactionTooLargeException`
Using `trunk`, test the following:
1. Update one of the products of your store with a long description (I used this site https://www.blindtextgenerator.com/lorem-ipsum to generate a description with 100000 characters)
2. Open the product details of this product.
3. send the app to the background.
4. Confirm the app crashes.

#### Confirm this PR fixes the issue
Pull changes of this branch, and repeat the above test, and confirm the app doesn't crash anymore.

#### Non-regression
Preferably enable "Don't keep activities" from the developer options, and smoke test the products:
1. Confirm the `save` button is displayed correctly in all cases.
2. Confirm product creation works as expected: saving as draft and publishing.
3. Whatever you can think of 🙂...

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
