### PR TITLE
[6186] - 1 UI test create empty order

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/2201/2201_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/2201/2201_detailed.json
@@ -1,0 +1,104 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+    "queryParameters": {
+      "json": {
+        "equalTo": "true"
+      },
+      "path": {
+        "matches": "/wc/v3/orders/(.*)"
+      },
+      "query": {
+        "matches": "(.*)per_page\":\"1\"(.*)include\":\"2201(.*)"
+      },
+      "locale": {
+        "matches": "(.*)"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "data": [{
+        "id":2201,
+        "parent_id":0,
+        "status":"processing",
+        "currency":"USD",
+        "version":"6.3.1",
+        "prices_include_tax":false,
+        "date_created":"{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{fnow offset='-10 minutes' format=customformat}}",
+        "date_modified":"{{fnow offset='-10 minutes' format=customformat}}",
+        "discount_total":"0.00",
+        "discount_tax":"0.00",
+        "shipping_total":"0.00",
+        "shipping_tax":"0.00",
+        "cart_tax":"0.00",
+        "total":"0.00",
+        "total_tax":"0.00",
+        "customer_id":0,
+        "order_key":"wc_order_itGmODLV25QAx",
+        "billing":{
+          "first_name":"",
+          "last_name":"",
+          "company":"",
+          "address_1":"",
+          "address_2":"",
+          "city":"",
+          "state":"",
+          "postcode":"",
+          "country":"",
+          "email":"",
+          "phone":""
+        },
+        "shipping":{
+          "first_name":"",
+          "last_name":"",
+          "company":"",
+          "address_1":"",
+          "address_2":"",
+          "city":"",
+          "state":"",
+          "postcode":"",
+          "country":"",
+          "phone":""
+        },
+        "payment_method":"",
+        "payment_method_title":"",
+        "transaction_id":"",
+        "customer_ip_address":"",
+        "customer_user_agent":"",
+        "created_via":"rest-api",
+        "customer_note":"",
+        "date_completed":null,
+        "date_paid":null,
+        "cart_hash":"",
+        "number":"2201",
+        "meta_data":[],
+        "line_items":[],
+        "tax_lines":[],
+        "shipping_lines":[],
+        "fee_lines":[],
+        "coupon_lines":[],
+        "refunds":[],
+        "date_created_gmt": "{{fnow offset='-10 minutes' format=customformat}}",
+        "date_modified_gmt": "{{fnow offset='-10 minutes' format=customformat}}",
+        "date_completed_gmt":null,
+        "date_paid_gmt":null,
+        "currency_symbol":"$",
+        "_links":{
+          "self": [{
+            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/orders\/2201"
+          }],
+          "collection": [{
+            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/orders"
+          }]
+        }
+      }]
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive"
+    }
+  }
+}

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_all_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_all_detailed.json
@@ -10,8 +10,8 @@
                 "matches": "/wc/v3/orders/(.*)"
             },
             "query": {
-                "matches": "(.*)include\":\"2789(.*)"
-            },             
+                "matches": "(.*)include(.*)"
+            },
             "locale": {
                 "matches": "(.*)"
             }
@@ -1093,7 +1093,7 @@
                 "date_created_gmt": "{{currentYear}}-01-27T10:09:44",
                 "date_modified_gmt": "{{currentYear}}-01-28T10:14:05",
                 "date_paid_gmt": "{{currentYear}}-01-28T10:10:19"
