### PR TITLE
Use `jalapeno` for running CI checks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,7 +27,7 @@ steps:
     command: |
       echo "--- 🧹 Linting"
       cp gradle.properties-example gradle.properties
-      ./gradlew lintVanillaRelease
+      ./gradlew lintJalapenoDebug
     plugins: *common_plugins
     artifact_paths:
       - "**/build/reports/lint-results*.*"
@@ -36,21 +36,21 @@ steps:
     command: |
       echo "--- 🧪 Testing"
       cp gradle.properties-example gradle.properties
-      ./gradlew testVanillaRelease
+      ./gradlew testJalapenoDebug
     plugins: *common_plugins
 
   - label: "Test CardReaderModule"
     command: |
       echo "--- 🧪 Testing"
       cp gradle.properties-example gradle.properties
-      ./gradlew lib:cardreader:testRelease
+      ./gradlew lib:cardreader:testDebug
     plugins: *common_plugins
 
   - label: "Ensure Screenshot Tests Build"
     command: |
       echo "--- ⚒️ Building"
       cp gradle.properties-example gradle.properties
-      ./gradlew assembleVanillaDebugAndroidTest
+      ./gradlew assembleJalapenoDebugAndroidTest
     plugins: *common_plugins
 
   - label: "🛠 Installable Build"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,17 +32,11 @@ steps:
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  - label: "Test WooCommerce"
+  - label: "Unit tests"
     command: |
       echo "--- 🧪 Testing"
       cp gradle.properties-example gradle.properties
       ./gradlew testJalapenoDebug
-    plugins: *common_plugins
-
-  - label: "Test CardReaderModule"
-    command: |
-      echo "--- 🧪 Testing"
-      cp gradle.properties-example gradle.properties
       ./gradlew lib:cardreader:testDebug
     plugins: *common_plugins
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6124
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates app variant used on CI and consolidates unit tests execution into a one step. For more details please see internal discussion: p91TBi-7YK-p2

Also, I'd suspect some performance improvement of the whole build as previously, we were running checks on both `vanilla` and `jalapeno` variants ([installable build runs](https://github.com/woocommerce/woocommerce-android/blob/trunk/fastlane/Fastfile#L640) `jalapeno`).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
CI checks are sufficient.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->