### PR TITLE
 Move localize_libs & send_strings_for_translation to complete_code_freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -87,9 +87,6 @@ platform :android do
     android_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
-
-    localize_libs()
-    send_strings_for_translation()
   end
 
   #####################################################################################
@@ -107,6 +104,10 @@ platform :android do
   desc "Creates a new release branch from the current trunk"
   lane :complete_code_freeze do | options |
     android_completecodefreeze_prechecks(options)
+
+    localize_libs()
+    send_strings_for_translation()
+
     new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
@@ -272,7 +273,7 @@ platform :android do
   #####################################################################################
   # build_and_upload_google_play
   # -----------------------------------------------------------------------------------
-  # This lane builds the app for Google Play, and will correctly select which build 
+  # This lane builds the app for Google Play, and will correctly select which build
   # should be produced based on the build number.
   # -----------------------------------------------------------------------------------
   # Usage:
@@ -577,7 +578,7 @@ platform :android do
         map { |locale|  locale[:google_play] }
     end
 
-    # Override the locales array with one locale until 
+    # Override the locales array with one locale until
     # https://github.com/fastlane/fastlane/issues/19521
     # is fixed:
     locales = ["en-EN"]
@@ -619,7 +620,7 @@ platform :android do
           launch_arguments: ["theme light"]
         }
       )
-    )    
+    )
   end
 
   #####################################################################################


### PR DESCRIPTION
We are making this change so that library version updates (such as for login library) can be directly made in the release branch instead of opening a preliminary PR such as https://github.com/woocommerce/woocommerce-android/pull/6161. As a result, we'll be able to do a code freeze without requiring an urgent PR review.

P.S: My editor made some minor whitespace corrections in the Fastfile, since this PR is simple enough, I didn't bother with reverting them.