### PR TITLE
issue/6194-order-creation-email-whitespace

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -214,7 +214,7 @@ class AddressViewModel @Inject constructor(
             Field.City -> currentAddress.copy(city = value)
             Field.State -> currentAddress.copy(state = AmbiguousLocation.Raw(value))
             Field.Zip -> currentAddress.copy(postcode = value)
-            Field.Email -> currentAddress.copy(email = value)
+            Field.Email -> currentAddress.copy(email = value.trim())
         }
         viewState = viewState.copy(
             addressSelectionStates = viewState.addressSelectionStates.mapValues { entry ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -103,7 +103,7 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
     }
 
     fun onBillingEmailChanged(email: String) {
-        viewState = viewState.copy(billingEmail = email)
+        viewState = viewState.copy(billingEmail = email.trim())
     }
 
     fun onDoneButtonClicked() {


### PR DESCRIPTION
Fixes #6194 - in both order creation and simple payments, entering an email address with whitespace at the end results in an "Invalid email" message. This PR corrects that.