### PR TITLE
Issue/6143 card reader manuals add compose screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsScreen.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.prefs.cardreader.manuals
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun CardReaderManualsScreen() {
+    // TODO add Jetpack Compose UI here
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsViewModel.kt
@@ -10,5 +10,5 @@ class CardReaderManualsViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
 
-    //TODO add manuals screen logic here
+    // TODO add manuals screen logic here
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsViewModel.kt
@@ -9,6 +9,5 @@ import javax.inject.Inject
 class CardReaderManualsViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-
     // TODO add manuals screen logic here
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/manuals/CardReaderManualsViewModel.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.prefs.cardreader.manuals
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CardReaderManualsViewModel @Inject constructor(
+    savedState: SavedStateHandle
+) : ScopedViewModel(savedState) {
+
+    //TODO add manuals screen logic here
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6143 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds the Jetpack Compose Screen file for the Card Reader manuals screen


- [ x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
