### PR TITLE
Products: Makes "new features card" and "sort-filter card" not sticky anymore

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 9.0
 -----
 - [*] Fixes a bug that caused the scheduled sale dates of a product to be different than the selected dates. [https://github.com/woocommerce/woocommerce-android/pull/6188]
+- [*] Makes "new features card" and "sort-filter card" not sticky anymore. [https://github.com/woocommerce/woocommerce-android/pull/6221]
 
 8.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -108,7 +108,7 @@ class ProductListFragment :
         binding.productsRecycler.isMotionEventSplittingEnabled = false
 
         binding.productsRefreshLayout.apply {
-            scrollUpChild = binding.productsRecycler
+            scrollUpChild = binding.productsScrollView
             setOnRefreshListener {
                 viewModel.onRefreshRequested()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
@@ -101,7 +101,7 @@ class ProductSelectionListFragment :
         productSelectionListAdapter.tracker = tracker
 
         binding.productsRefreshLayout.apply {
-            scrollUpChild = binding.productsRecycler
+            scrollUpChild = binding.productsScrollView
             setOnRefreshListener {
                 viewModel.onRefreshRequested()
             }

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -7,72 +7,78 @@
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.products.ProductListFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-
-        <!-- Products work in progress notice card -->
-        <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
-            android:id="@+id/products_wip_card"
-            style="@style/Woo.Card.Expandable"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/minor_100"
-            android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@+id/products_sort_filter_card"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="visible" />
-
-        <!-- Products filter and sort view -->
-        <com.woocommerce.android.ui.products.ProductSortAndFiltersCard
-            android:id="@+id/products_sort_filter_card"
-            style="@style/Woo.Card"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/minor_00"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
-            tools:visibility="visible" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/productsRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="?attr/colorSurface"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/products_sort_filter_card"
-            tools:itemCount="5"
-            tools:listitem="@layout/product_list_item" />
 
         <com.woocommerce.android.widgets.WCEmptyView
             android:id="@+id/empty_view"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:layout_height="match_parent"
+            android:visibility="gone" />
 
-        <ProgressBar
-            android:id="@+id/loadMoreProgress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/major_75"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:visibility="gone" />
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/products_scroll_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <!-- Products work in progress notice card -->
+                <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
+                    android:id="@+id/products_wip_card"
+                    style="@style/Woo.Card.Expandable"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/minor_100"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toTopOf="@+id/products_sort_filter_card"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:visibility="visible" />
+
+                <!-- Products filter and sort view -->
+                <com.woocommerce.android.ui.products.ProductSortAndFiltersCard
+                    android:id="@+id/products_sort_filter_card"
+                    style="@style/Woo.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/minor_00"
+                    android:visibility="gone"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
+                    tools:visibility="visible" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/productsRecycler"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?attr/colorSurface"
+                    android:nestedScrollingEnabled="true"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/products_sort_filter_card"
+                    tools:itemCount="5"
+                    tools:listitem="@layout/product_list_item" />
+
+                <ProgressBar
+                    android:id="@+id/loadMoreProgress"
+                    style="?android:attr/progressBarStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/major_75"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:visibility="gone" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.core.widget.NestedScrollView>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/addProductButton"
@@ -82,9 +88,7 @@
             android:layout_margin="@dimen/major_100"
             android:contentDescription="@string/add_products_button"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_gravity="end|bottom"
             tools:visibility="visible" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -24,13 +24,13 @@
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="wrap_content">
 
                 <!-- Products work in progress notice card -->
                 <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
                     android:id="@+id/products_wip_card"
                     style="@style/Woo.Card.Expandable"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/minor_100"
                     android:visibility="gone"
@@ -44,7 +44,7 @@
                 <com.woocommerce.android.ui.products.ProductSortAndFiltersCard
                     android:id="@+id/products_sort_filter_card"
                     style="@style/Woo.Card"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/minor_00"
                     android:visibility="gone"
@@ -55,7 +55,7 @@
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/productsRecycler"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:background="?attr/colorSurface"
                     android:nestedScrollingEnabled="true"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3260 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
New features card and Sort-Filter card were sticky in products screen. Only Sort-Filter card is mentioned in issue #3260, but new features card was also sticky. In iOS, they both are not sticky. 
This PR moves the new features card and Sort-Filter card to the scroll, so they're not sticky anymore. If you touch these cards, you couldn't scroll the list. You can scroll by tapping these cards now.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Go to the Products tab.
- Scroll down the product list. You should have enough products to be able to scroll.
- Notice new features and Sort-Filter cards are going up by scrolling down.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| before  | after |
| ------------- | ------------- |
| ![Screenshot_20220411_003244](https://user-images.githubusercontent.com/2471769/162641166-c66936da-9d8a-4aea-9bfe-f79037ef7c9d.png) | ![Screenshot_20220411_004621](https://user-images.githubusercontent.com/2471769/162641292-41bc98bf-da58-4d22-a038-57a6ab73d0b7.png) |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
