### PR TITLE
Issue/6262 fix order filters count

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -605,7 +605,7 @@ object AppPrefs {
 
     fun getOrderFilters(currentSiteId: Int, filterCategory: String) = getString(
         getOrderFilterKey(currentSiteId, filterCategory)
-    ).orNullIfEmpty()
+    )
 
     private fun getOrderFilterKey(currentSiteId: Int, filterCategory: String) =
         PrefKeyString("$ORDER_FILTER_PREFIX:$currentSiteId:$filterCategory")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -9,7 +9,18 @@ import android.content.SharedPreferences.Editor
 import androidx.preference.PreferenceManager
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.*
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_ONBOARDING_COMPLETED_STATUS_V2
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_PREFERRED_PLUGIN
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_PREFERRED_PLUGIN_VERSION
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_STATEMENT_DESCRIPTOR
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.DATABASE_DOWNGRADED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_COUPONS_ENABLED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_END
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_START
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
 import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PersistentOnboardingData
@@ -594,7 +605,7 @@ object AppPrefs {
 
     fun getOrderFilters(currentSiteId: Int, filterCategory: String) = getString(
         getOrderFilterKey(currentSiteId, filterCategory)
-    )
+    ).orNullIfEmpty()
 
     private fun getOrderFilterKey(currentSiteId: Int, filterCategory: String) =
         PrefKeyString("$ORDER_FILTER_PREFIX:$currentSiteId:$filterCategory")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
@@ -24,9 +24,10 @@ class OrderFiltersRepository @Inject constructor(
     }
 
     fun getCurrentFilterSelection(filterCategory: OrderListFilterCategory): List<String> =
-        selectedSite.getIfExists()?.let {
-            appSharedPrefs.getOrderFilters(it.id, filterCategory.name)
-                ?.split(",")
+        selectedSite.getIfExists()?.let { site ->
+            appSharedPrefs.getOrderFilters(site.id, filterCategory.name)
+                .split(",")
+                .filter { it.isNotBlank() }
         } ?: emptyList()
 
     fun getCustomDateRangeFilter(): Pair<Long, Long> =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6262 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When I visit the order list, it shows that two filters are applied even though there are no filters. This persists even after clearing storage or uninstalling the app.

We recently applied some [changes](https://github.com/woocommerce/woocommerce-android/pull/6159) in `AppPrefsWrapper`. Ideally, these changes shouldn't have any impact on the default values returned from preferences when there is no persisted value for a given key. But in that refactor we missed one method that it was returning `null` before the changes and now returns an empty string. This caused the bug where we returned a non-empty list of selected filters with just one element: an empty string. This caused `GetSelectedOrderFiltersCount` to wrongly calculate there are 2 filters selected.  

I initially applied [the missing call](https://github.com/woocommerce/woocommerce-android/pull/6264/commits/24075cc2bcd710eb3ed523770610e0f8eb746267) to  the function `.orNullIfEmpty()`, which is what we missed in this [PR](https://github.com/woocommerce/woocommerce-android/pull/6159). This ensures we return null value in case there is nothing saved in preferences for order filters. But given how `GetSelectedOrderFiltersCount` is implemented I thought this could be risky as changes in the future over the code could potentially lead to the same problem. Instead i applied a small fix in `OrderFiltersRepository` that ensures there are no blank elements inside the returned filter values from preferences.

### Testing instructions
- Open order list
- Check the value for filters tag matches the number of selected filters. 
- Select unselect different combination of filters and check the value is properly updated. 
