### PR TITLE
Updates FluxC to 1.39.0, WordPress-Login-Flow-Android to 0.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-23e8fe682e21e4e045cf365a06ca8be46f55d425'
+    fluxCVersion = '1.39.0'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'
@@ -106,7 +106,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = "2.3.0"
     mediapickerVersion = 'trunk-d0db2634cf27511bec3ef9b837f9cfe27c5ab601'
-    wordPressLoginVersion = 'trunk-d4f9830a9e2d2cbf7e1edec2886af687363b0980'
+    wordPressLoginVersion = '0.13.0'
     aboutAutomatticVersion = '0.0.4'
 
     // Compose and its module versions need to be consistent with each other (for example 'compose-theme-adapter')


### PR DESCRIPTION
WordPress-Login-Flow-Android `0.13.0` points to `d4f9830a9e2d2cbf7e1edec2886af687363b0980`, so this change shouldn't result in any changes.

FluxC `1.39.0` is a few PRs ahead of `d4f9830a9e2d2cbf7e1edec2886af687363b0980`.