### PR TITLE
Adding the fragment_card_reader_manuals.xml file

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_card_reader_manuals.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_manuals.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/color_surface">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/cardReaderManualsComposeView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6202 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Until now, for simplicity, all Compose code has been added inside an `androidx.compose.ui.platform.ComposeView` that lives inside a Fragment, so adding it to follow the same structure we have been using so far. Will add the actual Fragment file next. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
