### PR TITLE
Improve LiveDataDelegate

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/LiveDataExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/LiveDataExt.kt
@@ -69,12 +69,12 @@ fun <T : Any> LiveData<T?>.filterNotNull(): LiveData<T> {
     return mediator
 }
 
-fun <T, R> LiveData<T>.scan(initialValue: R?, accumulator: (R?, T) -> R): LiveData<R> {
+fun <T, R> LiveData<T>.scan(initialValue: R?, operation: (accumulator: R?, value: T) -> R): LiveData<R> {
     val outputLiveData: MediatorLiveData<R> = MediatorLiveData<R>()
     initialValue?.let { outputLiveData.value = it }
 
     outputLiveData.addSource(this) {
-        outputLiveData.value = accumulator(outputLiveData.value, it)
+        outputLiveData.value = operation(outputLiveData.value, it)
     }
     return outputLiveData
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/LiveDataExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/LiveDataExt.kt
@@ -68,3 +68,13 @@ fun <T : Any> LiveData<T?>.filterNotNull(): LiveData<T> {
     }
     return mediator
 }
+
+fun <T, R> LiveData<T>.scan(initialValue: R?, accumulator: (R?, T) -> R): LiveData<R> {
+    val outputLiveData: MediatorLiveData<R> = MediatorLiveData<R>()
+    initialValue?.let { outputLiveData.value = it }
+
+    outputLiveData.addSource(this) {
+        outputLiveData.value = accumulator(outputLiveData.value, it)
+    }
+    return outputLiveData
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -89,7 +89,6 @@ class ProductDetailViewModel @Inject constructor(
         if (old?.productDraft != new.productDraft) {
             new.productDraft?.let {
                 updateCards(it)
-                draftChanges.value = it
             }
         }
     }
@@ -97,9 +96,11 @@ class ProductDetailViewModel @Inject constructor(
 
     /**
      * The goal of this is to allow composition of reactive streams using the product draft changes,
-     * we need a separate stream because [LiveDataDelegate] supports a single observer.
      */
-    private val draftChanges = MutableStateFlow<Product?>(null)
+    private val draftChanges = productDetailViewStateData.liveData
+        .map { it.productDraft }
+        .asFlow()
+        .shareIn(viewModelScope, started = SharingStarted.WhileSubscribed())
 
     private val storedProduct = MutableStateFlow<Product?>(null)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
@@ -1,12 +1,7 @@
 package com.woocommerce.android.viewmodel
 
 import android.os.Parcelable
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
-import androidx.lifecycle.SavedStateHandle
-import java.lang.IllegalStateException
+import androidx.lifecycle.*
 import kotlin.reflect.KProperty
 
 /**
@@ -58,9 +53,9 @@ class LiveDataDelegate<T : Parcelable>(
         }
     }
 
-    operator fun setValue(ref: Any, p: KProperty<*>, value: T) {
+    operator fun setValue(ref: Any?, p: KProperty<*>, value: T) {
         _liveData.value = value
     }
 
-    operator fun getValue(ref: Any, p: KProperty<*>): T = _liveData.value!!
+    operator fun getValue(ref: Any?, p: KProperty<*>): T = _liveData.value!!
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegateTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegateTests.kt
@@ -74,14 +74,30 @@ class LiveDataDelegateTests : BaseUnitTest() {
         assertThat(new).isEqualTo(ExampleData(1))
     }
 
-
-    // This test fails now
     @Test
     fun `when having two observers, then previous value is calculated correctly`() {
         val livedataDelegate = LiveDataDelegate(SavedStateHandle(), ExampleData(0))
         var dataHolder by livedataDelegate
 
         livedataDelegate.observeForever { _, _ -> }
+
+        var lastData: Pair<ExampleData?, ExampleData?> = Pair(null, null)
+        livedataDelegate.observeForever { old, new ->
+            lastData = Pair(old, new)
+        }
+        dataHolder = dataHolder.copy(data = 1)
+
+        val (old, new) = lastData
+        assertThat(old).isEqualTo(ExampleData(0))
+        assertThat(new).isEqualTo(ExampleData(1))
+    }
+
+    @Test
+    fun `when observing livedata directly, then previous value is calculated correctly`() {
+        val livedataDelegate = LiveDataDelegate(SavedStateHandle(), ExampleData(0))
+        var dataHolder by livedataDelegate
+
+        livedataDelegate.liveData.observeForever { }
 
         var lastData: Pair<ExampleData?, ExampleData?> = Pair(null, null)
         livedataDelegate.observeForever { old, new ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegateTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegateTests.kt
@@ -1,0 +1,99 @@
+package com.woocommerce.android.viewmodel
+
+import android.os.Parcelable
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.SavedStateHandle
+import kotlinx.parcelize.Parcelize
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class LiveDataDelegateTests : BaseUnitTest() {
+    @Test
+    fun `when observed for the first time, then emit initial value`() {
+        val livedataDelegate = LiveDataDelegate(SavedStateHandle(), ExampleData(0))
+
+        livedataDelegate.observeForever { old, new ->
+            assertThat(old).isNull()
+            assertThat(new).isEqualTo(ExampleData(0))
+        }
+    }
+
+    @Test
+    fun `when a new value is set before observing, then the previous value will be null`() {
+        val livedataDelegate = LiveDataDelegate(SavedStateHandle(), ExampleData(0))
+        var dataHolder by livedataDelegate
+
+        dataHolder = dataHolder.copy(data = 1)
+
+        livedataDelegate.observeForever { old, new ->
+            assertThat(old).isEqualTo(null)
+            assertThat(new).isEqualTo(ExampleData(1))
+        }
+    }
+
+    @Test
+    fun `when a new value is set after observing, then emit previous value`() {
+        val livedataDelegate = LiveDataDelegate(SavedStateHandle(), ExampleData(0))
+        var dataHolder by livedataDelegate
+
+        var lastData: Pair<ExampleData?, ExampleData?> = Pair(null, null)
+        livedataDelegate.observeForever { old, new ->
+            lastData = Pair(old, new)
+        }
+        dataHolder = dataHolder.copy(data = 1)
+
+        val (old, new) = lastData
+        assertThat(old).isEqualTo(ExampleData(0))
+        assertThat(new).isEqualTo(ExampleData(1))
+    }
+
+    @Test
+    fun `when an observer is destroyed, then previous value is still calculated correctly`() {
+        val livedataDelegate = LiveDataDelegate(SavedStateHandle(), ExampleData(0))
+        var dataHolder by livedataDelegate
+
+        val lifecycleOwner = object : LifecycleOwner {
+            private val lifecycle = LifecycleRegistry(this)
+            override fun getLifecycle() = lifecycle
+        }
+        livedataDelegate.observe(lifecycleOwner) { _, _ -> }
+        lifecycleOwner.lifecycle.currentState = Lifecycle.State.STARTED
+        lifecycleOwner.lifecycle.currentState = Lifecycle.State.DESTROYED
+
+        dataHolder = dataHolder.copy(data = 1)
+
+        var lastData: Pair<ExampleData?, ExampleData?> = Pair(null, null)
+        livedataDelegate.observeForever { old, new ->
+            lastData = Pair(old, new)
+        }
+
+        val (old, new) = lastData
+        assertThat(old).isEqualTo(ExampleData(0))
+        assertThat(new).isEqualTo(ExampleData(1))
+    }
+
+
+    // This test fails now
+    @Test
+    fun `when having two observers, then previous value is calculated correctly`() {
+        val livedataDelegate = LiveDataDelegate(SavedStateHandle(), ExampleData(0))
+        var dataHolder by livedataDelegate
+
+        livedataDelegate.observeForever { _, _ -> }
+
+        var lastData: Pair<ExampleData?, ExampleData?> = Pair(null, null)
+        livedataDelegate.observeForever { old, new ->
+            lastData = Pair(old, new)
+        }
+        dataHolder = dataHolder.copy(data = 1)
+
+        val (old, new) = lastData
+        assertThat(old).isEqualTo(ExampleData(0))
+        assertThat(new).isEqualTo(ExampleData(1))
+    }
+}
+
+@Parcelize
+data class ExampleData(val data: Int) : Parcelable


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
The current implementation of `LiveDataDelegate` enforces a single observer, which means using its `liveData` property to compose other LiveData streams is not possible, and we need instead to resort to its `onChange` parameter.

A callback function doesn't scale well for making composing reactive streams, so in this PR, I attempt to refactor `LiveDataDelegate` to allow having multiple observers while keeping the calculation of `previousValue` correct.

The functionality now uses the extension `scan` (inspired by the same operator provided by `RxJava` and `Flow`) to keep track of the previous value, and to make sure I don't break the functionality, I added some unit tests before the refactoring, and I made sure they are still green after, I also added new unit tests to test the functionality with multiple observers.

### Testing instructions
Smoke test the app, hopefully this doesn't break anything.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
