### PR TITLE
issue/6250-fee-amount-currency

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_order_creation_fee.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_fee.xml
@@ -28,7 +28,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_75"
-                android:hint="@string/order_creation_fee_amount_hint"
+                android:hint="@string/amount"
                 android:imeOptions="flagNoFullscreen"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_shipping.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_shipping.xml
@@ -19,7 +19,7 @@
                 android:id="@+id/amountEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/order_creation_shipping_amount"
+                android:hint="@string/amount"
                 android:imeOptions="flagNoFullscreen"
                 app:supportsEmptyState="false"
                 app:supportsNegativeValues="true" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="exclusive_or">or</string>
     <string name="count">Count: %s</string>
     <string name="no_sku">No SKU</string>
+    <string name="amount">Amount</string>
 
     <!--
         Date/Time Labels
@@ -371,14 +372,12 @@
     <string name="order_creation_success_snackbar">Order created</string>
     <string name="order_creation_payment_tax">Taxes</string>
     <string name="order_creation_price_calculation_failed">Couldn’t update pricing</string>
-    <string name="order_creation_shipping_amount">Amount</string>
     <string name="order_creation_shipping_name">Name</string>
     <string name="order_creation_shipping_title_add">Add Shipping</string>
     <string name="order_creation_add_shipping">Add shipping</string>
     <string name="order_creation_edit_shipping">Shipping</string>
     <string name="order_creation_remove_shipping">Remove shipping from order</string>
     <string name="order_creation_add_fee_removal_hint">Remove fee from order</string>
-    <string name="order_creation_fee_amount_hint">Amount ($)</string>
     <string name="order_creation_fee_percentage_hint">Percentage (%)</string>
     <string name="order_creation_fee_percentage_toggle_text">Percentage fee</string>
     <!--


### PR DESCRIPTION
Fixes #6250 - previously the order creation fee amount hint contained a hard coded US dollar. This PR addresses this to match the shipping amount hint, which has no currency.

**Before**

![before](https://user-images.githubusercontent.com/3903757/163224822-2c14d908-1301-42f5-891a-444d75f1c001.png)


**After**

![after](https://user-images.githubusercontent.com/3903757/163224855-fc624932-5767-48c7-aed5-9faa93d44dea.png)

