### PR TITLE
Issue/6120 Removes setting receipt email

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -66,7 +66,6 @@ internal class CreatePaymentAction(
             .setCurrency(paymentInfo.currency)
             .setMetadata(createMetaData(paymentInfo))
         with(paymentInfo) {
-            customerEmail?.takeIf { it.isNotEmpty() }?.let { builder.setReceiptEmail(it) }
             statementDescriptor?.takeIf { it.isNotEmpty() }?.let { builder.setStatementDescriptor(it) }
         }
         return builder.build()

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -53,7 +53,6 @@ internal class CreatePaymentActionTest {
         whenever(paymentIntentParametersFactory.createBuilder(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setAmount(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setCurrency(any())).thenReturn(intentParametersBuilder)
-        whenever(intentParametersBuilder.setReceiptEmail(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setDescription(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setMetadata(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.build()).thenReturn(mock())
@@ -121,12 +120,12 @@ internal class CreatePaymentActionTest {
     }
 
     @Test
-    fun `when customer email not empty, then PaymentIntent setReceiptEmail invoked`() = runBlockingTest {
+    fun `when customer email not empty, then PaymentIntent setReceiptEmail not invoked`() = runBlockingTest {
         val expectedEmail = "test@test.cz"
 
         action.createPaymentIntent(createPaymentInfo(customerEmail = expectedEmail)).toList()
 
-        verify(intentParametersBuilder).setReceiptEmail(expectedEmail)
+        verify(intentParametersBuilder, never()).setReceiptEmail(any())
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6120 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As we have the plan to stop using Stripe's email generation mechanism, this PR removes setting this as part of the payment intent. More details - pdjVC1-sB-p2#comment-672

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Try to collect payment. Check receipt generation and sending


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->