### PR TITLE
Added androidx.lifecycle:lifecycle-process as dependency to the quicklogin module

### DIFF
--- a/quicklogin/build.gradle
+++ b/quicklogin/build.gradle
@@ -70,10 +70,11 @@ android {
     }
 
     targetProjectPath ':WooCommerce'
-    targetVariant 'debug'
 }
 
 dependencies {
+    implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
+
     implementation "androidx.test.uiautomator:uiautomator:2.2.0"
     implementation "junit:junit:$jUnitVersion"
     implementation "androidx.test.ext:junit:$jUnitExtVersion"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6206 
Closes: #6208 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes crash of the quicklogin test due to 

> Caused by: java.lang.NoSuchMethodError: No virtual method getTargetState()Landroidx/lifecycle/Lifecycle$State; in class Landroidx/lifecycle/Lifecycle$Event; or its super classes (declaration of 'androidx.lifecycle.Lifecycle$Event' appears in /data/app/~~R4CUCdjBmjTO1tFBuWn93w==/com.woocommerce.android.dev.quicklogin-byf432qm3XuqYMOYw5M3aw==/base.apk)

The issue caused by this commit - 128581159f29558e6c97715ec2031b83e906950b, but I have no idea what exactly sentry plugin does so it broke the test

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Run woo-login.sh with your credentials, and notice that it works again

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
