### PR TITLE
Disable CodeCov expired reports validation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,4 +4,5 @@ coverage:
   status:
     project: off
     patch: off
-
+codecov:
+  max_report_age: off


### PR DESCRIPTION
### Description

The majority of code coverage reports are considered incorrect by CodeCov (see [here](https://app.codecov.io/gh/woocommerce/woocommerce-android/commits?page=1)).

As valid reports exist (see e.g. #6241 ) I'm leaning toward the theory that the problem is with time-based validation from CodeCov ([docs](https://docs.codecov.com/docs/codecov-yaml#expired-reports)).

#### How CodeCov knows when a report has been generated?

At the beginning of the XML report, there's a piece of information about the sessions that created the report. Usually, there are two of them (because of two `.exec` files I suppose). There's timestamp for session creation and "dump" there. This is the only time-based information (I could find) that we send to CodeCov so I believe they take one of those values. You can find it by opening any failed report for e.g. commit, on the right under `Uploads` there's `Download` section to see payload. Then, look for `start="` phrase. 

If you convert those milliseconds to date, you can see that sometimes those point to a date a few days back. Also, I'm not sure if `session dump` means exactly the time of generating the report - I have a feeling that it's more like time of generating `.exec` file.

#### Why are the reports outdated?

Probably Gradle Build cache or cached up-to-date checks for generating `.exec` file (artifact from tests task). Just disabling cache for `jacocoTestReport` doesn't solve the issue. I'm not 100% sure how it works under the hood though, but I decided to timebox my time for that as it's still an experiment.

#### How does that influence CodeCov?

CodeCov by default doesn't accept reports than were generated 12h+ before sending payload. While this might work for other frameworks, I'm not sure if it's a good fit for JaCoCo (and Gradle).

I'm suggesting removing this validation - if our reports will happen to be invalid, we have a problem in our cache configuration and not with CodeCov.

See similar CodeCov issue: 
https://community.codecov.com/t/reports-are-not-displayed-there-was-an-error-processing-coverage-reports/750