### PR TITLE
Issue/6211 order creation done button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -73,6 +73,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_order_creation, menu)
+
         createOrderMenuItem = menu.findItem(R.id.menu_create).apply {
             isEnabled = viewModel.viewStateData.liveData.value?.canCreateOrder ?: false
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -74,7 +74,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_order_creation, menu)
         createOrderMenuItem = menu.findItem(R.id.menu_create).apply {
-            isVisible = viewModel.viewStateData.liveData.value?.canCreateOrder ?: false
+            isEnabled = viewModel.viewStateData.liveData.value?.canCreateOrder ?: false
         }
     }
 
@@ -202,7 +202,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                 if (show) showProgressDialog() else hideProgressDialog()
             }
             new.canCreateOrder.takeIfNotEqualTo(old?.canCreateOrder) {
-                createOrderMenuItem?.isVisible = it
+                createOrderMenuItem?.isEnabled = it
             }
             new.isUpdatingOrderDraft.takeIfNotEqualTo(old?.isUpdatingOrderDraft) { show ->
                 binding.paymentSection.loadingProgress.isVisible = show

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/notes/OrderCreationCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/notes/OrderCreationCustomerNoteFragment.kt
@@ -32,7 +32,7 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
         }
         binding.customerOrderNoteEditor.doAfterTextChanged {
             if (::doneMenuItem.isInitialized) {
-                doneMenuItem.isVisible = hasChanges()
+                doneMenuItem.isEnabled = hasChanges()
             }
         }
     }
@@ -42,7 +42,7 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
-        doneMenuItem.isVisible = hasChanges()
+        doneMenuItem.isEnabled = hasChanges()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsCustomerNoteFragment.kt
@@ -41,7 +41,7 @@ class SimplePaymentsCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_c
         }
         binding.customerOrderNoteEditor.doAfterTextChanged {
             if (::doneMenuItem.isInitialized) {
-                doneMenuItem.isVisible = hasChanges()
+                doneMenuItem.isEnabled = hasChanges()
             }
         }
     }
@@ -61,7 +61,7 @@ class SimplePaymentsCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_c
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
-        doneMenuItem.isVisible = hasChanges()
+        doneMenuItem.isEnabled = hasChanges()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
Fixes #6211 - previously we would hide the Done button in the order creation and simple payment customer note screens when there were no changes. This PR changes that to disable rather than hide the button.

This also fixes #6193 by handling the order creation Create button similarly.