### PR TITLE
Add `flagNoFullScreen` IME options to the Percentage fee Edit Text

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_order_creation_fee.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_fee.xml
@@ -42,8 +42,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_75"
                 android:hint="@string/order_creation_fee_percentage_hint"
-                android:visibility="gone"
+                android:imeOptions="flagNoFullscreen"
                 android:inputType="numberDecimal|numberSigned"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/fee_type_switch" />


### PR DESCRIPTION
Summary
==========
Fix issue #6130 by simply adding the `flagnoFullScreen` configuration to the Percentage fee EditText.

How to Test
==========
1. Go to the Order Creation view
2. Add any Product to the Order
3. Wait for the sync and then hit the `Add Fee` button
4. Activate the percentage toggle and select the percentage EditText
5. Rotate the device to landscape mode and verify that the EdiText doesn't show in fullscreen anymore.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.