### PR TITLE
Adjust order creation views for RTL support

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_order_creation_shipping.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_shipping.xml
@@ -29,6 +29,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/order_creation_shipping_name"
+                android:textDirection="locale"
                 android:imeOptions="flagNoFullscreen"
                 android:inputType="text" />
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>

--- a/WooCommerce/src/main/res/layout/product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_list_item.xml
@@ -56,6 +56,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/minor_00"
             android:ellipsize="end"
+            android:textDirection="locale"
             android:includeFontPadding="false"
             android:maxLines="2"
             tools:text="Awesome Sauce and all that jazz is all I gotta tell you how do we go " />


### PR DESCRIPTION
Summary
==========
Fix issue #6134 by setting the text direction of non-RTL supporting fields to follow the locale language rule. TBH I'm not really sure if using the `textDirection` property would be the best approach to fix this one, but the `start` and `end` constraint of those UI elements seems just fine.

How to Test
==========
1. Set the testing device to any RTL language and test the Order Creation feature to verify if there's any element not following the right alignment rule.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
