### PR TITLE
Extract declaration of search typing delay value to app constants

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppConstants.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppConstants.kt
@@ -5,6 +5,7 @@ package com.woocommerce.android
  */
 object AppConstants {
     const val REQUEST_TIMEOUT = 40L * 1000
+    const val SEARCH_TYPING_DELAY_MS = 500L
     const val TWITTER_USERNAME = "woocommerce"
     const val INSTAGRAM_USERNAME = "woocommerce"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.map
+import com.woocommerce.android.AppConstants
 import com.woocommerce.android.extensions.differsFrom
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.ShowProductVariations
@@ -92,7 +93,7 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
         searchJob?.cancel()
         searchJob = launch {
             if (delayed) {
-                delay(SEARCH_TYPING_DELAY_MS)
+                delay(AppConstants.SEARCH_TYPING_DELAY_MS)
             }
             if (query.isEmpty()) {
                 productList.value = emptyList()
@@ -154,8 +155,4 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
     ) : Parcelable
 
     data class AddProduct(val productId: Long) : MultiLiveEvent.Event()
-
-    companion object {
-        private const val SEARCH_TYPING_DELAY_MS = 500L
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -54,7 +54,6 @@ class OrderListFragment :
         const val TAG: String = "OrderListFragment"
         const val STATE_KEY_SEARCH_QUERY = "search-query"
         const val STATE_KEY_IS_SEARCHING = "is_searching"
-        private const val SEARCH_TYPING_DELAY_MS = 500L
         const val FILTER_CHANGE_NOTICE_KEY = "filters_changed_notice"
     }
 
@@ -452,7 +451,7 @@ class OrderListFragment :
                     if (query == it.query.toString()) handleNewSearchRequest(query)
                 }
             },
-            SEARCH_TYPING_DELAY_MS
+            AppConstants.SEARCH_TYPING_DELAY_MS
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R.string
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.extensions.isInteger
@@ -25,9 +26,6 @@ class ProductInventoryViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val productRepository: ProductDetailRepository
 ) : ScopedViewModel(savedState) {
-    companion object {
-        private const val SEARCH_TYPING_DELAY_MS = 500L
-    }
     private val navArgs: ProductInventoryFragmentArgs by savedState.navArgs()
     private val isProduct = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_INVENTORY
 
@@ -79,7 +77,7 @@ class ProductInventoryViewModel @Inject constructor(
                 // so we don't actually perform the fetch until the user stops typing
                 skuVerificationJob?.cancel()
                 skuVerificationJob = launch {
-                    delay(SEARCH_TYPING_DELAY_MS)
+                    delay(AppConstants.SEARCH_TYPING_DELAY_MS)
 
                     // only after the SKU is available remotely, reset the error if it's available locally, as well
                     // to avoid showing/hiding error message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -37,7 +38,6 @@ class ProductListViewModel @Inject constructor(
     mediaFileUploadHandler: MediaFileUploadHandler
 ) : ScopedViewModel(savedState) {
     companion object {
-        private const val SEARCH_TYPING_DELAY_MS = 500L
         private const val KEY_PRODUCT_FILTER_OPTIONS = "key_product_filter_options"
         private const val KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME = "key_product_filter_selected_category_name"
     }
@@ -237,7 +237,7 @@ class ProductListViewModel @Inject constructor(
             // the fetch until the user stops typing
             searchJob?.cancel()
             searchJob = launch {
-                delay(SEARCH_TYPING_DELAY_MS)
+                delay(AppConstants.SEARCH_TYPING_DELAY_MS)
                 if (checkConnection()) {
                     viewState = viewState.copy(
                         isLoading = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
@@ -28,10 +29,6 @@ class ProductSelectionListViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val productRepository: ProductListRepository
 ) : ScopedViewModel(savedState) {
-    companion object {
-        private const val SEARCH_TYPING_DELAY_MS = 500L
-    }
-
     private val navArgs: ProductSelectionListFragmentArgs by savedState.navArgs()
 
     private val _productList = MutableLiveData<List<Product>>()
@@ -130,7 +127,7 @@ class ProductSelectionListViewModel @Inject constructor(
             // the fetch until the user stops typing
             searchJob?.cancel()
             searchJob = launch {
-                delay(SEARCH_TYPING_DELAY_MS)
+                delay(AppConstants.SEARCH_TYPING_DELAY_MS)
                 productSelectionListViewState = productSelectionListViewState.copy(
                     isLoading = true,
                     isLoadingMore = loadMore,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -33,10 +34,6 @@ class ProductTagsFragment :
     BaseProductFragment(R.layout.fragment_product_tags),
     OnLoadMoreListener,
     OnProductTagClickListener {
-    companion object {
-        private const val SEARCH_TYPING_DELAY_MS = 250L
-    }
-
     private lateinit var productTagsAdapter: ProductTagsAdapter
 
     private val skeletonView = SkeletonView()
@@ -115,7 +112,7 @@ class ProductTagsFragment :
                     viewModel.setProductTagsFilter(filter)
                 }
             },
-            SEARCH_TYPING_DELAY_MS
+            AppConstants.SEARCH_TYPING_DELAY_MS
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6073 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR Moves the declaration of `SEARCH_TYPING_DELAY_MS = 500L` to `AppConstants`.

As explained in the original issue, we have `SEARCH_TYPING_DELAY_MS` declared in multiple places, which could be improved by extracting the declaration to `AppConstants` and thus consolidating the delay.

**⚠️ Remark** I didn't touch the value in `ProductTagsFragment` because that appears to have been shortened on purpose in commit [7f90ee53](https://github.com/woocommerce/woocommerce-android/commit/7f90ee53d892bbea36e678888e9871aee1297214#diff-26df6d474da900cdbc6bd48ee7e2247030a686f3000f4d90ea605b4a2743b03fR37).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Verify CI pipelines are green.

The changes are quite trivial, since the actual values in the app don't change — only the reference to where the value is read from — I don't think it's needed to test the search delays via the UI 🤷 .

### PR submission checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

### PR reviewer notes
- One review should be enough for this.