### PR TITLE
[Coupons] fix some UI inconsistencies in the list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListItem
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListState
@@ -118,9 +117,8 @@ fun CouponListItem(
         coupon.code?.let {
             Text(
                 text = it,
-                style = MaterialTheme.typography.h6,
+                style = MaterialTheme.typography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
-                fontSize = 20.sp
             )
         }
 
@@ -136,9 +134,8 @@ fun CouponListItemInfo(
 ) {
     Text(
         text = summary,
-        style = MaterialTheme.typography.body2,
-        color = colorResource(id = R.color.color_surface_variant),
-        fontSize = 14.sp,
+        style = MaterialTheme.typography.caption,
+        color = colorResource(id = R.color.color_on_surface_medium),
         modifier = Modifier.padding(vertical = 4.dp)
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -104,6 +104,7 @@ fun CouponListItem(
     onCouponClick: (Long) -> Unit
 ) {
     Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
         modifier = Modifier
             .fillMaxWidth()
             .clickable(
@@ -135,8 +136,7 @@ fun CouponListItemInfo(
     Text(
         text = summary,
         style = MaterialTheme.typography.caption,
-        color = colorResource(id = R.color.color_on_surface_medium),
-        modifier = Modifier.padding(vertical = 4.dp)
+        color = colorResource(id = R.color.color_on_surface_medium)
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -81,7 +81,6 @@ fun CouponList(
     onCouponClick: (Long) -> Unit
 ) {
     LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(0.dp),
         modifier = Modifier
             .background(color = MaterialTheme.colors.surface)
     ) {
@@ -108,14 +107,13 @@ fun CouponListItem(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
             .clickable(
                 enabled = true,
                 onClickLabel = stringResource(id = R.string.coupon_list_view_coupon),
                 role = Role.Button,
                 onClick = { onCouponClick(coupon.id) }
-            ),
-        verticalArrangement = Arrangement.spacedBy(0.dp)
+            )
+            .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         coupon.code?.let {
             Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -90,14 +90,12 @@ fun CouponList(
                 coupon = coupon,
                 onCouponClick = onCouponClick
             )
-            if (index < coupons.lastIndex) {
-                Divider(
-                    modifier = Modifier
-                        .offset(x = 16.dp),
-                    color = colorResource(id = R.color.divider_color),
-                    thickness = 1.dp
-                )
-            }
+            Divider(
+                modifier = Modifier
+                    .offset(x = 16.dp),
+                color = colorResource(id = R.color.divider_color),
+                thickness = 1.dp
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/components/CouponExpirationLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/components/CouponExpirationLabel.kt
@@ -31,7 +31,7 @@ fun CouponExpirationLabel(active: Boolean = true) {
 
         Text(
             text = status,
-            style = MaterialTheme.typography.body1,
+            style = MaterialTheme.typography.caption,
             color = MaterialTheme.colors.onSecondary,
             modifier = Modifier
                 .background(color = color)


### PR DESCRIPTION
### Description
This PR just improves the UI of the coupons list to match what we have in Figma, it's mainly just text styles and colors, and a fix to ripple feedback:

| Before | After |
| ---- | ---- |
| <img width="300" src="https://user-images.githubusercontent.com/1657201/162776113-79fa2832-7520-4495-8b4b-1209977b1be8.png"/> | <img width="300" src="https://user-images.githubusercontent.com/1657201/162776133-8fd2e46a-1308-42d0-b49f-9ce4d45314f6.png"/> |
| <img width="300" src="https://user-images.githubusercontent.com/1657201/162776221-963d2fba-02f5-40b3-8721-0059d69b3a72.png" /> | <img width="300" src="https://user-images.githubusercontent.com/1657201/162776335-8a9114ff-cfd4-4ff3-b1af-05a9acbd62f7.png"/> |

And for comparison, here is how the screen is supposed to look like in Figma:
<img width="300" alt="Screen Shot 2022-04-11 at 15 34 51" src="https://user-images.githubusercontent.com/1657201/162776873-7881141c-054c-40a3-a8a9-40c2d9217e9e.png">

### Testing instructions
Just make sure I didn't break anything 😄 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
