### PR TITLE
Fix: Hidden last item in coupon list.

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_coupon_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_coupon_list.xml
@@ -20,9 +20,10 @@
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/couponsComposeView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/couponsWIPcard" />
+        app:layout_constraintTop_toBottomOf="@id/couponsWIPcard"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6115
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes sure the last item in the Coupon list is shown properly when scrolling down.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Have a test site with a lot of coupons (I have 8 in my test site),
2. Start app, go to Menu > Coupons
3. When the coupons are loaded, scroll down and make sure the last item is shown properly with no element hidden/being cut-off.


