### PR TITLE
issue/6248-order-creation-dark-mode-buttons

### DIFF
--- a/WooCommerce/src/main/res/color/action_menu_fg_selector.xml
+++ b/WooCommerce/src/main/res/color/action_menu_fg_selector.xml
@@ -4,7 +4,7 @@
         android:state_enabled="false"
         android:color="@color/color_on_surface_disabled"/>
     <item
-        android:color="@color/woo_pink_50"/>
+        android:color="@color/woo_pink_30"/>
 </selector>
 
 

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -21,7 +21,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
     <style name="Widget.Woo.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
         <item name="actionMenuTextColor">@color/action_menu_fg_selector</item>
-        <item name="colorControlNormal">@color/woo_pink_50</item>
+        <item name="colorControlNormal">@color/woo_pink_30</item>
     </style>
     <style name="TextAppearance.Woo.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
         <item name="android:textColor">@color/color_on_surface</item>


### PR DESCRIPTION
Fixes #6248 - This PR corrects a subtle issue in order creation in that there's a slight difference between the color of the Create button and the Edit button.

The problem is that the Create button is an action menu item (`actionMenuTextColor`) which is `woo_pink_50`. The Edit button, like other buttons, is `color_secondary`, which is `woo_pink_30`

This PR addresses this by making action menu items `woo_pink_30` to match the button color. This affects every screen in the app that uses an action menu item, which I think is fine.

Before and after shots below.

![before-and-after](https://user-images.githubusercontent.com/3903757/163237281-ca036228-3fd5-43b9-90a0-414732ffc171.png)

