### PR TITLE
Fix product sale dates different than what's selected in the date picker

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 9.0
 -----
-
+- [*] Fixes a bug that caused the scheduled sale dates of a product to be different than the selected dates. [https://github.com/woocommerce/woocommerce-android/pull/6188]
 
 8.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -2,15 +2,12 @@ package com.woocommerce.android.extensions
 
 import android.content.Context
 import android.text.format.DateFormat
-import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import org.apache.commons.lang3.time.DateUtils.isSameDay
 import java.text.DateFormatSymbols
 import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
-import java.util.Locale
+import java.util.*
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
@@ -73,8 +70,6 @@ fun Date.getTimeString(context: Context): String = DateFormat.getTimeFormat(cont
 fun Date.getShortDate(context: Context): String = DateFormat.getDateFormat(context).format(this)
 
 fun Date.getMediumDate(context: Context): String = DateFormat.getMediumDateFormat(context).format(this)
-
-fun Date?.offsetGmtDate(gmtOffset: Float) = this?.let { DateUtils.offsetGmtDate(it, gmtOffset) }
 
 fun Date.formatToYYYYmmDDhhmmss(): String =
     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).format(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -150,7 +150,6 @@ class ProductPricingFragment :
         }
 
         val scheduleSale = pricingData.isSaleScheduled == true
-        val gmtOffset = viewModel.parameters.gmtOffset
 
         enableScheduleSale(scheduleSale)
         with(binding.scheduleSaleSwitch) {
@@ -168,9 +167,7 @@ class ProductPricingFragment :
                     binding.scheduleSaleStartDate,
                     OnDateSetListener {
                         _, selectedYear, selectedMonth, dayOfMonth ->
-                        val selectedDate = dateUtils.localDateToGmt(
-                            selectedYear, selectedMonth, dayOfMonth, gmtOffset, true
-                        )
+                        val selectedDate = dateUtils.getDateAtStartOfDay(selectedYear, selectedMonth, dayOfMonth)
 
                         viewModel.onDataChanged(saleStartDate = selectedDate)
                     }
@@ -185,9 +182,7 @@ class ProductPricingFragment :
                     binding.scheduleSaleEndDate,
                     OnDateSetListener {
                         _, selectedYear, selectedMonth, dayOfMonth ->
-                        val selectedDate = dateUtils.localDateToGmt(
-                            selectedYear, selectedMonth, dayOfMonth, gmtOffset, false
-                        )
+                        val selectedDate = dateUtils.getDateAtStartOfDay(selectedYear, selectedMonth, dayOfMonth)
 
                         viewModel.onDataChanged(saleEndDate = selectedDate)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -174,7 +174,7 @@ class ProductPricingFragment :
             }
         }
 
-        updateSaleEndDate(pricingData.saleEndDate, viewModel.parameters.gmtOffset)
+        updateSaleEndDate(pricingData.saleEndDate)
         with(binding.scheduleSaleEndDate) {
             setClickListener {
                 endDatePickerDialog = displayDatePickerDialog(
@@ -234,7 +234,7 @@ class ProductPricingFragment :
         selectedStartDate?.let { viewModel.onDataChanged(saleStartDate = it) }
     }
 
-    private fun updateSaleEndDate(selectedDate: Date?, offset: Float) {
+    private fun updateSaleEndDate(selectedDate: Date?) {
         // The end sale date is optional => null is a valid value
         if (selectedDate != null) {
             binding.scheduleSaleEndDate.setText(selectedDate.formatForDisplay())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.formatToMMMddYYYY
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
-import com.woocommerce.android.extensions.offsetGmtDate
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
@@ -160,7 +159,7 @@ class ProductPricingFragment :
             }
         }
 
-        updateSaleStartDate(pricingData.saleStartDate, pricingData.saleEndDate, viewModel.parameters.gmtOffset)
+        updateSaleStartDate(pricingData.saleStartDate, pricingData.saleEndDate)
         with(binding.scheduleSaleStartDate) {
             setClickListener {
                 startDatePickerDialog = displayDatePickerDialog(
@@ -215,7 +214,7 @@ class ProductPricingFragment :
     }
 
     /**
-     * Method to update the start date of a sale using the [offset]
+     * Method to update the start date of a sale
      *
      * If the [selectedStartDate] is empty or null, then the default is set to the current date,
      * only if the [endDate] > the current date.
@@ -224,21 +223,21 @@ class ProductPricingFragment :
      * the discard dialog from being displayed when there have been no user initiated changes made
      * to the screen.
      */
-    private fun updateSaleStartDate(selectedStartDate: Date?, endDate: Date?, offset: Float) {
+    private fun updateSaleStartDate(selectedStartDate: Date?, endDate: Date?) {
         val currentDate = Date()
         val date = selectedStartDate
             ?: if (endDate?.after(currentDate) == true) {
                 currentDate
             } else null
 
-        date?.let { binding.scheduleSaleStartDate.setText(formatSaleDateForDisplay(it, offset)) }
+        date?.let { binding.scheduleSaleStartDate.setText(it.formatForDisplay()) }
         selectedStartDate?.let { viewModel.onDataChanged(saleStartDate = it) }
     }
 
     private fun updateSaleEndDate(selectedDate: Date?, offset: Float) {
         // The end sale date is optional => null is a valid value
         if (selectedDate != null) {
-            binding.scheduleSaleEndDate.setText(formatSaleDateForDisplay(selectedDate, offset))
+            binding.scheduleSaleEndDate.setText(selectedDate.formatForDisplay())
         } else {
             binding.scheduleSaleEndDate.setText("")
         }
@@ -299,15 +298,11 @@ class ProductPricingFragment :
     }
 
     /**
-     * Parses the given [date] and applies the passed [gmtOffset] and
-     * formats this formatted date to MMM dd, YYYY format
-     *
-     * If given [date] is null, current date is used
+     * Formats the given [date] or the current date if it's null to `'MMM dd, YYYY'`
      */
-    private fun formatSaleDateForDisplay(date: Date?, gmtOffset: Float): String {
-        val currentDate = DateUtils.offsetGmtDate(Date(), gmtOffset)
-        val dateOnSaleFrom = date?.offsetGmtDate(gmtOffset) ?: currentDate
-        return dateOnSaleFrom.formatToMMMddYYYY()
+    private fun Date?.formatForDisplay(): String {
+        val date = this ?: Date()
+        return date.formatToMMMddYYYY()
     }
 
     override fun onProductItemSelected(resultCode: Int, selectedItem: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -204,7 +204,7 @@ class DateUtils @Inject constructor(
             val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", locale)
             val targetFormat = SimpleDateFormat("hha", locale)
             val date = originalFormat.parse(iso8601Date)
-            targetFormat.format(date!!).toLowerCase(locale).trimStart('0')
+            targetFormat.format(date!!).lowercase(locale).trimStart('0')
         } catch (e: Exception) {
             "Date string argument is not of format yyyy-MM-dd H: $iso8601Date".reportAsError(e)
             return null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -534,25 +534,6 @@ class DateUtils @Inject constructor(
         const val THREE = 3
 
         /**
-         * Returns a date with the passed GMT offset applied - note that this assumes the passed date is GMT
-         *
-         * The [operator] can either be [Int::plus] or [Int::minus]
-         * [Int::plus] is passed when formatting gmtDate to local date
-         * [Int::minus] is passed when formatting local date to gmt
-         */
-        fun offsetGmtDate(dateGmt: Date, gmtOffset: Float, operator: (Int, Int) -> Int = Int::plus): Date {
-            if (gmtOffset == 0f) {
-                return dateGmt
-            }
-
-            val secondsOffset = (3600 * gmtOffset).toInt() // 3600 is the number of seconds in an hour
-            val calendar = Calendar.getInstance()
-            calendar.time = dateGmt
-            calendar.set(Calendar.SECOND, operator(calendar.get(Calendar.SECOND), secondsOffset))
-            return calendar.time
-        }
-
-        /**
          * Compares two dates to determine if [date2] is after [date1]. Note that
          * this method strips the time information from the comparison and is only comparing
          * the dates.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -254,7 +254,7 @@ class DateUtils @Inject constructor(
      */
     fun getYearString(iso8601Month: String): String? {
         return try {
-            val (year, month) = iso8601Month.split("-")
+            val (year, _) = iso8601Month.split("-")
             year
         } catch (e: Exception) {
             "Date string argument is not of format yyyy-MM: $iso8601Month".reportAsError(e)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -252,9 +252,10 @@ class DateUtils @Inject constructor(
      *
      * return null if the argument is not a valid iso8601 date string.
      */
+    @Suppress("UNUSED_VARIABLE", "Applying the suggestion to rename 'month' to '_' makes the test fail")
     fun getYearString(iso8601Month: String): String? {
         return try {
-            val (year, _) = iso8601Month.split("-")
+            val (year, month) = iso8601Month.split("-")
             year
         } catch (e: Exception) {
             "Date string argument is not of format yyyy-MM: $iso8601Month".reportAsError(e)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -252,7 +252,7 @@ class DateUtils @Inject constructor(
      *
      * return null if the argument is not a valid iso8601 date string.
      */
-    @Suppress("UNUSED_VARIABLE", "Applying the suggestion to rename 'month' to '_' makes the test fail")
+    @Suppress("UNUSED_VARIABLE") // Applying the suggestion to rename 'month' to '_' makes the test fail
     fun getYearString(iso8601Month: String): String? {
         return try {
             val (year, month) = iso8601Month.split("-")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -263,52 +263,14 @@ class DateUtils @Inject constructor(
     }
 
     /**
-     * Converts the given [year] [month] [day] to a [Date] object
-     * and applies the passed [gmtOffset] to the date
-     *
-     * [timeAtStartOfDay] is set to true for start date and set to false for end dates
+     * Converts the given [year], [month], [day] to a [Date] object at midnight
      */
-    fun localDateToGmt(
+    fun getDateAtStartOfDay(
         year: Int,
         month: Int,
-        day: Int,
-        gmtOffset: Float,
-        timeAtStartOfDay: Boolean
+        day: Int
     ): Date {
-        val hour = if (timeAtStartOfDay) 0 else 23
-        val minuteSecond = if (timeAtStartOfDay) 0 else 59
-        val operator: (Int, Int) -> Int = if (timeAtStartOfDay) Int::minus else Int::plus
-        val date = GregorianCalendar(year, month, day, hour, minuteSecond, minuteSecond).time
-        return offsetGmtDate(date, gmtOffset, operator)
-    }
-
-    /**
-     * Converts the given [dateString] to a [Date] object
-     * and applies the passed [gmtOffset] to the date
-     */
-    fun localDateToGmt(
-        dateString: String,
-        gmtOffset: Float,
-        timeAtStartOfDay: Boolean
-    ): Date? {
-        return try {
-            val dateFormat = SimpleDateFormat("MMM dd, yyyy", locale)
-            val date = dateFormat.parse(dateString) ?: Date()
-
-            val calendar = Calendar.getInstance()
-            calendar.time = date
-
-            localDateToGmt(
-                year = calendar.get(Calendar.YEAR),
-                month = calendar.get(Calendar.MONTH),
-                day = calendar.get(Calendar.DATE),
-                gmtOffset = gmtOffset,
-                timeAtStartOfDay = timeAtStartOfDay
-            )
-        } catch (e: Exception) {
-            "Date string argument is not of format MMM dd, yyyy: $dateString".reportAsError(e)
-            return null
-        }
+        return GregorianCalendar(year, month, day).time
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PriceUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PriceUtils.kt
@@ -4,12 +4,11 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.extensions.formatToMMMddYYYY
 import com.woocommerce.android.extensions.isSet
-import com.woocommerce.android.extensions.offsetGmtDate
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
-import java.util.Date
+import java.util.*
 
 object PriceUtils {
     @Suppress("LongParameterList")
@@ -40,20 +39,20 @@ object PriceUtils {
                 )
             }
 
-            // display product sale dates using the site's timezone, if available
+            // display product sale dates
             if (isSaleScheduled) {
-                val dateOnSaleFrom = saleStartDateGmt?.offsetGmtDate(parameters.gmtOffset)
-                val dateOnSaleTo = saleEndDateGmt?.offsetGmtDate(parameters.gmtOffset)
-
                 val saleDates = when {
-                    (dateOnSaleFrom != null && dateOnSaleTo != null) -> {
-                        getProductSaleDates(dateOnSaleFrom, dateOnSaleTo, resources)
+                    // both dates are set
+                    (saleStartDateGmt != null && saleEndDateGmt != null) -> {
+                        getProductSaleDates(saleStartDateGmt, saleEndDateGmt, resources)
                     }
-                    (dateOnSaleFrom != null && dateOnSaleTo == null) -> {
-                        resources.getString(R.string.product_sale_date_from, dateOnSaleFrom.formatToMMMddYYYY())
+                    // only start date is set
+                    (saleStartDateGmt != null && saleEndDateGmt == null) -> {
+                        resources.getString(R.string.product_sale_date_from, saleStartDateGmt.formatToMMMddYYYY())
                     }
-                    (dateOnSaleFrom == null && dateOnSaleTo != null) -> {
-                        resources.getString(R.string.product_sale_date_to, dateOnSaleTo.formatToMMMddYYYY())
+                    // only end date is set
+                    (saleStartDateGmt == null && saleEndDateGmt != null) -> {
+                        resources.getString(R.string.product_sale_date_to, saleEndDateGmt.formatToMMMddYYYY())
                     }
                     else -> null
                 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -20,6 +20,11 @@ import kotlin.test.assertNull
 class DateUtilsTest {
     lateinit var dateUtilsUnderTest: DateUtils
 
+    /**
+     * SimpleDateFormat of `"yyyy-MM-dd HH:mm:ss"`
+     */
+    private val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+
     @Before
     fun setUp() {
         dateUtilsUnderTest = DateUtils(
@@ -451,7 +456,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForFirstDayOfCurrentWeek() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val todayCalendar = Calendar.getInstance(Locale.US).apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }
@@ -465,7 +469,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForFirstDayOfCurrentMonth() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val todayCalendar = Calendar.getInstance().apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }
@@ -479,7 +482,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForFirstDayOfCurrentQuarter() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val todayCalendar = Calendar.getInstance().apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }
@@ -493,7 +495,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForFirstDayOfCurrentYear() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val todayCalendar = Calendar.getInstance().apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }
@@ -507,7 +508,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForFirstDayOfPreviousWeek() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val todayCalendar = Calendar.getInstance(Locale.US).apply {
             time = sdf.parse("2021-11-22 00:00:00")!!
         }
@@ -521,7 +521,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForFirstDayOfPreviousMonth() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val today = Calendar.getInstance().apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }
@@ -535,7 +534,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForFirstDayOfPreviousQuarter() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val today = Calendar.getInstance().apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }
@@ -549,7 +547,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForFirstDayOfPreviousYear() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val todayCalendar = Calendar.getInstance().apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }
@@ -563,7 +560,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForLastDayOfPreviousMonth() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val todayCalendar = Calendar.getInstance().apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }
@@ -577,7 +573,6 @@ class DateUtilsTest {
 
     @Test
     fun `getDateForLastDayOfPreviousQuarter() returns correct values`() {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         val today = Calendar.getInstance().apply {
             time = sdf.parse("2021-11-21 00:00:00")!!
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.extensions.formatDateToYear
 import com.woocommerce.android.extensions.formatDateToYearMonth
 import com.woocommerce.android.extensions.formatToDateOnly
 import com.woocommerce.android.extensions.formatToMonthDateOnly
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -583,5 +584,24 @@ class DateUtilsTest {
         }
 
         assertEquals(lastDayOfPreviousQuarter.time, dateUtilsUnderTest.getDateForLastDayOfPreviousQuarter(1, today))
+    }
+
+    @Test
+    fun `getDateAtStartOfDay() returns correct value`() {
+        val year = 1999
+        val month = 11
+        val day = 31
+
+        val calendar = Calendar.getInstance().apply {
+            time = dateUtilsUnderTest.getDateAtStartOfDay(1999, month, day)
+        }
+
+        assertEquals(year, calendar.get(Calendar.YEAR))
+        assertEquals(month, calendar.get(Calendar.MONTH))
+        assertEquals(day, calendar.get(Calendar.DAY_OF_MONTH))
+
+        assertThat(calendar.get(Calendar.MINUTE)).isZero
+        assertThat(calendar.get(Calendar.HOUR)).isZero
+        assertThat(calendar.get(Calendar.SECOND)).isZero
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -12,7 +12,8 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/PriceUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/PriceUtilsTest.kt
@@ -1,0 +1,82 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.viewmodel.ResourceProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import java.math.BigDecimal
+import java.util.*
+
+const val SALE_DATES_PRICING_GROUP_KEY = "SALE"
+
+const val TEXT_FROM = "FROM {START_DATE}"
+const val TEXT_UNTIL = "UNTIL {END_DATE}"
+const val TEXT_FROM_TO = "{START_DATE} - {END_DATE}"
+
+class PriceUtilsTest {
+    private val dateUtils = DateUtils(
+        Locale.US,
+        mock()
+    )
+
+    private val resourcesProviderMock = mock<ResourceProvider> {
+        on { getString(R.string.product_sale_dates) }.thenReturn(SALE_DATES_PRICING_GROUP_KEY)
+        on { getString(eq(R.string.product_sale_date_from), any()) }.thenReturn(TEXT_FROM)
+        on { getString(eq(R.string.product_sale_date_to), any()) }.thenReturn(TEXT_UNTIL)
+        on { getString(eq(R.string.product_sale_date_from_to), any(), any()) }
+            .thenReturn(TEXT_FROM_TO)
+    }
+
+    @Test
+    fun `Given both sale dates, when getPriceGroup, then the sale dates text is formatted correctly`() {
+        val saleDatesText = getSaleDatesPricingGroupValue(
+            saleStartDateGmt = dateUtils.getDateAtStartOfDay(2020, 11, 1),
+            saleEndDateGmt = dateUtils.getDateAtStartOfDay(2020, 11, 31),
+        )
+
+        assertEquals(TEXT_FROM_TO, saleDatesText)
+    }
+
+    @Test
+    fun `Given only the start sale date, when getPriceGroup, then the sale dates text is formatted correctly`() {
+        val saleDatesText = getSaleDatesPricingGroupValue(
+            saleStartDateGmt = dateUtils.getDateAtStartOfDay(2020, 11, 1),
+        )
+
+        assertEquals(TEXT_FROM, saleDatesText)
+    }
+
+    @Test
+    fun `Given only the end sale date, when getPriceGroup, then the sale dates text is formatted correctly`() {
+        val saleDatesText = getSaleDatesPricingGroupValue(
+            saleEndDateGmt = dateUtils.getDateAtStartOfDay(2020, 11, 31),
+        )
+
+        assertEquals(TEXT_UNTIL, saleDatesText)
+    }
+
+    private fun getSaleDatesPricingGroupValue(
+        saleStartDateGmt: Date? = null,
+        saleEndDateGmt: Date? = null,
+    ) = PriceUtils.getPriceGroup(
+        SiteParameters(
+            null,
+            null,
+            null,
+            null,
+            null,
+            -2.0F,
+        ),
+        resourcesProviderMock,
+        mock(),
+        regularPrice = BigDecimal(100),
+        salePrice = BigDecimal(75),
+        isSaleScheduled = true,
+        saleStartDateGmt = saleStartDateGmt,
+        saleEndDateGmt = saleEndDateGmt,
+    )[SALE_DATES_PRICING_GROUP_KEY]
+}


### PR DESCRIPTION
Fixes: #2988

## Description
Fixes a bug that caused the scheduled sale dates of a product to be different than what the user selects in the date picker:
- **Start** date → was incorrectly set one day **before** the selected date by the user.
- **End** date → was incorrectly set one day **after** the selected date by the user.

For fixing the bug, **I removed the code that was applying the time zone offset manually to the dates** — both on the product detail screen and on the product price screen.

<details>
<summary><h3>Why?</h3></summary>

I've tested a lot of different setups and researched the legacy Java date-time APIs in depth with no good result. In the end I came across [this StackOverflow answer](https://stackoverflow.com/a/35891809/4129245) and it finally started to click:
> _In Java, Dates are internally represented in UTC milliseconds since the epoch (so timezones are not taken into account)_

Then I started to look at it from a higher level which got me to the idea that for the user, when selecting a date, the time should not matter.

From this point of view a solution emerged → **Ignore the time and time zone for the UI.**

I'm not 💯 sure this is the correct way because it's a bit of a radical approach but the more I think about it and check it with different questions, the more I end up with an answer that gets me even more confident that this is the correct solution:
**To ignore the time and time-zone on the UI.**

This confusion and the bugs that pop up when using a `Date` when we're not interested in the time or timezone info could be avoided by using a [`java.time.LocalDate`](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html) object for the UI state model:
> This class does not store or represent a time or time-zone.
</details>


## Testing instructions
1. Navigate to the products tab.
2. Tap on a product.
3. Tap on `Price`.
4. Enable the `Schedule sale` toggle.
5. Tap on the `From` field to open the date picker.
6. Select a `From` date
   → **Verify** that the `From` field shows the selected day.
8. Tap on the `To` field to open the date picker.
9. Select a `To` date
   → **Verify** that the `To` field shows the selected day.
10. Navigate back
11. Tap `SAVE` menu button on the product details page.
12. Exit app
13. Open app & go to the detail screen of the same product you updated
   → **Verify** that the displayed sale dates under `Price` are the ones you saved.
14. Tap on `Price`
   → **Verify** that the displayed scheduled sale `from` and `to` dates are the ones you saved. 

### Preview
<details>
<summary>Before</summary>


https://user-images.githubusercontent.com/4588074/162283587-f327f542-795d-4d4e-aaa5-5187d7f87343.mov
</details>

<details open>
<summary>After</summary>

https://user-images.githubusercontent.com/4588074/162324467-06340a6e-6973-4a91-bf24-013ef313f5d7.mp4
</details>


### PR Submission Checklist
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
