### PR TITLE
Remove AppBarLayout shadow from products filter screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -412,8 +412,13 @@ class MainActivity :
             }
             showCrossIcon = false
         } else {
-            binding.appBarLayout.elevation =
-                resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
+            if (destination.id == R.id.productFilterListFragment) {
+                binding.appBarLayout.elevation = 0f
+                binding.appBarDivider.visibility = View.VISIBLE
+            } else {
+                binding.appBarDivider.visibility = View.GONE
+                binding.appBarLayout.elevation = resources.getDimensionPixelSize(dimen.appbar_elevation).toFloat()
+            }
 
             showCrossIcon = when (destination.id) {
                 R.id.productFilterListFragment,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -412,12 +412,19 @@ class MainActivity :
             }
             showCrossIcon = false
         } else {
-            if (destination.id == R.id.productFilterListFragment) {
-                binding.appBarLayout.elevation = 0f
-                binding.appBarDivider.visibility = View.VISIBLE
-            } else {
-                binding.appBarDivider.visibility = View.GONE
-                binding.appBarLayout.elevation = resources.getDimensionPixelSize(dimen.appbar_elevation).toFloat()
+            // Add divider and remove shadow under the app bar for some screens
+            when (destination.id) {
+                R.id.productFilterListFragment,
+                R.id.productFilterOptionListFragment,
+                R.id.orderFilterCategoriesFragment,
+                R.id.orderFilterOptionsFragment -> {
+                    binding.appBarLayout.elevation = 0f
+                    binding.appBarDivider.visibility = View.VISIBLE
+                }
+                else -> {
+                    binding.appBarDivider.visibility = View.GONE
+                    binding.appBarLayout.elevation = resources.getDimensionPixelSize(dimen.appbar_elevation).toFloat()
+                }
             }
 
             showCrossIcon = when (destination.id) {

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -47,8 +47,8 @@
 
             <View
                 android:id="@+id/app_bar_divider"
-                style="@style/Woo.Divider"
                 android:layout_gravity="bottom"
+                style="@style/Woo.Divider"
                 android:visibility="gone" />
         </com.google.android.material.appbar.AppBarLayout>
 

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -44,6 +44,12 @@
                     android:id="@+id/toolbar"
                     layout="@layout/view_toolbar" />
             </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+            <View
+                android:id="@+id/app_bar_divider"
+                style="@style/Woo.Divider"
+                android:layout_gravity="bottom"
+                android:visibility="gone" />
         </com.google.android.material.appbar.AppBarLayout>
 
         <FrameLayout


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3258
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
In products filter screen, there is a dropshadow under the app bar which shouldn't be there. This PR removes the shadow and adds a divider under the app bar.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Go to Products tab.
- Tap on the Filters button at the top of the product list.
- Notice that there is a divider without a dropshadow under the app bar.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|before|after|
|-|-|
|![before](https://user-images.githubusercontent.com/2471769/163403111-0d197260-f0ed-4090-8677-7974a0a28f68.png)|![after](https://user-images.githubusercontent.com/2471769/163403134-120ab17f-cb6f-4df8-b230-e0bbcc018582.png)|

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
