### PR TITLE
Use BaseUnitTest.testBlocking everywhere across the main module

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.ui.common.UserEligibilityErrorViewModel.ViewState
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
@@ -68,7 +68,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the user eligibility error screen correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the user eligibility error screen correctly`() = testBlocking {
         doReturn(testUser).whenever(userEligibilityFetcher).getUserByEmail(any())
         whenever(appPrefsWrapper.getUserEmail()).thenReturn(testUser.email)
 
@@ -83,7 +83,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Handles retry button correctly when user is not eligible`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(testUser).whenever(userEligibilityFetcher).fetchUserInfo()
             doReturn(false).whenever(appPrefsWrapper).isUserEligible()
 
@@ -110,7 +110,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Handles retry button correctly when user is eligible`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Handles retry button correctly when user is eligible`() = testBlocking {
         testUser.roles = "[\"shop_manager\"]"
         doReturn(testUser).whenever(userEligibilityFetcher).fetchUserInfo()
         doReturn(true).whenever(appPrefsWrapper).isUserEligible()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcherTest.kt
@@ -58,7 +58,7 @@ class UserEligibilityFetcherTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Fetches user info correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Fetches user info correctly`() = testBlocking {
         doReturn(expectedUser.isUserEligible()).whenever(appPrefsWrapper).isUserEligible()
         doReturn(expectedUser.email).whenever(appPrefsWrapper).getUserEmail()
 
@@ -81,7 +81,7 @@ class UserEligibilityFetcherTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Do not update prefs when request failed`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Do not update prefs when request failed`() = testBlocking {
         doReturn(true).whenever(appPrefsWrapper).isUserEligible()
         doReturn(null).whenever(appPrefsWrapper).getUserEmail()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcherTest.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsUsageTracksEventEmitterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsUsageTracksEventEmitterTest.kt
@@ -46,7 +46,7 @@ class MyStoreStatsUsageTracksEventEmitterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given some interactions, when the site is changed, then it will not emit an event`() = runBlockingTest {
+    fun `given some interactions, when the site is changed, then it will not emit an event`() = testBlocking {
         // Given
         usageTracksEventEmitter.interacted(
             "2021-11-23T00:00:00Z",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsUsageTracksEventEmitterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsUsageTracksEventEmitterTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.model.SiteModel

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -27,7 +27,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -767,7 +767,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `refresh shipping tracking items when an item is added`() = runBlockingTest {
+    fun `refresh shipping tracking items when an item is added`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",
             trackingNumber = "123456",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -108,7 +108,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             it
         }
         doReturn(site).whenever(selectedSite).getIfExists()
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
         }
 
@@ -144,7 +144,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the order detail view correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the order detail view correctly`() = testBlocking {
         val nonRefundedOrder = order.copy(refundTotal = BigDecimal.ZERO)
 
         val expectedViewState = orderWithParameters.copy(orderInfo = orderInfo.copy(order = nonRefundedOrder))
@@ -221,7 +221,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `collect button hidden if payment is not collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
             doReturn(order).whenever(repository).getOrderById(any())
@@ -238,7 +238,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `collect button shown if payment is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any())
             doReturn(order).whenever(repository).getOrderById(any())
@@ -255,7 +255,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hasVirtualProductsOnly returns false if there are no products for the order`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = order.copy(items = emptyList())
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
@@ -273,7 +273,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hasVirtualProductsOnly returns true if and only if there are no physical products for the order`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val virtualItems = listOf(item.copy(productId = 3), item.copy(productId = 4))
             val virtualOrder = order.copy(items = virtualItems)
@@ -296,7 +296,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hasVirtualProductsOnly returns false if there are both virtual and physical products for the order`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val mixedItems = listOf(item, item.copy(productId = 2))
             val mixedOrder = order.copy(items = mixedItems)
@@ -320,7 +320,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `don't fetch products if we have all products`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val items = listOf(item, item.copy(productId = 2))
             val ids = items.map { it.productId }
@@ -335,7 +335,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `fetch products if there are some missing`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val items = listOf(item, item.copy(productId = 2))
             val ids = items.map { it.productId }
@@ -360,7 +360,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Do not display product list when all products are refunded`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
 
@@ -394,7 +394,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Display product list when shipping labels are available`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
 
@@ -428,7 +428,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Hide Create shipping label button and show Products area menu when shipping labels are available`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
 
@@ -475,7 +475,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Show Create shipping label button and hide Products area menu when no shipping labels are available`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
 
@@ -523,7 +523,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Do not display shipment tracking when shipping labels are available`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
 
@@ -555,7 +555,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Do not display shipment tracking when order is eligible for in-person payments`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any())
@@ -603,7 +603,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Display error message on fetch order error`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Display error message on fetch order error`() = testBlocking {
         whenever(repository.fetchOrderById(ORDER_ID)).thenReturn(null)
         whenever(repository.getOrderById(ORDER_ID)).thenReturn(null)
 
@@ -621,7 +621,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Shows and hides order detail skeleton correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(null).whenever(repository).getOrderById(any())
 
             val isSkeletonShown = ArrayList<Boolean>()
@@ -636,7 +636,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Do not fetch order from api when not connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Do not fetch order from api when not connected`() = testBlocking {
         doReturn(null).whenever(repository).getOrderById(any())
         doReturn(false).whenever(networkStatus).isConnected()
 
@@ -654,7 +654,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Update order status and handle undo action`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Update order status and handle undo action`() = testBlocking {
         val newOrderStatus = OrderStatus(CoreOrderStatus.PROCESSING.value, CoreOrderStatus.PROCESSING.value)
 
         doReturn(order).whenever(repository).getOrderById(any())
@@ -706,7 +706,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Update order status when network connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Update order status when network connected`() = testBlocking {
         val newOrderStatus = OrderStatus(CoreOrderStatus.PROCESSING.value, CoreOrderStatus.PROCESSING.value)
 
         doReturn(order).whenever(repository).getOrderById(any())
@@ -743,7 +743,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Do not update order status when not connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Do not update order status when not connected`() = testBlocking {
         doReturn(order).whenever(repository).getOrderById(any())
         doReturn(false).whenever(networkStatus).isConnected()
 
@@ -802,7 +802,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `show shipping label creation if the order is eligible`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `show shipping label creation if the order is eligible`() = testBlocking {
         doReturn(order).whenever(repository).getOrderById(any())
         doReturn(order).whenever(repository).fetchOrderById(any())
 
@@ -830,7 +830,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hide shipping label creation if wcs is older than supported version`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
 
@@ -858,7 +858,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hide shipping label creation if the order is not eligible`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
@@ -892,7 +892,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hide shipping label creation if wcs plugin is not installed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
 
@@ -922,7 +922,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `re-fetch order when payment flow completes`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `re-fetch order when payment flow completes`() = testBlocking {
         viewModel.start()
         val orderAfterPayment = order.copy(status = Status.fromDataModel(CoreOrderStatus.COMPLETED)!!)
         doReturn(orderAfterPayment).whenever(repository).getOrderById(any())
@@ -935,7 +935,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show order status updated snackbar on updating status from dialog`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
@@ -957,7 +957,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show order status updated snackbar on updating status to completed from dialog`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
@@ -979,7 +979,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show order completed snackbar on updating status to completed from fulfill screen`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
@@ -996,7 +996,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show error changing order snackbar if updating status failed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
@@ -1020,7 +1020,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `do not show error changing order snackbar if updating status failed because of cancellation`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
@@ -1040,7 +1040,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `do not show error changing order snackbar if updating status did not fail`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
@@ -1059,7 +1059,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given receipt url available, when user taps on see receipt, then preview receipt screen shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any())
@@ -1075,7 +1075,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user presses collect payment button, then start card reader payment flow`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())
@@ -1092,7 +1092,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user presses collect payment button, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(order).whenever(repository).fetchOrderById(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -243,7 +243,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `refresh shipping tracking items when an item is added`() = runBlockingTest {
+    fun `refresh shipping tracking items when an item is added`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",
             trackingNumber = "123456",
@@ -270,7 +270,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `handle onBackButtonClicked when new shipment tracking is added`() = runBlockingTest {
+    fun `handle onBackButtonClicked when new shipment tracking is added`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",
             trackingNumber = "123456",
@@ -312,7 +312,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `handle onBackButtonClicked when no shipment is added`() = runBlockingTest {
+    fun `handle onBackButtonClicked when no shipment is added`() = testBlocking {
         doReturn(order).whenever(repository).getOrderById(any())
         doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -19,7 +19,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -93,7 +93,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the order detail view correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the order detail view correctly`() = testBlocking {
         val nonRefundedOrder = order.copy(refundTotal = BigDecimal.ZERO)
         val expectedViewState = orderWithParameters.copy(order = order.copy(refundTotal = nonRefundedOrder.refundTotal))
 
@@ -129,7 +129,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hasVirtualProductsOnly returns false if there are no products for the order`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = order.copy(items = emptyList())
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
@@ -140,7 +140,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hasVirtualProductsOnly returns true if and only if there are no physical products for the order`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val virtualItems = listOf(item.copy(productId = 3), item.copy(productId = 4))
             val virtualOrder = order.copy(items = virtualItems)
@@ -155,7 +155,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
 
     @Test
     fun `hasVirtualProductsOnly returns false if there are both virtual and physical products for the order`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val mixedItems = listOf(item, item.copy(productId = 2))
             val mixedOrder = order.copy(items = mixedItems)
@@ -171,7 +171,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Do not display product list when all products are refunded`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
             doReturn(testOrderRefunds).whenever(repository).getOrderRefunds(any())
@@ -189,7 +189,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Do not display shipment tracking when shipping labels are available`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(order).whenever(repository).getOrderById(any())
             doReturn(orderShippingLabels).whenever(repository).getOrderShippingLabels(any())
 
@@ -201,7 +201,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Update order status when network connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Update order status when network connected`() = testBlocking {
         doReturn(order).whenever(repository).getOrderById(any())
         doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 
@@ -225,7 +225,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Do not update order status when not connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Do not update order status when not connected`() = testBlocking {
         doReturn(false).whenever(networkStatus).isConnected()
 
         var snackbar: ShowSnackbar? = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.ui.orders.cardreader.payment.CardReaderPaymentCur
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -39,7 +39,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order is paid, then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(datePaid = Date())
 
             val isCollectable = checker.isCollectable(order)
@@ -49,7 +49,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order not paid, then show collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(datePaid = null)
 
             val isCollectable = checker.isCollectable(order)
@@ -59,7 +59,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when total amount less than zero, then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(total = BigDecimal(-2))
 
             val isCollectable = checker.isCollectable(order)
@@ -69,7 +69,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when total amount equal to zero, then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(total = BigDecimal(0))
 
             val isCollectable = checker.isCollectable(order)
@@ -79,7 +79,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when total amount greater than zero, then show collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(total = BigDecimal(2))
             val isCollectable = checker.isCollectable(order)
 
@@ -88,7 +88,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has empty payment method, then it is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentMethod = "")
 
             val isCollectable = checker.isCollectable(order)
@@ -98,7 +98,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order in USD then it is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(currency = "USD")
 
             val isCollectable = checker.isCollectable(order)
@@ -108,7 +108,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order in not supported country then it is not collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(currency = "INR")
             whenever(
                 cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("INR")
@@ -121,7 +121,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `given Canada flag is enabled, when order in Canada, then it is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(currency = "CAD")
             whenever(
                 cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("CAD")
@@ -134,7 +134,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `given Canada IPP flag is disabled, when order in Canada, then it is not collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(currency = "CAD")
             whenever(
                 cardReaderPaymentCurrencySupportedChecker.isCurrencySupported("CAD")
@@ -147,7 +147,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has no subscriptions items, then is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder()
             doReturn(false).whenever(repository).hasSubscriptionProducts(any())
 
@@ -158,7 +158,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has subscriptions items, then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder()
             doReturn(true).whenever(repository).hasSubscriptionProducts(any())
 
@@ -169,7 +169,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has code payment method, then is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentMethod = "cod")
 
             val isCollectable = checker.isCollectable(order)
@@ -179,7 +179,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has non code payment method, then it is not collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentMethod = "stripe")
 
             val isCollectable = checker.isCollectable(order)
@@ -189,7 +189,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has processing status, then is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Processing)
 
             val isCollectable = checker.isCollectable(order)
@@ -199,7 +199,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has on hold status, then is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentStatus = Order.Status.OnHold)
 
             val isCollectable = checker.isCollectable(order)
@@ -209,7 +209,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has pending status, then is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Pending)
 
             val isCollectable = checker.isCollectable(order)
@@ -219,7 +219,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has refunded status, then is not collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Refunded)
 
             val isCollectable = checker.isCollectable(order)
@@ -229,7 +229,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has custom status, then is not collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Custom("custom"))
 
             val isCollectable = checker.isCollectable(order)
@@ -239,7 +239,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has failed status, then is not collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Failed)
 
             val isCollectable = checker.isCollectable(order)
@@ -249,7 +249,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has completed status, then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Completed)
 
             val isCollectable = checker.isCollectable(order)
@@ -259,7 +259,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has cancelled status, then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Cancelled)
 
             val isCollectable = checker.isCollectable(order)
@@ -269,7 +269,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has been refunded, then hide collect button `() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val order = getOrder(refundTotal = 99)
 
             val isCollectable = checker.isCollectable(order)
@@ -279,7 +279,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has "woocommerce_payments" payment method, then it is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val order = getOrder(paymentMethod = "woocommerce_payments")
 
@@ -292,7 +292,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Test
     fun `when order has "wc-booking-gateway" payment method, then it is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val order = getOrder(paymentMethod = "wc-booking-gateway")
 
