### PR TITLE
[Coupons] introduce a CouponDetailsRepository

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.coupons.details
+
+import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponUi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.wordpress.android.fluxc.store.CouponStore
+import java.math.BigDecimal
+import javax.inject.Inject
+
+@Suppress("UnusedPrivateMember")
+class CouponDetailsRepository @Inject constructor(private val store: CouponStore) {
+    // TODO This should return a [com.woocommerce.android.model.Coupon] instead of [CouponUi]
+    @Suppress("MagicNumber")
+    fun loadCoupon(couponId: Long): Flow<CouponUi> {
+        return flowOf(
+            CouponUi(
+                id = 1,
+                code = "ABCDE",
+                amount = BigDecimal(25),
+                formattedDiscount = "25%",
+                affectedArticles = "Everything excl. 5 products",
+                formattedSpendingInfo = "Minimum spend of $20 \n\nMaximum spend of $200 \n",
+                isActive = true
+            )
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -4,9 +4,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -15,8 +16,10 @@ import javax.inject.Inject
 class CouponDetailsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val wooCommerceStore: WooCommerceStore,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val couponDetailsRepository: CouponDetailsRepository
 ) : ScopedViewModel(savedState) {
+    private val navArgs by savedState.navArgs<CouponDetailsFragmentArgs>()
     private val currencyCode by lazy {
         wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode
     }
@@ -24,21 +27,8 @@ class CouponDetailsViewModel @Inject constructor(
     val couponState = loadCoupon().asLiveData()
 
     @Suppress("MagicNumber")
-    private fun loadCoupon(): Flow<CouponDetailsState> = flow {
-        emit(
-            CouponDetailsState(
-                coupon = CouponUi(
-                    id = 1,
-                    code = "ABCDE",
-                    amount = BigDecimal(25),
-                    formattedDiscount = "25%",
-                    affectedArticles = "Everything excl. 5 products",
-                    formattedSpendingInfo = "Minimum spend of $20 \n\nMaximum spend of $200 \n",
-                    isActive = true
-                ),
-            )
-        )
-    }
+    private fun loadCoupon(): Flow<CouponDetailsState> = couponDetailsRepository.loadCoupon(navArgs.couponId)
+        .map { CouponDetailsState(coupon = it) }
 
     data class CouponDetailsState(
         val isLoading: Boolean = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -31,6 +32,8 @@ class CouponDetailsViewModel @Inject constructor(
 
     val couponState = combine(couponDetails, couponPerformance) { details, _ ->
         CouponDetailsState(coupon = details)
+    }.onStart {
+        emit(CouponDetailsState(isLoading = true))
     }.catch {
         // TODO trigger an error Snackbar and navigate up
     }.asLiveData()

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -362,15 +362,14 @@
         android:label="CouponListFragment">
         <action
             android:id="@+id/action_couponListFragment_to_couponSummaryFragment"
-            app:destination="@id/couponSummaryFragment">
-            <argument
-                android:name="couponId"
-                app:argType="long" />
-        </action>
+            app:destination="@id/couponSummaryFragment"/>
     </fragment>
     <fragment
         android:id="@+id/couponSummaryFragment"
         android:name="com.woocommerce.android.ui.coupons.details.CouponDetailsFragment"
-        android:label="CouponSummaryFragment" />
-
+        android:label="CouponSummaryFragment" >
+        <argument
+            android:name="couponId"
+            app:argType="long" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
### Description
@hafizrahman this PR is just to set the groundwork for fetching coupon details and the performance report, the goal is to avoid having unmanageable conflicts when working on next PRs, this branch will be the start for my PR about coupon performance report.

### Testing instructions
Make sure the coupon details screen show demo data correctly.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
