### PR TITLE
Introduce the CARD_READER_MANUALS feature flag file.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsFeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsFeatureFlag.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.prefs.cardreader.manuals
+
+import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+
+class CardReaderManualsFeatureFlag @Inject constructor() {
+    fun isEnabled() = FeatureFlag.CARD_READER_MANUALS.isEnabled(null)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -13,6 +13,7 @@ enum class FeatureFlag {
     ANALYTICS_HUB,
     PAYMENTS_STRIPE_EXTENSION,
     IN_PERSON_PAYMENTS_CANADA,
+    CARD_READER_MANUALS,
     MORE_MENU_INBOX,
     MORE_MENU_COUPONS;
 
@@ -28,6 +29,7 @@ enum class FeatureFlag {
             ORDER_FILTERS,
             ANALYTICS_HUB,
             IN_PERSON_PAYMENTS_CANADA,
+            CARD_READER_MANUALS,
             MORE_MENU_INBOX,
             MORE_MENU_COUPONS -> PackageUtils.isDebugBuild()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6145 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Introducing a new feature flag for the Card Reader Manual tab CardReaderManualsFeatureFlag.kt and adding the CARD_READER_MANUAL constant to the FeatureFlag enum class

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
