### PR TITLE
Fix price loss in Product Details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,11 +2,10 @@
 
 8.9
 -----
-
+- [*] Fixed an issue to update the product price to zero, if required. [https://github.com/woocommerce/woocommerce-android/pull/6039]
 
 8.8
 -----
-- [*] Fixed an issue to update the product price to zero, if required. [https://github.com/woocommerce/woocommerce-android/pull/6039]
 
 8.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.variations.VariationListFragment
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.VariationListData
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.Optional
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
@@ -163,8 +164,8 @@ class ProductDetailFragment :
         }
         handleResult<PricingData>(BaseProductEditorFragment.KEY_PRICING_DIALOG_RESULT) {
             viewModel.updateProductDraft(
-                regularPrice = it.regularPrice,
-                salePrice = it.salePrice,
+                regularPrice = Optional(it.regularPrice),
+                salePrice = Optional(it.salePrice),
                 saleStartDate = it.saleStartDate,
                 saleEndDate = it.saleEndDate,
                 isSaleScheduled = it.isSaleScheduled,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.ui.products.variations.VariationRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.Optional
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -827,8 +828,8 @@ class ProductDetailViewModel @Inject constructor(
         soldIndividually: Boolean? = null,
         stockQuantity: Double? = null,
         backorderStatus: ProductBackorderStatus? = null,
-        regularPrice: BigDecimal? = null,
-        salePrice: BigDecimal? = null,
+        regularPrice: Optional<BigDecimal?>? = null,
+        salePrice: Optional<BigDecimal?>? = null,
         isOnSale: Boolean? = null,
         isVirtual: Boolean? = null,
         isSaleScheduled: Boolean? = null,
@@ -877,13 +878,13 @@ class ProductDetailViewModel @Inject constructor(
                 backorderStatus = backorderStatus ?: product.backorderStatus,
                 stockQuantity = stockQuantity ?: product.stockQuantity,
                 images = images ?: product.images,
-                regularPrice = if (regularPrice isNotEqualTo product.regularPrice) {
-                    regularPrice
+                regularPrice = if (regularPrice != null) {
+                    regularPrice.value
                 } else {
                     product.regularPrice
                 },
-                salePrice = if (salePrice isNotEqualTo product.salePrice) {
-                    salePrice
+                salePrice = if (salePrice != null) {
+                    salePrice.value
                 } else {
                     product.salePrice
                 },

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.ui.products.variations.VariationRepository
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.Optional
 import com.woocommerce.android.util.ProductUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
@@ -42,7 +43,6 @@ import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.*
-import kotlin.collections.ArrayList
 import kotlin.test.assertNull
 
 @ExperimentalCoroutinesApi
@@ -354,7 +354,10 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         val updatedRegularPrice = null
         val updatedSalePrice = null
-        viewModel.updateProductDraft(regularPrice = updatedRegularPrice, salePrice = updatedSalePrice)
+        viewModel.updateProductDraft(
+            regularPrice = Optional(updatedRegularPrice),
+            salePrice = Optional(updatedSalePrice)
+        )
 
         assertNull(productData?.productDraft?.regularPrice)
         assertNull(productData?.productDraft?.salePrice)
@@ -373,7 +376,10 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         val updatedRegularPrice = BigDecimal.ZERO
         val updatedSalePrice = BigDecimal.ZERO
-        viewModel.updateProductDraft(regularPrice = updatedRegularPrice, salePrice = updatedSalePrice)
+        viewModel.updateProductDraft(
+            regularPrice = Optional(updatedRegularPrice),
+            salePrice = Optional(updatedSalePrice)
+        )
 
         assertThat(productData?.productDraft?.regularPrice).isEqualTo(updatedRegularPrice)
         assertThat(productData?.productDraft?.salePrice).isEqualTo(updatedSalePrice)


### PR DESCRIPTION
### Description
The PR #6039 introduced a regression in product details, when changing anything other than the price data in the product details screen, we set the product's price to `null`, which would result in data loss. 

### Testing instructions
1. Pull `trunk`.
2. Open a product.
3. Edit the name.
4. Notice the price is lost.
5. Pull this branch.
6. Repeat the above steps and confirm the price is not impacted.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
