### PR TITLE
R8 rule to keep fromSavedStateHandle

### DIFF
--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -73,3 +73,10 @@
 ###### Glide - begin
 -keep class com.bumptech.glide.GeneratedAppGlideModuleImpl { *; }
 ###### Glide - end
+
+###### SavedStateHandleExt - begin
+###### We use reflection so we have to keep this method
+-keepclassmembers class * extends androidx.navigation.NavArgs {
+    fromSavedStateHandle(androidx.lifecycle.SavedStateHandle);
+}
+###### SavedStateHandleExt - end


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Apparently, due to the update of AGP, R8 was updated too. It started to mess with a method we call via reflection. The PR adds a rule to keep this method

Crash:

```
2022-04-05 12:00:16.105 29336-29336/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.woocommerce.android.prealpha, PID: 29336
    java.lang.NoSuchMethodException: com.woocommerce.android.ui.orders.details.OrderDetailFragmentArgs.fromSavedStateHandle [class androidx.lifecycle.SavedStateHandle]
        at java.lang.Class.getMethod(Class.java:2103)
        at java.lang.Class.getMethod(Class.java:1724)
        at com.woocommerce.android.viewmodel.NavArgsLazy.getValue(SavedStateHandleExt.kt:35)
        at com.woocommerce.android.viewmodel.NavArgsLazy.getValue(SavedStateHandleExt.kt:24)
        at com.woocommerce.android.ui.orders.details.OrderDetailViewModel.getNavArgs(OrderDetailViewModel.kt:76)
        at com.woocommerce.android.ui.orders.details.OrderDetailViewModel.access$getNavArgs(OrderDetailViewModel.kt:56)
        at com.woocommerce.android.ui.orders.details.OrderDetailViewModel$start$1.invokeSuspend(OrderDetailViewModel.kt:129)
```

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open order details or/and product details on a production build
* Notice that it doesn't crash anymore