@@ -308,7 +308,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
      */
     @Test
     fun `given bookings order requires confirmation, when checking collectibility, then it is collectable`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val order = getOrder(paymentMethod = "wc-booking-gateway")
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -32,7 +32,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     @Before
     fun setUp() {
         doReturn(false).whenever(repository).hasSubscriptionProducts(any())
-        runBlockingTest {
+        testBlocking {
             whenever(cardReaderPaymentCurrencySupportedChecker.isCurrencySupported(any())).thenReturn(true)
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUns
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.cardreader.payment.CardReaderPaymentCurrencySupportedChecker
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCurrencySupportedCheckerTest.kt
@@ -40,7 +40,7 @@ class CardReaderPaymentCurrencySupportedCheckerTest : BaseUnitTest() {
 
     @Test
     fun `given usd currency, when store location in USA, then isCurrencySupported returns true`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(wooStore.getStoreCountryCode(site)).thenReturn("US")
             whenever(
                 cardReaderConfigFactory.getCardReaderConfigFor("US")
@@ -53,7 +53,7 @@ class CardReaderPaymentCurrencySupportedCheckerTest : BaseUnitTest() {
 
     @Test
     fun `given usd currency, when store location in Canada, then isCurrencySupported returns false`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
             whenever(
                 cardReaderConfigFactory.getCardReaderConfigFor("CA")
@@ -66,7 +66,7 @@ class CardReaderPaymentCurrencySupportedCheckerTest : BaseUnitTest() {
 
     @Test
     fun `given cad currency, when store location in Canada, then isCurrencySupported returns true`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
             whenever(
                 cardReaderConfigFactory.getCardReaderConfigFor("CA")
@@ -79,7 +79,7 @@ class CardReaderPaymentCurrencySupportedCheckerTest : BaseUnitTest() {
 
     @Test
     fun `given cad currency, when store location in USA, then isCurrencySupported returns false`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(wooStore.getStoreCountryCode(site)).thenReturn("US")
             whenever(
                 cardReaderConfigFactory.getCardReaderConfigFor("US")
@@ -92,7 +92,7 @@ class CardReaderPaymentCurrencySupportedCheckerTest : BaseUnitTest() {
 
     @Test
     fun `given usd currency, when store location in unsupported country, then isCurrencySupported returns false`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(wooStore.getStoreCountryCode(site)).thenReturn("IN")
             whenever(
                 cardReaderConfigFactory.getCardReaderConfigFor("IN")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -88,7 +88,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper = mock()
 
     @Before
-    fun setUp() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun setUp() = testBlocking {
         viewModel = CardReaderPaymentViewModel(
             savedState,
             cardReaderManager = cardReaderManager,
@@ -140,7 +140,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment shown, when RETRY message received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(RETRY_CARD))
@@ -159,7 +159,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment shown, when INSERT_CARD received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(INSERT_CARD))
@@ -178,7 +178,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment shown, when INSERT_OR_SWIPE_CARD received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(INSERT_OR_SWIPE_CARD))
@@ -197,7 +197,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment shown, when SWIPE_CARD received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(SWIPE_CARD))
@@ -216,7 +216,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment shown, when REMOVE_CARD received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(REMOVE_CARD))
@@ -235,7 +235,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment shown, when TRY_OTHER_CARD message received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(TRY_ANOTHER_CARD))
@@ -254,7 +254,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment shown, when TRY_OTHER_READ message received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(TRY_ANOTHER_READ_METHOD))
@@ -273,7 +273,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment shown, when MULTIPLE_CARDS_DETECTED received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
                 flow {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(MULTIPLE_CONTACTLESS_CARDS_DETECTED))
@@ -292,7 +292,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given fetching order fails, when payment screen shown, then FailedPayment state is shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(orderRepository.fetchOrderById(ORDER_ID)).thenReturn(null)
 
             viewModel.start()
@@ -302,7 +302,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when fetching order fails, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(orderRepository.fetchOrderById(ORDER_ID)).thenReturn(null)
 
             viewModel.start()
@@ -312,7 +312,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given fetching order fails, when payment screen shown, then correct error message shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(orderRepository.fetchOrderById(ORDER_ID)).thenReturn(null)
 
             viewModel.start()
@@ -323,7 +323,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given fetching order succeeds, when payment screen shown, then order currency stored `() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.start()
 
             verify(cardReaderTrackingInfoKeeper).setCurrency(("GBP"))
@@ -338,7 +338,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment not collectable, then flow terminated and snackbar shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(false)
             val events = mutableListOf<Event>()
             viewModel.event.observeForever {
@@ -357,7 +357,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when flow started, then correct payment description is propagated to CardReaderManager`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val siteName = "testName"
             val expectedResult = "hooray"
             whenever(selectedSite.get()).thenReturn(
@@ -378,7 +378,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when flow started, then correct statement descriptor is propagated to CardReaderManager`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val expectedResult = "hooray"
             whenever(appPrefsWrapper.getCardReaderStatementDescriptor(anyOrNull(), anyOrNull(), anyOrNull()))
                 .thenReturn(expectedResult)
@@ -392,7 +392,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when initializing payment, then ui updated to initializing payment state `() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(InitializingPayment) }
             }
@@ -404,7 +404,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when collecting payment, then ui updated to collecting payment state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CollectingPayment) }
             }
@@ -416,7 +416,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment, then ui updated to processing payment state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPayment) }
             }
@@ -428,7 +428,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment completed with card present, then tracking keeper stores payment type`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPaymentCompleted(PaymentMethodType.CARD_PRESENT)) }
             }
@@ -440,7 +440,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment completed with interac present, then tracking keeper stores payment type`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPaymentCompleted(PaymentMethodType.INTERAC_PRESENT)) }
             }
@@ -452,7 +452,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment completed with interac present, then track interac success`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPaymentCompleted(PaymentMethodType.INTERAC_PRESENT)) }
             }
@@ -464,7 +464,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment completed with card present, then do not track interac success`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPaymentCompleted(PaymentMethodType.CARD_PRESENT)) }
             }
@@ -476,7 +476,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment completed with unknown type, then do not track interac success`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPaymentCompleted(PaymentMethodType.UNKNOWN)) }
             }
@@ -488,7 +488,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment completed with unknown, then tracking keeper stores payment type`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPaymentCompleted(PaymentMethodType.UNKNOWN)) }
             }
@@ -500,7 +500,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when capturing payment, then ui updated to capturing payment state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CapturingPayment) }
             }
@@ -512,7 +512,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email empty, when payment completed, then ui updated to payment successful state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -524,7 +524,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing not empty, when payment completed, then ui updated to payment successful receipt sent state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(mockedAddress.email).thenReturn("nonemptyemail")
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -539,7 +539,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment completed, then cha-ching sound is played`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -555,7 +555,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment completed, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -567,7 +567,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails, then ui updated to failed state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -581,7 +581,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of NoNetwork, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -598,7 +598,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of Unknown, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -615,7 +615,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of CARD_READ_TIMEOUT, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -632,7 +632,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
             }
@@ -644,7 +644,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of NO_NETWORK, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -661,7 +661,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of declined Unknown, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -678,7 +678,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of CARD_READ_TIME_OUT, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -695,7 +695,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of GENERIC_ERROR, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -712,7 +712,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of SERVER_ERROR, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Server)).thenReturn(PaymentFlowError.Server)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithServerError) }
@@ -728,7 +728,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of AMOUNT_TOO_SMALL, then error is mapped correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall))
                 .thenReturn(AmountTooSmall)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -745,7 +745,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of AMOUNT_TOO_SMALL, then failed state has ok button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall))
                 .thenReturn(AmountTooSmall)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -762,7 +762,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails not because of AMOUNT_TOO_SMALL, then failed state has Try again button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Server))
                 .thenReturn(PaymentFlowError.Server)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -779,7 +779,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails because of AMOUNT_TOO_SMALL, then clicking on ok button triggers exit event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall))
                 .thenReturn(AmountTooSmall)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -794,7 +794,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user clicks on retry, when payment fails and retryData are null, then flow restarted from scratch`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -811,7 +811,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user clicks on retry, when payment fails, then retryCollectPayment invoked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -827,7 +827,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user clicks on retry, when payment fails, then flow retried with provided PaymentData`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic)).thenReturn(PaymentFlowError.Generic)
             val paymentData = mock<PaymentData>()
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -842,7 +842,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when loading data, then only progress is visible`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `when loading data, then only progress is visible`() = testBlocking {
         viewModel.start()
         val viewState = viewModel.viewStateData.value!!
 
@@ -863,7 +863,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when collecting payment, then progress and buttons are hidden`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CollectingPayment) }
             }
@@ -878,7 +878,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when collecting payment, then correct labels and illustration is shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CollectingPayment) }
             }
@@ -902,7 +902,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment, then progress and buttons are hidden`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPayment) }
             }
@@ -917,7 +917,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment, then correct labels and illustration is shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPayment) }
             }
@@ -941,7 +941,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when capturing payment, then progress and buttons are hidden`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CapturingPayment) }
             }
@@ -956,7 +956,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when capturing payment, then correct labels and illustration is shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CapturingPayment) }
             }
@@ -980,7 +980,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails, then progress and secondary button are hidden`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic)).thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -995,7 +995,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails, then correct labels, illustration and button are shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic)).thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -1020,7 +1020,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails with no network error, then correct paymentStateLabel is shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork)).thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentFailed(NoNetwork, null, "")) }
@@ -1035,7 +1035,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails with payment unknown error, then correct paymentStateLabel is shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -1051,7 +1051,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails with server error, then correct paymentStateLabel is shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Server))
                 .thenReturn(PaymentFlowError.Server)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -1067,7 +1067,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment succeeds, then receiptUrl stored into a persistant storage`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val receiptUrl = "testUrl"
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted(receiptUrl)) }
@@ -1080,7 +1080,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment succeeds, then correct labels, illustration and buttons are shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1107,7 +1107,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow already started, when start() is invoked, then flow is not restarted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow<CardPaymentStatus> {}
             }
@@ -1123,7 +1123,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email empty, when user clicks on print receipt button, then PrintReceipt event emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1136,7 +1136,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email not empty, when user clicks on print receipt button, then PrintReceipt event emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(mockedAddress.email).thenReturn("nonemptyemail")
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1151,7 +1151,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email empty, when user clicks on print receipt button, then printing receipt state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1165,7 +1165,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email not empty, when user clicks on print receipt button, then printing receipt state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(mockedAddress.email).thenReturn("nonemptyemail")
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1181,7 +1181,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email empty, when print result received, then payment successful state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1195,7 +1195,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email not empty, when print result received, then payment success receipt sent state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(mockedAddress.email).thenReturn("nonemptyemail")
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1212,7 +1212,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given in printing receipt state, when view recreated, then PrintReceipt event emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1226,7 +1226,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given not in printing receipt state, when view recreated, then state not changed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow<CardPaymentStatus> {}
             }
@@ -1241,7 +1241,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email empty, when user clicks on print receipt button, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1254,7 +1254,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email not empty, when user clicks on print receipt button, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(mockedAddress.email).thenReturn("nonemptyemail")
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1290,7 +1290,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on send receipt button, then SendReceipt event emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1303,7 +1303,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on send receipt button, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1316,7 +1316,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email empty, when user clicks on save for later button, then Exit event emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1329,7 +1329,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given billing email not empty, when user clicks on save for later button, then Exit event emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(mockedAddress.email).thenReturn("nonemptyemail")
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -1344,7 +1344,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when email activity not found, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onEmailActivityNotFound()
 
             verify(tracker).trackEmailReceiptFailed()
@@ -1352,7 +1352,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses back button, when re-fetching order, then ReFetchingOrderState shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             simulateFetchOrderJobState(inProgress = true)
 
             viewModel.onBackPressed()
@@ -1362,7 +1362,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow is loading, when user presses back button, then cancel event is tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(LoadingDataState) }
             }
@@ -1375,7 +1375,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow is collecting state, when user presses back button, then cancel event is tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CollectingPayment) }
             }
@@ -1388,7 +1388,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow is processing state, when user presses back button, then cancel event is tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(ProcessingPayment) }
             }
@@ -1401,7 +1401,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow is capturing state, when user presses back button, then cancel event is tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(CapturingPayment) }
             }
@@ -1414,7 +1414,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow is payment failed, when user presses back button, then cancel event is not tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -1429,7 +1429,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow is success state, when user presses back button, then cancel event is not tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1442,7 +1442,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow is receipt print state, when user presses back button, then cancel event is not tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1456,7 +1456,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow is refetching order, when user presses back button, then cancel event is not tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1470,7 +1470,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given re-fetching order, when user clicks on save for later button, then ReFetchingOrderState shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
             }
@@ -1484,7 +1484,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses back, when already in ReFetchingOrderState, then snackbar shown and screen dismissed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             simulateFetchOrderJobState(inProgress = true)
             viewModel.onBackPressed() // shows ReFetchingOrderState screen
             val events = mutableListOf<Event>()
@@ -1500,7 +1500,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses back, when already showing ReFetchingOrderState, then correct snackbar message shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             simulateFetchOrderJobState(inProgress = true)
             viewModel.onBackPressed() // shows ReFetchingOrderState screen
             val events = mutableListOf<Event>()
@@ -1516,7 +1516,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses back button, when re-fetching order, then screen not dismissed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             simulateFetchOrderJobState(inProgress = true)
 
             viewModel.onBackPressed()
@@ -1526,7 +1526,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses back button, when not re-fetching order, then screen dismissed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             simulateFetchOrderJobState(inProgress = false)
 
             viewModel.onBackPressed()
@@ -1536,7 +1536,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given ReFetchingOrderState shown, when re-fetching order completes, then screen auto-dismissed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             simulateFetchOrderJobState(inProgress = true)
             viewModel.onBackPressed() // show ReFetchingOrderState screen
 
@@ -1547,7 +1547,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given ReFetchingOrderState not shown, when re-fetching order completes, then screen not auto-dismissed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             simulateFetchOrderJobState(inProgress = true)
 
             viewModel.reFetchOrder()
@@ -1557,7 +1557,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when re-fetching order fails, then SnackBar shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(orderRepository.fetchOrderById(any())).thenReturn(null)
             val events = mutableListOf<Event>()
             viewModel.event.observeForever {
@@ -1571,7 +1571,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user leaves the screen, when payment fails, then payment canceled`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithValidDataForRetry) }
             }
