### PR TITLE
[Coupons] Put Coupons Management behind Beta Features instead of Feature Flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -45,6 +45,7 @@ object AppPrefs {
         DATABASE_DOWNGRADED,
         IS_PRODUCTS_FEATURE_ENABLED,
         IS_PRODUCT_ADDONS_ENABLED,
+        IS_COUPONS_ENABLED,
         LOGIN_USER_BYPASSED_JETPACK_REQUIRED,
         SELECTED_ORDER_LIST_TAB_POSITION,
         IMAGE_OPTIMIZE_ENABLED,
@@ -159,6 +160,10 @@ object AppPrefs {
     var isProductAddonsEnabled: Boolean
         get() = getBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, false)
         set(value) = setBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, value)
+
+    var isCouponsEnabled: Boolean
+        get() = getBoolean(IS_COUPONS_ENABLED, false)
+        set(value) = setBoolean(IS_COUPONS_ENABLED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -34,6 +34,8 @@ object AppUrls {
     const val ORDER_CREATION_SURVEY = "https://automattic.survey.fm/woo-app-order-creation-production"
 
     const val COUPONS_SURVEY_DEBUG = "https://automattic.survey.fm/woo-app-coupon-management-testing"
+
+    // Will be used later when the feature is fully launched.
     const val COUPONS_SURVEY = "https://automattic.survey.fm/woo-app-coupon-management-production"
 
     const val WOOCOMMERCE_USER_ROLES =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.feedback
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.BuildConfig
-import com.woocommerce.android.util.FeatureFlag
 
 @Suppress("MagicNumber")
 enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
@@ -12,7 +12,7 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     ORDER_CREATION(AppUrls.ORDER_CREATION_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
     COUPONS(
-        if (FeatureFlag.MORE_MENU_COUPONS.isEnabled()) { AppUrls.COUPONS_SURVEY_DEBUG } else { AppUrls.COUPONS_SURVEY }
+        if (AppPrefs.isCouponsEnabled) { AppUrls.COUPONS_SURVEY_DEBUG } else { AppUrls.COUPONS_SURVEY }
     );
 
     val url

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.feedback
 
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.BuildConfig
 
@@ -11,9 +10,7 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     SIMPLE_PAYMENTS(AppUrls.SIMPLE_PAYMENTS_SURVEY, 1),
     ORDER_CREATION(AppUrls.ORDER_CREATION_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
-    COUPONS(
-        if (AppPrefs.isCouponsEnabled) { AppUrls.COUPONS_SURVEY_DEBUG } else { AppUrls.COUPONS_SURVEY }
-    );
+    COUPONS(AppUrls.COUPONS_SURVEY);
 
     val url
         get() = "$untaggedUrl?$platformTag$appVersionTag$milestoneTag"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -10,7 +10,7 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     SIMPLE_PAYMENTS(AppUrls.SIMPLE_PAYMENTS_SURVEY, 1),
     ORDER_CREATION(AppUrls.ORDER_CREATION_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
-    COUPONS(AppUrls.COUPONS_SURVEY);
+    COUPONS(AppUrls.COUPONS_SURVEY_DEBUG);
 
     val url
         get() = "$untaggedUrl?$platformTag$appVersionTag$milestoneTag"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.moremenu
 import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -67,7 +68,7 @@ class MoreMenuViewModel @Inject constructor(
                 type = COUPONS,
                 text = R.string.more_menu_button_coupons,
                 icon = R.drawable.ic_more_menu_coupons,
-                isEnabled = FeatureFlag.MORE_MENU_COUPONS.isEnabled(),
+                isEnabled = AppPrefs.isCouponsEnabled,
                 onClick = ::onCouponsButtonClick
             ),
             MenuUiButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -102,6 +102,14 @@ class AppSettingsActivity :
         }
     }
 
+    override fun onCouponsOptionChanged(enabled: Boolean) {
+        if (AppPrefs.isCouponsEnabled != enabled) {
+            isBetaOptionChanged = true
+            AppPrefs.isCouponsEnabled = enabled
+            setResult(RESULT_CODE_BETA_OPTIONS_CHANGED)
+        }
+    }
+
     override fun finishLogout() {
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -28,6 +28,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
 
         with(FragmentSettingsBetaBinding.bind(view)) {
             bindProductAddonsToggle()
+            bindCouponsToggle()
         }
     }
 
@@ -43,6 +44,14 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
             )
 
             settingsListener?.onProductAddonsOptionChanged(isChecked)
+                ?: handleToggleChangeFailure(switch, isChecked)
+        }
+    }
+
+    private fun FragmentSettingsBetaBinding.bindCouponsToggle() {
+        switchCouponsToggle.isChecked = AppPrefs.isCouponsEnabled
+        switchCouponsToggle.setOnCheckedChangeListener { switch, isChecked ->
+            settingsListener?.onCouponsOptionChanged(isChecked)
                 ?: handleToggleChangeFailure(switch, isChecked)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -47,6 +47,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     interface AppSettingsListener {
         fun onRequestLogout()
         fun onProductAddonsOptionChanged(enabled: Boolean)
+        fun onCouponsOptionChanged(enabled: Boolean)
     }
 
     private lateinit var settingsListener: AppSettingsListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -252,6 +252,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     private fun generateBetaFeaturesTitleList() =
         mutableListOf<String>().apply {
             add(getString(R.string.beta_features_add_ons))
+            add(getString(R.string.beta_features_coupons))
         }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,8 +14,7 @@ enum class FeatureFlag {
     PAYMENTS_STRIPE_EXTENSION,
     IN_PERSON_PAYMENTS_CANADA,
     CARD_READER_MANUALS,
-    MORE_MENU_INBOX,
-    MORE_MENU_COUPONS;
+    MORE_MENU_INBOX;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -30,8 +29,7 @@ enum class FeatureFlag {
             ANALYTICS_HUB,
             IN_PERSON_PAYMENTS_CANADA,
             CARD_READER_MANUALS,
-            MORE_MENU_INBOX,
-            MORE_MENU_COUPONS -> PackageUtils.isDebugBuild()
+            MORE_MENU_INBOX -> PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -14,6 +14,13 @@
         app:toggleOptionDesc="@string/settings_enable_product_addons_teaser_message"
         app:toggleOptionTitle="@string/settings_enable_product_addons_teaser_title" />
 
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+        android:id="@+id/switchCouponsToggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:toggleOptionDesc="@string/coupon_beta_features_subheading"
+        app:toggleOptionTitle="@string/coupon_beta_features_heading" />
+
     <View style="@style/Woo.Divider" />
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1486,6 +1486,7 @@
     <string name="send_feedback">Send feedback</string>
     <string name="beta_features">Beta features</string>
     <string name="beta_features_add_ons">View Add-ons</string>
+    <string name="beta_features_coupons">Coupons Management</string>
     <string name="beta_features_simple_payments">Simple payments</string>
     <string name="settings_signout">Log out</string>
     <string name="settings_preferences">Preferences</string>
@@ -1888,6 +1889,8 @@
     <string name="coupon_summary_template">%1$s off %2$s</string>
     <string name="coupon_details_expiration_date">Expires %1$s</string>
     <string name="coupon_summary_loading_failure">Loading coupon summary failed</string>
+    <string name="coupon_beta_features_heading">Coupons Management</string>
+    <string name="coupon_beta_features_subheading">Test out managing coupons in the app</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>


### PR DESCRIPTION

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR puts Coupons Management behind the Beta Features toggle in Settings, instead of behind Feature Flag as before. This is as discussed in p1644409509237329-slack-C02TD63FZA8

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Run app, go to More menu, make sure "Coupons" button is not shown,
2. Go to Settings, find "Beta Features" and make sure "Coupons Management" is listed in the option description,
4. Tap "Beta Features", make sure "Coupons Management" toggle is shown,
5. Toggle on "Coupons Management",
6. Go back to More menu, make sure "Coupons" button is now shown and working as usual,
7. Go back to Settings > Beta Features, toggle off "Coupons Management" again and make sure this hides "Coupons" button in More menu.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Beta features in Settings | Coupon Management toggle |
|-|-|
| ![Screenshot_20220412_213305](https://user-images.githubusercontent.com/266376/162986688-2c830e3b-8027-4fa3-bcec-2f4c70daca52.png) | ![Screenshot_20220412_213320](https://user-images.githubusercontent.com/266376/162986679-d616952e-5da6-4dec-a13c-2198e25b99b0.png) |

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->