### PR TITLE
Feature/5973/retain state of percentage fee

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -199,9 +199,12 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onFeeButtonClicked() {
-        val currentOrderTotal = _orderDraft.value.total
-        val currentFeeTotal = _orderDraft.value.feesLines.firstOrNull()?.total
-        triggerEvent(EditFee(currentOrderTotal, currentFeeTotal))
+        triggerEvent(
+            EditFee(
+                orderTotal = _orderDraft.value.productsTotal,
+                currentLocalFee = localFeeManager.localFeeLine
+            )
+        )
     }
 
     fun onShippingButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -205,7 +205,7 @@ class OrderCreationViewModel @Inject constructor(
     fun onFeeButtonClicked() {
         triggerEvent(
             EditFee(
-                orderTotal = _orderDraft.value.productsTotal,
+                orderTotal = _orderDraft.value.total,
                 currentLocalFee = localFeeManager.localFeeLine
             )
         )
@@ -258,7 +258,7 @@ class OrderCreationViewModel @Inject constructor(
     private fun monitorOrderChanges() {
         viewModelScope.launch {
             val orderDraftFlow = _orderDraft.map { draft ->
-                localFeeManager.updateFeeLine(draft.feesLines, draft.productsTotal)
+                localFeeManager.updateFeeLine(draft.feesLines, draft.total)
                 draft.copy(feesLines = localFeeManager.getFeeLines())
             }
             createOrUpdateOrderDraft(orderDraftFlow, retryOrderDraftUpdateTrigger)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -205,7 +205,7 @@ class OrderCreationViewModel @Inject constructor(
     fun onFeeButtonClicked() {
         triggerEvent(
             EditFee(
-                orderTotal = _orderDraft.value.total,
+                orderTotal = _orderDraft.value.productsTotal,
                 currentLocalFee = localFeeManager.localFeeLine
             )
         )
@@ -258,7 +258,7 @@ class OrderCreationViewModel @Inject constructor(
     private fun monitorOrderChanges() {
         viewModelScope.launch {
             val orderDraftFlow = _orderDraft.map { draft ->
-                localFeeManager.updateFeeLine(draft.feesLines, draft.total)
+                localFeeManager.updateFeeLine(draft.feesLines, draft.productsTotal)
                 draft.copy(feesLines = localFeeManager.getFeeLines())
             }
             createOrUpdateOrderDraft(orderDraftFlow, retryOrderDraftUpdateTrigger)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeLine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeLine.kt
@@ -46,7 +46,6 @@ data class LocalAmountFee(
     override var amount: BigDecimal,
     override val totalTax: BigDecimal,
 ) : LocalFeeLine, Parcelable {
-
     override fun getTotal(): BigDecimal = amount
     override fun getType(): LocalFeeLineType = LocalFeeLineType.AMOUNT
     override fun copyFee(
@@ -93,7 +92,6 @@ data class LocalPercentageFee(
     override val totalTax: BigDecimal,
     val orderTotal: BigDecimal
 ) : LocalFeeLine, Parcelable {
-
     override fun getTotal(): BigDecimal = (amount * orderTotal) / PERCENTAGE_BASE
     override fun getType(): LocalFeeLineType = LocalFeeLineType.PERCENTAGE
     override fun copyFee(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeLine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeLine.kt
@@ -1,0 +1,136 @@
+package com.woocommerce.android.ui.orders.creation.fees
+
+import android.os.Parcelable
+import com.woocommerce.android.model.Order
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+enum class LocalFeeLineType { AMOUNT, PERCENTAGE }
+
+interface LocalFeeLine : Parcelable {
+    val id: Long
+    val name: String?
+    val amount: BigDecimal
+    val totalTax: BigDecimal
+
+    fun toOrderFeeLine(
+        id: Long = this.id,
+        name: String? = this.name,
+        totalTax: BigDecimal = this.totalTax
+    ): Order.FeeLine
+
+    fun getTotal(): BigDecimal
+    fun getType(): LocalFeeLineType
+
+    fun copyFee(
+        id: Long = this.id,
+        name: String? = this.name,
+        amount: BigDecimal = this.amount,
+        totalTax: BigDecimal = this.totalTax
+    ): LocalFeeLine
+
+    companion object {
+        val EMPTY = LocalAmountFee(
+            id = 0,
+            name = "",
+            amount = BigDecimal.ZERO,
+            totalTax = BigDecimal.ZERO
+        )
+    }
+}
+
+@Parcelize
+data class LocalAmountFee(
+    override val id: Long,
+    override val name: String?,
+    override var amount: BigDecimal,
+    override val totalTax: BigDecimal,
+) : LocalFeeLine, Parcelable {
+
+    override fun getTotal(): BigDecimal = amount
+    override fun getType(): LocalFeeLineType = LocalFeeLineType.AMOUNT
+    override fun copyFee(
+        id: Long,
+        name: String?,
+        amount: BigDecimal,
+        totalTax: BigDecimal
+    ): LocalFeeLine = LocalAmountFee(
+        id = id,
+        name = name,
+        amount = amount,
+        totalTax = totalTax
+    )
+
+    override fun toOrderFeeLine(
+        id: Long,
+        name: String?,
+        totalTax: BigDecimal
+    ): Order.FeeLine =
+        Order.FeeLine(
+            id = id,
+            name = name,
+            total = getTotal(),
+            totalTax = totalTax
+        )
+
+    companion object {
+        fun toAmountFee(localFeeLine: LocalFeeLine): LocalAmountFee {
+            return LocalAmountFee(
+                id = localFeeLine.id,
+                amount = localFeeLine.amount,
+                name = localFeeLine.name,
+                totalTax = localFeeLine.totalTax
+            )
+        }
+    }
+}
+
+@Parcelize
+data class LocalPercentageFee(
+    override val id: Long,
+    override val name: String?,
+    override var amount: BigDecimal,
+    override val totalTax: BigDecimal,
+    val orderTotal: BigDecimal
+) : LocalFeeLine, Parcelable {
+
+    override fun getTotal(): BigDecimal = (amount * orderTotal) / PERCENTAGE_BASE
+    override fun getType(): LocalFeeLineType = LocalFeeLineType.PERCENTAGE
+    override fun copyFee(
+        id: Long,
+        name: String?,
+        amount: BigDecimal,
+        totalTax: BigDecimal
+    ): LocalFeeLine = LocalPercentageFee(
+        id = id,
+        name = name,
+        amount = amount,
+        totalTax = totalTax,
+        orderTotal = orderTotal
+    )
+
+    override fun toOrderFeeLine(
+        id: Long,
+        name: String?,
+        totalTax: BigDecimal
+    ): Order.FeeLine =
+        Order.FeeLine(
+            id = id,
+            name = name,
+            total = getTotal(),
+            totalTax = totalTax
+        )
+
+    companion object {
+        private val PERCENTAGE_BASE = BigDecimal(100)
+        fun toPercentageFee(localFeeLine: LocalFeeLine, orderTotal: BigDecimal): LocalPercentageFee {
+            return LocalPercentageFee(
+                id = localFeeLine.id,
+                amount = localFeeLine.amount,
+                name = localFeeLine.name,
+                totalTax = localFeeLine.totalTax,
+                orderTotal = orderTotal
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeManager.kt
@@ -4,13 +4,12 @@ import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.Order
 import java.math.BigDecimal
 
-
 class LocalFeeManager(private val feeName: String) {
     var localFeeLine: LocalFeeLine = LocalFeeLine.EMPTY
         private set
 
     fun updateFeeLine(feeLines: List<Order.FeeLine>, orderTotal: BigDecimal) {
-        if(feeLines.isEmpty()){
+        if (feeLines.isEmpty()) {
             localFeeLine = LocalFeeLine.EMPTY
             return
         }
@@ -39,7 +38,11 @@ class LocalFeeManager(private val feeName: String) {
     }
 
     fun editFee(editedLocalFee: LocalFeeLine) {
-        localFeeLine = if (editedLocalFee.name.isNullOrEmpty()) editedLocalFee.copyFee(name = feeName) else editedLocalFee
+        localFeeLine =
+            if (editedLocalFee.name.isNullOrEmpty())
+                editedLocalFee.copyFee(name = feeName)
+            else
+                editedLocalFee
     }
 
     fun getFeeLines(): List<Order.FeeLine> = if (localFeeLine == LocalFeeLine.EMPTY) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeManager.kt
@@ -1,0 +1,54 @@
+package com.woocommerce.android.ui.orders.creation.fees
+
+import com.woocommerce.android.extensions.exhaustive
+import com.woocommerce.android.model.Order
+import java.math.BigDecimal
+
+
+class LocalFeeManager(private val feeName: String) {
+    var localFeeLine: LocalFeeLine = LocalFeeLine.EMPTY
+        private set
+
+    fun updateFeeLine(feeLines: List<Order.FeeLine>, orderTotal: BigDecimal) {
+        if(feeLines.isEmpty()){
+            localFeeLine = LocalFeeLine.EMPTY
+            return
+        }
+        val orderFeeLine = feeLines.first()
+        when (localFeeLine.getType()) {
+            LocalFeeLineType.PERCENTAGE -> {
+                if (orderTotal.compareTo(BigDecimal.ZERO) == 0) {
+                    onFeeRemoved()
+                    return
+                }
+                localFeeLine = (localFeeLine as LocalPercentageFee).copy(
+                    id = orderFeeLine.id,
+                    name = orderFeeLine.name,
+                    totalTax = orderFeeLine.totalTax,
+                    orderTotal = orderTotal
+                )
+            }
+            LocalFeeLineType.AMOUNT -> {
+                localFeeLine = (localFeeLine as LocalAmountFee).copy(
+                    id = orderFeeLine.id,
+                    name = orderFeeLine.name,
+                    totalTax = orderFeeLine.totalTax
+                )
+            }
+        }.exhaustive
+    }
+
+    fun editFee(editedLocalFee: LocalFeeLine) {
+        localFeeLine = if (editedLocalFee.name.isNullOrEmpty()) editedLocalFee.copyFee(name = feeName) else editedLocalFee
+    }
+
+    fun getFeeLines(): List<Order.FeeLine> = if (localFeeLine == LocalFeeLine.EMPTY) {
+        emptyList()
+    } else {
+        listOf(localFeeLine.toOrderFeeLine())
+    }
+
+    fun onFeeRemoved() {
+        localFeeLine = LocalFeeLine.EMPTY.copy(id = localFeeLine.id, name = null)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/LocalFeeManager.kt
@@ -1,13 +1,16 @@
 package com.woocommerce.android.ui.orders.creation.fees
 
+import android.os.Parcelable
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.Order
+import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 
-class LocalFeeManager(private val feeName: String) {
-    var localFeeLine: LocalFeeLine = LocalFeeLine.EMPTY
-        private set
-
+@Parcelize
+class LocalFeeManager(
+    private val feeName: String,
+    private var localFeeLine: LocalFeeLine = LocalFeeLine.EMPTY
+) : Parcelable {
     fun updateFeeLine(feeLines: List<Order.FeeLine>, orderTotal: BigDecimal) {
         if (feeLines.isEmpty()) {
             localFeeLine = LocalFeeLine.EMPTY
@@ -44,6 +47,8 @@ class LocalFeeManager(private val feeName: String) {
             else
                 editedLocalFee
     }
+
+    fun getLocalFeeLine() = localFeeLine
 
     fun getFeeLines(): List<Order.FeeLine> = if (localFeeLine == LocalFeeLine.EMPTY) {
         emptyList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModel.kt
@@ -15,7 +15,6 @@ import javax.inject.Inject
 class OrderCreationFeeViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-
     private val navArgs: OrderCreationFeeFragmentArgs by savedState.navArgs()
 
     val orderTotal = navArgs.orderTotal

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreationNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreationNavigationTarget.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.creation.navigation
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.ShippingLine
+import com.woocommerce.android.ui.orders.creation.fees.LocalFeeLine
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import java.math.BigDecimal
 
@@ -13,8 +14,5 @@ sealed class OrderCreationNavigationTarget : Event() {
     data class ShowProductDetails(val item: Order.Item) : OrderCreationNavigationTarget()
     data class ShowCreatedOrder(val orderId: Long) : OrderCreationNavigationTarget()
     data class EditShipping(val currentShippingLine: ShippingLine?) : OrderCreationNavigationTarget()
-    data class EditFee(
-        val orderTotal: BigDecimal,
-        val currentFeeValue: BigDecimal? = null
-    ) : OrderCreationNavigationTarget()
+    data class EditFee(val orderTotal: BigDecimal, val currentLocalFee: LocalFeeLine?) : OrderCreationNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreationNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreationNavigator.kt
@@ -20,7 +20,7 @@ object OrderCreationNavigator {
             is EditFee ->
                 OrderCreationFormFragmentDirections.actionOrderCreationFragmentToOrderCreationEditFeeFragment(
                     orderTotal = target.orderTotal,
-                    currentFeeValue = target.currentFeeValue
+                    currentFee = target.currentLocalFee
                 )
             is ShowProductDetails ->
                 OrderCreationFormFragmentDirections

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -64,8 +64,8 @@
                 android:name="orderTotal"
                 app:argType="java.math.BigDecimal" />
             <argument
-                android:name="currentFeeValue"
-                app:argType="java.math.BigDecimal"
+                android:name="currentFee"
+                app:argType="com.woocommerce.android.ui.orders.creation.fees.LocalFeeLine"
                 app:nullable="true"
                 android:defaultValue="@null"/>
         </action>
@@ -165,8 +165,8 @@
             android:name="orderTotal"
             app:argType="java.math.BigDecimal" />
         <argument
-            android:name="currentFeeValue"
-            app:argType="java.math.BigDecimal"
+            android:name="currentFee"
+            app:argType="com.woocommerce.android.ui.orders.creation.fees.LocalFeeLine"
             app:nullable="true"
             android:defaultValue="@null"/>
     </fragment>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5973

### Description
This PR aims to retain the fee state by using a local fee manager as the source of truth. We were facing the problem that the app calculated the percentage and created an amount fee with the result when selecting a percentage fee. We don't manage such a thing as a percentage fee on the server-side, so, by using it as the source of truth, we couldn't be sure, because all fees were saved as amount fees (FeeLine), whether the user was creating a percentage fee or an amount fee. 
Another problem I found was that when we updated the total order amount by adding new products, the percentage fee, as was calculated once, didn't update. 
What should happen with the percentage fee if we delete all products? 🤔
One solution proposed by Nick was to update the design to reflect what the app was doing (calculating the percentage but stored as an amount) and be consistent with what we have in code. The design needed to update, though.
This PR tries a different solution. It uses a Local Fee Manager to save the Fee state locally (in the device) and use it as the source of truth for Fees. It also solves the other problems mentioned before (recalculate percentages fees when the total order updates and removes the percentage fee when we don't have products). This solution is possible because we don't save the order draft to resume the creation in another device.
I needed to make some concessions and calculate the percentage based on product total and not order total because order total includes taxes. When auto-updated, the percentages ended up with an infinite loop (percentages depend on total and affect taxes -> taxes updates total) if I use order total. Maybe this could be improved to total = product total + shipping total. 🤔
This PR will solve the state problem of the percentage fee and be consistent with the design intentions. Nevertheless, I needed to change the total used for calculating the fees, and it will require some context to maintain this code in the future (the source of truth is the Fee Manager unless the Fee is removed). I would love a confidence check if it is something to push forward or is better to change the UI and be consistent with what we can do on the BE.

### Testing instructions
1. Orders -> New Order -> Create Order
2. Add Product -> Select Product -> Check product total updates.
3. Add Fee -> Enable **Percentage fee** Switch
4. Enter 10 in Percentage(%) EditText -> Press Done -> Check Fee is 10% of Products Total
5. Press + to add another Product -> Check Fee is and Products Total updates (Check fee is 10% of Products Total)
6. Remove all products -> Check the Fee is also removed
7. Press Add Fee -> Check  Enable **Percentage fee** Switch is not visible
8. Enter 100 in Amount ($) EditText -> Press Done -> Check Fee is $100

### Images/gif

Result using products total
https://user-images.githubusercontent.com/18119390/160474169-56ecb5d7-b392-4b07-8976-f0aafe25a8c1.mp4

Result using order total
https://user-images.githubusercontent.com/18119390/160475155-bae00b91-2fa6-4d5b-b388-cc27246f3ed1.mp4