@@ -1584,7 +1584,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user leaves the screen, when payment succeeded on retry, then payment NOT canceled`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(errorMapper.mapPaymentErrorToUiError(Generic)).thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any()))
                 .thenAnswer {
@@ -1602,7 +1602,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given collect payment NOT shown, when show additional info event received, then event ignored`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow {
                     emit(ProcessingPayment)
@@ -1630,7 +1630,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is connecting, when payment screen is shown, then make sure NOT to initiate payment`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
 
@@ -1643,7 +1643,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is NOT connected, when payment screen is shown, then make sure NOT to initiate payment`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
 
@@ -1656,7 +1656,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is connected, when payment screen is shown, then proceed to initiate payment`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
 
@@ -1669,7 +1669,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is NOT connected, when payment screen is shown, then show error Snackbar`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             val events = mutableListOf<Event>()
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
@@ -1686,7 +1686,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is NOT connected, when payment screen is shown, then Snackbar is shown with message`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             val events = mutableListOf<Event>()
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
@@ -1704,7 +1704,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is NOT connected, when payment screen is shown, then exit event is triggered`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
 
@@ -1718,7 +1718,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is connecting, when payment screen is shown, then show error Snackbar`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             val events = mutableListOf<Event>()
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
@@ -1735,7 +1735,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is connecting, when payment screen is shown, then Snackbar is shown with the message`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             val events = mutableListOf<Event>()
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
@@ -1753,7 +1753,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader status is connecting, when payment screen is shown, then exit event is triggered`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
 
@@ -1767,7 +1767,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when flow started, then correct order key is propagated to CardReaderManager`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             val captor = argumentCaptor<PaymentInfo>()
 
@@ -1781,7 +1781,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given null saved plugin, when flow started, then wc pay can send receipt is false`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any())).thenReturn(null)
             val captor = argumentCaptor<PaymentInfo>()
@@ -1796,7 +1796,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given stripe saved plugin, when flow started, then wc pay can send receipt is false`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
                 .thenReturn(PluginType.STRIPE_EXTENSION_GATEWAY)
@@ -1812,7 +1812,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given null saved plugin version, when flow started, then wc pay can send receipt is false`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
                 .thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
@@ -1829,7 +1829,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given saved plugin version 3-9-9, when flow started, then wc pay can send receipt is false`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
                 .thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
@@ -1847,7 +1847,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given saved plugin version 4-0-0, when flow started, then wc pay can send receipt is true`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
                 .thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
@@ -1865,7 +1865,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given saved plugin version 16-3-13, when flow started, then wc pay can send receipt is true`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // Given
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
                 .thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ReceiptPreviewViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ReceiptPreviewViewModelTest.kt
@@ -74,7 +74,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on send email, then send receipt event emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onSendEmailClicked()
 
             assertThat(viewModel.event.value).isInstanceOf(SendReceipt::class.java)
@@ -82,7 +82,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on send email, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onSendEmailClicked()
 
             verify(tracker).track(RECEIPT_EMAIL_TAPPED)
@@ -90,7 +90,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when email application not found, then SnackBar with error shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onEmailActivityNotFound()
 
             assertThat(viewModel.event.value).isInstanceOf(ShowSnackbar::class.java)
@@ -98,7 +98,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when email application not found, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onEmailActivityNotFound()
 
             verify(tracker).track(RECEIPT_EMAIL_FAILED)
@@ -106,7 +106,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on print receipt, then print receipt event emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onPrintClicked()
 
             assertThat(viewModel.event.value).isInstanceOf(PrintReceipt::class.java)
@@ -114,7 +114,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on print receipt, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onPrintClicked()
 
             verify(tracker).track(RECEIPT_PRINT_TAPPED)
@@ -122,7 +122,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when printing receipt fails, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onPrintResult(FAILED)
 
             verify(tracker).track(RECEIPT_PRINT_FAILED)
@@ -130,7 +130,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user cancels printing receipt, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onPrintResult(CANCELLED)
 
             verify(tracker).track(RECEIPT_PRINT_CANCELED)
@@ -138,7 +138,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when printing receipt succeeds, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel.onPrintResult(STARTED)
 
             verify(tracker).track(RECEIPT_PRINT_SUCCESS)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ReceiptPreviewViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/ReceiptPreviewViewModelTest.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.*
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -29,7 +29,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
     private val pluginVersion = "4.0.0"
 
     @Test
-    fun `given hub flow, when vm init, then navigates to onboarding`() = runBlockingTest {
+    fun `given hub flow, when vm init, then navigates to onboarding`() = testBlocking {
         // GIVEN
         val param = CardReaderFlowParam.CardReadersHub
 
@@ -42,7 +42,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given payment flow and connected reader, when vm init, then navigates to payment`() = runBlockingTest {
+    fun `given payment flow and connected reader, when vm init, then navigates to payment`() = testBlocking {
         // GIVEN
         val orderId = 1L
         val param = CardReaderFlowParam.ConnectAndAcceptPayment(orderId = orderId)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -57,7 +57,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow and not connected and onboarding error, when vm init, then navigates to onboarding`() =
-        runBlockingTest {
+        testBlocking {
             // GIVEN
             val orderId = 1L
             val param = CardReaderFlowParam.ConnectAndAcceptPayment(orderId = orderId)
@@ -74,7 +74,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow and not connected and onboarding success, when vm init, then navigates to welcome`() =
-        runBlockingTest {
+        testBlocking {
             // GIVEN
             val orderId = 1L
             val param = CardReaderFlowParam.ConnectAndAcceptPayment(orderId = orderId)
@@ -97,7 +97,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow and not connected and onboarding success, when vm init, then tracks onboarding state`() =
-        runBlockingTest {
+        testBlocking {
             // GIVEN
             val orderId = 1L
             val param = CardReaderFlowParam.ConnectAndAcceptPayment(orderId = orderId)
@@ -119,7 +119,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow onboarding success welcome shown, when vm init, then navigates to connection`() =
-        runBlockingTest {
+        testBlocking {
             // GIVEN
             val orderId = 1L
             val param = CardReaderFlowParam.ConnectAndAcceptPayment(orderId = orderId)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Before

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
@@ -157,7 +157,7 @@ class OrderCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when hitting the edit order status button, then trigger ViewOrderStatusSelector event`() = runBlockingTest {
+    fun `when hitting the edit order status button, then trigger ViewOrderStatusSelector event`() = testBlocking {
         var lastReceivedEvent: Event? = null
         sut.event.observeForever {
             lastReceivedEvent = it
@@ -177,7 +177,7 @@ class OrderCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when decreasing product quantity to zero, then call the full product view`() = runBlockingTest {
+    fun `when decreasing product quantity to zero, then call the full product view`() = testBlocking {
         var lastReceivedEvent: Event? = null
         sut.event.observeForever {
             lastReceivedEvent = it
@@ -240,7 +240,7 @@ class OrderCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when adding products, then update product liveData when quantity is one or more`() = runBlockingTest {
+    fun `when adding products, then update product liveData when quantity is one or more`() = testBlocking {
         var products: List<ProductUIModel> = emptyList()
         sut.products.observeForever {
             products = it
@@ -255,7 +255,7 @@ class OrderCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when remove a product, then update orderDraft liveData with the quantity set to zero`() = runBlockingTest {
+    fun `when remove a product, then update orderDraft liveData with the quantity set to zero`() = testBlocking {
         var orderDraft: Order? = null
         sut.orderDraft.observeForever {
             orderDraft = it

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
@@ -45,7 +45,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should replicate billing to shipping when toggle is activated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             orderEditingRepository.stub {
                 onBlocking {
                     updateBothOrderAddresses(any(), any(), any())
@@ -68,7 +68,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should replicate shipping to billing when toggle is activated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             orderEditingRepository.stub {
                 onBlocking {
                     updateBothOrderAddresses(any(), any(), any())
@@ -131,7 +131,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should replace email info with original one when empty`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val originalOrder = testOrder.copy(
                 billingAddress = addressToUpdate.copy(email = "original@email.com")
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -67,7 +67,7 @@ class AddressViewModelTest : BaseUnitTest() {
     @Test
     fun `Should fetch countries and states on start if they've never been fetched`() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             addressViewModel.start(
                 mapOf(SHIPPING to shippingAddress)
             )
@@ -78,7 +78,7 @@ class AddressViewModelTest : BaseUnitTest() {
     @Test
     fun `Should NOT execute start more than once`() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             addressViewModel.start(
                 mapOf(SHIPPING to shippingAddress)
             )
@@ -92,7 +92,7 @@ class AddressViewModelTest : BaseUnitTest() {
     @Test
     fun `Should execute start again after onScreenDetached is called`() {
         whenever(dataStore.getCountries()).thenReturn(emptyList())
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             addressViewModel.start(
                 mapOf(SHIPPING to shippingAddress)
             )
@@ -114,7 +114,7 @@ class AddressViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should NOT fetch countries and states on start if countries have already been fetched`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             addressViewModel.start(
                 mapOf(SHIPPING to shippingAddress)
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.orders.details.editing.address.AddressViewMode
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelTestUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.*

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModelTest.kt
@@ -57,7 +57,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hide customer note checkbox if no email`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `hide customer note checkbox if no email`() = testBlocking {
         val testOrder = testOrder.let {
             val address = it.billingAddress.copy(email = "")
             it.copy(billingAddress = address)
@@ -74,7 +74,7 @@ class AddOrderNoteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `show customer note checkbox if no email`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `show customer note checkbox if no email`() = testBlocking {
         val testOrder = testOrder.let {
             val address = it.billingAddress.copy(email = "test@emai.com")
             it.copy(billingAddress = address)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModelTest.kt
@@ -117,7 +117,7 @@ class PrintShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Do not print shipping label when not connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Do not print shipping label when not connected`() = testBlocking {
         initViewModel()
         doReturn(false).whenever(networkStatus).isConnected()
 
@@ -131,7 +131,7 @@ class PrintShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Print shipping label when api connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Print shipping label when api connected`() = testBlocking {
         val testString = "testString"
         doReturn(true).whenever(networkStatus).isConnected()
         doReturn(WooResult(testString)).whenever(repository).printShippingLabels(any(), any())
@@ -155,7 +155,7 @@ class PrintShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Print shipping label results in an error`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Print shipping label results in an error`() = testBlocking {
         doReturn(true).whenever(networkStatus).isConnected()
         doReturn(
             WooResult<Boolean>(WooError(API_ERROR, NETWORK_ERROR, ""))
@@ -186,7 +186,7 @@ class PrintShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `consider an anonymized label as expired`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `consider an anonymized label as expired`() = testBlocking {
         val label = OrderTestUtils.generateShippingLabel(shippingLabelId = REMOTE_SHIPPING_LABEL_ID)
             .copy(status = "ANONYMIZED")
         doReturn(label)
@@ -203,7 +203,7 @@ class PrintShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `disable printing if label expiry date passed`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `disable printing if label expiry date passed`() = testBlocking {
         val label = OrderTestUtils.generateShippingLabel(shippingLabelId = REMOTE_SHIPPING_LABEL_ID)
             .copy(expiryDate = Date(System.currentTimeMillis() - 60_000))
         doReturn(label)
@@ -220,7 +220,7 @@ class PrintShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `enable printing if label hasn't expired yet`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `enable printing if label hasn't expired yet`() = testBlocking {
         val label = OrderTestUtils.generateShippingLabel(shippingLabelId = REMOTE_SHIPPING_LABEL_ID)
             .copy(expiryDate = Date(System.currentTimeMillis() + 60_000))
         doReturn(label)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModelTest.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.util.Base64Decoder
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModelTest.kt
@@ -64,7 +64,7 @@ class ShippingLabelRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the refund shipping label view correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the refund shipping label view correctly`() = testBlocking {
         var shippingLabelData: ShippingLabelRefundViewState? = null
         viewModel.shippingLabelRefundViewStateData.observeForever { _, new -> shippingLabelData = new }
 
@@ -73,7 +73,7 @@ class ShippingLabelRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Refunds the shipping label correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Refunds the shipping label correctly`() = testBlocking {
         doReturn(WooResult(true)).whenever(repository).refundShippingLabel(any(), any())
 
         var snackBar: ShowSnackbar? = null
@@ -92,7 +92,7 @@ class ShippingLabelRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Refunds the shipping label results in an error`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Refunds the shipping label results in an error`() = testBlocking {
         doReturn(
             WooResult<Boolean>(WooError(API_ERROR, NETWORK_ERROR, ""))
         ).whenever(repository).refundShippingLabel(any(), any())
@@ -113,7 +113,7 @@ class ShippingLabelRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `disable refund if label is anonymized`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `disable refund if label is anonymized`() = testBlocking {
         doReturn(shippingLabel.copy(status = "ANONYMIZED"))
             .whenever(repository).getShippingLabelByOrderIdAndLabelId(any(), any())
 
@@ -126,7 +126,7 @@ class ShippingLabelRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `disable refund if label is older than 30 days`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `disable refund if label is older than 30 days`() = testBlocking {
         doReturn(shippingLabel.copy(createdDate = Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(31))))
             .whenever(repository).getShippingLabelByOrderIdAndLabelId(any(), any())
 
@@ -139,7 +139,7 @@ class ShippingLabelRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `enable refund if label is recent than 30 days`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `enable refund if label is recent than 30 days`() = testBlocking {
         doReturn(shippingLabel.copy(createdDate = Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(29))))
             .whenever(repository).getShippingLabelByOrderIdAndLabelId(any(), any())
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModelTest.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -189,7 +189,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays create shipping label view correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays create shipping label view correctly`() = testBlocking {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
@@ -197,7 +197,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays data-loaded state correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays data-loaded state correctly`() = testBlocking {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
@@ -216,7 +216,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays origin-address validated state correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays origin-address validated state correctly`() = testBlocking {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
@@ -240,7 +240,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays shipping-address validated state correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays shipping-address validated state correctly`() = testBlocking {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
@@ -269,7 +269,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Continue click in origin address triggers validation`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Continue click in origin address triggers validation`() = testBlocking {
         stateFlow.value = Transition(WaitingForInput(data), null)
 
         viewModel.onContinueButtonTapped(FlowStep.ORIGIN_ADDRESS)
@@ -305,7 +305,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Purchase a label successfully`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Purchase a label successfully`() = testBlocking {
         val purchasedLabels = listOf(
             OrderTestUtils.generateShippingLabel(shippingLabelId = 1)
         )
@@ -319,7 +319,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Show print screen after purchase`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Show print screen after purchase`() = testBlocking {
         val purchasedLabels = listOf(
             OrderTestUtils.generateShippingLabel(shippingLabelId = 1)
         )
@@ -335,7 +335,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `fulfill order after successful purchase`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `fulfill order after successful purchase`() = testBlocking {
         val purchasedLabels = listOf(
             OrderTestUtils.generateShippingLabel(shippingLabelId = 1)
         )
@@ -358,7 +358,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
 
     @Test
     fun `notify user if fulfilment fail after successful purchase`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val purchasedLabels = listOf(
                 OrderTestUtils.generateShippingLabel(shippingLabelId = 1)
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -28,7 +28,6 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -71,7 +71,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `test first opening of the screen`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `test first opening of the screen`() = testBlocking {
         whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
@@ -85,7 +85,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `test edit flow`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `test edit flow`() = testBlocking {
         val currentShippingPackages = arrayOf(
             CreateShippingLabelTestUtils.generateShippingLabelPackage(
                 selectedPackage = availablePackages[0]
@@ -101,7 +101,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `no last used package`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `no last used package`() = testBlocking {
         whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(null)
 
         setup(emptyArray())
@@ -112,7 +112,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `edit weight of package`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `edit weight of package`() = testBlocking {
         whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
@@ -125,7 +125,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `select a package`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `select a package`() = testBlocking {
         whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
@@ -138,7 +138,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `exit without saving changes`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `exit without saving changes`() = testBlocking {
         whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
@@ -151,7 +151,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
     @Suppress("UNCHECKED_CAST")
     @Test
-    fun `save changes and exit`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `save changes and exit`() = testBlocking {
         whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.*

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModelTest.kt
@@ -38,7 +38,7 @@ class ShippingLabelAddressSuggestionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays entered and suggested address correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays entered and suggested address correctly`() = testBlocking {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
@@ -46,7 +46,7 @@ class ShippingLabelAddressSuggestionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Updates the selected address`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Updates the selected address`() = testBlocking {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
@@ -60,7 +60,7 @@ class ShippingLabelAddressSuggestionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Triggers the edit address event`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Triggers the edit address event`() = testBlocking {
         var event: Event? = null
         viewModel.event.observeForever { event = it }
 
@@ -71,7 +71,7 @@ class ShippingLabelAddressSuggestionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Triggers the use address event`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Triggers the use address event`() = testBlocking {
         var event: Event? = null
         viewModel.event.observeForever { event = it }
 
@@ -82,7 +82,7 @@ class ShippingLabelAddressSuggestionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Exits the screen with a exit event`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Exits the screen with a exit event`() = testBlocking {
         var event: Event? = null
         viewModel.event.observeForever { event = it }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModelTest.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModelTest.kt
@@ -156,7 +156,7 @@ class ShippingLabelCreateCustomPackageViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when a package is created successfully, then trigger success event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(shippingRepository.createCustomPackage(any())).thenReturn(WooResult(true))
             setup()
             populateFields()
@@ -168,7 +168,7 @@ class ShippingLabelCreateCustomPackageViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when a package creation is not saved properly, then show Snackbar`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val error = WooError(API_ERROR, NETWORK_ERROR, "")
             whenever(shippingRepository.createCustomPackage(any())).thenReturn(WooResult(error = error))
             setup()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModelTest.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModelTest.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModelTest.kt
@@ -60,7 +60,7 @@ class ShippingLabelCreateServicePackageViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when selectable packages fetching fails, then display a Snackbar`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(shippingRepository.getSelectableServicePackages()).thenReturn(
                 WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             )
@@ -71,7 +71,7 @@ class ShippingLabelCreateServicePackageViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given no selected packages, when Done button is tapped, then display a Snackbar`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(shippingRepository.getSelectableServicePackages()).thenReturn(WooResult(availablePackages))
             setup()
             var event: MultiLiveEvent.Event? = null
@@ -83,7 +83,7 @@ class ShippingLabelCreateServicePackageViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when package is saved successfully, then trigger success event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(shippingRepository.getSelectableServicePackages()).thenReturn(WooResult(availablePackages))
             whenever(shippingRepository.activateServicePackage(any())).thenReturn(WooResult(true))
             setup()
@@ -95,7 +95,7 @@ class ShippingLabelCreateServicePackageViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when package is not saved successfully, then show Snackbar`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val error = WooError(API_ERROR, NETWORK_ERROR, "")
             whenever(shippingRepository.getSelectableServicePackages()).thenReturn(WooResult(availablePackages))
             whenever(shippingRepository.activateServicePackage(any())).thenReturn(WooResult(error = error))
@@ -113,7 +113,7 @@ class ShippingLabelCreateServicePackageViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given no available packages, when service package tab is opened, then show empty view and hide done button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(shippingRepository.getSelectableServicePackages()).thenReturn(WooResult(emptyList()))
             setup()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -56,7 +56,7 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Test the data login sequence of events after start`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Test the data login sequence of events after start`() = testBlocking {
         val expectedSideEffectCount = 3 // necessary to terminate the flow
         var transition: Transition? = null
         launch {
@@ -84,7 +84,7 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Test successful address verification`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Test successful address verification`() = testBlocking {
         val expectedSideEffectCount = 5 // necessary to terminate the flow
         var transition: Transition? = null
         launch {
@@ -110,7 +110,7 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
     }
 
     @Test
-    fun `test show packages step`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `test show packages step`() = testBlocking {
         val packagesList = listOf(
             ShippingLabelPackage(
                 position = 1,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModelTest.kt
@@ -50,7 +50,7 @@ class ShippingPackageSelectorViewModelTest : BaseUnitTest() {
                 gmtOffset = 0f
             )
         )
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(shippingRepository.getShippingPackages()).thenReturn(WooResult(availablePackages))
         }
         viewModel = ShippingPackageSelectorViewModel(
@@ -61,7 +61,7 @@ class ShippingPackageSelectorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `display list of packages`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `display list of packages`() = testBlocking {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, state -> viewState = state }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModelTest.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModelTests.kt
@@ -50,7 +50,7 @@ class SimplePaymentsFragmentViewModelTests : BaseUnitTest() {
 
     @Test
     fun `when charging taxes is enabled, then taxes are applied to the total amount of the order`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             initViewModel()
             viewModel.onChargeTaxesChanged(chargeTaxes = true)
             assertThat(viewModel.orderDraft.total).isGreaterThan(viewModel.orderDraft.feesTotal)
@@ -58,7 +58,7 @@ class SimplePaymentsFragmentViewModelTests : BaseUnitTest() {
 
     @Test
     fun `when charging taxes is NOT enabled, then total amount is equal to the total fee`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             initViewModel()
             viewModel.onChargeTaxesChanged(chargeTaxes = false)
             assertThat(viewModel.orderDraft.total).isEqualTo(viewModel.orderDraft.feesTotal)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/simplepayments/SimplePaymentsFragmentViewModelTests.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModelTest.kt
@@ -51,7 +51,7 @@ class AddOrderShipmentTrackingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Add order shipment tracking when network is available - success`() = runBlockingTest {
+    fun `Add order shipment tracking when network is available - success`() = testBlocking {
         doReturn(OnOrderChanged()).whenever(repository).addOrderShipmentTracking(any(), any())
 
         val events = mutableListOf<Event>()
@@ -75,7 +75,7 @@ class AddOrderShipmentTrackingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Add order shipment tracking fails`() = runBlockingTest {
+    fun `Add order shipment tracking fails`() = testBlocking {
         doReturn(OnOrderChanged().also { it.error = OrderError(type = GENERIC_ERROR, message = "") })
             .whenever(repository).addOrderShipmentTracking(any(), any())
 
@@ -99,7 +99,7 @@ class AddOrderShipmentTrackingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Add order shipment tracking when network offline`() = runBlockingTest {
+    fun `Add order shipment tracking when network offline`() = testBlocking {
         doReturn(false).whenever(networkStatus).isConnected()
 
         var event: Event? = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModelTest.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.*

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModelTest.kt
@@ -46,7 +46,7 @@ class AddOrderTrackingProviderListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Shows and hides the provider list skeleton correctly`() = runBlockingTest {
+    fun `Shows and hides the provider list skeleton correctly`() = testBlocking {
         doReturn(testShipmentProvider).whenever(shipmentProvidersRepository)
             .fetchOrderShipmentProviders(ORDER_ID)
 
@@ -62,7 +62,7 @@ class AddOrderTrackingProviderListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Display error snackbar when provider list is empty`() = runBlockingTest {
+    fun `Display error snackbar when provider list is empty`() = testBlocking {
         doReturn(emptyList<OrderShipmentProvider>()).whenever(shipmentProvidersRepository)
             .fetchOrderShipmentProviders(ORDER_ID)
 
@@ -78,7 +78,7 @@ class AddOrderTrackingProviderListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Display error snackbar when error occurs`() = runBlockingTest {
+    fun `Display error snackbar when error occurs`() = testBlocking {
         doReturn(null).whenever(shipmentProvidersRepository)
             .fetchOrderShipmentProviders(ORDER_ID)
 
@@ -94,7 +94,7 @@ class AddOrderTrackingProviderListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `filter results`() = runBlockingTest {
+    fun `filter results`() = testBlocking {
         doReturn(testShipmentProvider).whenever(shipmentProvidersRepository)
             .fetchOrderShipmentProviders(ORDER_ID)
 
@@ -111,7 +111,7 @@ class AddOrderTrackingProviderListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `handle carrier selection`() = runBlockingTest {
+    fun `handle carrier selection`() = testBlocking {
         doReturn(testShipmentProvider).whenever(shipmentProvidersRepository)
             .fetchOrderShipmentProviders(ORDER_ID)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -19,7 +19,6 @@ import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
 class AppSettingsPresenterTest : BaseUnitTest() {
-
     private val appSettingsContractView: AppSettingsContract.View = mock()
 
     private val dispatcher: Dispatcher = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -18,7 +18,7 @@ import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
-class AppSettingsPresenterTest: BaseUnitTest() {
+class AppSettingsPresenterTest : BaseUnitTest() {
 
     private val appSettingsContractView: AppSettingsContract.View = mock()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -1,12 +1,10 @@
 package com.woocommerce.android.ui.prefs
 
 import com.woocommerce.android.ui.orders.cardreader.ClearCardReaderDataAction
-import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.Dispatcher
@@ -20,9 +18,7 @@ import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
-class AppSettingsPresenterTest {
-    @Rule @JvmField
-    val coroutinesTestRule = CoroutineTestRule()
+class AppSettingsPresenterTest: BaseUnitTest() {
 
     private val appSettingsContractView: AppSettingsContract.View = mock()
 
@@ -74,7 +70,7 @@ class AppSettingsPresenterTest {
     @Test
     fun `cleanPaymentsData with initialized manager should disconnect reader`() {
         if (FeatureFlag.CARD_READER.isEnabled()) {
-            coroutinesTestRule.testDispatcher.runBlockingTest {
+            testBlocking {
                 appSettingsPresenter.logout()
 
                 verify(clearCardReaderDataAction).invoke()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.STRIPE_
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderTrackerTest.kt
@@ -58,7 +58,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when track learn more invoked, then CARD_PRESENT_ONBOARDING_LEARN_MORE_TAPPED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingLearnMoreTapped()
 
             verify(trackerWrapper).track(
@@ -69,7 +69,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state GenericError, then reason=generic_error tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(CardReaderOnboardingState.GenericError)
 
             verify(trackerWrapper).track(
@@ -79,7 +79,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state StoreCountryNotSupported, then reason=country_not_supported tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(CardReaderOnboardingState.StoreCountryNotSupported(""))
 
             verify(trackerWrapper).track(
@@ -90,7 +90,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state PluginIsNotSupportedInTheCountry woo, then wcpay_is_not_supported_in_CA tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.PluginIsNotSupportedInTheCountry(
                     WOOCOMMERCE_PAYMENTS,
@@ -106,7 +106,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state PluginIsNotSupportedInTheCountry str, then stripe_extension_is_not_supported_in_US`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.PluginIsNotSupportedInTheCountry(
                     STRIPE_EXTENSION_GATEWAY,
@@ -122,7 +122,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state StripeAccountCountryNotSupported, then reason=account_country_not_supported tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.StripeAccountCountryNotSupported(
                     mock(),
@@ -138,7 +138,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state WcpayNotInstalled, then reason=wcpay_not_installed tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(CardReaderOnboardingState.WcpayNotInstalled)
 
             verify(trackerWrapper).track(
@@ -149,7 +149,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state WcpayNotActivated, then reason=wcpay_not_activated tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(CardReaderOnboardingState.WcpayNotActivated)
 
             verify(trackerWrapper).track(
@@ -160,7 +160,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state PluginUnsupportedVersion WCPay, then reason=wcpay_unsupported_version tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.PluginUnsupportedVersion(WOOCOMMERCE_PAYMENTS)
             )
@@ -173,7 +173,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding PluginUnsupportedVersion Stripe, then reason=stripe_extension_unsupported_version tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
             )
@@ -186,7 +186,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state SetupNotCompleted WCPay, then reason=wcpay_not_setup tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.SetupNotCompleted(WOOCOMMERCE_PAYMENTS)
             )
@@ -199,7 +199,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state SetupNotCompleted Stripe, then reason=stripe_extension_not_setup tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.SetupNotCompleted(STRIPE_EXTENSION_GATEWAY)
             )
@@ -212,7 +212,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding StripeAccountPendingRequirement WCPay, then reason=account_pending_requirements tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.StripeAccountPendingRequirement(
                     null,
@@ -230,7 +230,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding StripeAccountPendingRequirement Stripe, then reason=account_pending_requirements tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.StripeAccountPendingRequirement(
                     null,
@@ -248,7 +248,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state StripeAccountOverdueRequirement, then reason=account_overdue_requirements tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(CardReaderOnboardingState.StripeAccountOverdueRequirement(mock()))
 
             verify(trackerWrapper).track(
@@ -259,7 +259,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state StripeAccountUnderReview, then reason=account_under_review tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(CardReaderOnboardingState.StripeAccountUnderReview(mock()))
 
             verify(trackerWrapper).track(
@@ -270,7 +270,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state StripeAccountRejected, then reason=account_rejected tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(CardReaderOnboardingState.StripeAccountRejected(mock()))
 
             verify(trackerWrapper).track(
@@ -281,7 +281,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when wcpay in test mode with live account, then wcpay_in_test_mode_with_live_account`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker
                 .trackOnboardingState(
                     CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(WOOCOMMERCE_PAYMENTS)
@@ -295,7 +295,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when stripe in test mode with live account, then stripe_extension_in_test_mode_with_live_account`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker
                 .trackOnboardingState(
                     CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(STRIPE_EXTENSION_GATEWAY)
@@ -309,7 +309,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state OnboardingCompleted WCPay, then event NOT tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.OnboardingCompleted(
                     WOOCOMMERCE_PAYMENTS,
@@ -323,7 +323,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state OnboardingCompleted Stripe, then event NOT tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackOnboardingState(
                 CardReaderOnboardingState.OnboardingCompleted(STRIPE_EXTENSION_GATEWAY, PLUGIN_VERSION, COUNTRY_CODE)
             )
@@ -333,7 +333,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when track software update started, then CARD_READER_SOFTWARE_UPDATE_STARTED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackSoftwareUpdateStarted(true)
 
             verify(trackerWrapper).track(
@@ -344,7 +344,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `given update required, when track software update started, then event with REQUIRED_UPDATE tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackSoftwareUpdateStarted(requiredUpdate = true)
 
             verify(trackerWrapper).track(
@@ -357,7 +357,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `given update not required, when track software update started, then event with OPTIONAL_UPDATE tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackSoftwareUpdateStarted(requiredUpdate = false)
 
             verify(trackerWrapper).track(
@@ -370,7 +370,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when track software update failed, then CARD_READER_SOFTWARE_UPDATE_FAILED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val dummyMessage = "abcd"
             cardReaderTracker.trackSoftwareUpdateFailed(Failed(mock(), dummyMessage), requiredUpdate = false)
 
@@ -385,7 +385,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when software update canceled, then CARD_READER_SOFTWARE_UPDATE_FAILED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackSoftwareUpdateCancelled(false)
 
             verify(trackerWrapper).track(
@@ -399,7 +399,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `given required update, when software update canceled, then required update property tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackSoftwareUpdateCancelled(requiredUpdate = true)
 
             verify(trackerWrapper).track(
@@ -415,7 +415,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `given optional update, when software update canceled, then optional update property tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackSoftwareUpdateCancelled(requiredUpdate = false)
 
             verify(trackerWrapper).track(
@@ -431,7 +431,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when auto connection started, then CARD_READER_AUTO_CONNECTION_STARTED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackAutoConnectionStarted()
 
             verify(trackerWrapper).track(eq(CARD_READER_AUTO_CONNECTION_STARTED), any())
@@ -439,7 +439,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when scanning fails, then CARD_READER_DISCOVERY_FAILED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val dummyErrorMgs = "dummy error"
             cardReaderTracker.trackReaderDiscoveryFailed(dummyErrorMgs)
 
@@ -450,7 +450,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when reader found, then CARD_READER_DISCOVERY_READER_DISCOVERED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val dummyCount = 99
             cardReaderTracker.trackReadersDiscovered(dummyCount)
 
@@ -463,7 +463,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when reader found, then reader_count tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val dummyCount = 99
             cardReaderTracker.trackReadersDiscovered(dummyCount)
 
@@ -476,7 +476,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when location fetching fails, then CARD_READER_LOCATION_FAILURE tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val dummyErrorMgs = "dummy error"
             cardReaderTracker.trackFetchingLocationFailed(dummyErrorMgs)
 
@@ -568,7 +568,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when location fetching succeeds, then CARD_READER_LOCATION_SUCCESS tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackFetchingLocationSucceeded()
 
             verify(trackerWrapper).track(eq(CARD_READER_LOCATION_SUCCESS), any())
@@ -576,7 +576,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails, then CARD_PRESENT_COLLECT_PAYMENT_FAILED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val dummyMessage = "error msg"
             cardReaderTracker.trackPaymentFailed(dummyMessage)
 
@@ -587,7 +587,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when payment completed, then CARD_PRESENT_COLLECT_PAYMENT_SUCCESS tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackPaymentSucceeded()
 
             verify(trackerWrapper).track(eq(CARD_PRESENT_COLLECT_PAYMENT_SUCCESS), any())
@@ -595,7 +595,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on print receipt button, then RECEIPT_PRINT_TAPPED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackPrintReceiptTapped()
 
             verify(trackerWrapper).track(eq(RECEIPT_PRINT_TAPPED), any())
@@ -624,7 +624,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on send receipt button, then RECEIPT_EMAIL_TAPPED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackEmailReceiptTapped()
 
             verify(trackerWrapper).track(eq(RECEIPT_EMAIL_TAPPED), any())
@@ -632,7 +632,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when user cancels payment, then CARD_PRESENT_COLLECT_PAYMENT_CANCELLED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val currentPaymentState = "dummy state"
             cardReaderTracker.trackPaymentCancelled(currentPaymentState)
 
@@ -647,7 +647,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `when user taps collect payment button, then CARD_PRESENT_COLLECT_PAYMENT_TAPPED tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             cardReaderTracker.trackCollectPaymentTapped()
 
             verify(trackerWrapper).track(eq(CARD_PRESENT_COLLECT_PAYMENT_TAPPED), any())
@@ -655,7 +655,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `given wcpay is preferred plugin, when event tracked, then wcpay plugin slug tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
                 .thenReturn(WOOCOMMERCE_PAYMENTS)
 
@@ -669,7 +669,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `given stripe is preferred plugin, when event tracked, then stripe plugin slug tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
                 .thenReturn(STRIPE_EXTENSION_GATEWAY)
 
@@ -683,7 +683,7 @@ class CardReaderTrackerTest : BaseUnitTest() {
 
     @Test
     fun `given preferred plugin not stored, when event tracked, then unknown slug tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
                 .thenReturn(null)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -65,19 +65,19 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     private val locationId = "location_id"
 
     @Before
-    fun setUp() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun setUp() = testBlocking {
         viewModel = initVM()
     }
 
     @Test
     fun `when onboarding completed, then location permissions check requested`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             assertThat(viewModel.event.value).isInstanceOf(CheckLocationPermissions::class.java)
         }
 
     @Test
     fun `given permissions enabled, when connection flow started, then location enabled check emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
 
             assertThat(viewModel.event.value).isInstanceOf(CheckLocationEnabled::class.java)
@@ -85,7 +85,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given permissions not enabled, when connection flow started, then permissions requested`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(false)
 
             assertThat(viewModel.event.value).isInstanceOf(RequestLocationPermissions::class.java)
@@ -93,7 +93,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given permissions granted, when permissions requested, then location enabled check emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(false)
 
             (viewModel.event.value as RequestLocationPermissions).onPermissionsRequestResult(true)
@@ -103,7 +103,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given permissions not granted, when permissions requested, then missing permissions error shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(false)
 
             (viewModel.event.value as RequestLocationPermissions).onPermissionsRequestResult(false)
@@ -113,7 +113,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when Open app settings button clicked, then user redirected to app settings`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(false)
             (viewModel.event.value as RequestLocationPermissions).onPermissionsRequestResult(false)
 
@@ -124,7 +124,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given app on missing permissions error screen, when apps comes to foreground, then permissions re-checked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(false)
             (viewModel.event.value as RequestLocationPermissions).onPermissionsRequestResult(false)
 
@@ -135,7 +135,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given app on missing bt permissions screen, when apps comes to foreground, then permissions re-checked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(false)
@@ -149,7 +149,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given NOT on missing permissions screen, when apps comes to foreground, then permissions not re-checked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
 
             viewModel.onScreenStarted()
@@ -159,7 +159,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given NOT on bt missing permissions screen, when apps comes to foreground, then permissions not re-checked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(true)
@@ -171,7 +171,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given app on missing permissions, when apps comes to foreground, then permissions not re-requested`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(false)
             (viewModel.event.value as RequestLocationPermissions).onPermissionsRequestResult(false)
             viewModel.onScreenStarted()
@@ -183,7 +183,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location disabled, when connection flow started, then location disabled error shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(false)
 
@@ -192,7 +192,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location enabled, when connection flow started, then check bluetooth permission emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
 
@@ -201,7 +201,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on open location settings, then openLocationSettings emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(false)
 
@@ -214,7 +214,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when location settings closed, then checkLocationEnabled emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(false)
             (viewModel.viewStateData.value as? LocationDisabledError)?.let {
@@ -228,7 +228,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given bluetooth disabled, when connection flow started, then enable-bluetooth request emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(true)
@@ -239,7 +239,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given request rejected, when enable-bluetooth requested, then bluetooth disabled error shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(true)
@@ -252,7 +252,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given request accepted, when enable-bluetooth requested, then card manager initialized`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(true)
@@ -264,7 +264,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given request accepted, when bt permissions requested, then card manager initialized`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(false)
@@ -277,7 +277,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given request not accepted, when bt permissions requested, then card manager not initialized`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(false)
@@ -289,7 +289,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given request accepted and manager init, when enable-bluetooth requested, then manager is not initialized`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.initialized).thenReturn(true)
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
@@ -303,7 +303,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on open bluetooth settings, then enable-bluetooth request emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(true)
@@ -317,7 +317,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when cardReaderManager gets initialized, then scan is started`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
 
             verify(cardReaderManager).discoverReaders(anyBoolean(), any())
@@ -325,7 +325,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given installation started, when cardReaderManager gets initialized, then show update in progress emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.softwareUpdateStatus).thenReturn(
                 flow {
                     emit(SoftwareUpdateStatus.InstallationStarted)
@@ -341,7 +341,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given installing update, when cardReaderManager gets initialized, then show update in progress emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.softwareUpdateStatus).thenReturn(
                 flow {
                     emit(SoftwareUpdateStatus.Installing(0.1f))
@@ -357,7 +357,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given connection in progress, when cardReaderManager gets initialized, then connecting status emitted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
 
             init()
@@ -367,7 +367,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given connection in progress and connected, when cardReaderManager gets initialized, then goes to tutorial`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(cardReaderManager.softwareUpdateStatus).thenReturn(
                 flow { emit(SoftwareUpdateStatus.Unknown) }
             )
@@ -382,7 +382,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when scan fails, then scanning failed state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = FAILED)
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(ScanningFailedState::class.java)
@@ -390,7 +390,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given scanning failed screen shown, when user clicks on retry, then flow restarted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = FAILED)
 
             (viewModel.viewStateData.value as ScanningFailedState).onPrimaryActionClicked.invoke()
@@ -400,7 +400,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when reader found, then reader found state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(ReaderFoundState::class.java)
@@ -408,7 +408,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given last connected reader is null, when reader found, then reader found state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(appPrefs.getLastConnectedCardReaderId()).thenReturn(null)
 
             init(scanState = READER_FOUND)
@@ -418,7 +418,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given last connected reader is matching, when reader found, then reader connecting state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val readerStatusStateFlow = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connecting)
             whenever(cardReaderManager.readerStatus).thenReturn(readerStatusStateFlow)
 
@@ -430,7 +430,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given last connected reader is matching, when reader found, then auto reconnection event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(appPrefs.getLastConnectedCardReaderId()).thenReturn("Dummy1")
 
             init(scanState = READER_FOUND)
@@ -440,7 +440,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given last connected reader is not matching, when reader found, then reader found state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(appPrefs.getLastConnectedCardReaderId()).thenReturn("Dummy2")
 
             init(scanState = READER_FOUND)
@@ -450,7 +450,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given reader id is null, when reader found, then reader is ignored`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(reader.id).thenReturn(null)
 
             init(scanState = READER_FOUND)
@@ -460,7 +460,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when multiple readers found, then multiple readers found state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = MULTIPLE_READERS_FOUND)
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(MultipleReadersFoundState::class.java)
@@ -468,7 +468,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when scanning fails, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = FAILED)
 
             verify(tracker).trackReaderDiscoveryFailed(any())
@@ -476,7 +476,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when reader found, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
 
             verify(tracker)
@@ -485,7 +485,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when multiple readers found, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = MULTIPLE_READERS_FOUND)
 
             verify(tracker)
@@ -494,7 +494,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location fetching fails address, when user clicks on connect to reader button, then track failure`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
                 CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress("")
@@ -507,7 +507,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location fetching invalid postcode, when user clicks on connect to reader button, then track failure`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
                 CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode
@@ -520,7 +520,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location fetching fails, when user clicks on connect to reader button, then track failure event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
                 CardReaderLocationRepository.LocationIdFetchingResult.Error.Other("selected site missing")
@@ -533,7 +533,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location fetching fails address, when user clicks on update address, then track tapped event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
                 CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress("")
@@ -548,7 +548,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location fetching passes, when user clicks on connect to reader button, then track success event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
                 CardReaderLocationRepository.LocationIdFetchingResult.Success("")
@@ -561,7 +561,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location fetching fails, when user clicks on connect to reader button, then show error state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
                 CardReaderLocationRepository.LocationIdFetchingResult.Error.Other("Error")
@@ -575,7 +575,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location fetching missing address, when user clicks on connect button, then show address error state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
                 CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress("")
@@ -591,7 +591,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given location fetching invalid postcode, when user clicks on connect button, then invalid pc error state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
                 CardReaderLocationRepository.LocationIdFetchingResult.Error.InvalidPostalCode
@@ -607,7 +607,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given address empty on wp com, when user clicks enter address, then opens authenticated webview`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(siteModel.isWPCom).thenReturn(true)
             init()
             val url = "https://wordpress.com"
@@ -629,7 +629,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given address empty on atomic, when user clicks enter address, then opens authenticated webview`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(siteModel.isWPComAtomic).thenReturn(true)
             init()
             val url = "https://wordpress.com"
@@ -651,7 +651,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given address empty on selfhosted, when user clicks enter address, then opens unauthenticated webview`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val events = mutableListOf<Event>()
             viewModel.event.observeForever {
                 events.add(it)
@@ -679,7 +679,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given address empty on selfhosted, when user clicks enter address, then emits exit event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(siteModel.isWPComAtomic).thenReturn(false)
             whenever(siteModel.isWPCom).thenReturn(false)
             init()
@@ -696,7 +696,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on connect to reader button, then app starts connecting to reader`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -706,7 +706,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on connect to reader button, then card reader model stored for tracking`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val readerType = "STRIPE_M2"
             whenever(reader.type).thenReturn(readerType)
 
@@ -719,7 +719,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given multiple readers found, when user clicks on connect, then app connects to the correct reader`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = MULTIPLE_READERS_FOUND)
 
             val reader = (viewModel.viewStateData.value as MultipleReadersFoundState).listItems[1] as CardReaderListItem
@@ -730,7 +730,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given card reader has location id, when connect to, then readers location id used`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = MULTIPLE_READERS_FOUND)
             val locationId = "old_location_id"
             whenever(reader2.locationId).thenReturn(locationId)
@@ -743,7 +743,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when multiple readers found, then scanning in progress item shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = MULTIPLE_READERS_FOUND)
 
             assertThat((viewModel.viewStateData.value as MultipleReadersFoundState).listItems.last())
@@ -752,7 +752,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user clicks on connect, when reader found, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -762,7 +762,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user clicks on connect, when multiple readers found, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = MULTIPLE_READERS_FOUND)
 
             val reader = (viewModel.viewStateData.value as MultipleReadersFoundState).listItems[1] as CardReaderListItem
@@ -773,7 +773,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app is connecting to reader, then connecting state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -784,7 +784,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app successfully connects to reader, then navigate to tutorial`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -795,7 +795,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app successfully connects to reader, then reader id stored`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -806,7 +806,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when connecting to reader succeeds, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
             readerStatusFlow.emit(CardReaderStatus.Connected(reader))
@@ -816,7 +816,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when connecting to reader for the first time, then navigate to tutorial`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
             readerStatusFlow.emit(CardReaderStatus.Connected(reader))
@@ -825,7 +825,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when connecting to reader not for the first time, then navigate to tutorial`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
             readerStatusFlow.emit(CardReaderStatus.Connected(reader))
@@ -834,7 +834,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when connecting to reader fails, then connecting failed state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -846,7 +846,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given error message is not null, when connecting to reader fails, then toast is shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val errorMessage = "error_message"
 
             init()
@@ -860,7 +860,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given error message is null, when connecting to reader fails, then toast is not shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -872,7 +872,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when connecting to reader fails, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
             readerStatusFlow.emit(CardReaderStatus.Connecting)
@@ -883,7 +883,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given connecting failed screen shown, when user clicks on retry, then flow restarted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
             readerStatusFlow.emit(CardReaderStatus.Connecting)
@@ -896,7 +896,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given invalid postcode screen shown, when user clicks on retry, then flow restarted`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
 
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
@@ -912,7 +912,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given app in scanning state, when user clicks on cancel, then flow finishes`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = SCANNING)
 
             (viewModel.viewStateData.value as ScanningState).onSecondaryActionClicked.invoke()
@@ -922,7 +922,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given app in reader found state, when user clicks on cancel, then flow finishes`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
 
             (viewModel.viewStateData.value as ReaderFoundState).onSecondaryActionClicked.invoke()
@@ -932,7 +932,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given app in connecting state, when user clicks on cancel, then flow finishes`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -944,7 +944,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given app in scanning failed state, when user clicks on cancel, then flow finishes`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = FAILED)
 
             (viewModel.viewStateData.value as ScanningFailedState).onSecondaryActionClicked.invoke()
@@ -952,7 +952,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given app in connecting failed state, when user clicks on cancel, then flow finishes`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init()
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
             readerStatusFlow.emit(CardReaderStatus.Connecting)
@@ -965,7 +965,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in scanning state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = SCANNING)
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(ScanningState::class.java)
@@ -991,7 +991,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in readers found state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(ReaderFoundState::class.java)
@@ -1023,7 +1023,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in connecting state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
 
             viewModel.viewStateData.value!!.onPrimaryActionClicked!!.invoke()
@@ -1052,7 +1052,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in scanning failed state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = FAILED)
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(ScanningFailedState::class.java)
@@ -1075,7 +1075,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in connecting failed state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -1102,7 +1102,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in missing address failed state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
             readerStatusFlow.emit(CardReaderStatus.NotConnected())
             val url = "https://wordpress.com"
@@ -1129,7 +1129,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given invalid postcode state, when connecting to reader, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             init(scanState = READER_FOUND)
             readerStatusFlow.emit(CardReaderStatus.NotConnected())
             whenever(locationRepository.getDefaultLocationId(any())).thenReturn(
@@ -1156,7 +1156,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in missing location permissions state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(false)
             (viewModel.event.value as RequestLocationPermissions).onPermissionsRequestResult(false)
 
@@ -1183,7 +1183,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in location disabled state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(false)
 
@@ -1210,7 +1210,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app in bluetooth disabled state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(true)
@@ -1240,7 +1240,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when app bluetooth permission not given state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             (viewModel.event.value as CheckLocationPermissions).onLocationPermissionsCheckResult(true)
             (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
             (viewModel.event.value as CheckBluetoothPermissionsGiven).onBluetoothPermissionsGivenCheckResult(false)
@@ -1299,7 +1299,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when discovery readers, then supported readers list used`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val captor = argumentCaptor<CardReaderTypesToDiscover.SpecificReaders>()
 
             init()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
@@ -25,7 +25,7 @@ class CardReaderLocationRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given store returns success, when get default location, then location returned`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val locationId = "locationId"
             whenever(store.getStoreLocationForSite(any(), any())).thenReturn(
@@ -46,7 +46,7 @@ class CardReaderLocationRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given store returns generic error, when get default location, then other error returned`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             whenever(store.getStoreLocationForSite(any(), any())).thenReturn(
                 WCTerminalStoreLocationResult(
@@ -65,7 +65,7 @@ class CardReaderLocationRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given store returns missing address error, when get default location, then missing address error returned`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val url = "https://wordpress.com"
             whenever(store.getStoreLocationForSite(any(), any())).thenReturn(
@@ -85,7 +85,7 @@ class CardReaderLocationRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given store returns invalid postcode error, when get default location, then invalid pc error returned`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             whenever(store.getStoreLocationForSite(any(), any())).thenReturn(
                 WCTerminalStoreLocationResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.prefs.cardreader.connect
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -25,7 +25,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -63,7 +63,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when view model init with connected state and update up to date should emit connected view state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState()
 
@@ -76,7 +76,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when view model init with connected state should emit correct values of connected state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState()
 
@@ -98,7 +98,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when view model init with connected state and battery should emit correct values of connected state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState(batteryLevel = 0.325f)
 
@@ -120,7 +120,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when view model init with connected state and empty name should emit connected view state with fallbacks`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState(readersName = null, batteryLevel = null)
 
@@ -182,7 +182,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when view model init with connected state should invoke software update availability`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = MutableStateFlow(CardReaderStatus.Connected(mock()))
             whenever(cardReaderManager.readerStatus).thenReturn(status)
@@ -196,7 +196,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when view model init with connected state and update available should emit connected state with update`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState(updateAvailable = SoftwareUpdateAvailability.Available)
 
@@ -231,7 +231,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given up to date software, when on update result successful, then connected state without update emitted`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val viewModel = createViewModel()
             initConnectedState()
@@ -255,7 +255,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given connected state, when click on reader name, then copy and snackbar event triggers`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState()
             val viewModel = createViewModel()
@@ -277,7 +277,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given software update available, when on update result successful, then connected without update emitted`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val viewModel = createViewModel()
             initConnectedState(updateAvailable = SoftwareUpdateAvailability.Available)
@@ -314,7 +314,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when on disconnect button clicked with success should do nothing`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState()
             whenever(cardReaderManager.disconnectReader()).thenReturn(true)
@@ -329,7 +329,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when on disconnect button clicked with fail should change to not connected state`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState()
             whenever(cardReaderManager.disconnectReader()).thenReturn(false)
@@ -344,7 +344,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given not connected state, when connect button clicked should track event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = MutableStateFlow(CardReaderStatus.NotConnected())
             whenever(cardReaderManager.readerStatus).thenReturn(status)
@@ -359,7 +359,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when disconnect button clicked should track event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState()
             whenever(cardReaderManager.disconnectReader()).thenReturn(true)
@@ -374,7 +374,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when card reader disconnected successfully, then trigger accessibility announcement`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = MutableStateFlow(CardReaderStatus.NotConnected())
             whenever(cardReaderManager.readerStatus).thenReturn(status)
@@ -391,7 +391,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when card reader disconnection fails, then do not trigger accessibility announcement`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = MutableStateFlow(CardReaderStatus.Connected(mock()))
             whenever(cardReaderManager.readerStatus).thenReturn(status)
@@ -408,7 +408,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when card reader connected successfully, then trigger accessibility announcement`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = MutableStateFlow(CardReaderStatus.Connected(mock()))
             whenever(cardReaderManager.readerStatus).thenReturn(status)
@@ -425,7 +425,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when card reader connection fails, then do not trigger accessibility announcement`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = MutableStateFlow(CardReaderStatus.Connecting)
             whenever(cardReaderManager.readerStatus).thenReturn(status)
@@ -442,7 +442,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wcpay active and reader not connected, when user taps on learn more, then show wcpay docs`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = MutableStateFlow(CardReaderStatus.NotConnected())
             whenever(cardReaderManager.readerStatus).thenReturn(status)
@@ -459,7 +459,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wcpay active and reader connected, when user taps on learn more, then show wcpay docs`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState()
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any())).thenReturn(WOOCOMMERCE_PAYMENTS)
@@ -475,7 +475,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given stripe active and reader not connected, when user taps on learn more, then show stripe docs`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = MutableStateFlow(CardReaderStatus.NotConnected())
             whenever(cardReaderManager.readerStatus).thenReturn(status)
@@ -493,7 +493,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given stripe active and reader connected, when user taps on learn more, then show stripe docs`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             initConnectedState()
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
@@ -561,7 +561,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         batteryLevel: Float? = 0.65F,
         firmwareVersion: String = DUMMY_FIRMWARE_VERSION,
         updateAvailable: SoftwareUpdateAvailability = SoftwareUpdateAvailability.NotAvailable
-    ) = coroutinesTestRule.testDispatcher.runBlockingTest {
+    ) = testBlocking {
         val reader: CardReader = mock {
             on { this.id }.thenReturn(readersName)
             on { this.currentBatteryLevel }.thenReturn(batteryLevel)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.STRIPE_
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.*

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -51,7 +51,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given hub flow, when onboarding completed, then navigates to card reader hub screen`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.OnboardingCompleted(WOOCOMMERCE_PAYMENTS, pluginVersion, countryCode)
             )
@@ -64,7 +64,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow, when onboarding completed, then navigates to card reader connection screen`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.OnboardingCompleted(WOOCOMMERCE_PAYMENTS, pluginVersion, countryCode)
             )
@@ -81,7 +81,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when store country not supported, then country not supported state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
 
@@ -92,7 +92,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wcpay is not supported in country, when init, then wcpay in country not supported state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.PluginIsNotSupportedInTheCountry(
@@ -108,7 +108,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given stripe is not supported in country, when init, then stripe in country not supported state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.PluginIsNotSupportedInTheCountry(
@@ -124,7 +124,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when stripe account country not supported, then country not supported state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
 
@@ -137,7 +137,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wcpay not supported in country, when init, then current store country name shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.PluginIsNotSupportedInTheCountry(
@@ -157,7 +157,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when country not supported, then current store country name shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported("US"))
             val viewModel = createVM()
@@ -172,7 +172,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wcpay not supported in country, when learn more clicked, then app shows learn more section`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.PluginIsNotSupportedInTheCountry(
@@ -191,7 +191,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given store country not supported, when learn more clicked, then app shows learn more section`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
             val viewModel = createVM()
@@ -205,7 +205,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given store country not supported, when contact support clicked, then app navigates to support screen`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
             val viewModel = createVM()
@@ -218,7 +218,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wcpay in not supported in country, when contact support clicked, then app nav to support screen`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.PluginIsNotSupportedInTheCountry(
@@ -237,7 +237,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given preferred plugin Stripe, when learn more clicked, then app navigates to Stripe docs`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
@@ -253,7 +253,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given preferred plugin WCPay, when learn more clicked, then app navigates to wcpay docs`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
@@ -269,7 +269,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given preferred plugin null, when learn more clicked, then app navigates to wcpay docs`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StoreCountryNotSupported(""))
             whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
@@ -285,7 +285,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given stripe account country not supported, when learn more clicked, then app shows learn more section`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
             val viewModel = createVM()
@@ -299,7 +299,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given stripe account country not supported, when contact support clicked, then app navs to support screen`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
             val viewModel = createVM()
@@ -312,7 +312,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when wcpay not installed, then wcpay not installed state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WcpayNotInstalled)
 
             val viewModel = createVM()
@@ -322,7 +322,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when wcpay not activated, then wcpay not activated state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WcpayNotActivated)
 
             val viewModel = createVM()
@@ -332,7 +332,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when wcpay not setup, then wcpay not setup state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.SetupNotCompleted(WOOCOMMERCE_PAYMENTS))
 
@@ -343,7 +343,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when stripe extension not setup, then stripe extension not setup state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.SetupNotCompleted(STRIPE_EXTENSION_GATEWAY))
 
@@ -356,7 +356,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when stripe extension not setup, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.SetupNotCompleted(STRIPE_EXTENSION_GATEWAY))
 
@@ -381,7 +381,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when unsupported wcpay version installed, then unsupported wcpay version state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.PluginUnsupportedVersion(WOOCOMMERCE_PAYMENTS))
 
@@ -392,7 +392,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when wcpay in test mode with live stripe account, then wcpay in test mode state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(mock()))
 
@@ -405,7 +405,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when unsupported stripe extension installed, then unsupported stripe extension state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
             )
@@ -419,7 +419,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when stripe extension outdated, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
             )
@@ -457,7 +457,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when wcpay and stripe extension installed-activated, then wcpay and stripe extension activated state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated
             )
@@ -471,7 +471,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user is admin, when wcpay and stripe extension active, then open wpadmin button shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated
             )
@@ -485,7 +485,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when wcpay and stripe extension active, then refresh screen button shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated
             )
@@ -498,7 +498,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when refresh clicked, then loading screen shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
                 CardReaderOnboardingState.WcpayAndStripeActivated
             )
@@ -516,7 +516,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given site is self-hosted, when user taps on Go To Plugin Admin, then generic webview shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(selectedSite.get())
                 .thenReturn(
                     SiteModel()
@@ -540,7 +540,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given site is wpcom, when user taps on Go To Plugin Admin, then wpcom webview shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(selectedSite.get()).thenReturn(
                 SiteModel()
                     .apply {
@@ -562,7 +562,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given site is atomic, when user taps on Go To Plugin Admin, then wpcom webview shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(selectedSite.get()).thenReturn(
                 SiteModel().apply {
                     setIsWPComAtomic(true)
@@ -583,7 +583,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user taps on Go To Plugin Admin, then app navigates to Plugin Admin url`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(selectedSite.get()).thenReturn(
                 SiteModel().apply {
                     url = DUMMY_SITE_URL
@@ -604,7 +604,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user is NOT admin, when wcpay and stripe extension active, then open wpadmin button NOT shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(userEligibilityFetcher.fetchUserInfo()).thenAnswer {
                 val model = mock<WCUserModel>()
                 whenever(model.getUserRoles())
@@ -624,7 +624,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when account rejected, then account rejected state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StripeAccountRejected(mock()))
 
@@ -636,7 +636,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when account pending requirements, then account pending requirements state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.StripeAccountPendingRequirement(
@@ -656,7 +656,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given account pending requirements and hub, when button clicked, then continues to hub`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.StripeAccountPendingRequirement(
@@ -677,7 +677,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given account pending requirements and payment, when button clicked, then continues to connection`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.StripeAccountPendingRequirement(
@@ -702,7 +702,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when account pending requirements, then due date not empty`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     CardReaderOnboardingState.StripeAccountPendingRequirement(
@@ -722,7 +722,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when account overdue requirements, then account overdue requirements state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StripeAccountOverdueRequirement(mock()))
 
@@ -735,7 +735,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when account under review, then account under review state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.StripeAccountUnderReview(mock()))
 
@@ -748,7 +748,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding check fails, then generic state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.GenericError)
 
@@ -759,7 +759,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when network not available, then no connection error shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.NoConnectionError)
 
@@ -771,7 +771,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     // Tracking Begin
     @Test
     fun `when learn more tapped, then event tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(CardReaderOnboardingState.GenericError)
             val viewModel = createVM()
@@ -783,7 +783,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when onboarding state checked, then event propagated to tracker`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val onboardingState: CardReaderOnboardingState = mock()
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(onboardingState)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -35,7 +35,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given required update, when view model created, then installation not started`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val requiredUpdate = true
 
@@ -48,7 +48,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given optional update, when view model created, then installation started`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val requiredUpdate = false
 
@@ -61,7 +61,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given installation started status, when view model created, then update about to start`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = InstallationStarted
 
@@ -81,7 +81,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given installation about to start, when view model created, then announce for accessibility`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = InstallationStarted
 
@@ -100,7 +100,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given installation 10 status, when view model created, then announce update progress for accessibility`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = Installing(.1f)
 
@@ -121,7 +121,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given installing 10 status, when view model created, then updating state with 10`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = Installing(.1f)
 
@@ -135,7 +135,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given failed status with failed type, when view model created, then exit with failed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val reason = "reason"
             val status = Failed(SoftwareUpdateStatusErrorType.Failed, reason)
@@ -151,7 +151,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given failed status with battery low type, when view model created, then battery low status`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val reason = "reason"
             val batteryLevel = 0.3f
@@ -177,7 +177,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given failed status with battery low with battery level, when view model created, then special description`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val reason = "reason"
             val status = Failed(SoftwareUpdateStatusErrorType.BatteryLow(null), reason)
@@ -197,7 +197,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given success status, when view model created, then exit with success`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = Success
 
@@ -212,7 +212,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given success status for required update, when view model created, then success tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = Success
 
@@ -226,7 +226,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given success status for optional update, when view model created, then success tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = Success
 
@@ -240,7 +240,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given failed status for optional update, when view model created, then failed tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = Failed(SoftwareUpdateStatusErrorType.Failed, "Failed")
 
@@ -254,7 +254,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given required update started, when view model created, then started tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = InstallationStarted
 
@@ -268,7 +268,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given optional update started, when view model created, then started tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = InstallationStarted
 
@@ -282,7 +282,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given failed status for required update, when view model created, then failed tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val status = Failed(SoftwareUpdateStatusErrorType.Failed, "")
 
@@ -296,7 +296,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses cancel, when optional update is shown, then cancel event is tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             softwareStatus.value = Installing(0.5f)
             val viewModel = createViewModel()
@@ -311,7 +311,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses cancel, when required update is shown, then cancel event is tracked`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             softwareStatus.value = Installing(0.5f)
             val viewModel = createViewModel(requiredUpdate = true)
@@ -326,7 +326,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses back, when progress state shown, then dialog not dismissed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             softwareStatus.value = InstallationStarted
             val viewModel = createViewModel()
@@ -340,7 +340,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given required update user presses back, when progress state shown, then updating canceling state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val requiredUpdate = true
             val viewModel = createViewModel(requiredUpdate = requiredUpdate)
@@ -355,7 +355,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given optional update user presses back, when progress state shown, then updating canceling state shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val requiredUpdate = false
             val viewModel = createViewModel(requiredUpdate = requiredUpdate)
@@ -370,7 +370,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given user presses back, when canceling state shown, then cancel hid`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val viewModel = createViewModel()
             softwareStatus.value = Installing(0f)
@@ -385,7 +385,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given UpdatingState state shown, when update progresses, then progress percentage updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val currentProgress = 0.2f
             val viewModel = createViewModel()
@@ -401,7 +401,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given UpdatingCancelingState state shown, when update progresses, then progress percentage updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val currentProgress = 0.2f
             val viewModel = createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModelTest.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.doReturn

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModelTest.kt
@@ -46,7 +46,7 @@ class GroupedProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the grouped product list view correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the grouped product list view correctly`() = testBlocking {
         doReturn(productList).whenever(productRepository).fetchProductList(groupedProductIds)
 
         createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -31,7 +31,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -183,7 +183,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the product detail properties correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the product detail properties correctly`() = testBlocking {
         viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var cards: List<ProductPropertyCard>? = null
@@ -197,7 +197,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Display success message on add product success`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Display success message on add product success`() = testBlocking {
         // given
         doReturn(product).whenever(productRepository).getProductAsync(any())
         doReturn(Pair(true, 1L)).whenever(productRepository).addProduct(any())
@@ -230,7 +230,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Display error message on add product failed`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Display error message on add product failed`() = testBlocking {
         // given
         doReturn(Pair(false, 0L)).whenever(productRepository).addProduct(any())
 
@@ -256,7 +256,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Display error message on add product for NO network`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Display error message on add product for NO network`() = testBlocking {
         // given
         doReturn(false).whenever(networkStatus).isConnected()
 
@@ -283,7 +283,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
     @Test
     fun `Display correct message on updating a freshly added product`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // given
             doReturn(product).whenever(productRepository).getProductAsync(any())
             doReturn(Pair(true, 1L)).whenever(productRepository).addProduct(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
@@ -72,7 +72,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Test that the initial data is displayed correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Test that the initial data is displayed correctly`() = testBlocking {
         var actual: InventoryData? = null
         viewModel.viewStateData.observeForever { _, new ->
             actual = new.inventoryData
@@ -83,7 +83,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Test that when data is changed the view state is updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             var actual: InventoryData? = null
             viewModel.viewStateData.observeForever { _, new ->
                 actual = new.inventoryData
@@ -102,7 +102,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Test that an error is shown if SKU is already taken`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Test that an error is shown if SKU is already taken`() = testBlocking {
         whenever(productDetailRepository.isSkuAvailableLocally(takenSku)).thenReturn(false)
         whenever(productDetailRepository.isSkuAvailableRemotely(expectedData.sku!!)).thenReturn(true)
         whenever(productDetailRepository.isSkuAvailableLocally(expectedData.sku!!)).thenReturn(true)
@@ -125,7 +125,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Test that a discard dialog isn't shown if no data changed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val events = mutableListOf<Event>()
             viewModel.event.observeForever {
                 events.add(it)
@@ -141,7 +141,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Test that a the correct data is returned when exiting`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Test that a the correct data is returned when exiting`() = testBlocking {
         val events = mutableListOf<Event>()
         viewModel.event.observeForever {
             events.add(it)
@@ -169,7 +169,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Test that the individual sale switch is visible for products`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             var viewState: ViewState? = null
             viewModel.viewStateData.observeForever { _, new ->
                 viewState = new
@@ -180,7 +180,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Test that the individual sale switch is not visible for variations`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel = createViewModel(RequestCodes.VARIATION_DETAIL_INVENTORY)
 
             var viewState: ViewState? = null
@@ -193,7 +193,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Test that stock quantity field is not editable if stock quantity is non-whole decimal`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel = createViewModel(RequestCodes.PRODUCT_DETAIL_INVENTORY, initialDataWithNonWholeDecimalQuantity)
 
             var viewState: ViewState? = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -51,7 +51,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the product list view correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the product list view correctly`() = testBlocking {
         doReturn(productList).whenever(productRepository).fetchProductList(productFilterOptions = emptyMap())
 
         createViewModel()
@@ -65,7 +65,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Do not fetch product list from api when not connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Do not fetch product list from api when not connected`() = testBlocking {
         doReturn(false).whenever(networkStatus).isConnected()
 
         createViewModel()
@@ -82,7 +82,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Shows and hides product list skeleton correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Shows and hides product list skeleton correctly`() = testBlocking {
         doReturn(emptyList<Product>()).whenever(productRepository).getProductList()
         doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
 
@@ -100,7 +100,7 @@ class ProductListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Shows and hides product list load more progress correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(true).whenever(productRepository).canLoadMoreProducts
             doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
 
@@ -117,7 +117,7 @@ class ProductListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Shows and hides add product button correctly when loading list of products`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // when
             doReturn(productList).whenever(productRepository).fetchProductList()
 
@@ -138,7 +138,7 @@ class ProductListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Hides add product button when list of products is empty`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // when
             doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
 
@@ -159,7 +159,7 @@ class ProductListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Hides add product button when searching`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // when
             doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
 
@@ -182,7 +182,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     @Test
     /* We show the Add Product FAB after searching is completed. */
     fun `Shows add product button after opening and closing search`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // when
             doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
 
@@ -206,7 +206,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     @Test
     /* We hide the filters when searching. */
     fun `Hides filters buttons when searching`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // when
             doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
 
@@ -228,7 +228,7 @@ class ProductListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Shows filters buttons after opening and closing search`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // when
             doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductPricingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductPricingViewModelTest.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductPricingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductPricingViewModelTest.kt
@@ -102,7 +102,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the initial price information correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the initial price information correctly`() = testBlocking {
         var state: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> state = new }
 
@@ -110,7 +110,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays and hides the done button after data change`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays and hides the done button after data change`() = testBlocking {
         var state: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> state = new }
 
@@ -138,7 +138,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays error message if there is validation error`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays error message if there is validation error`() = testBlocking {
         var state: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> state = new }
 
@@ -156,7 +156,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Hides the tax section for variation pricing`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Hides the tax section for variation pricing`() = testBlocking {
         val savedState = ProductPricingFragmentArgs(RequestCodes.VARIATION_DETAIL_PRICING, pricingData)
             .initSavedStateHandle()
 
@@ -182,7 +182,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Makes sale end date equal to start date if earlier`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Makes sale end date equal to start date if earlier`() = testBlocking {
         var state: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> state = new }
 
@@ -209,7 +209,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Nulls the sale schedule dates if switch off`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Nulls the sale schedule dates if switch off`() = testBlocking {
         var state: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> state = new }
 
@@ -263,7 +263,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Displays sale price error message when sale price is greater than regular price`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             var state: ViewState? = null
             viewModel.viewStateData.observeForever { _, new -> state = new }
 
@@ -274,7 +274,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Hides sale price error message when sale price is less than regular price`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             var state: ViewState? = null
             viewModel.viewStateData.observeForever { _, new -> state = new }
 
@@ -288,7 +288,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Display sale price error message when sale price is zero and regular price has negative value`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             var state: ViewState? = null
             viewModel.viewStateData.observeForever { _, new -> state = new }
 
@@ -303,7 +303,7 @@ class ProductPricingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Hide sale price error message when sale price is null and regular price has any value`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             var state: ViewState? = null
             viewModel.viewStateData.observeForever { _, new -> state = new }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
@@ -48,7 +48,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the product list view correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Displays the product list view correctly`() = testBlocking {
         val expectedProductList = productList.toMutableList().apply {
             excludedProductIds.forEach { excludedIds ->
                 this.removeIf { it.remoteId == excludedIds }
@@ -72,7 +72,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Do not fetch product list from api when not connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Do not fetch product list from api when not connected`() = testBlocking {
         doReturn(false).whenever(networkStatus).isConnected()
 
         createViewModel()
@@ -89,7 +89,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Shows and hides product list skeleton correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Shows and hides product list skeleton correctly`() = testBlocking {
         doReturn(emptyList<Product>()).whenever(productRepository).getProductList(
             excludedProductIds = excludedProductIds
         )
@@ -109,7 +109,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Shows and hides product list load more progress correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(true).whenever(productRepository).canLoadMoreProducts
             doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList(
                 excludedProductIds = excludedProductIds
@@ -142,7 +142,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should exclude the current product from product selection list`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val expectedProductList = productList.toMutableList().apply {
                 excludedProductIds.forEach { excludedIds ->
                     this.removeIf { it.remoteId == excludedIds }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.*

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductShippingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductShippingViewModelTest.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductShippingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductShippingViewModelTest.kt
@@ -47,7 +47,7 @@ class ProductShippingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Test that the initial data is displayed correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Test that the initial data is displayed correctly`() = testBlocking {
         var actual: ShippingData? = null
         viewModel.viewStateData.observeForever { _, new ->
             actual = new.shippingData
@@ -58,7 +58,7 @@ class ProductShippingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Test that when data is changed the view state is updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             var actual: ShippingData? = null
             viewModel.viewStateData.observeForever { _, new ->
                 actual = new.shippingData
@@ -78,7 +78,7 @@ class ProductShippingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Test that a discard dialog isn't shown if no data changed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val events = mutableListOf<Event>()
             viewModel.event.observeForever {
                 events.add(it)
@@ -94,7 +94,7 @@ class ProductShippingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Test that a the correct data is returned when exiting`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Test that a the correct data is returned when exiting`() = testBlocking {
         val events = mutableListOf<Event>()
         viewModel.event.observeForever {
             events.add(it)
@@ -121,7 +121,7 @@ class ProductShippingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Test that the class section is visible for products`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Test that the class section is visible for products`() = testBlocking {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new ->
             viewState = new
@@ -132,7 +132,7 @@ class ProductShippingViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Test that the class section is not visible for variations`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             viewModel = createViewModel(RequestCodes.VARIATION_DETAIL_SHIPPING)
 
             var viewState: ViewState? = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
@@ -62,7 +62,7 @@ class VariationListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Do not fetch product variations from api when not connected`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(false).whenever(networkStatus).isConnected()
 
             createViewModel()
@@ -81,7 +81,7 @@ class VariationListViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Shows and hides product variations skeleton correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Shows and hides product variations skeleton correctly`() = testBlocking {
         doReturn(emptyList<ProductVariation>())
             .whenever(variationRepository).getProductVariationList(productRemoteId)
 
@@ -97,7 +97,7 @@ class VariationListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Display empty view on fetch product variations error`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Display empty view on fetch product variations error`() = testBlocking {
         whenever(variationRepository.fetchProductVariations(productRemoteId)).thenReturn(null)
         whenever(variationRepository.getProductVariationList(productRemoteId)).thenReturn(null)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -54,7 +54,6 @@ class AddonRepositoryTest: BaseUnitTest() {
     @Before
     fun setUp() {
         siteModelMock = mock {
-            on { id }.doReturn(321)
             on { siteId }.doReturn(321)
         }
         selectedSiteMock = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.fluxc.store.WCProductStore
 import kotlin.test.fail
 
 @ExperimentalCoroutinesApi
-class AddonRepositoryTest: BaseUnitTest() {
+class AddonRepositoryTest : BaseUnitTest() {
     private lateinit var repositoryUnderTest: AddonRepository
 
     private lateinit var orderStoreMock: WCOrderStore

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -10,16 +10,20 @@ import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultOrder
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultOrderModel
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultWCOrderItemList
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultWCProductModel
+import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.times
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCAddonsStore
@@ -28,7 +32,7 @@ import org.wordpress.android.fluxc.store.WCProductStore
 import kotlin.test.fail
 
 @ExperimentalCoroutinesApi
-class AddonRepositoryTest {
+class AddonRepositoryTest: BaseUnitTest() {
     private lateinit var repositoryUnderTest: AddonRepository
 
     private lateinit var orderStoreMock: WCOrderStore
@@ -69,7 +73,7 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `fetchOrderAddonsData should return both order addons and product addons data`() = runBlockingTest {
+    fun `fetchOrderAddonsData should return both order addons and product addons data`() = testBlocking {
         configureSuccessfulOrderResponse()
         configureSuccessfulAddonResponse()
 
@@ -88,7 +92,7 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `fetchOrderAddonsData should map and filter orderAddons keys as List correctly`() = runBlockingTest {
+    fun `fetchOrderAddonsData should map and filter orderAddons keys as List correctly`() = testBlocking {
         configureSuccessfulOrderResponse()
         configureSuccessfulAddonResponse()
 
@@ -108,7 +112,7 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `fetchOrderAddonsData should map productAddons correctly`() = runBlockingTest {
+    fun `fetchOrderAddonsData should map productAddons correctly`() = testBlocking {
         configureSuccessfulOrderResponse()
         configureSuccessfulAddonResponse()
 
@@ -128,7 +132,7 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `containsAddonsFrom should return true for valid OrderItem`() = runBlockingTest {
+    fun `containsAddonsFrom should return true for valid OrderItem`() = testBlocking {
         configureSuccessfulAddonResponse()
 
         val orderItem = defaultOrderModel.let { orderMapper.toAppModel(it) }.items.first()
@@ -137,7 +141,7 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `containsAddonsFrom should return false when requested with invalid OrderItem`() = runBlockingTest {
+    fun `containsAddonsFrom should return false when requested with invalid OrderItem`() = testBlocking {
         configureSuccessfulAddonResponse()
 
         val orderItem = defaultOrderModel.let { orderMapper.toAppModel(it) }.items.first()
@@ -152,35 +156,35 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `fetchOrderAddonsData should return null if product addon data fails`() = runBlockingTest {
+    fun `fetchOrderAddonsData should return null if product addon data fails`() = testBlocking {
         configureSuccessfulOrderResponse()
         val response = repositoryUnderTest.getOrderAddonsData(123, 999, 333)
         assertThat(response).isNull()
     }
 
     @Test
-    fun `fetchOrderAddonsData should return null if order addon data fails`() = runBlockingTest {
+    fun `fetchOrderAddonsData should return null if order addon data fails`() = testBlocking {
         configureSuccessfulAddonResponse()
         val response = repositoryUnderTest.getOrderAddonsData(123, 999, 333)
         assertThat(response).isNull()
     }
 
     @Test
-    fun `fetchOrderAddonsData should return null if order item ID is incorrect`() = runBlockingTest {
+    fun `fetchOrderAddonsData should return null if order item ID is incorrect`() = testBlocking {
         configureSuccessfulAddonResponse()
         val response = repositoryUnderTest.getOrderAddonsData(123, 0, 333)
         assertThat(response).isNull()
     }
 
     @Test
-    fun `hasAddons should return false if there's no add-ons for given product`() = runBlockingTest {
+    fun `hasAddons should return false if there's no add-ons for given product`() = testBlocking {
         whenever(addonStoreMock.observeProductSpecificAddons(any(), any())).thenReturn(emptyFlow())
 
         assertThat(repositoryUnderTest.hasAnyProductSpecificAddons(remoteProductID)).isEqualTo(false)
     }
 
     @Test
-    fun `hasAddons should return true if there are add-ons for given product`() = runBlockingTest {
+    fun `hasAddons should return true if there are add-ons for given product`() = testBlocking {
         whenever(addonStoreMock.observeProductSpecificAddons(any(), any())).thenReturn(flowOf(defaultAddonsList))
 
         assertThat(repositoryUnderTest.hasAnyProductSpecificAddons(remoteProductID)).isEqualTo(true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -68,7 +68,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should trigger a successful parse to all data at once`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(true)
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(Pair(defaultProductAddonList, defaultOrderAttributes))
@@ -87,7 +87,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should parse Addons with parsed option as FlatFee when matching PercentageBased option is found`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(Pair(defaultProductAddonList, orderAttributesWithPercentageBasedItem))
             whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(false)
@@ -106,7 +106,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should request data even if fetchGlobalAddons returns an error`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(Pair(defaultProductAddonList, defaultOrderAttributes))
             whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(false)
@@ -125,7 +125,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should inject Attribute data when matching option is NOT found`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val mockResponse = Pair(
                 listOf(
                     emptyProductAddon.copy(
@@ -165,7 +165,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should return Addon with single option when matching option is found`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(
                     Pair(
@@ -206,7 +206,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should return two Addons with a single option when matching addon is found twice`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .doReturn(
                     Pair(
@@ -266,7 +266,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should enable and disable skeleton view when loading the view data`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(true)
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(Pair(defaultProductAddonList, defaultOrderAttributes))
@@ -293,7 +293,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should enable and disable skeleton view when loading the view data fails`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(false)
 
             var timesCalled = 0
@@ -318,7 +318,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should change isLoadingFailure to true when loading the view data fails`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(false)
 
             var timesCalled = 0
@@ -343,7 +343,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should change isLoadingFailure to true when the Ordered Addons data is empty`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(false)
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(Pair(emptyList(), emptyList()))
@@ -370,7 +370,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Test
     fun `should keep isLoadingFailure to false when loading the view data succeeds`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(true)
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(Pair(defaultProductAddonList, defaultOrderAttributes))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.ui.products.addons.AddonTestFixtures.orderedAddon
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -83,7 +83,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when order has zero taxes and no shipping and fees, then refund notice is not visible`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(OrderTestUtils.generateOrder())
 
             initViewModel()
@@ -97,7 +97,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when order has taxes and no shipping and fees, then only the taxes are mentioned in the notice`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val orderWithTax = OrderTestUtils.generateOrder().copy(totalTax = "4.00")
             whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithTax)
 
@@ -113,7 +113,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when order has one shipping and fees without taxes, then the notice not visible`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val orderWithFeesAndShipping = OrderTestUtils.generateOrderWithFee()
             whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithFeesAndShipping)
 
@@ -128,7 +128,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when order has one shipping, and fees and taxes, then taxes are mentioned in the notice`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val orderWithFeesAndShipping = OrderTestUtils.generateOrderWithFee().copy(totalTax = "4.00")
             whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithFeesAndShipping)
 
@@ -144,7 +144,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when order has multiple shipping, multiple shipping are mentioned in the notice`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines()
             whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
 
@@ -160,7 +160,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given non cash order, when successfully charge data loaded, then card info is visible`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val chargeId = "charge_id"
             val cardBrand = "visa"
             val cardLast4 = "1234"
@@ -189,7 +189,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given non cash order, when charge data loaded with error, then card info is not visible`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val chargeId = "charge_id"
             val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
                 paymentMethod = "cod",
@@ -213,7 +213,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given non cash order and non charge id in order, when charge data loading, then card info is not visible`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
                 paymentMethod = "cod",
                 metaData = "[]"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/PaymentChargeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/PaymentChargeRepositoryTest.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/PaymentChargeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/PaymentChargeRepositoryTest.kt
@@ -48,7 +48,7 @@ class PaymentChargeRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given active plugin saved and card response successful, when fetching data, then card details returned`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val chargeId = "charge_id"
             whenever(appPrefs.getCardReaderPreferredPlugin(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
@@ -76,7 +76,7 @@ class PaymentChargeRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given active plugin saved and interac response successful, when fetching data, then card details returned`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val chargeId = "charge_id"
             whenever(appPrefs.getCardReaderPreferredPlugin(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
@@ -107,7 +107,7 @@ class PaymentChargeRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given active plugin saved and unknown response successful, when fetching data, then card details null`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val chargeId = "charge_id"
             whenever(appPrefs.getCardReaderPreferredPlugin(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
@@ -135,7 +135,7 @@ class PaymentChargeRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given active plugin saved and response not successful, when fetching data, then error returned`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val chargeId = "charge_id"
             whenever(appPrefs.getCardReaderPreferredPlugin(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))
@@ -160,7 +160,7 @@ class PaymentChargeRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given active plugin is not saved, when fetching data, then error returned`() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             // GIVEN
             val chargeId = "charge_id"
             whenever(appPrefs.getCardReaderPreferredPlugin(siteModel.id, siteModel.siteId, siteModel.selfHostedSiteId))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
@@ -105,7 +105,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
      * a review is processed successfully by the detail view.
      */
     @Test
-    fun `Handle successful review moderation correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `Handle successful review moderation correctly`() = testBlocking {
         doReturn(notification).whenever(repository).getCachedNotificationForReview(any())
         doReturn(review).whenever(repository).getCachedProductReview(any())
         doReturn(RequestResult.SUCCESS).whenever(repository).fetchProductReview(any())
@@ -134,7 +134,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
      */
     @Test
     fun `Handle review moderation failed due to offline correctly`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        testBlocking {
             doReturn(false).whenever(networkStatus).isConnected()
 
             doReturn(review).whenever(repository).getCachedProductReview(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/UploadEncryptedLogsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/UploadEncryptedLogsTest.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.util.crashlogging
 
-import com.woocommerce.android.util.CoroutineTestRule
-import kotlinx.coroutines.test.runBlockingTest
+import com.woocommerce.android.viewmodel.BaseUnitTest
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
@@ -13,13 +11,10 @@ import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.store.EncryptedLogStore
 
 @RunWith(MockitoJUnitRunner::class)
-class UploadEncryptedLogsTest {
+class UploadEncryptedLogsTest : BaseUnitTest() {
     private lateinit var sut: UploadEncryptedLogs
 
     private val encryptedLogStore: EncryptedLogStore = mock()
-
-    @get:Rule
-    val coroutinesTestRule = CoroutineTestRule()
 
     @Before
     fun setUp() {
@@ -30,7 +25,7 @@ class UploadEncryptedLogsTest {
     }
 
     @Test
-    fun `should start upload when invoked`() = runBlockingTest {
+    fun `should start upload when invoked`() = testBlocking {
         sut.invoke()
 
         verify(encryptedLogStore, times(1)).uploadQueuedEncryptedLogs()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I recommend reviewing one commit at a time - it should be pretty easy to follow and most of the changes are done using automated tools.

The goal of this PR is to make our tests a bit more consistent - attempts to use `testBlocking` which lives in BaseUnitTest across all tests in the main WooCommerce module. The main reason for this is that it'll make migration to Kotlin Coroutines Test 1.6 easier - especially the review of that PR will be much easier. Unless I'm missing something, this PR doesn't make any real changes - if I missed something please let me know.

One change which is not just about `testBlocking` is in this commit - https://github.com/woocommerce/woocommerce-android/pull/6272/commits/2fb3fb1b22e9fd97945f161aa30a983b38603f52.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
No testing required.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
