### PR TITLE
[Coupons] Coupons summary section

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -128,7 +128,7 @@ fun CouponListItem(
             )
         }
 
-        CouponListItemInfo(coupon.formattedDiscount, coupon.affectedArticles)
+        CouponListItemInfo(coupon.summary)
 
         CouponExpirationLabel(coupon.isActive)
     }
@@ -136,11 +136,10 @@ fun CouponListItem(
 
 @Composable
 fun CouponListItemInfo(
-    amount: String,
-    affectedArticles: String,
+    summary: String,
 ) {
     Text(
-        text = "$amount ${stringResource(id = R.string.coupon_list_item_label_off)} $affectedArticles",
+        text = summary,
         style = MaterialTheme.typography.body2,
         color = colorResource(id = R.color.color_surface_variant),
         fontSize = 14.sp,
@@ -157,24 +156,21 @@ fun CouponListPreview() {
         CouponListItem(
             id = 1,
             code = "ABCDE",
-            formattedDiscount = "USD 10.00",
-            affectedArticles = "all products",
+            summary = "USD 10.00 off all products",
             isActive = true
         ),
 
         CouponListItem(
             id = 2,
             code = "10off",
-            formattedDiscount = "5%",
-            affectedArticles = "1 product, 2 categories",
+            summary = "5% off 1 product, 2 categories",
             isActive = true
         ),
 
         CouponListItem(
             id = 3,
             code = "BlackFriday",
-            formattedDiscount = "USD 3.00",
-            affectedArticles = "all products",
+            summary = "USD 3.00 off all products",
             isActive = true
         ),
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -117,7 +117,7 @@ fun CouponListItem(
                 enabled = true,
                 onClickLabel = stringResource(id = R.string.coupon_list_view_coupon),
                 role = Role.Button,
-                onClick = { onCouponClick(0L) }
+                onClick = { onCouponClick(coupon.id) }
             ),
         verticalArrangement = Arrangement.spacedBy(0.dp)
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -7,17 +7,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -29,6 +26,7 @@ import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListItem
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListState
+import com.woocommerce.android.ui.coupons.components.CouponExpirationLabel
 
 @Composable
 fun CouponListScreen(viewModel: CouponListViewModel) {
@@ -132,7 +130,7 @@ fun CouponListItem(
 
         CouponListItemInfo(coupon.formattedDiscount, coupon.affectedArticles)
 
-        CouponListExpirationLabel(coupon.isActive)
+        CouponExpirationLabel(coupon.isActive)
     }
 }
 
@@ -148,33 +146,6 @@ fun CouponListItemInfo(
         fontSize = 14.sp,
         modifier = Modifier.padding(vertical = 4.dp)
     )
-}
-
-@Composable
-fun CouponListExpirationLabel(active: Boolean = true) {
-    // todo this should check a coupon's expiration date
-    // to show either "Active" or "Expired" Label
-    Surface(
-        modifier = Modifier
-            .clip(RoundedCornerShape(4.dp, 4.dp, 4.dp, 4.dp))
-    ) {
-        val status = if (active) {
-            stringResource(id = R.string.coupon_list_item_label_active)
-        } else {
-            stringResource(id = R.string.coupon_list_item_label_expired)
-        }
-
-        val color = if (active) colorResource(id = R.color.woo_celadon_5) else colorResource(id = R.color.woo_gray_5)
-
-        Text(
-            text = status,
-            style = MaterialTheme.typography.body1,
-            color = MaterialTheme.colors.onSecondary,
-            modifier = Modifier
-                .background(color = color)
-                .padding(horizontal = 6.dp, vertical = 2.dp)
-        )
-    }
 }
 
 @ExperimentalFoundationApi

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -12,7 +12,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 
 @HiltViewModel
@@ -45,13 +45,7 @@ class CouponListViewModel @Inject constructor(
         return CouponListItem(
             id = id,
             code = code,
-            formattedDiscount = couponUtils.formatDiscount(amount, type, currencyCode),
-            affectedArticles = couponUtils.formatAffectedArticles(
-                products.size,
-                excludedProducts.size,
-                categories.size,
-                excludedCategories.size
-            ),
+            summary = couponUtils.generateSummary(this, currencyCode),
             isActive = dateExpiresGmt?.after(Date()) ?: true
         )
     }
@@ -68,8 +62,7 @@ class CouponListViewModel @Inject constructor(
     data class CouponListItem(
         val id: Long,
         val code: String? = null,
-        val formattedDiscount: String,
-        val affectedArticles: String,
+        val summary: String,
         val isActive: Boolean
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/components/CouponExpirationLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/components/CouponExpirationLabel.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.ui.coupons.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+
+@Composable
+fun CouponExpirationLabel(active: Boolean = true) {
+    // to show either "Active" or "Expired" Label
+    Surface(
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp, 4.dp, 4.dp, 4.dp))
+    ) {
+        val status = if (active) {
+            stringResource(id = R.string.coupon_list_item_label_active)
+        } else {
+            stringResource(id = R.string.coupon_list_item_label_expired)
+        }
+
+        val color = if (active) colorResource(id = R.color.woo_celadon_5) else colorResource(id = R.color.woo_gray_5)
+
+        Text(
+            text = status,
+            style = MaterialTheme.typography.body1,
+            color = MaterialTheme.colors.onSecondary,
+            modifier = Modifier
+                .background(color = color)
+                .padding(horizontal = 6.dp, vertical = 2.dp)
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsFragment.kt
@@ -6,11 +6,13 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCouponDetailsBinding
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -44,6 +46,7 @@ class CouponDetailsFragment : BaseFragment(R.layout.fragment_coupon_details) {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
@@ -1,35 +1,30 @@
 package com.woocommerce.android.ui.coupons.details
 
 import com.woocommerce.android.WooException
+import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.CouponPerformanceReport
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponUi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.store.CouponStore
-import java.math.BigDecimal
 import javax.inject.Inject
 
 class CouponDetailsRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val store: CouponStore
 ) {
-    // TODO This should return a [com.woocommerce.android.model.Coupon] instead of [CouponUi]
-    @Suppress("MagicNumber", "UnusedPrivateMember")
-    fun loadCoupon(couponId: Long): Flow<CouponUi> {
-        return flowOf(
-            CouponUi(
-                id = 1,
-                code = "ABCDE",
-                amount = BigDecimal(25),
-                usageCount = 10,
-                formattedDiscount = "25%",
-                affectedArticles = "Everything excl. 5 products",
-                formattedSpendingInfo = "Minimum spend of $20 \n\nMaximum spend of $200 \n",
-                isActive = true
-            )
-        )
+    fun observeCoupon(couponId: Long): Flow<Coupon> = store.observeCoupon(selectedSite.get(), couponId)
+        .filterNotNull()
+        .map { it.toAppModel() }
+
+    suspend fun fetchCoupon(couponId: Long): Result<Unit> {
+        val result = store.fetchCoupon(selectedSite.get(), couponId)
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            else -> Result.success(Unit)
+        }
     }
 
     suspend fun fetchCouponPerformance(couponId: Long): Result<CouponPerformanceReport> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.coupons.details
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -11,15 +9,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
-import com.woocommerce.android.R.color
-import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.coupons.components.CouponExpirationLabel
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.*
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponPerformanceState.Loading
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponPerformanceState.Success
@@ -37,10 +32,10 @@ fun CouponDetailsScreen(state: CouponDetailsState) {
         modifier = Modifier
             .fillMaxSize()
     ) {
-        state.coupon?.let { coupon ->
+        state.couponSummary?.let { coupon ->
             CouponSummaryHeading(
                 code = coupon.code,
-                isActive = true
+                isActive = state.couponSummary.isActive
             )
             CouponSummarySection(coupon)
         }
@@ -63,44 +58,17 @@ fun CouponSummaryHeading(
         code?.let {
             Text(
                 text = it,
-                style = MaterialTheme.typography.h1,
+                style = MaterialTheme.typography.h5,
                 color = MaterialTheme.colors.onSurface,
-                fontSize = 24.sp,
                 fontWeight = FontWeight.Bold
             )
         }
-        CouponSummaryExpirationLabel(isActive)
+        CouponExpirationLabel(isActive)
     }
 }
 
 @Composable
-fun CouponSummaryExpirationLabel(isActive: Boolean) {
-    Surface(
-        modifier = Modifier
-            .clip(RoundedCornerShape(4.dp, 4.dp, 4.dp, 4.dp))
-            .padding(vertical = 4.dp)
-    ) {
-        val status = if (isActive) {
-            stringResource(id = R.string.coupon_list_item_label_active)
-        } else {
-            stringResource(id = R.string.coupon_list_item_label_expired)
-        }
-
-        val color = if (isActive) colorResource(id = R.color.woo_celadon_5) else colorResource(id = R.color.woo_gray_5)
-
-        Text(
-            text = status,
-            style = MaterialTheme.typography.body1,
-            color = MaterialTheme.colors.onSecondary,
-            modifier = Modifier
-                .background(color = color)
-                .padding(horizontal = 6.dp, vertical = 4.dp)
-        )
-    }
-}
-
-@Composable
-fun CouponSummarySection(coupon: CouponUi) {
+fun CouponSummarySection(couponSummary: CouponSummaryUi) {
     Surface(
         elevation = 1.dp,
         modifier = Modifier
@@ -108,62 +76,36 @@ fun CouponSummarySection(coupon: CouponUi) {
             .padding(vertical = 16.dp)
     ) {
         Column(
-            modifier = Modifier.padding(24.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(16.dp)
         ) {
             Text(
                 text = stringResource(id = R.string.coupon_summary_heading),
-                style = MaterialTheme.typography.h2,
+                style = MaterialTheme.typography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 8.dp)
             )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            CouponDetailsItemInfo(
-                amount = coupon.formattedDiscount,
-                affectedArticles = coupon.affectedArticles
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            CouponDetailsSpendingInfo(coupon.formattedSpendingInfo)
-
-            /* Hardcoded for design work purposes */
-            Text(
-                text = "Expires August 4, 2022",
-                style = MaterialTheme.typography.body1,
-                color = MaterialTheme.colors.onSurface,
-                fontSize = 20.sp
-            )
+            SummaryLabel(couponSummary.discountType)
+            SummaryLabel(couponSummary.summary)
+            SummaryLabel(couponSummary.minimumSpending)
+            SummaryLabel(couponSummary.maximumSpending)
+            SummaryLabel(couponSummary.expiration)
         }
     }
 }
 
 @Composable
-fun CouponDetailsItemInfo(
-    amount: String,
-    affectedArticles: String
-) {
-    Text(
-        text = "$amount ${stringResource(id = R.string.coupon_list_item_label_off)} $affectedArticles",
-        style = MaterialTheme.typography.body2,
-        color = MaterialTheme.colors.onSurface,
-        fontSize = 20.sp,
-        modifier = Modifier.padding(vertical = 4.dp)
-    )
+private fun SummaryLabel(text: String?) {
+    text?.let {
+        Text(
+            text = it,
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface,
+        )
+    }
 }
 
-@Composable
-fun CouponDetailsSpendingInfo(formattedSpendingInfo: String) {
-    Text(
-        style = MaterialTheme.typography.body1,
-        text = formattedSpendingInfo,
-        fontSize = 20.sp
-    )
-}
-
-// todo use actual data instead of hardcoded value
 @Composable
 private fun CouponPerformanceSection(couponPerformanceState: CouponPerformanceState) {
     Surface(
@@ -172,10 +114,10 @@ private fun CouponPerformanceSection(couponPerformanceState: CouponPerformanceSt
             .fillMaxWidth()
     ) {
         Column(
-            modifier = Modifier.padding(24.dp)
+            modifier = Modifier.padding(16.dp)
         ) {
             Text(
-                text = stringResource(id = string.coupon_summary_performance_heading),
+                text = stringResource(id = R.string.coupon_summary_performance_heading),
                 style = MaterialTheme.typography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
                 fontWeight = FontWeight.Bold
@@ -208,9 +150,9 @@ private fun CouponPerformanceCount(
         modifier = modifier
     ) {
         Text(
-            text = stringResource(id = string.coupon_summary_performance_discounted_order_heading),
+            text = stringResource(id = R.string.coupon_summary_performance_discounted_order_heading),
             style = MaterialTheme.typography.subtitle1,
-            color = colorResource(id = color.color_surface_variant)
+            color = colorResource(id = R.color.color_surface_variant)
         )
 
         Text(
@@ -232,9 +174,9 @@ private fun CouponPerformanceAmount(
         modifier = modifier
     ) {
         Text(
-            text = stringResource(id = string.coupon_summary_performance_amount_heading),
+            text = stringResource(id = R.string.coupon_summary_performance_amount_heading),
             style = MaterialTheme.typography.subtitle1,
-            color = colorResource(id = color.color_surface_variant)
+            color = colorResource(id = R.color.color_surface_variant)
         )
         when (couponPerformanceState) {
             is Loading -> CircularProgressIndicator(modifier = Modifier.size(32.dp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -53,7 +53,7 @@ fun CouponSummaryHeading(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp, vertical = 24.dp)
+            .padding(horizontal = 16.dp, vertical = 16.dp)
     ) {
         code?.let {
             Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -46,8 +46,10 @@ class CouponDetailsViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             couponDetailsRepository.fetchCoupon(navArgs.couponId).onFailure {
-                triggerEvent(ShowSnackbar(R.string.coupon_details_performance_loading_failure))
-                triggerEvent(Exit)
+                if (coupon.value == null) {
+                    triggerEvent(ShowSnackbar(R.string.coupon_summary_loading_failure))
+                    triggerEvent(Exit)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.viewmodel.ResourceProvider
 import java.math.BigDecimal
@@ -108,7 +109,7 @@ class CouponUtils @Inject constructor(
     ): String {
         val sb = StringBuilder()
 
-        if (minimumAmount != null) {
+        if (minimumAmount != null && minimumAmount.isNotEqualTo(BigDecimal.ZERO)) {
             sb.append(
                 resourceProvider.getString(
                     R.string.coupon_summary_minimum_spend,
@@ -117,7 +118,10 @@ class CouponUtils @Inject constructor(
             )
         }
 
-        if (maximumAmount != null) {
+        if (maximumAmount != null && maximumAmount.isNotEqualTo(BigDecimal.ZERO)) {
+            if (sb.isNotEmpty()) {
+                sb.append(" ")
+            }
             sb.append(
                 resourceProvider.getString(
                     R.string.coupon_summary_maximum_spend,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -48,7 +48,7 @@ class CouponUtils @Inject constructor(
         Coupon.Type.FixedCart -> resourceProvider.getString(R.string.coupon_type_fixed_cart)
         Coupon.Type.FixedProduct -> resourceProvider.getString(R.string.coupon_type_fixed_product)
         Coupon.Type.Percent -> resourceProvider.getString(R.string.coupon_type_percent)
-        is Coupon.Type.Custom -> couponType.value
+        is Coupon.Type.Custom -> resourceProvider.getString(R.string.coupon_type_custom, couponType.value)
     }
 
     /*

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.util
 
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.isNotEqualTo
+import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.viewmodel.ResourceProvider
 import java.math.BigDecimal
+import java.text.SimpleDateFormat
+import java.util.Date
 import javax.inject.Inject
 
 class CouponUtils @Inject constructor(
@@ -29,6 +31,24 @@ class CouponUtils @Inject constructor(
         } else {
             ""
         }
+    }
+
+    fun generateSummary(coupon: Coupon, currencyCode: String?): String {
+        val amount = formatDiscount(coupon.amount, coupon.type, currencyCode)
+        val affectedArticles = formatAffectedArticles(
+            coupon.products.size,
+            coupon.excludedProducts.size,
+            coupon.categories.size,
+            coupon.excludedCategories.size
+        )
+        return resourceProvider.getString(R.string.coupon_summary_template, amount, affectedArticles)
+    }
+
+    fun localizeType(couponType: Coupon.Type): String = when (couponType) {
+        Coupon.Type.FixedCart -> resourceProvider.getString(R.string.coupon_type_fixed_cart)
+        Coupon.Type.FixedProduct -> resourceProvider.getString(R.string.coupon_type_fixed_product)
+        Coupon.Type.Percent -> resourceProvider.getString(R.string.coupon_type_percent)
+        is Coupon.Type.Custom -> couponType.value
     }
 
     /*
@@ -102,34 +122,24 @@ class CouponUtils @Inject constructor(
         } else ""
     }
 
-    fun formatSpendingInfo(
-        minimumAmount: BigDecimal?,
-        maximumAmount: BigDecimal?,
-        currencyCode: String?
-    ): String {
-        val sb = StringBuilder()
+    fun formatMinimumSpendingInfo(minimumAmount: BigDecimal?, currencyCode: String?): String? {
+        if (minimumAmount == null || minimumAmount.isEqualTo(BigDecimal.ZERO)) return null
+        return resourceProvider.getString(
+            R.string.coupon_summary_minimum_spend,
+            formatCurrency(minimumAmount, currencyCode)
+        )
+    }
 
-        if (minimumAmount != null && minimumAmount.isNotEqualTo(BigDecimal.ZERO)) {
-            sb.append(
-                resourceProvider.getString(
-                    R.string.coupon_summary_minimum_spend,
-                    formatCurrency(minimumAmount, currencyCode)
-                )
-            )
-        }
+    fun formatMaximumSpendingInfo(maximumAmount: BigDecimal?, currencyCode: String?): String? {
+        if (maximumAmount == null || maximumAmount.isEqualTo(BigDecimal.ZERO)) return null
+        return resourceProvider.getString(
+            R.string.coupon_summary_maximum_spend,
+            formatCurrency(maximumAmount, currencyCode)
+        )
+    }
 
-        if (maximumAmount != null && maximumAmount.isNotEqualTo(BigDecimal.ZERO)) {
-            if (sb.isNotEmpty()) {
-                sb.append(" ")
-            }
-            sb.append(
-                resourceProvider.getString(
-                    R.string.coupon_summary_maximum_spend,
-                    formatCurrency(maximumAmount, currencyCode)
-                )
-            )
-        }
-
-        return sb.toString()
+    fun formatExpirationDate(expirationDate: Date): String {
+        val dateFormat = SimpleDateFormat.getDateInstance(SimpleDateFormat.LONG)
+        return resourceProvider.getString(R.string.coupon_details_expiration_date, dateFormat.format(expirationDate))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ScopedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ScopedViewModel.kt
@@ -1,12 +1,11 @@
 package com.woocommerce.android.viewmodel
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -28,4 +27,17 @@ abstract class ScopedViewModel(
         event.isHandled = false
         _event.value = event
     }
+
+    /**
+     * Convert a [Flow] to [StateFlow].
+     *
+     * This uses a policy of keeping the upstream active for 5 seconds after disappearance of last collector
+     * to avoid restarting the Flow during configuration changes.
+     */
+    @Suppress("MagicNumber")
+    protected fun <T> Flow<T>.toStateFlow(initialValue: T) = stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = initialValue
+    )
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1867,7 +1867,6 @@
     <string name="coupons">Coupons</string>
     <string name="coupon_list_item_label_active">Active</string>
     <string name="coupon_list_item_label_expired">Expired</string>
-    <string name="coupon_list_item_label_off">off</string>
     <string name="coupon_list_item_label_everything">everything</string>
     <string name="coupon_list_item_label_products_and_categories">%1s and %2s</string>
     <string name="coupon_list_item_label_included_and_excluded">%1s excl. %2s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1884,7 +1884,7 @@
     <string name="coupon_type_percent">Percentage Discount</string>
     <string name="coupon_type_fixed_cart">Fixed Cart Discount</string>
     <string name="coupon_type_fixed_product">Fixed Product Discount</string>
-    <string name="coupon_type_other">Other</string>
+    <string name="coupon_type_custom">Custom Discount (%1$s)</string>
     <string name="coupon_summary_template">%1$s off %2$s</string>
     <string name="coupon_details_expiration_date">Expires %1$s</string>
     <string name="coupon_summary_loading_failure">Loading coupon summary failed</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1882,6 +1882,12 @@
     <string name="coupon_summary_performance_discounted_order_heading">Discounted Orders</string>
     <string name="coupon_summary_performance_amount_heading">Amount</string>
     <string name="coupon_details_performance_loading_failure">Loading coupon performance failed</string>
+    <string name="coupon_type_percent">Percentage Discount</string>
+    <string name="coupon_type_fixed_cart">Fixed Cart Discount</string>
+    <string name="coupon_type_fixed_product">Fixed Product Discount</string>
+    <string name="coupon_type_other">Other</string>
+    <string name="coupon_summary_template">%1$s off %2$s</string>
+    <string name="coupon_details_expiration_date">Expires %1$s</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1888,6 +1888,7 @@
     <string name="coupon_type_other">Other</string>
     <string name="coupon_summary_template">%1$s off %2$s</string>
     <string name="coupon_details_expiration_date">Expires %1$s</string>
+    <string name="coupon_summary_loading_failure">Loading coupon summary failed</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5529
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds handling of fetching and loading of coupon, and updates the handling of formatting for different parts of the summary.

For reference, I followed the same logic as this [PR](https://github.com/woocommerce/woocommerce-ios/pull/6522) for the different labels of the summary section.

Additional changes:
1. I updated some parts in the List screen to align with different refactorings I had to do.
2. I updated different padding and text styles to align with what we have in Figma.

### Testing instructions
1. Click on More tab.
3. Click on coupons.
4. Click on one of the coupons, and confirm the summary section contains the correct data.

### Images/gif
<img width=360 src="https://user-images.githubusercontent.com/1657201/162033580-f063187d-bd89-4322-ae30-e654f1df3d53.png"/> <img width=360 src="https://user-images.githubusercontent.com/1657201/162033586-ad77606d-82fc-4782-9943-5aeab77a03d9.png"/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
