### PR TITLE
Product Details: refactor menu handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -373,7 +373,7 @@ class ProductDetailFragment :
         return when (item.itemId) {
             R.id.menu_publish -> {
                 ActivityUtils.hideKeyboard(activity)
-                viewModel.onUpdateButtonClicked(isPublish = true)
+                viewModel.onPublishButtonClicked()
                 true
             }
 
@@ -389,7 +389,7 @@ class ProductDetailFragment :
 
             R.id.menu_save -> {
                 ActivityUtils.hideKeyboard(activity)
-                viewModel.onUpdateButtonClicked(isPublish = false)
+                viewModel.onSaveButtonClicked()
                 true
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -15,7 +15,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.forEach
 import androidx.core.view.isVisible
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
@@ -243,36 +242,30 @@ class ProductDetailFragment :
             }
         }
 
-        viewModel.productDetailCards.observe(
-            viewLifecycleOwner,
-            Observer {
-                showProductCards(it)
-            }
-        )
+        viewModel.productDetailCards.observe(viewLifecycleOwner) {
+            showProductCards(it)
+        }
 
-        viewModel.event.observe(
-            viewLifecycleOwner,
-            Observer { event ->
-                when (event) {
-                    is LaunchUrlInChromeTab -> {
-                        ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
-                    }
-                    is RefreshMenu -> activity?.invalidateOptionsMenu()
-                    is ExitWithResult<*> -> {
-                        navigateBackWithResult(
-                            KEY_PRODUCT_DETAIL_RESULT,
-                            Bundle().also {
-                                it.putLong(KEY_REMOTE_PRODUCT_ID, event.data as Long)
-                                it.putBoolean(KEY_PRODUCT_DETAIL_DID_TRASH, true)
-                            }
-                        )
-                    }
-                    is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
-                    is HideImageUploadErrorSnackbar -> imageUploadErrorsSnackbar?.dismiss()
-                    else -> event.isHandled = false
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is LaunchUrlInChromeTab -> {
+                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
+                is RefreshMenu -> activity?.invalidateOptionsMenu()
+                is ExitWithResult<*> -> {
+                    navigateBackWithResult(
+                        KEY_PRODUCT_DETAIL_RESULT,
+                        Bundle().also {
+                            it.putLong(KEY_REMOTE_PRODUCT_ID, event.data as Long)
+                            it.putBoolean(KEY_PRODUCT_DETAIL_DID_TRASH, true)
+                        }
+                    )
+                }
+                is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
+                is HideImageUploadErrorSnackbar -> imageUploadErrorsSnackbar?.dismiss()
+                else -> event.isHandled = false
             }
-        )
+        }
 
         viewModel.menuButtonsState.observe(viewLifecycleOwner) {
             menu?.updateOptions(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -13,7 +13,6 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
-import androidx.core.view.forEach
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -346,25 +345,6 @@ class ProductDetailFragment :
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
 
-        fun Menu.printItems(): String = buildString {
-            this@printItems.forEach {
-                append("${resources.getResourceName(it.itemId)}\n")
-            }
-        }
-
-        // Some users are experiencing a crash because the entry R.id.menu_view_product is missing from the menu
-        // see: https://github.com/woocommerce/woocommerce-android/issues/3241
-        // If this happens, we will send the below report, and we avoid the crash using the null checks below
-        // TODO: remove the null checks once the root cause is identified is fixed
-        if (menu.findItem(R.id.menu_view_product) == null) {
-            val message = """menu.findItem(R.id.menu_view_product) is null
-                |User is ${if (viewModel.isProductUnderCreation) "creating a product" else "modifying a product"}
-                |menu elements:
-                |${menu.printItems()}
-            """.trimMargin()
-            crashLogging.sendReport(exception = NullPointerException(message))
-        }
-
         // change the font color of the trash menu item to red, and only show it if it should be enabled
         with(menu.findItem(R.id.menu_trash_product)) {
             if (this == null) return@with
@@ -387,15 +367,6 @@ class ProductDetailFragment :
         viewModel.menuButtonsState.value?.let {
             menu.updateOptions(it)
         }
-
-//        if (saveMenuItem?.isVisible ?: false) {
-//            publishMenuItem?.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_NEVER)
-//            publishMenuItem?.title = getString(R.string.product_add_tool_bar_menu_button_done)
-//        } else {
-//            publishMenuItem?.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_IF_ROOM)
-//            publishMenuItem?.title =
-//                getString(R.string.product_add_tool_bar_menu_button_done).uppercase(Locale.getDefault())
-//        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -217,7 +217,6 @@ class ProductDetailFragment :
     private fun setupObservers(viewModel: ProductDetailViewModel) {
         viewModel.productDetailViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.productDraft?.takeIfNotEqualTo(old?.productDraft) { showProductDetails(it) }
-            new.isProductUpdated?.takeIfNotEqualTo(old?.isProductUpdated) { requireActivity().invalidateOptionsMenu() }
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isProgressDialogShown?.takeIfNotEqualTo(old?.isProgressDialogShown) {
                 if (it) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -628,14 +628,17 @@ class ProductDetailViewModel @Inject constructor(
         }
     }
 
-    /**
-     * Called when the UPDATE/PUBLISH menu button is clicked in the product detail screen.
-     * Displays a progress dialog and updates/publishes the product
-     */
-    fun onUpdateButtonClicked(isPublish: Boolean) {
+    fun onSaveButtonClicked() {
         when (isProductUnderCreation) {
-            true -> startPublishProduct()
-            else -> startUpdateProduct(isPublish)
+            true -> startPublishProduct(productStatus = viewState.productDraft?.status ?: PUBLISH)
+            else -> startUpdateProduct(isPublish = false)
+        }
+    }
+
+    fun onPublishButtonClicked() {
+        when (isProductUnderCreation) {
+            true -> startPublishProduct(productStatus = PUBLISH)
+            else -> startUpdateProduct(isPublish = true)
         }
     }
 
@@ -682,7 +685,7 @@ class ProductDetailViewModel @Inject constructor(
         }
     }
 
-    private fun startPublishProduct(productStatus: ProductStatus = PUBLISH, exitWhenDone: Boolean = false) {
+    private fun startPublishProduct(productStatus: ProductStatus, exitWhenDone: Boolean = false) {
         viewState.productDraft?.let {
             val product = it.copy(status = productStatus)
             trackPublishing(product)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1006,7 +1006,7 @@ class ProductDetailViewModel @Inject constructor(
 
         launch {
             // fetch product
-            val productInDb = productRepository.getProduct(remoteProductId)
+            val productInDb = productRepository.getProductAsync(remoteProductId)
             if (productInDb != null) {
                 val shouldFetch = remoteProductId != getRemoteProductId()
                 updateProductState(productInDb)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -184,8 +184,8 @@ class ProductDetailViewModel @Inject constructor(
             val canBeSavedAsDraft = isAddFlowEntryPoint &&
                 !isProductStoredAtSite &&
                 productDraft.status != DRAFT
-            val isProductPublishedOrPrivate = productDraft.status == PUBLISH || productDraft.status == PRIVATE
-            val isProductPublished = viewState.productDraft?.status == PUBLISH
+            val isProductPublished = productDraft.status == PUBLISH
+            val isProductPublishedOrPrivate = isProductPublished || productDraft.status == PRIVATE
             MenuButtonsState(
                 saveOption = hasChanges && !canBeSavedAsDraft,
                 saveAsDraftOption = canBeSavedAsDraft,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -566,7 +566,7 @@ class ProductDetailViewModel @Inject constructor(
      * changes have been made to the [Product] model locally that still need to be saved to the backend.
      */
     fun onBackButtonClickedProductDetail(): Boolean {
-        val isProductDetailUpdated = viewState.isProductUpdated ?: false
+        val isProductDetailUpdated = hasChanges.value ?: false
         // Consider a non created product with ongoing uploads same as product with non saved changes
         val isUploadingImagesForNonCreatedProduct = isProductUnderCreation && isUploadingImages()
 
@@ -934,8 +934,6 @@ class ProductDetailViewModel @Inject constructor(
                 numVariations = numVariation ?: product.numVariations
             )
             viewState = viewState.copy(productDraft = updatedProduct)
-
-            updateProductEditAction()
         }
     }
 
@@ -1105,19 +1103,6 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     fun isUploadingImages() = !viewState.uploadingImageUris.isNullOrEmpty()
-
-    /**
-     * Updates the UPDATE menu button in the product detail screen. UPDATE is only displayed
-     * when there are changes made to the [Product] model and this can be verified by comparing
-     * the viewState.product with storedProduct.value model.
-     */
-    private fun updateProductEditAction() {
-        viewState.productDraft?.let { draft ->
-            val isProductUpdated = storedProduct.value?.isSameProduct(draft) == false ||
-                viewState.isPasswordChanged
-            viewState = viewState.copy(isProductUpdated = isProductUpdated)
-        }
-    }
 
     /**
      * Loads the attributes assigned to the draft product, used by the attribute list fragment
@@ -1514,8 +1499,7 @@ class ProductDetailViewModel @Inject constructor(
                 triggerEvent(ShowSnackbar(successMsg))
             }
             viewState = viewState.copy(
-                productDraft = null,
-                isProductUpdated = false
+                productDraft = null
             )
             loadRemoteProduct(product.remoteId)
         } else {
@@ -1537,8 +1521,7 @@ class ProductDetailViewModel @Inject constructor(
         val (isSuccess, newProductRemoteId) = result
         if (isSuccess) {
             viewState = viewState.copy(
-                productDraft = null,
-                isProductUpdated = false
+                productDraft = null
             )
             loadRemoteProduct(newProductRemoteId)
             triggerEvent(RefreshMenu)
@@ -2031,10 +2014,6 @@ class ProductDetailViewModel @Inject constructor(
      * if we need to display the UPDATE menu button (which is only displayed if there are changes made to
      * any of the product fields).
      *
-     * [isProductUpdated] is used to determine if there are any changes made to the product by comparing
-     * [productDraft] and [storedProduct.value]. Currently used in the product detail screen to display or hide the UPDATE
-     * menu button.
-     *
      * When the user first enters the product detail screen, the [productDraft] and [storedProduct.value] are the same.
      * When a change is made to the product in the UI, the [productDraft] model is updated with whatever change
      * has been made in the UI.
@@ -2045,7 +2024,6 @@ class ProductDetailViewModel @Inject constructor(
         val isSkeletonShown: Boolean? = null,
         val uploadingImageUris: List<Uri>? = null,
         val isProgressDialogShown: Boolean? = null,
-        val isProductUpdated: Boolean? = null,
         val storedPassword: String? = null,
         val draftPassword: String? = null,
         val showBottomSheetButton: Boolean? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -172,22 +172,24 @@ class ProductDetailViewModel @Inject constructor(
     val productDraftAttributes
         get() = viewState.productDraft?.attributes ?: emptyList()
 
-    val menuButtonsState = draftChanges.combine(_hasChanges) { productDraft, hasChanges ->
-        Pair(productDraft, hasChanges)
-    }.map { (productDraft, hasChanges) ->
-        val canBeSavedAsDraft = isAddFlowEntryPoint &&
-            !isProductStoredAtSite
-        val isProductPublishedOrPrivate = productDraft?.status == PUBLISH || productDraft?.status == PRIVATE
-        val isProductPublished = viewState.productDraft?.status == PUBLISH
-        MenuButtonsState(
-            saveOption = hasChanges && !canBeSavedAsDraft,
-            saveAsDraftOption = canBeSavedAsDraft,
-            publishOption = !isProductPublishedOrPrivate || isProductUnderCreation,
-            viewProductOption = isProductPublished && !isProductUnderCreation,
-            shareOption = !isProductUnderCreation,
-            trashOption = !isProductUnderCreation && navArgs.isTrashEnabled
-        )
-    }.asLiveData()
+    val menuButtonsState = draftChanges
+        .filterNotNull()
+        .combine(_hasChanges) { productDraft, hasChanges ->
+            Pair(productDraft, hasChanges)
+        }.map { (productDraft, hasChanges) ->
+            val canBeSavedAsDraft = isAddFlowEntryPoint &&
+                !isProductStoredAtSite
+            val isProductPublishedOrPrivate = productDraft.status == PUBLISH || productDraft.status == PRIVATE
+            val isProductPublished = viewState.productDraft?.status == PUBLISH
+            MenuButtonsState(
+                saveOption = hasChanges && !canBeSavedAsDraft,
+                saveAsDraftOption = canBeSavedAsDraft,
+                publishOption = !isProductPublishedOrPrivate || isProductUnderCreation,
+                viewProductOption = isProductPublished && !isProductUnderCreation,
+                shareOption = !isProductUnderCreation,
+                trashOption = !isProductUnderCreation && navArgs.isTrashEnabled
+            )
+        }.asLiveData()
 
     /**
      * Validates if the product exists at the Store or if it's currently defined only inside the app

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -182,7 +182,8 @@ class ProductDetailViewModel @Inject constructor(
             Pair(productDraft, hasChanges)
         }.map { (productDraft, hasChanges) ->
             val canBeSavedAsDraft = isAddFlowEntryPoint &&
-                !isProductStoredAtSite
+                !isProductStoredAtSite &&
+                productDraft.status != DRAFT
             val isProductPublishedOrPrivate = productDraft.status == PUBLISH || productDraft.status == PRIVATE
             val isProductPublished = viewState.productDraft?.status == PUBLISH
             MenuButtonsState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -262,10 +262,12 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     private fun initializeStoredProductAfterRestoration() {
-        storedProduct = if (isAddFlowEntryPoint && !isProductStoredAtSite) {
-            createDefaultProductForAddFlow()
-        } else {
-            productRepository.getProduct(viewState.productDraft?.remoteId ?: navArgs.remoteProductId)
+        launch {
+            storedProduct = if (isAddFlowEntryPoint && !isProductStoredAtSite) {
+                createDefaultProductForAddFlow()
+            } else {
+                productRepository.getProductAsync(viewState.productDraft?.remoteId ?: navArgs.remoteProductId)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -95,6 +95,10 @@ class ProductDetailViewModel @Inject constructor(
     }
     private var viewState by productDetailViewStateData
 
+    /**
+     * The goal of this is to allow composition of reactive streams using the product draft changes,
+     * we need a separate stream because [LiveDataDelegate] supports a single observer.
+     */
     private val draftChanges = MutableStateFlow<Product?>(null)
 
     private val storedProduct = MutableStateFlow<Product?>(null)

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -5,21 +5,25 @@
     <item
         android:id="@+id/menu_save"
         android:title="@string/save"
+        android:visible="false"
         app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/menu_publish"
         android:title="@string/product_add_tool_bar_menu_button_done"
+        android:visible="false"
         app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/menu_save_as_draft"
         android:title="@string/product_detail_save_as_draft"
+        android:visible="false"
         app:showAsAction="withText" />
 
     <item
         android:id="@+id/menu_share"
         android:title="@string/share"
+        android:visible="false"
         app:showAsAction="withText" />
 
     <item
@@ -36,5 +40,6 @@
     <item
         android:id="@+id/menu_trash_product"
         android:title="@string/product_trash"
+        android:visible="false"
         app:showAsAction="withText" />
 </menu>

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -31,7 +31,6 @@
     <item
         android:id="@+id/menu_product_settings"
         android:title="@string/product_settings"
-        android:visible="false"
         app:showAsAction="withText" />
 
     <item

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -413,7 +413,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        viewModel.onUpdateButtonClicked(false)
+        viewModel.onSaveButtonClicked()
 
         assertThat(isProgressDialogShown).containsExactly(true, false)
     }
@@ -433,7 +433,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        viewModel.onUpdateButtonClicked(false)
+        viewModel.onSaveButtonClicked()
 
         verify(productRepository, times(0)).updateProduct(any())
         assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.offline_error))
@@ -455,7 +455,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        viewModel.onUpdateButtonClicked(false)
+        viewModel.onSaveButtonClicked()
 
         verify(productRepository, times(1)).updateProduct(any())
         assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.product_detail_update_product_error))
@@ -482,7 +482,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        viewModel.onUpdateButtonClicked(false)
+        viewModel.onSaveButtonClicked()
 
         verify(productRepository, times(1)).updateProduct(any())
         verify(productRepository, times(2)).getProductAsync(PRODUCT_REMOTE_ID)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -385,6 +385,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Displays update menu action if product is edited`() {
         doReturn(product).whenever(productRepository).getProduct(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var hasChanges: Boolean? = null
         viewModel.hasChanges.observeForever { hasChanges = it }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -755,23 +755,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Publish option shown when product is published and from addProduct flow and is under product creation`() {
-        savedState = ProductDetailFragmentArgs(
-            remoteProductId = ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID,
-            isAddProduct = true
-        ).initSavedStateHandle()
-
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
-
-        var menuButtonsState: MenuButtonsState? = null
-        viewModel.menuButtonsState.observeForever { menuButtonsState = it }
-
-        viewModel.start()
-        viewModel.updateProductDraft(productStatus = ProductStatus.PUBLISH)
-        assertThat(menuButtonsState?.publishOption).isTrue
-    }
-
-    @Test
     fun `Publish option shown when product is Draft`() {
         doReturn(product).whenever(productRepository).getProduct(any())
         viewModel.productDetailViewStateData.observeForever { _, _ -> }
@@ -810,23 +793,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         viewModel.updateProductDraft(title = product.name + "2")
 
         assertThat(menuButtonsState?.saveOption).isTrue()
-    }
-
-    @Test
-    fun `Save option not shown when product has changes but in add product flow`() {
-        savedState = ProductDetailFragmentArgs(
-            remoteProductId = ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID,
-            isAddProduct = true
-        ).initSavedStateHandle()
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
-
-        var menuButtonsState: MenuButtonsState? = null
-        viewModel.menuButtonsState.observeForever { menuButtonsState = it }
-
-        viewModel.start()
-        viewModel.updateProductDraft(title = "name")
-
-        assertThat(menuButtonsState?.saveOption).isFalse()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -733,7 +733,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Publish option not shown when product is published except addProduct flow`() {
         doReturn(product).whenever(productRepository).getProduct(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         var menuButtonsState: MenuButtonsState? = null
         viewModel.menuButtonsState.observeForever { menuButtonsState = it }
 
@@ -745,7 +745,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Publish option not shown when product is published privately except addProduct flow`() {
         doReturn(product).whenever(productRepository).getProduct(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         var menuButtonsState: MenuButtonsState? = null
         viewModel.menuButtonsState.observeForever { menuButtonsState = it }
 
@@ -761,7 +761,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             isAddProduct = true
         ).initSavedStateHandle()
 
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var menuButtonsState: MenuButtonsState? = null
         viewModel.menuButtonsState.observeForever { menuButtonsState = it }
@@ -774,7 +774,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Publish option shown when product is Draft`() {
         doReturn(product).whenever(productRepository).getProduct(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var menuButtonsState: MenuButtonsState? = null
         viewModel.menuButtonsState.observeForever { menuButtonsState = it }
@@ -787,7 +787,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Publish option shown when product is Pending Review`() {
         doReturn(product).whenever(productRepository).getProduct(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var menuButtonsState: MenuButtonsState? = null
         viewModel.menuButtonsState.observeForever { menuButtonsState = it }
@@ -800,7 +800,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Save option shown when product has changes except add product flow irrespective of product statuses`() {
         doReturn(product).whenever(productRepository).getProduct(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var menuButtonsState: MenuButtonsState? = null
         viewModel.menuButtonsState.observeForever { menuButtonsState = it }
@@ -818,7 +818,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             remoteProductId = ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID,
             isAddProduct = true
         ).initSavedStateHandle()
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var menuButtonsState: MenuButtonsState? = null
         viewModel.menuButtonsState.observeForever { menuButtonsState = it }
@@ -834,7 +834,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         // Make sure draft product has different data than draft product
         doReturn(product.copy(name = product.name + "test")).whenever(productRepository).getProductAsync(any())
         savedState.set(ProductDetailViewState::class.java.name, productWithParameters)
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var hasChanges: Boolean? = null
         viewModel.hasChanges.observeForever { hasChanges = it }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.media.ProductImagesServiceWrapper
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductDetailViewModel.MenuButtonsState
@@ -467,7 +468,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
     @Test
     fun `given product status is draft, when save is clicked, then save product with correct status`() = testBlocking {
-        whenever(productRepository.updateProduct(any())).thenReturn(true)
+        whenever(productRepository.addProduct(any())).thenAnswer { it.arguments.first() as Product }
         var viewState: ProductDetailViewState? = null
         viewModel.productDetailViewStateData.observeForever { _, new -> viewState = new }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -464,4 +464,17 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
         assertThat(menuButtonsState?.saveOption).isFalse()
     }
+
+    @Test
+    fun `given product status is draft, when save is clicked, then save product with correct status`() = testBlocking {
+        whenever(productRepository.updateProduct(any())).thenReturn(true)
+        var viewState: ProductDetailViewState? = null
+        viewModel.productDetailViewStateData.observeForever { _, new -> viewState = new }
+
+        viewModel.start()
+        viewModel.updateProductDraft(productStatus = DRAFT)
+        viewModel.onSaveButtonClicked()
+
+        assertThat(viewState?.productDraft?.status).isEqualTo(DRAFT)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -217,7 +217,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
         viewModel.start()
 
-        viewModel.onUpdateButtonClicked(false)
+        viewModel.onPublishButtonClicked()
 
         // then
         verify(productRepository, times(1)).getProductAsync(1L)
@@ -247,7 +247,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
         viewModel.start()
 
-        viewModel.onUpdateButtonClicked(false)
+        viewModel.onPublishButtonClicked()
 
         // then
         assertThat(successSnackbarShown).isTrue()
@@ -273,7 +273,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
         viewModel.start()
 
-        viewModel.onUpdateButtonClicked(true)
+        viewModel.onPublishButtonClicked()
 
         // then
         assertThat(successSnackbarShown).isTrue()
@@ -303,7 +303,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
             viewModel.start()
 
-            viewModel.onUpdateButtonClicked(true)
+            viewModel.onPublishButtonClicked()
 
             // then
             verify(productRepository, times(1)).getProductAsync(1L)
@@ -316,7 +316,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
             // when
             doReturn(true).whenever(productRepository).updateProduct(any())
 
-            viewModel.onUpdateButtonClicked(true)
+            viewModel.onPublishButtonClicked()
             verify(productRepository, times(1)).updateProduct(any())
 
             viewModel.event.observeForever {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -334,7 +334,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     @Test
     fun `Save as draft shown in discard dialog when changes made in add flow`() {
         doReturn(true).whenever(viewModel).isProductUnderCreation
-        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         viewModel.start()
 
@@ -393,7 +393,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 .onCompletion { isObservingEvents = false }
             doReturn(successEvents).whenever(mediaFileUploadHandler)
                 .observeSuccessfulUploads(ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID)
-            viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
             viewModel.start()
             // Make some changes to trigger discard changes dialog
@@ -412,7 +412,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 .onCompletion { isObservingEvents = false }
             doReturn(successEvents).whenever(mediaFileUploadHandler)
                 .observeSuccessfulUploads(ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID)
-            viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
             viewModel.start()
             // Make some changes to trigger discard changes dialog
@@ -428,7 +428,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         testBlocking {
             doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any())
             doReturn(product).whenever(productRepository).getProduct(any())
-            viewModel.productDetailViewStateData.observeForever { _, _ ->  }
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
             viewModel.start()
             // Make some changes to trigger discard changes dialog

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -198,7 +198,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     @Test
     fun `Display success message on add product success`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         // given
-        doReturn(product).whenever(productRepository).getProduct(any())
+        doReturn(product).whenever(productRepository).getProductAsync(any())
         doReturn(Pair(true, 1L)).whenever(productRepository).addProduct(any())
 
         var successSnackbarShown = false
@@ -220,7 +220,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         viewModel.onUpdateButtonClicked(false)
 
         // then
-        verify(productRepository, times(1)).getProduct(1L)
+        verify(productRepository, times(1)).getProductAsync(1L)
 
         assertThat(successSnackbarShown).isTrue()
         assertThat(productData?.isProgressDialogShown).isFalse()
@@ -284,7 +284,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     fun `Display correct message on updating a freshly added product`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            doReturn(product).whenever(productRepository).getProduct(any())
+            doReturn(product).whenever(productRepository).getProductAsync(any())
             doReturn(Pair(true, 1L)).whenever(productRepository).addProduct(any())
 
             var successSnackbarShown = false
@@ -306,7 +306,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
             viewModel.onUpdateButtonClicked(true)
 
             // then
-            verify(productRepository, times(1)).getProduct(1L)
+            verify(productRepository, times(1)).getProductAsync(1L)
 
             assertThat(successSnackbarShown).isTrue()
             assertThat(productData?.isProgressDialogShown).isFalse()
@@ -375,7 +375,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     @Test
     fun `when a new product is saved, then assign the new id to ongoing image uploads`() = testBlocking {
         doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any())
-        doReturn(product).whenever(productRepository).getProduct(any())
+        doReturn(product).whenever(productRepository).getProductAsync(any())
         savedState = ProductDetailFragmentArgs(isAddProduct = true).initSavedStateHandle()
 
         setup()
@@ -428,7 +428,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     fun `given a product is under creation, when clicking on save product, then assign uploads to the new id`() =
         testBlocking {
             doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any())
-            doReturn(product).whenever(productRepository).getProduct(any())
+            doReturn(product).whenever(productRepository).getProductAsync(any())
             viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
             viewModel.start()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
+import com.woocommerce.android.ui.products.ProductDetailViewModel.MenuButtonsState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.addons.AddonRepository
@@ -438,4 +439,29 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
             verify(mediaFileUploadHandler).assignUploadsToCreatedProduct(PRODUCT_REMOTE_ID)
         }
+
+    @Test
+    fun `Publish option shown when product is published and from addProduct flow and is under product creation`() {
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+
+        var menuButtonsState: MenuButtonsState? = null
+        viewModel.menuButtonsState.observeForever { menuButtonsState = it }
+
+        viewModel.start()
+        viewModel.updateProductDraft(productStatus = ProductStatus.PUBLISH)
+        assertThat(menuButtonsState?.publishOption).isTrue
+    }
+
+    @Test
+    fun `Save option not shown when product has changes but in add product flow`() {
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+
+        var menuButtonsState: MenuButtonsState? = null
+        viewModel.menuButtonsState.observeForever { menuButtonsState = it }
+
+        viewModel.start()
+        viewModel.updateProductDraft(title = "name")
+
+        assertThat(menuButtonsState?.saveOption).isFalse()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -206,6 +206,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 successSnackbarShown = true
             }
         }
+        var hasChanges: Boolean? = null
+        viewModel.hasChanges.observeForever { hasChanges = it }
 
         var productData: ProductDetailViewState? = null
 
@@ -221,7 +223,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
         assertThat(successSnackbarShown).isTrue()
         assertThat(productData?.isProgressDialogShown).isFalse()
-        assertThat(productData?.isProductUpdated).isFalse()
+        assertThat(hasChanges).isFalse()
         assertThat(productData?.productDraft).isEqualTo(product)
     }
 
@@ -290,6 +292,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                     successSnackbarShown = true
                 }
             }
+            var hasChanges: Boolean? = null
+            viewModel.hasChanges.observeForever { hasChanges = it }
 
             var productData: ProductDetailViewState? = null
 
@@ -305,7 +309,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
             assertThat(successSnackbarShown).isTrue()
             assertThat(productData?.isProgressDialogShown).isFalse()
-            assertThat(productData?.isProductUpdated).isFalse()
+            assertThat(hasChanges).isFalse()
             assertThat(productData?.productDraft).isEqualTo(product)
 
             // when
@@ -323,13 +327,14 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
             // then
             assertThat(successSnackbarShown).isTrue()
             assertThat(productData?.isProgressDialogShown).isFalse()
-            assertThat(productData?.isProductUpdated).isFalse()
+            assertThat(hasChanges).isFalse()
             assertThat(productData?.productDraft).isEqualTo(product)
         }
 
     @Test
     fun `Save as draft shown in discard dialog when changes made in add flow`() {
         doReturn(true).whenever(viewModel).isProductUnderCreation
+        viewModel.productDetailViewStateData.observeForever { _, _ ->  }
 
         viewModel.start()
 
@@ -388,12 +393,11 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 .onCompletion { isObservingEvents = false }
             doReturn(successEvents).whenever(mediaFileUploadHandler)
                 .observeSuccessfulUploads(ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID)
-            savedState = ProductDetailFragmentArgs(isAddProduct = true).initSavedStateHandle()
+            viewModel.productDetailViewStateData.observeForever { _, _ ->  }
 
-            setup()
             viewModel.start()
             // Make some changes to trigger discard changes dialog
-            viewModel.onProductTitleChanged("Product")
+            viewModel.onProductTitleChanged("Product 2")
             viewModel.onBackButtonClickedProductDetail()
 
             assertThat(isObservingEvents).isFalse()
@@ -408,9 +412,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 .onCompletion { isObservingEvents = false }
             doReturn(successEvents).whenever(mediaFileUploadHandler)
                 .observeSuccessfulUploads(ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID)
-            savedState = ProductDetailFragmentArgs(isAddProduct = true).initSavedStateHandle()
+            viewModel.productDetailViewStateData.observeForever { _, _ ->  }
 
-            setup()
             viewModel.start()
             // Make some changes to trigger discard changes dialog
             viewModel.onProductTitleChanged("Product")
@@ -425,9 +428,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         testBlocking {
             doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any())
             doReturn(product).whenever(productRepository).getProduct(any())
-            savedState = ProductDetailFragmentArgs(isAddProduct = true).initSavedStateHandle()
+            viewModel.productDetailViewStateData.observeForever { _, _ ->  }
 
-            setup()
             viewModel.start()
             // Make some changes to trigger discard changes dialog
             viewModel.onProductTitleChanged("Product")


### PR DESCRIPTION
### Description
After working on #6097, I noticed that the detection of `hasChanges` is not reactive enough, in the sense that when we move to async operations to unblock threads, it stops working correctly (you can simulate the issue by checking out the commit c1fb727da29a1601e210fce161ef93502e11046d, then adding a `delay` in the function `initializeStoredProductAfterRestoration`, you'll notice that the `save` button won't have the correct state after restoring the Activity).
Also the handling was not centralized, which made following what's going on hard.

This is an attempt at refactoring things, with two big parts:
1. Making the logic reactive, via two observable Flows `hasChanges` and `menuButtonsState`
2. Consolidating the logic of updating the buttons state UI wise in a single function `Menu#updateOptions`

Please feel free to suggest any changes, or if you feel the refactoring is not needed.

**An advice for reviewing**: it's best to review the commit 40cb809 independently, since it's not related to the changes, instead it just moves to using the suspendable function `getProductAsync` for fetching initial product.

### Testing instructions
##### Edit Product
| Button | Conditions for visibility |
| ---- | ------ |
| Save | Product has non-saved Changes |
| View Product | Product has status "Published" with visibility different than "Private" |
| Share | Always |
| Trash | Product details is opened from Products List | 
| Publish | Product has status "draft" |
| Save as draft | never |
| Product Settings | Always |

##### Add product
| Button | Conditions for visibility |
| ---- | ------ |
| Save | (Product was saved to the remote site **or** has draft status) **and** has nonsaved changes. This aligns behavior with iOS and fixes #4373 |
| View Product | Product was saved to the remote site **and** has status "Published |
| Share | Product was saved to the remote site |
| Trash | never | 
| Publish | Product not saved yet in the remote site **or** has "draft" status |
| Save as draft | Product not saved yet in the remote site **and** doesn't have "draft" as status  |
| Product Settings | Always |

* Product was saved to the remote site means the product was pushed either using "save as draft" or "publish"

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
