### PR TITLE
issue/6269-simple-payment-track-copy-link

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -248,6 +248,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_SIMPLE_PAYMENTS_FEEDBACK = "simple_payments"
         const val VALUE_SIMPLE_PAYMENTS_COLLECT_CARD = "card"
         const val VALUE_SIMPLE_PAYMENTS_COLLECT_CASH = "cash"
+        const val VALUE_SIMPLE_PAYMENTS_COLLECT_LINK = "payment_link"
         const val VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT = "amount"
         const val VALUE_SIMPLE_PAYMENTS_SOURCE_SUMMARY = "summary"
         const val VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD = "payment_method"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CARD
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CASH
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -81,10 +82,22 @@ class TakePaymentViewModel @Inject constructor(
     }
 
     fun onSharePaymentUrlClicked() {
+        AnalyticsTracker.track(
+            AnalyticsEvent.SIMPLE_PAYMENTS_FLOW_COLLECT,
+            mapOf(
+                AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_LINK
+            )
+        )
         triggerEvent(SharePaymentUrl(selectedSite.get().name, order.paymentUrl))
     }
 
     fun onSharePaymentUrlCompleted() {
+        AnalyticsTracker.track(
+            AnalyticsEvent.SIMPLE_PAYMENTS_FLOW_COMPLETED,
+            mapOf(
+                AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_LINK
+            )
+        )
         launch {
             markOrderCompleted()
         }


### PR DESCRIPTION
Closes #6269 by tracking when the user taps to copy a payment link in the simple payments "Take payment" screen. Note that this was implemented to [match our iOS app](https://github.com/woocommerce/woocommerce-ios/blob/db2f2934697a3a852d3b7bd07be7476790d6d82c/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift#L486).