### PR TITLE
Fix feature feedback tag tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
@@ -48,15 +48,15 @@ object FeedbackPrefs {
         FeedbackPrefs.context = context.applicationContext
     }
 
-    fun getFeatureFeedbackSettings(key: FeatureFeedbackSettings.FeatureFeedbackKey) =
-        featureMap[key.value]
+    fun getFeatureFeedbackSettings(feature: FeatureFeedbackSettings.Feature) =
+        featureMap[feature.toString()]
             ?.let { gson.fromJson(it, FeatureFeedbackSettings::class.java) }
 
     fun setFeatureFeedbackSettings(settings: FeatureFeedbackSettings) {
         featureMap
             .toMutableMap()
             .run {
-                set(settings.featureFeedbackKey.value, gson.toJson(settings))
+                set(settings.key, gson.toJson(settings))
                 toMap()
             }
             .let { gson.toJson(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
@@ -48,15 +48,15 @@ object FeedbackPrefs {
         FeedbackPrefs.context = context.applicationContext
     }
 
-    fun getFeatureFeedbackSettings(featureKey: String) =
-        featureMap[featureKey]
+    fun getFeatureFeedbackSettings(feature: FeatureFeedbackSettings.Feature) =
+        featureMap[feature.tag]
             ?.let { gson.fromJson(it, FeatureFeedbackSettings::class.java) }
 
-    fun setFeatureFeedbackSettings(featureKey: String, settings: FeatureFeedbackSettings) {
+    fun setFeatureFeedbackSettings(settings: FeatureFeedbackSettings) {
         featureMap
             .toMutableMap()
             .run {
-                set(featureKey, gson.toJson(settings))
+                set(settings.feature.tag, gson.toJson(settings))
                 toMap()
             }
             .let { gson.toJson(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
@@ -48,7 +48,7 @@ object FeedbackPrefs {
         FeedbackPrefs.context = context.applicationContext
     }
 
-    fun getFeatureFeedbackSettings(key: FeatureFeedbackSettings.FeatureKey) =
+    fun getFeatureFeedbackSettings(key: FeatureFeedbackSettings.FeatureFeedbackKey) =
         featureMap[key.value]
             ?.let { gson.fromJson(it, FeatureFeedbackSettings::class.java) }
 
@@ -56,7 +56,7 @@ object FeedbackPrefs {
         featureMap
             .toMutableMap()
             .run {
-                set(settings.featureKey.value, gson.toJson(settings))
+                set(settings.featureFeedbackKey.value, gson.toJson(settings))
                 toMap()
             }
             .let { gson.toJson(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
@@ -48,15 +48,15 @@ object FeedbackPrefs {
         FeedbackPrefs.context = context.applicationContext
     }
 
-    fun getFeatureFeedbackSettings(feature: FeatureFeedbackSettings.Feature) =
-        featureMap[feature.tag]
+    fun getFeatureFeedbackSettings(key: FeatureFeedbackSettings.FeatureKey) =
+        featureMap[key.value]
             ?.let { gson.fromJson(it, FeatureFeedbackSettings::class.java) }
 
     fun setFeatureFeedbackSettings(settings: FeatureFeedbackSettings) {
         featureMap
             .toMutableMap()
             .run {
-                set(settings.feature.tag, gson.toJson(settings))
+                set(settings.featureKey.value, gson.toJson(settings))
                 toMap()
             }
             .let { gson.toJson(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -4,7 +4,7 @@ import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
 data class FeatureFeedbackSettings(
-    val featureKey: FeatureKey,
+    val featureFeedbackKey: FeatureFeedbackKey,
     val state: FeedbackState = UNANSWERED
 ) {
     fun registerItself() = FeedbackPrefs.setFeatureFeedbackSettings(this)
@@ -23,7 +23,7 @@ data class FeatureFeedbackSettings(
         COUPONS
     }
 
-    data class FeatureKey(
+    data class FeatureFeedbackKey(
         private val requestingView: String,
         private val feature: Feature
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -24,6 +24,6 @@ data class FeatureFeedbackSettings(
         class Coupons(requestingView: String): Feature(requestingView)
 
         val tag
-            get() = requestingView + "_" + javaClass.simpleName
+            get() = requestingView + "_" + this::class.java.simpleName
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -7,6 +7,7 @@ data class FeatureFeedbackSettings(
     val featureKey: FeatureKey,
     val state: FeedbackState = UNANSWERED
 ) {
+    fun registerItself() = FeedbackPrefs.setFeatureFeedbackSettings(this)
 
     enum class FeedbackState {
         GIVEN,
@@ -29,6 +30,4 @@ data class FeatureFeedbackSettings(
         val value
             get() = requestingView + "_" + feature::class.java.simpleName
     }
-
-    fun registerItself() = FeedbackPrefs.setFeatureFeedbackSettings(this)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -4,7 +4,7 @@ import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
 data class FeatureFeedbackSettings(
-    val feature: Feature,
+    val featureKey: FeatureKey,
     val state: FeedbackState = UNANSWERED
 ) {
 
@@ -14,16 +14,21 @@ data class FeatureFeedbackSettings(
         UNANSWERED
     }
 
-    fun registerItself() = FeedbackPrefs.setFeatureFeedbackSettings(this)
-
-    sealed class Feature(private val requestingView: String) {
-        class ShippingLabelM4(requestingView: String): Feature(requestingView)
-        class ProductVariations(requestingView: String): Feature(requestingView)
-        class ProductAddons(requestingView: String): Feature(requestingView)
-        class SimplePayments(requestingView: String): Feature(requestingView)
-        class Coupons(requestingView: String): Feature(requestingView)
-
-        val tag
-            get() = requestingView + "_" + this::class.java.simpleName
+    enum class Feature {
+        SHIPPING_LABEL_M4,
+        PRODUCT_VARIATIONS,
+        PRODUCT_ADDONS,
+        SIMPLE_PAYMENTS,
+        COUPONS
     }
+
+    data class FeatureKey(
+        private val requestingView: String,
+        private val feature: Feature
+    ) {
+        val value
+            get() = requestingView + "_" + feature::class.java.simpleName
+    }
+
+    fun registerItself() = FeedbackPrefs.setFeatureFeedbackSettings(this)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -28,6 +28,6 @@ data class FeatureFeedbackSettings(
         private val feature: Feature
     ) {
         val value
-            get() = requestingView + "_" + feature::class.java.simpleName
+            get() = requestingView + "_" + feature.toString()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -4,11 +4,9 @@ import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
 data class FeatureFeedbackSettings(
-    val name: String,
+    val feature: Feature,
     val state: FeedbackState = UNANSWERED
 ) {
-    val shouldRequestFeedback
-        get() = state == UNANSWERED
 
     enum class FeedbackState {
         GIVEN,
@@ -16,15 +14,16 @@ data class FeatureFeedbackSettings(
         UNANSWERED
     }
 
-    enum class Feature(val description: String) {
-        SHIPPING_LABELS_M4("shipping_labels_m4"),
-        PRODUCTS_VARIATIONS("products_variations"),
-        PRODUCT_ADDONS("product_addons"),
-        SIMPLE_PAYMENTS("simple_payments"),
-        COUPONS("coupons")
-    }
+    fun registerItself() = FeedbackPrefs.setFeatureFeedbackSettings(this)
 
-    fun registerItselfWith(featureKey: String) {
-        FeedbackPrefs.setFeatureFeedbackSettings(featureKey, this)
+    sealed class Feature(private val requestingView: String) {
+        class ShippingLabelM4(requestingView: String): Feature(requestingView)
+        class ProductVariations(requestingView: String): Feature(requestingView)
+        class ProductAddons(requestingView: String): Feature(requestingView)
+        class SimplePayments(requestingView: String): Feature(requestingView)
+        class Coupons(requestingView: String): Feature(requestingView)
+
+        val tag
+            get() = requestingView + "_" + javaClass.simpleName
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -4,9 +4,12 @@ import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
 data class FeatureFeedbackSettings(
-    val featureFeedbackKey: FeatureFeedbackKey,
-    val state: FeedbackState = UNANSWERED
+    val feature: Feature,
+    val feedbackState: FeedbackState = UNANSWERED
 ) {
+    val key
+        get() = feature.toString()
+
     fun registerItself() = FeedbackPrefs.setFeatureFeedbackSettings(this)
 
     enum class FeedbackState {
@@ -21,13 +24,5 @@ data class FeatureFeedbackSettings(
         PRODUCT_ADDONS,
         SIMPLE_PAYMENTS,
         COUPONS
-    }
-
-    data class FeatureFeedbackKey(
-        private val requestingView: String,
-        private val feature: Feature
-    ) {
-        val value
-            get() = requestingView + "_" + feature.toString()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.databinding.FragmentCouponListBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeatureFeedbackKey
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
@@ -27,13 +26,12 @@ import dagger.hilt.android.AndroidEntryPoint
 class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
     companion object {
         const val TAG: String = "CouponListFragment"
-        val feedbackFeatureKey = FeatureFeedbackKey(TAG, SIMPLE_PAYMENTS)
     }
 
     private var _binding: FragmentCouponListBinding? = null
     private val binding get() = _binding!!
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)?.state
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(SIMPLE_PAYMENTS)?.feedbackState
             ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
     private val viewModel: CouponListViewModel by viewModels()
@@ -110,7 +108,7 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
 
     private fun registerFeedbackSetting(state: FeatureFeedbackSettings.FeedbackState) {
         FeatureFeedbackSettings(
-            feedbackFeatureKey,
+            SIMPLE_PAYMENTS,
             state
         ).registerItself()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
@@ -16,10 +16,10 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentCouponListBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.FeatureFeedbackSettings
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SimplePayments
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
-import com.woocommerce.android.ui.orders.list.OrderListFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -31,7 +31,8 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
     private var _binding: FragmentCouponListBinding? = null
     private val binding get() = _binding!!
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)?.state ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(SimplePayments(TAG))?.state
+            ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
     private val viewModel: CouponListViewModel by viewModels()
 
@@ -107,9 +108,9 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
 
     private fun registerFeedbackSetting(state: FeatureFeedbackSettings.FeedbackState) {
         FeatureFeedbackSettings(
-            FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS.name,
+            SimplePayments(TAG),
             state
-        ).registerItselfWith(OrderListFragment.TAG)
+        ).registerItself()
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.databinding.FragmentCouponListBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeatureKey
+import com.woocommerce.android.model.FeatureFeedbackSettings.FeatureFeedbackKey
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
@@ -27,7 +27,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
     companion object {
         const val TAG: String = "CouponListFragment"
-        val feedbackFeatureKey = FeatureKey(TAG, SIMPLE_PAYMENTS)
+        val feedbackFeatureKey = FeatureFeedbackKey(TAG, SIMPLE_PAYMENTS)
     }
 
     private var _binding: FragmentCouponListBinding? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
@@ -16,7 +16,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentCouponListBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SimplePayments
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS
+import com.woocommerce.android.model.FeatureFeedbackSettings.FeatureKey
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
@@ -26,12 +27,13 @@ import dagger.hilt.android.AndroidEntryPoint
 class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
     companion object {
         const val TAG: String = "CouponListFragment"
+        val feedbackFeatureKey = FeatureKey(TAG, SIMPLE_PAYMENTS)
     }
 
     private var _binding: FragmentCouponListBinding? = null
     private val binding get() = _binding!!
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(SimplePayments(TAG))?.state
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)?.state
             ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
     private val viewModel: CouponListViewModel by viewModels()
@@ -108,7 +110,7 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
 
     private fun registerFeedbackSetting(state: FeatureFeedbackSettings.FeedbackState) {
         FeatureFeedbackSettings(
-            SimplePayments(TAG),
+            feedbackFeatureKey,
             state
         ).registerItself()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.*
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SHIPPING_LABEL_M4
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
@@ -74,7 +75,6 @@ import javax.inject.Inject
 class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderProductActionListener {
     companion object {
         val TAG: String = OrderDetailFragment::class.java.simpleName
-        val feedbackFeatureKey = FeatureFeedbackKey(TAG, Feature.SHIPPING_LABEL_M4)
     }
 
     private val viewModel: OrderDetailViewModel by viewModels()
@@ -99,7 +99,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         }
 
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)?.state
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(SHIPPING_LABEL_M4)?.feedbackState
             ?: UNANSWERED
 
     override fun onResume() {
@@ -518,7 +518,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
 
     private fun registerFeedbackSetting(state: FeedbackState) {
         FeatureFeedbackSettings(
-            feedbackFeatureKey,
+            SHIPPING_LABEL_M4,
             state
         ).registerItself()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -74,7 +74,7 @@ import javax.inject.Inject
 class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderProductActionListener {
     companion object {
         val TAG: String = OrderDetailFragment::class.java.simpleName
-        val feedbackFeatureKey = FeatureKey(TAG, Feature.SHIPPING_LABEL_M4)
+        val feedbackFeatureKey = FeatureFeedbackKey(TAG, Feature.SHIPPING_LABEL_M4)
     }
 
     private val viewModel: OrderDetailViewModel by viewModels()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -74,6 +74,7 @@ import javax.inject.Inject
 class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderProductActionListener {
     companion object {
         val TAG: String = OrderDetailFragment::class.java.simpleName
+        val feedbackFeatureKey = FeatureKey(TAG, Feature.SHIPPING_LABEL_M4)
     }
 
     private val viewModel: OrderDetailViewModel by viewModels()
@@ -98,7 +99,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         }
 
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(Feature.ShippingLabelM4(TAG))?.state
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)?.state
             ?: UNANSWERED
 
     override fun onResume() {
@@ -517,7 +518,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
 
     private fun registerFeedbackSetting(state: FeedbackState) {
         FeatureFeedbackSettings(
-            Feature.ShippingLabelM4(TAG),
+            feedbackFeatureKey,
             state
         ).registerItself()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -30,8 +30,7 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SHIPPING_LABELS_M4
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
+import com.woocommerce.android.model.FeatureFeedbackSettings.*
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
@@ -99,7 +98,8 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         }
 
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)?.state ?: UNANSWERED
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(Feature.ShippingLabelM4(TAG))?.state
+            ?: UNANSWERED
 
     override fun onResume() {
         super.onResume()
@@ -516,8 +516,10 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
     }
 
     private fun registerFeedbackSetting(state: FeedbackState) {
-        FeatureFeedbackSettings(SHIPPING_LABELS_M4.name, state)
-            .run { FeedbackPrefs.setFeatureFeedbackSettings(TAG, this) }
+        FeatureFeedbackSettings(
+            Feature.ShippingLabelM4(TAG),
+            state
+        ).registerItself()
     }
 
     private fun displayUndoSnackbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.*
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.*
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -55,7 +56,6 @@ class OrderListFragment :
         const val STATE_KEY_IS_SEARCHING = "is_searching"
         private const val SEARCH_TYPING_DELAY_MS = 500L
         const val FILTER_CHANGE_NOTICE_KEY = "filters_changed_notice"
-        val feedbackFeatureKey = FeatureFeedbackKey(TAG, Feature.SIMPLE_PAYMENTS)
     }
 
     @Inject internal lateinit var uiMessageResolver: UIMessageResolver
@@ -92,7 +92,7 @@ class OrderListFragment :
         get() = binding.orderListView.emptyView
 
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)?.state
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(SIMPLE_PAYMENTS)?.feedbackState
             ?: FeedbackState.UNANSWERED
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -566,7 +566,7 @@ class OrderListFragment :
 
     private fun registerFeedbackSetting(state: FeedbackState) {
         FeatureFeedbackSettings(
-            feedbackFeatureKey,
+            SIMPLE_PAYMENTS,
             state
         ).registerItself()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -55,7 +55,7 @@ class OrderListFragment :
         const val STATE_KEY_IS_SEARCHING = "is_searching"
         private const val SEARCH_TYPING_DELAY_MS = 500L
         const val FILTER_CHANGE_NOTICE_KEY = "filters_changed_notice"
-        val feedbackFeatureKey = FeatureKey(TAG, Feature.SIMPLE_PAYMENTS)
+        val feedbackFeatureKey = FeatureFeedbackKey(TAG, Feature.SIMPLE_PAYMENTS)
     }
 
     @Inject internal lateinit var uiMessageResolver: UIMessageResolver

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -24,7 +24,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SimplePayments
+import com.woocommerce.android.model.FeatureFeedbackSettings.*
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -55,6 +55,7 @@ class OrderListFragment :
         const val STATE_KEY_IS_SEARCHING = "is_searching"
         private const val SEARCH_TYPING_DELAY_MS = 500L
         const val FILTER_CHANGE_NOTICE_KEY = "filters_changed_notice"
+        val feedbackFeatureKey = FeatureKey(TAG, Feature.SIMPLE_PAYMENTS)
     }
 
     @Inject internal lateinit var uiMessageResolver: UIMessageResolver
@@ -91,8 +92,8 @@ class OrderListFragment :
         get() = binding.orderListView.emptyView
 
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(SimplePayments(TAG))?.state
-            ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)?.state
+            ?: FeedbackState.UNANSWERED
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -520,7 +521,7 @@ class OrderListFragment :
 
     private fun displaySimplePaymentsWIPCard(show: Boolean) {
         if (!show ||
-            feedbackState == FeatureFeedbackSettings.FeedbackState.DISMISSED ||
+            feedbackState == FeedbackState.DISMISSED ||
             !viewModel.isCardReaderOnboardingCompleted()
         ) {
             binding.simplePaymentsWIPcard.isVisible = false
@@ -545,7 +546,7 @@ class OrderListFragment :
                 AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
             )
         )
-        registerFeedbackSetting(FeatureFeedbackSettings.FeedbackState.GIVEN)
+        registerFeedbackSetting(FeedbackState.GIVEN)
         NavGraphMainDirections
             .actionGlobalFeedbackSurveyFragment(SurveyType.SIMPLE_PAYMENTS)
             .apply { findNavController().navigateSafely(this) }
@@ -559,13 +560,13 @@ class OrderListFragment :
                 AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
             )
         )
-        registerFeedbackSetting(FeatureFeedbackSettings.FeedbackState.DISMISSED)
+        registerFeedbackSetting(FeedbackState.DISMISSED)
         displaySimplePaymentsWIPCard(false)
     }
 
-    private fun registerFeedbackSetting(state: FeatureFeedbackSettings.FeedbackState) {
+    private fun registerFeedbackSetting(state: FeedbackState) {
         FeatureFeedbackSettings(
-            SimplePayments(TAG),
+            feedbackFeatureKey,
             state
         ).registerItself()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.FeatureFeedbackSettings
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SimplePayments
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -90,7 +91,8 @@ class OrderListFragment :
         get() = binding.orderListView.emptyView
 
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)?.state ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(SimplePayments(TAG))?.state
+            ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -563,8 +565,8 @@ class OrderListFragment :
 
     private fun registerFeedbackSetting(state: FeatureFeedbackSettings.FeedbackState) {
         FeatureFeedbackSettings(
-            FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS.name,
+            SimplePayments(TAG),
             state
-        ).registerItselfWith(TAG)
+        ).registerItself()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.extensions.pinFabAboveBottomNavigationBar
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.*
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.PRODUCT_VARIATIONS
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
@@ -61,7 +62,6 @@ class ProductListFragment :
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
         val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
-        val feedbackFeatureKey = FeatureFeedbackKey(TAG, Feature.PRODUCT_VARIATIONS)
     }
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
@@ -85,7 +85,7 @@ class ProductListFragment :
 
     private val feedbackState: FeedbackState
         get() =
-            FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)?.state
+            FeedbackPrefs.getFeatureFeedbackSettings(PRODUCT_VARIATIONS)?.feedbackState
                 ?: UNANSWERED
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -530,7 +530,7 @@ class ProductListFragment :
 
     private fun registerFeedbackSetting(state: FeedbackState) {
         FeatureFeedbackSettings(
-            feedbackFeatureKey,
+            PRODUCT_VARIATIONS,
             state
         ).registerItself()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -61,6 +61,7 @@ class ProductListFragment :
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
         val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
+        val feedbackFeatureKey = FeatureKey(TAG, Feature.PRODUCT_VARIATIONS)
     }
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
@@ -84,7 +85,7 @@ class ProductListFragment :
 
     private val feedbackState: FeedbackState
         get() =
-            FeedbackPrefs.getFeatureFeedbackSettings(Feature.ProductVariations(TAG))?.state
+            FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)?.state
                 ?: UNANSWERED
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -529,7 +530,7 @@ class ProductListFragment :
 
     private fun registerFeedbackSetting(state: FeedbackState) {
         FeatureFeedbackSettings(
-            Feature.ProductVariations(TAG),
+            feedbackFeatureKey,
             state
         ).registerItself()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -61,7 +61,7 @@ class ProductListFragment :
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
         val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
-        val feedbackFeatureKey = FeatureKey(TAG, Feature.PRODUCT_VARIATIONS)
+        val feedbackFeatureKey = FeatureFeedbackKey(TAG, Feature.PRODUCT_VARIATIONS)
     }
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -30,7 +30,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.pinFabAboveBottomNavigationBar
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
+import com.woocommerce.android.model.FeatureFeedbackSettings.*
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
@@ -60,7 +60,6 @@ class ProductListFragment :
     OnActionExpandListener {
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
-        val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCTS_VARIATIONS
         val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
     }
 
@@ -85,9 +84,8 @@ class ProductListFragment :
 
     private val feedbackState: FeedbackState
         get() =
-            FeedbackPrefs.getFeatureFeedbackSettings(TAG)
-                ?.takeIf { it.name == CURRENT_WIP_NOTICE_FEATURE.name }
-                ?.state ?: UNANSWERED
+            FeedbackPrefs.getFeatureFeedbackSettings(Feature.ProductVariations(TAG))?.state
+                ?: UNANSWERED
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -530,8 +528,10 @@ class ProductListFragment :
     }
 
     private fun registerFeedbackSetting(state: FeedbackState) {
-        FeatureFeedbackSettings(CURRENT_WIP_NOTICE_FEATURE.name, state)
-            .run { FeedbackPrefs.setFeatureFeedbackSettings(TAG, this) }
+        FeatureFeedbackSettings(
+            Feature.ProductVariations(TAG),
+            state
+        ).registerItself()
     }
 
     override fun shouldExpandToolbar(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -31,10 +31,6 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
-    companion object {
-        val TAG: String = OrderedAddonFragment::class.java.simpleName
-    }
-
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     private val viewModel: OrderedAddonViewModel by viewModels()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderedAddonBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.products.addons.AddonListAdapter
@@ -34,7 +33,6 @@ import javax.inject.Inject
 class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     companion object {
         val TAG: String = OrderedAddonFragment::class.java.simpleName
-        val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCT_ADDONS
     }
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -8,13 +8,12 @@ import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.*
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.PRODUCT_ADDONS
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
-import com.woocommerce.android.ui.products.addons.order.OrderedAddonFragment.Companion.TAG
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -38,7 +37,6 @@ class OrderedAddonViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
-        private val feedbackFeatureKey = FeatureFeedbackKey(TAG, Feature.PRODUCT_ADDONS)
     }
 
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
@@ -48,8 +46,8 @@ class OrderedAddonViewModel @Inject constructor(
     val orderedAddonsData: LiveData<List<Addon>> = _orderedAddons
 
     private val currentFeedbackSettings
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)
-            ?: FeatureFeedbackSettings(feedbackFeatureKey)
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(PRODUCT_ADDONS)
+            ?: FeatureFeedbackSettings(PRODUCT_ADDONS)
                 .apply { registerItself() }
 
     /**
@@ -79,7 +77,7 @@ class OrderedAddonViewModel @Inject constructor(
         trackFeedback(AnalyticsTracker.VALUE_FEEDBACK_GIVEN)
 
         FeatureFeedbackSettings(
-            feedbackFeatureKey,
+            PRODUCT_ADDONS,
             GIVEN
         ).registerItself()
 
@@ -90,7 +88,7 @@ class OrderedAddonViewModel @Inject constructor(
         trackFeedback(AnalyticsTracker.VALUE_FEEDBACK_DISMISSED)
 
         FeatureFeedbackSettings(
-            feedbackFeatureKey,
+            PRODUCT_ADDONS,
             DISMISSED
         ).registerItself()
 
@@ -183,7 +181,7 @@ class OrderedAddonViewModel @Inject constructor(
             viewState = viewState.copy(
                 isSkeletonShown = false,
                 isLoadingFailure = false,
-                shouldDisplayFeedbackCard = currentFeedbackSettings.state != DISMISSED
+                shouldDisplayFeedbackCard = currentFeedbackSettings.feedbackState != DISMISSED
             )
             track(result)
             _orderedAddons.value = result

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.FeatureFeedbackSettings
+import com.woocommerce.android.model.FeatureFeedbackSettings.*
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
 import com.woocommerce.android.model.Order
@@ -45,10 +46,12 @@ class OrderedAddonViewModel @Inject constructor(
     private val _orderedAddons = MutableLiveData<List<Addon>>()
     val orderedAddonsData: LiveData<List<Addon>> = _orderedAddons
 
+    private val feedbackFeature = Feature.ProductAddons(TAG)
+
     private val currentFeedbackSettings
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)
-            ?: FeatureFeedbackSettings(OrderedAddonFragment.CURRENT_WIP_NOTICE_FEATURE.name)
-                .apply { registerItselfWith(TAG) }
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeature)
+            ?: FeatureFeedbackSettings(feedbackFeature)
+                .apply { registerItself() }
 
     /**
      * Provides the currencyCode for views who requires display prices
@@ -77,9 +80,9 @@ class OrderedAddonViewModel @Inject constructor(
         trackFeedback(AnalyticsTracker.VALUE_FEEDBACK_GIVEN)
 
         FeatureFeedbackSettings(
-            OrderedAddonFragment.CURRENT_WIP_NOTICE_FEATURE.name,
+            feedbackFeature,
             GIVEN
-        ).registerItselfWith(TAG)
+        ).registerItself()
 
         triggerEvent(ShowSurveyView)
     }
@@ -88,9 +91,9 @@ class OrderedAddonViewModel @Inject constructor(
         trackFeedback(AnalyticsTracker.VALUE_FEEDBACK_DISMISSED)
 
         FeatureFeedbackSettings(
-            OrderedAddonFragment.CURRENT_WIP_NOTICE_FEATURE.name,
+            feedbackFeature,
             DISMISSED
-        ).registerItselfWith(TAG)
+        ).registerItself()
 
         viewState = viewState.copy(shouldDisplayFeedbackCard = false)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -38,6 +38,7 @@ class OrderedAddonViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
+        private val feedbackFeatureKey = FeatureKey(TAG, Feature.PRODUCT_ADDONS)
     }
 
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
@@ -46,11 +47,9 @@ class OrderedAddonViewModel @Inject constructor(
     private val _orderedAddons = MutableLiveData<List<Addon>>()
     val orderedAddonsData: LiveData<List<Addon>> = _orderedAddons
 
-    private val feedbackFeature = Feature.ProductAddons(TAG)
-
     private val currentFeedbackSettings
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeature)
-            ?: FeatureFeedbackSettings(feedbackFeature)
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(feedbackFeatureKey)
+            ?: FeatureFeedbackSettings(feedbackFeatureKey)
                 .apply { registerItself() }
 
     /**
@@ -80,7 +79,7 @@ class OrderedAddonViewModel @Inject constructor(
         trackFeedback(AnalyticsTracker.VALUE_FEEDBACK_GIVEN)
 
         FeatureFeedbackSettings(
-            feedbackFeature,
+            feedbackFeatureKey,
             GIVEN
         ).registerItself()
 
@@ -91,7 +90,7 @@ class OrderedAddonViewModel @Inject constructor(
         trackFeedback(AnalyticsTracker.VALUE_FEEDBACK_DISMISSED)
 
         FeatureFeedbackSettings(
-            feedbackFeature,
+            feedbackFeatureKey,
             DISMISSED
         ).registerItself()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -38,7 +38,7 @@ class OrderedAddonViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
-        private val feedbackFeatureKey = FeatureKey(TAG, Feature.PRODUCT_ADDONS)
+        private val feedbackFeatureKey = FeatureFeedbackKey(TAG, Feature.PRODUCT_ADDONS)
     }
 
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
@@ -9,22 +9,17 @@ class FeatureFeedbackSettingsTest {
 
     @Test
     fun `when settings is created with no define state, then set it as UNANSWERED by default`() {
-        val featureKey = FeatureFeedbackKey("testViewName", Feature.values().first())
+        sut = FeatureFeedbackSettings(Feature.values().first())
 
-        sut = FeatureFeedbackSettings(featureFeedbackKey = featureKey)
-
-        assertThat(sut.state).isEqualTo(FeedbackState.UNANSWERED)
+        assertThat(sut.feedbackState).isEqualTo(FeedbackState.UNANSWERED)
     }
 
     @Test
     fun `when settings is created, then set tag value as requesting view with Feature class simple name`() {
-        val requestingViewName = "testViewName"
         val selectedFeature = Feature.values().first()
-        val featureKey = FeatureFeedbackKey(requestingViewName, selectedFeature)
 
-        sut = FeatureFeedbackSettings(featureFeedbackKey = featureKey)
+        sut = FeatureFeedbackSettings(selectedFeature)
 
-        val expectedTag = requestingViewName + "_" + selectedFeature.toString()
-        assertThat(sut.featureFeedbackKey.value).isEqualTo(expectedTag)
+        assertThat(sut.key).isEqualTo(selectedFeature.toString())
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
@@ -9,9 +9,9 @@ class FeatureFeedbackSettingsTest {
 
     @Test
     fun `when settings is created with no define state, then set it as UNANSWERED by default`() {
-        val featureKey = FeatureKey("testViewName", Feature.values().first())
+        val featureKey = FeatureFeedbackKey("testViewName", Feature.values().first())
 
-        sut = FeatureFeedbackSettings(featureKey = featureKey)
+        sut = FeatureFeedbackSettings(featureFeedbackKey = featureKey)
 
         assertThat(sut.state).isEqualTo(FeedbackState.UNANSWERED)
     }
@@ -20,11 +20,11 @@ class FeatureFeedbackSettingsTest {
     fun `when settings is created, then set tag value as requesting view with Feature class simple name`() {
         val requestingViewName = "testViewName"
         val selectedFeature = Feature.values().first()
-        val featureKey = FeatureKey(requestingViewName, selectedFeature)
+        val featureKey = FeatureFeedbackKey(requestingViewName, selectedFeature)
 
-        sut = FeatureFeedbackSettings(featureKey = featureKey)
+        sut = FeatureFeedbackSettings(featureFeedbackKey = featureKey)
 
         val expectedTag = requestingViewName + "_" + selectedFeature.toString()
-        assertThat(sut.featureKey.value).isEqualTo(expectedTag)
+        assertThat(sut.featureFeedbackKey.value).isEqualTo(expectedTag)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
@@ -1,23 +1,29 @@
 package com.woocommerce.android.model
 
-import org.junit.Before
+import com.woocommerce.android.model.FeatureFeedbackSettings.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class FeatureFeedbackSettingsTest {
-    private lateinit var sut: FeatureFeedbackSettingsTest
-
-    @Before
-    fun setUp() {
-
-    }
+    private lateinit var sut: FeatureFeedbackSettings
 
     @Test
     fun `when settings is created with no define state, then set it as UNANSWERED by default`() {
+        sut = FeatureFeedbackSettings(
+            feature = Feature.SimplePayments("test-view-name")
+        )
 
+        assertThat(sut.state).isEqualTo(FeedbackState.UNANSWERED)
     }
 
     @Test
     fun `when settings is created, then set tag value as requesting view with Feature class simple name`() {
+        sut = FeatureFeedbackSettings(
+            feature = Feature.ProductVariations("test-view-name")
+        )
 
+        assertThat(sut.feature.tag).isEqualTo("")
     }
+
+
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.model
+
+import org.junit.Before
+import org.junit.Test
+
+class FeatureFeedbackSettingsTest {
+    private lateinit var sut: FeatureFeedbackSettingsTest
+
+    @Before
+    fun setUp() {
+
+    }
+
+    @Test
+    fun `when settings is created with no define state, then set it as UNANSWERED by default`() {
+
+    }
+
+    @Test
+    fun `when settings is created, then set tag value as requesting view with Feature class simple name`() {
+
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
@@ -9,9 +9,9 @@ class FeatureFeedbackSettingsTest {
 
     @Test
     fun `when settings is created with no define state, then set it as UNANSWERED by default`() {
-        sut = FeatureFeedbackSettings(
-            feature = Feature.SimplePayments("test-view-name")
-        )
+        val featureKey = FeatureKey("testViewName", Feature.values().first())
+
+        sut = FeatureFeedbackSettings(featureKey = featureKey)
 
         assertThat(sut.state).isEqualTo(FeedbackState.UNANSWERED)
     }
@@ -19,12 +19,13 @@ class FeatureFeedbackSettingsTest {
     @Test
     fun `when settings is created, then set tag value as requesting view with Feature class simple name`() {
         val requestingViewName = "testViewName"
-        val feature = Feature.ProductVariations(requestingViewName)
+        val selectedFeature = Feature.values().first()
+        val featureKey = FeatureKey(requestingViewName, selectedFeature)
 
-        sut = FeatureFeedbackSettings(feature = feature)
+        sut = FeatureFeedbackSettings(featureKey = featureKey)
 
-        val expectedTag = requestingViewName + "_" + feature::class.java.simpleName
-        assertThat(sut.feature.tag).isEqualTo(expectedTag)
+        val expectedTag = requestingViewName + "_" + selectedFeature::class.java.simpleName
+        assertThat(sut.featureKey.value).isEqualTo(expectedTag)
     }
 
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
@@ -27,6 +27,4 @@ class FeatureFeedbackSettingsTest {
         val expectedTag = requestingViewName + "_" + selectedFeature::class.java.simpleName
         assertThat(sut.featureKey.value).isEqualTo(expectedTag)
     }
-
-
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
@@ -18,11 +18,13 @@ class FeatureFeedbackSettingsTest {
 
     @Test
     fun `when settings is created, then set tag value as requesting view with Feature class simple name`() {
-        sut = FeatureFeedbackSettings(
-            feature = Feature.ProductVariations("test-view-name")
-        )
+        val requestingViewName = "testViewName"
+        val feature = Feature.ProductVariations(requestingViewName)
 
-        assertThat(sut.feature.tag).isEqualTo("")
+        sut = FeatureFeedbackSettings(feature = feature)
+
+        val expectedTag = requestingViewName + "_" + feature::class.java.simpleName
+        assertThat(sut.feature.tag).isEqualTo(expectedTag)
     }
 
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/FeatureFeedbackSettingsTest.kt
@@ -24,7 +24,7 @@ class FeatureFeedbackSettingsTest {
 
         sut = FeatureFeedbackSettings(featureKey = featureKey)
 
-        val expectedTag = requestingViewName + "_" + selectedFeature::class.java.simpleName
+        val expectedTag = requestingViewName + "_" + selectedFeature.toString()
         assertThat(sut.featureKey.value).isEqualTo(expectedTag)
     }
 }


### PR DESCRIPTION
Summary
==========
Fixes issue #6118 by refactoring how we store the state of Feedback using the feature as the state key, this way, we make the feedback state related to the feature itself, not the requesting view, and when a new Feature is added, a new state is stored.

⚠️ With this change, we will end up resetting the state of each Feedback banner interaction with all merchants, but since the banner is non-intrusive and this bug affects our capability of displaying the banner for new relevant features, I think it's worth it.

How to Test
==========
1. Do a fresh install of the Woo app
2. Go to the Order list and hit `Dismiss` to the current feedback feature banner there
3. Go back to the code and add to the `FeedbackFeatureSettings` a new kind of Feature and change it inside the `ProductListFragment`or any other view using Feedback banners.
4. Verify that this new feature state is still set as `Unanswered` and the banner is correctly displayed for that view.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