-            }]          
+            }]
         },
         "headers": {
             "Content-Type": "application/json",

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_create.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_create.json
@@ -1,26 +1,22 @@
 {
     "request": {
-        "method": "GET",
+        "method": "POST",
         "urlPathPattern": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
         "queryParameters": {
-            "json": {
-                "equalTo": "true"
-            },
-            "path": {
-                "matches": "/wc/v3/orders/(.*)"
-            },
-            "query": {
-                "matches": "\\{\"per_page\":\"1\",\"offset\":\"0\",\"status\":\"any\"\\}"
-            },
             "locale": {
                 "matches": "(.*)"
             }
-        }
+        },
+        "bodyPatterns" : [ {
+            "equalToJson" : "{ \"path\": \"/wc/v3/orders/&_method=post\" }",
+            "ignoreArrayOrder" : true,
+            "ignoreExtraElements" : true
+        } ]
     },
     "response": {
         "status": 200,
-        "jsonBody": {
-            "data": [{
+        "jsonBody":{
+            "data": {
                 "id":2201,
                 "parent_id":0,
                 "status":"processing",
@@ -94,7 +90,7 @@
                         "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/orders"
                     }]
                 }
-            }]
+            }
         },
         "headers": {
             "Content-Type": "application/json",

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderCreationScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderCreationScreen.kt
@@ -1,5 +1,8 @@
 package com.woocommerce.android.screenshots.orders
 
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.util.Screen
 
@@ -11,8 +14,17 @@ class OrderCreationScreen : Screen {
 
     constructor() : super(ORDER_CREATION)
 
-    fun createOrder(): SingleOrderScreen {
+    fun createEmptyOrder(): SingleOrderScreen {
         clickOn(CREATE_BUTTON)
         return SingleOrderScreen()
+    }
+
+    fun assertNewOrderScreen(): OrderCreationScreen {
+        Espresso.onView(withId(R.id.collapsing_toolbar))
+            .check(matches(hasDescendant(withText(R.string.order_creation_fragment_title))))
+            .check(matches(isDisplayed()))
+        Espresso.onView(withId(ORDER_CREATION)).check(matches(isDisplayed()))
+        Espresso.onView(withId(CREATE_BUTTON)).check(matches(isDisplayed()))
+        return this
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderCreationScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderCreationScreen.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.screenshots.orders
+
+import com.woocommerce.android.R
+import com.woocommerce.android.screenshots.util.Screen
+
+class OrderCreationScreen : Screen {
+    companion object {
+        const val ORDER_CREATION = R.id.order_creation_root
+        const val CREATE_BUTTON = R.id.menu_create
+    }
+
+    constructor() : super(ORDER_CREATION)
+
+    fun createOrder(): SingleOrderScreen {
+        clickOn(CREATE_BUTTON)
+        return SingleOrderScreen()
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderListScreen.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.screenshots.orders
 
 import com.woocommerce.android.R
-import com.woocommerce.android.screenshots.TabNavComponent
 import com.woocommerce.android.screenshots.util.Screen
 
 class OrderListScreen : Screen {
@@ -9,9 +8,10 @@ class OrderListScreen : Screen {
         const val LIST_VIEW = R.id.ordersList
         const val LIST_ITEM = R.id.linearLayout
         const val SEARCH_BUTTON = R.id.menu_search
+        const val NEW_ORDER_BUTTON = R.id.createOrderButton
+        const val CREATE_ORDER_OPTION = R.id.order_creation_button
+        const val CREATE_SIMPLE_PAYMENT_OPTION = R.id.simple_payment_button
     }
-
-    val tabBar = TabNavComponent()
 
     constructor() : super(LIST_VIEW)
 
@@ -24,5 +24,11 @@ class OrderListScreen : Screen {
     fun openSearchPane(): OrderSearchScreen {
         clickOn(SEARCH_BUTTON)
         return OrderSearchScreen()
+    }
+
+    fun newOrder():OrderCreationScreen{
+        clickOn(NEW_ORDER_BUTTON)
+        clickOn(CREATE_ORDER_OPTION)
+        return OrderCreationScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderListScreen.kt
@@ -26,7 +26,7 @@ class OrderListScreen : Screen {
         return OrderSearchScreen()
     }
 
-    fun newOrder():OrderCreationScreen{
+    fun newOrder(): OrderCreationScreen {
         clickOn(NEW_ORDER_BUTTON)
         clickOn(CREATE_ORDER_OPTION)
         return OrderCreationScreen()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderListScreen.kt
@@ -8,7 +8,7 @@ class OrderListScreen : Screen {
         const val LIST_VIEW = R.id.ordersList
         const val LIST_ITEM = R.id.linearLayout
         const val SEARCH_BUTTON = R.id.menu_search
-        const val NEW_ORDER_BUTTON = R.id.createOrderButton
+        const val CREATE_ORDER_BUTTON = R.id.createOrderButton
         const val CREATE_ORDER_OPTION = R.id.order_creation_button
         const val CREATE_SIMPLE_PAYMENT_OPTION = R.id.simple_payment_button
     }
@@ -26,8 +26,12 @@ class OrderListScreen : Screen {
         return OrderSearchScreen()
     }
 
-    fun newOrder(): OrderCreationScreen {
-        clickOn(NEW_ORDER_BUTTON)
+    fun createFABTap(): OrderListScreen {
+        clickOn(CREATE_ORDER_BUTTON)
+        return this
+    }
+
+    fun newOrderTap(): OrderCreationScreen {
         clickOn(CREATE_ORDER_OPTION)
         return OrderCreationScreen()
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
@@ -1,7 +1,11 @@
 package com.woocommerce.android.screenshots.orders
 
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers.*
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.util.Screen
+import org.hamcrest.Matchers
 
 class SingleOrderScreen : Screen {
     companion object {
@@ -13,5 +17,34 @@ class SingleOrderScreen : Screen {
     fun goBackToOrdersScreen(): OrderListScreen {
         pressBack()
         return OrderListScreen()
+    }
+
+    fun assertSingleOrderScreen(): SingleOrderScreen {
+        Espresso.onView(withId(R.id.toolbar))
+            .check(ViewAssertions.matches(hasDescendant(withSubstring("#"))))
+            .check(ViewAssertions.matches(isDisplayed()))
+        Espresso.onView(withId(ORDER_NUMBER_LABEL))
+            .check(ViewAssertions.matches(isDisplayed()))
+        Espresso.onView(withId(R.id.paymentInfo_total))
+            .check(ViewAssertions.matches(isDisplayed()))
+        Espresso.onView(withId(R.id.orderDetail_customerInfo))
+            .check(ViewAssertions.matches(isDisplayed()))
+        return this
+    }
+
+    fun assertSingleOrderScreenWithEmptyOrder(): SingleOrderScreen {
+        Espresso.onView(
+            Matchers.allOf(
+                withId(R.id.orderStatus_header),
+                withText(R.string.orderdetail_customer_name_default)
+            )
+        ).check(ViewAssertions.matches(isDisplayed()))
+        Espresso.onView(
+            Matchers.allOf(
+                withId(R.id.paymentInfo_total),
+                withText("$0.00")
+            )
+        ).check(ViewAssertions.matches(isDisplayed()))
+        return assertSingleOrderScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/SingleProductScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/SingleProductScreen.kt
@@ -71,7 +71,7 @@ class SingleProductScreen : Screen {
             ).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
         }
 
-        return SingleProductScreen()
+        return this
     }
 
     // Checks that label and actual value are siblings in view hierarchy:

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
@@ -1,0 +1,50 @@
+package com.woocommerce.android.ui.main
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.rule.ActivityTestRule
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.helpers.InitializationRule
+import com.woocommerce.android.helpers.TestBase
+import com.woocommerce.android.screenshots.TabNavComponent
+import com.woocommerce.android.screenshots.login.WelcomeScreen
+import com.woocommerce.android.screenshots.orders.OrderListScreen
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@HiltAndroidTest
+class OrdersUITest : TestBase() {
+    @get:Rule(order = 0)
+    val rule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeTestRule = createComposeRule()
+
+    @get:Rule(order = 2)
+    val initRule = InitializationRule()
+
+    @get:Rule(order = 3)
+    var activityRule = ActivityTestRule(MainActivity::class.java)
+
+    @Before
+    fun setUp() {
+        WelcomeScreen
+            .logoutIfNeeded(composeTestRule)
+            .selectLogin()
+            .proceedWith(BuildConfig.SCREENSHOTS_URL)
+            .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)
+            .proceedWith(BuildConfig.SCREENSHOTS_PASSWORD)
+
+        TabNavComponent().gotoOrdersScreen()
+    }
+
+    @Test
+    fun createOrderTest() {
+        OrderListScreen()
+            .newOrder()
+            .createOrder()
+            .goBackToOrdersScreen()
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
@@ -41,10 +41,13 @@ class OrdersUITest : TestBase() {
     }
 
     @Test
-    fun createOrderTest() {
+    fun createEmptyOrderTest() {
         OrderListScreen()
-            .newOrder()
-            .createOrder()
+            .createFABTap()
+            .newOrderTap()
+            .assertNewOrderScreen()
+            .createEmptyOrder()
+            .assertSingleOrderScreenWithEmptyOrder()
             .goBackToOrdersScreen()
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent">
 
     <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/order_creation_root"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">


### PR DESCRIPTION
Part of: #6186

### Description
This PR adds a very basic UI test for Order Creation. It creates an empty order.

### Changes

- Add `OrderCreationScreen` to manipulate the order creation fragment, so far it only hits the create button.
- Update `OrderListScreen` to interact with the (+) button and navigate to `OrderCreationScreen`.
- Add `OrdersUITests` and create the order creation test
- Update Wiremock stubs. Add a new JSON for the creating order POST request, update query stubs for order details to match the created order ID, and fix the order query stubs. 

### Testing instructions
Run `OrdersUITest` and confirm it passes.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
