### PR TITLE
Site picker crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -217,7 +217,7 @@ class SitePickerActivity :
             unifiedLoginTracker.getFlow()?.value?.let {
                 outState.putString(KEY_UNIFIED_TRACKER_FLOW, it)
             }
-            outState.putString(KEY_UNIFIED_TRACKER_FLOW, unifiedLoginTracker.getSource().value)
+            outState.putString(KEY_UNIFIED_TRACKER_SOURCE, unifiedLoginTracker.getSource().value)
             outState.putString(KEY_UNIFIED_TRACKER_STEP, unifiedLoginTracker.currentStep?.value)
         }
 


### PR DESCRIPTION
Fixes #6173. This bug was caused by using the wrong key to save the state, which overwrote the original `flow` value.

**To test:**
1. Log in using an email/username
2. When on site picker, rotate the screen multiple times
3. Notice the app doesn't crash