### PR TITLE
issue/6042-customer-address-state-margin

### DIFF
--- a/WooCommerce/src/main/res/layout/layout_address_form.xml
+++ b/WooCommerce/src/main/res/layout/layout_address_form.xml
@@ -184,7 +184,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginVertical="@dimen/major_100"
             android:hint="@string/shipping_label_edit_address_state"
             android:imeOptions="flagNoFullscreen"
             android:inputType="text"


### PR DESCRIPTION
Fixes #6042 by using the same vertical margin for the state EditText and spinner (previously the EditText had no bottom margin). To test, select a country that has no states (such as American Samoa) and ensure the bottom margin matches that of the state spinner when there are states.

Before and after:

![before](https://user-images.githubusercontent.com/3903757/163257490-ee2a90fb-cb95-4749-9070-661be17fba6c.png)

