### PR TITLE
Fix failing test in OrderDetailViewModel after migrating coroutines from 1.5 to 1.6

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -8,21 +8,51 @@ import androidx.lifecycle.SavedStateHandle
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
-import com.woocommerce.android.analytics.AnalyticsEvent.*
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_PULLED_TO_REFRESH
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE_FAILED
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_ADD
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_DELETE_FAILED
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_DELETE_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED
+import com.woocommerce.android.analytics.AnalyticsEvent.SHIPPING_LABEL_ORDER_IS_ELIGIBLE
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_EDITING
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
-import com.woocommerce.android.model.*
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
+import com.woocommerce.android.model.OrderNote
+import com.woocommerce.android.model.OrderShipmentTracking
+import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.RequestResult.SUCCESS
+import com.woocommerce.android.model.ShippingLabel
+import com.woocommerce.android.model.getNonRefundedProducts
+import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.ProductImageMap.OnProductFetchedListener
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.OrderNavigationTarget.*
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.PreviewReceipt
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.PrintShippingLabel
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.RefundShippingLabel
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartCardReaderPaymentFlow
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartShippingLabelCreationFlow
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewCreateShippingLabelInfo
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderFulfillInfo
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderedAddons
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintCustomsForm
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintingInstructions
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
 import com.woocommerce.android.ui.orders.cardreader.payment.CardReaderPaymentCollectibilityChecker
 import com.woocommerce.android.ui.prefs.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.products.addons.AddonRepository
@@ -37,8 +67,10 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.*
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -460,21 +492,19 @@ final class OrderDetailViewModel @Inject constructor(
 
     private suspend fun updateOrderState() {
         val isPaymentCollectable = isPaymentCollectable(order)
-        withContext(coroutineDispatchers.main) {
-            val orderStatus = orderDetailRepository.getOrderStatus(order.status.value)
-            viewState = viewState.copy(
-                orderInfo = OrderInfo(
-                    order = order,
-                    isPaymentCollectableWithCardReader = isPaymentCollectable,
-                    isReceiptButtonsVisible = FeatureFlag.CARD_READER.isEnabled() &&
-                        !loadReceiptUrl().isNullOrEmpty()
-                ),
-                orderStatus = orderStatus,
-                toolbarTitle = resourceProvider.getString(
-                    string.orderdetail_orderstatus_ordernum, order.number
-                )
+        val orderStatus = orderDetailRepository.getOrderStatus(order.status.value)
+        viewState = viewState.copy(
+            orderInfo = OrderInfo(
+                order = order,
+                isPaymentCollectableWithCardReader = isPaymentCollectable,
+                isReceiptButtonsVisible = FeatureFlag.CARD_READER.isEnabled() &&
+                    !loadReceiptUrl().isNullOrEmpty()
+            ),
+            orderStatus = orderStatus,
+            toolbarTitle = resourceProvider.getString(
+                string.orderdetail_orderstatus_ordernum, order.number
             )
-        }
+        )
     }
 
     private suspend fun isPaymentCollectable(order: Order) = paymentCollectibilityChecker.isCollectable(order)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6273 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The intention of [this method](https://github.com/woocommerce/woocommerce-android/blob/96839d09d9ad00de2e9ff2e2bb1ebf11c9d8cfb6/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt#L143) is to updateOrderState, then loadOrderNotes and after that re-render productAndShipping details. However, this commit (https://github.com/woocommerce/woocommerce-android/commit/9aaea01d683fad309649f8e4c487eed26e5676fc) changed the behavior, since updateOrderState is now asynchronous - the other two methods might be (probably will be) run before the order state gets updated => however, this breaks the behavior since the other two methods rely on orderState to be already updated, but it's not.

This was caught while migrating the coroutine from 1.5 to 1.6.

This PR removes launching `updateOrderState` in the new coroutine and instead makes it a suspend function and moves the coroutine into `displayOrderDetails` so that productAndShipping details won't execute before `updateOrderState`.

Props to @malinajirka  for catching this bug [here](https://github.com/woocommerce/woocommerce-android/pull/6200#discussion_r851027975)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Make sure Order Detail ViewModel unit tests pass after migrating coroutines from 1.5 to 1.6


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
