### PR TITLE
issue/6249-order-creation-addresses-dark-mode

### DIFF
--- a/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
@@ -57,7 +57,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?attr/textAppearanceBody2"
-        android:textColor="@color/woo_black"
         app:layout_constraintStart_toStartOf="@id/shipping_header"
         app:layout_constraintTop_toBottomOf="@id/shipping_header"
         tools:text="George Costanza\n2270 Oak Street\nNew York, NY 13420\nUnited States" />
@@ -86,7 +85,6 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textAppearance="?attr/textAppearanceBody2"
-        android:textColor="@color/woo_black"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="@id/shipping_address_details"
         app:layout_constraintTop_toBottomOf="@id/billing_header"


### PR DESCRIPTION
Fixes #6249 - prior to this PR the customer addresses in order creation weren't readable in dark mode, due to the `TextViews` being hardcoded to use black. This PR corrects this.

**Before**

![before](https://user-images.githubusercontent.com/3903757/163229014-f3550567-5755-4bad-9ced-4a7361ea871b.png)

**After**

![after](https://user-images.githubusercontent.com/3903757/163229046-e669a44a-d6ce-4ad9-b86e-9cfd703b303b.png)


