### PR TITLE
Issue/5377 product tags adapter exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -26,10 +26,6 @@ class ProductTagsAdapter(
         fun onProductTagRemoved(productTag: ProductTag)
     }
 
-    fun setProductTags(productTags: List<ProductTag>) {
-        submitList(productTags)
-    }
-
     override fun getItemId(position: Int) = getItem(position).remoteTagId
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductTagViewHolder {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -17,12 +17,6 @@ class ProductTagsAdapter(
 ) : ListAdapter<ProductTag, ProductTagViewHolder>(ProductTagDiffCallback) {
     private var currentFilter: String = ""
 
-    var productTags: List<ProductTag> = emptyList()
-        set(value) {
-            submitList(value)
-            field = value
-        }
-
     init {
         setHasStableIds(true)
     }
@@ -32,9 +26,11 @@ class ProductTagsAdapter(
         fun onProductTagRemoved(productTag: ProductTag)
     }
 
-    override fun getItemId(position: Int) = productTags[position].remoteTagId
+    fun setProductTags(productTags: List<ProductTag>) {
+        submitList(productTags)
+    }
 
-    override fun getItemCount() = productTags.size
+    override fun getItemId(position: Int) = getItem(position).remoteTagId
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductTagViewHolder {
         return ProductTagViewHolder(
@@ -43,7 +39,7 @@ class ProductTagsAdapter(
     }
 
     override fun onBindViewHolder(holder: ProductTagViewHolder, position: Int) {
-        holder.bind(productTags[position])
+        holder.bind(getItem(position))
 
         if (position == itemCount - 1) {
             loadMoreListener.onRequestLoadMore()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.ProductTagListItemBinding
 import com.woocommerce.android.model.ProductTag
@@ -13,19 +14,13 @@ import com.woocommerce.android.ui.products.tags.ProductTagsAdapter.ProductTagVie
 class ProductTagsAdapter(
     private val loadMoreListener: OnLoadMoreListener,
     private val clickListener: OnProductTagClickListener
-) : RecyclerView.Adapter<ProductTagViewHolder>() {
+) : ListAdapter<ProductTag, ProductTagViewHolder>(ProductTagDiffCallback) {
     private var currentFilter: String = ""
 
     var productTags: List<ProductTag> = emptyList()
         set(value) {
-            val diffResult = DiffUtil.calculateDiff(
-                ProductTagItemDiffUtil(
-                    field,
-                    value
-                )
-            )
+            submitList(value)
             field = value
-            diffResult.dispatchUpdatesTo(this)
         }
 
     init {
@@ -89,20 +84,18 @@ class ProductTagsAdapter(
         }
     }
 
-    private class ProductTagItemDiffUtil(
-        val oldList: List<ProductTag>,
-        val newList: List<ProductTag>
-    ) : DiffUtil.Callback() {
-        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-            oldList[oldItemPosition].remoteTagId == newList[newItemPosition].remoteTagId
+    object ProductTagDiffCallback : DiffUtil.ItemCallback<ProductTag>() {
+        override fun areItemsTheSame(
+            oldItem: ProductTag,
+            newItem: ProductTag
+        ): Boolean {
+            return oldItem.remoteTagId == newItem.remoteTagId
+        }
 
-        override fun getOldListSize(): Int = oldList.size
-
-        override fun getNewListSize(): Int = newList.size
-
-        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            val oldItem = oldList[oldItemPosition]
-            val newItem = newList[newItemPosition]
+        override fun areContentsTheSame(
+            oldItem: ProductTag,
+            newItem: ProductTag
+        ): Boolean {
             return oldItem == newItem
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -14,8 +14,19 @@ class ProductTagsAdapter(
     private val loadMoreListener: OnLoadMoreListener,
     private val clickListener: OnProductTagClickListener
 ) : RecyclerView.Adapter<ProductTagViewHolder>() {
-    private val productTags = ArrayList<ProductTag>()
     private var currentFilter: String = ""
+
+    var productTags: List<ProductTag> = emptyList()
+        set(value) {
+            val diffResult = DiffUtil.calculateDiff(
+                ProductTagItemDiffUtil(
+                    field,
+                    value
+                )
+            )
+            field = value
+            diffResult.dispatchUpdatesTo(this)
+        }
 
     init {
         setHasStableIds(true)
@@ -42,18 +53,6 @@ class ProductTagsAdapter(
         if (position == itemCount - 1) {
             loadMoreListener.onRequestLoadMore()
         }
-    }
-
-    fun setProductTags(productsTags: List<ProductTag>) {
-        if (productsTags == this.productTags) {
-            return
-        }
-
-        val diffResult =
-            DiffUtil.calculateDiff(ProductTagItemDiffUtil(this.productTags, productsTags))
-        this.productTags.clear()
-        this.productTags.addAll(productsTags)
-        diffResult.dispatchUpdatesTo(this)
     }
 
     fun hasFilter() = currentFilter.isNotEmpty()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -175,7 +175,7 @@ class ProductTagsFragment :
     }
 
     private fun showProductTags(productTags: List<ProductTag>) {
-        productTagsAdapter.setProductTags(productTags)
+        productTagsAdapter.submitList(productTags)
         updateSelectedTags()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -175,7 +175,7 @@ class ProductTagsFragment :
     }
 
     private fun showProductTags(productTags: List<ProductTag>) {
-        productTagsAdapter.setProductTags(productTags)
+        productTagsAdapter.productTags = productTags
         updateSelectedTags()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -175,7 +175,7 @@ class ProductTagsFragment :
     }
 
     private fun showProductTags(productTags: List<ProductTag>) {
-        productTagsAdapter.productTags = productTags
+        productTagsAdapter.setProductTags(productTags)
         updateSelectedTags()
     }
 


### PR DESCRIPTION
This is an attempt to fix #5377, which so far we've not been able to reproduce but as of today it has been experienced by 127 users for a total of 1.1k events.

@wzieba I'm requesting your review since on the issue [you suggested](https://github.com/woocommerce/woocommerce-android/issues/5377#issuecomment-982372857):

1. > Changing `ProductTagsAdapter` to override from `androidx.recyclerview.widget.ListAdapter` so diff will be computed on the background thread
2. > Simplify `ProductTagsAdapter#setProductTags` - I think it could have only one line that delegates all diff calculations to `DiffUtil#calculateDiff`

This PR makes both those changes,