### PR TITLE
Add Gradle Enterprise to Project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,16 +179,4 @@ tasks.register("configureApply") {
     }
 }
 
-buildScan {
-    // Always run Gradle scan on CI builds
-    if (System.getenv('CI')) {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
-        tag 'CI'
-        publishAlways()
-        // Otherwise CI might shut down before it's uploaded
-        uploadInBackground = false
-    }
-}
-
 apply from: './config/gradle/jacoco.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,17 @@ gradleEnterprise {
     }
 }
 
+if (System.getenv().containsKey("CI")) {
+    buildCache {
+        remote(HttpBuildCache) {
+            url = "http://10.0.2.215:5071/cache/"
+            allowUntrustedServer = true
+            allowInsecureProtocol = true
+            push = true
+        }
+    }
+}
+
 rootProject.name = 'WCAndroid'
 
 include ':quicklogin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,10 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
+gradleEnterprise {
+    server = "https://gradle.a8c.com"
+}
+
 rootProject.name = 'WCAndroid'
 
 include ':quicklogin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,6 +43,7 @@ pluginManagement {
 
 plugins {
     id 'com.gradle.enterprise' version '3.9'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.5'
 }
 
 gradleEnterprise {

--- a/settings.gradle
+++ b/settings.gradle
@@ -53,6 +53,7 @@ gradleEnterprise {
         capture {
             taskInputFiles = true
         }
+        uploadInBackground = System.getenv("CI") == null
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -47,6 +47,7 @@ plugins {
 
 gradleEnterprise {
     server = "https://gradle.a8c.com"
+    allowUntrustedServer = false
 }
 
 rootProject.name = 'WCAndroid'

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,6 +50,9 @@ gradleEnterprise {
     allowUntrustedServer = false
     buildScan {
         publishAlways()
+        capture {
+            taskInputFiles = true
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,9 @@ plugins {
 gradleEnterprise {
     server = "https://gradle.a8c.com"
     allowUntrustedServer = false
+    buildScan {
+        publishAlways()
+    }
 }
 
 rootProject.name = 'WCAndroid'

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,7 +42,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gradle.enterprise' version '3.8.1'
+    id 'com.gradle.enterprise' version '3.9'
 }
 
 rootProject.name = 'WCAndroid'

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,8 @@ plugins {
     id 'com.gradle.enterprise' version '3.8.1'
 }
 
+rootProject.name = 'WCAndroid'
+
 include ':quicklogin'
 include ':libs:cardreader'
 include ':WooCommerce'

--- a/settings.gradle
+++ b/settings.gradle
@@ -119,15 +119,3 @@ if (localBuilds.exists()) {
         }
     }
 }
-
-// Use the build cache in CI
-if (System.getenv().containsKey("CI")) {
-    buildCache {
-        remote(HttpBuildCache) {
-            url = "http://10.0.2.215:5071/cache/"
-            allowUntrustedServer = true
-            allowInsecureProtocol = true
-            push = true
-        }
-    }
-}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The goal of this PR is to test the `Gradle Enterprise` configuration in order for the GE trial to begin.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Verify builds on [gradle.a8c.com](https://gradle.a8c.com/) (ie `Dashboard`, `Build Scan`, etc).
- CI should also publish to GE (ie `Build Scan` urls, etc).
- Additionally, you could also build and test GE locally (ie `Build Scan` urls, etc).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
