### PR TITLE
Set `wasabiDebug` a default developer variant

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -123,6 +123,7 @@ android {
         wasabi { // Development only version, can be installed along release versions
             applicationId "com.woocommerce.android.dev"
             dimension "buildType"
+            isDefault true
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release and dev versions.
@@ -142,6 +143,7 @@ android {
         debug {
             minifyEnabled false
             pseudoLocalesEnabled true
+            isDefault true
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6110 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR sets `wasabiDebug` a default variant when opening Android Studio for the first time (or after clean). For arguments for that please see #6110 .

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
To make things easier I suggest going with a fresh clone
1. `git clone git@github.com:woocommerce/woocommerce-android.git woo2`
2. Checkout this branch: `git checkout origin/issue/6110_default_variant`
3. Prepare repository: `cd woo2 && cp gradle.properties-example gradle.properties` 
4. Open new repository in Android Studio
5. Click on `Trust project`
6. Wait for sync
7. See in `variants` tab that `wasabiDebug` is selected

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="447" alt="image" src="https://user-images.githubusercontent.com/5845095/160584746-bc0339f3-434e-4e20-b1b4-e9b3d76df991.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
