### PR TITLE
Do not check if onboarding complete, but always show card payment option

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.orders.simplepayments
 
 import android.os.Bundle
 import android.view.View
-import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
@@ -39,17 +38,11 @@ class TakePaymentFragment : BaseFragment(R.layout.fragment_take_payment) {
             viewModel.onCardPaymentClicked()
         }
 
-        setUpObservers(binding)
+        setUpObservers()
         setupResultHandlers()
     }
 
-    private fun setUpObservers(binding: FragmentTakePaymentBinding) {
-        viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
-            new.isCardPaymentEnabled.takeIfNotEqualTo(old?.isCardPaymentEnabled) {
-                binding.textCard.isVisible = it == true
-            }
-        }
-
+    private fun setUpObservers() {
         viewModel.event.observe(
             viewLifecycleOwner
         ) { event ->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6127
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Now we check if onboarding is complete on every payment collection attempt, including Simple Payment. As discussed, we show the "card" payment option every time

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Start Simple Payment after clean installation
* Notice that "card" payment is visible even if the onboarding check was not performed
* Try to collect the payment
* Notice that onboarding check is performed

<img width="262" alt="image" src="https://user-images.githubusercontent.com/4923871/162959193-3438d7e8-cff2-4655-8ee5-cf26da242d54.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
