### PR TITLE
Issue/6261 inbox tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -586,5 +586,10 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     // -- More Menu (aka Hub Menu)
     HUB_MENU_SWITCH_STORE_TAPPED,
     HUB_MENU_OPTION_TAPPED,
-    HUB_MENU_SETTINGS_TAPPED
+    HUB_MENU_SETTINGS_TAPPED,
+
+    //Inbox
+    INBOX_NOTES_LOADED,
+    INBOX_NOTES_LOAD_FAILED,
+    INBOX_NOTE_ACTION,
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -588,7 +588,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     HUB_MENU_OPTION_TAPPED,
     HUB_MENU_SETTINGS_TAPPED,
 
-    //Inbox
+    // Inbox
     INBOX_NOTES_LOADED,
     INBOX_NOTES_LOAD_FAILED,
     INBOX_NOTE_ACTION,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.util.WooLog.T
 import org.json.JSONObject
 import org.wordpress.android.fluxc.model.SiteModel
 import java.util.UUID
-import kotlin.collections.HashMap
 
 class AnalyticsTracker private constructor(private val context: Context) {
     private var tracksClient: TracksClient? = TracksClient.getClient(context)
@@ -316,6 +315,12 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_MORE_MENU_REVIEWS = "reviews"
         const val VALUE_MORE_MENU_INBOX = "inbox"
         const val VALUE_MORE_MENU_COUPONS = "coupons"
+
+        // -- Inbox note actions
+        const val KEY_INBOX_NOTE_ACTION = "action"
+        const val VALUE_INBOX_NOTE_ACTION_OPEN = "open"
+        const val VALUE_INBOX_NOTE_ACTION_DISMISS = "dismiss"
+        const val VALUE_INBOX_NOTE_ACTION_DISMISS_ALL = "dismiss_all"
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
@@ -59,24 +59,24 @@ class InboxViewModel @Inject constructor(
     }
 
     private fun trackInboxNotesLoaded(result: Result<Unit>, isLoadingMore: Boolean = false) {
-        val event = when {
-            result.isFailure -> INBOX_NOTES_LOAD_FAILED
-            else -> INBOX_NOTES_LOADED
-        }
-        val properties = when {
-            result.isFailure -> {
-                val errorProperties = mutableMapOf(
-                    KEY_ERROR_TYPE to result.exceptionOrNull(),
-                    KEY_ERROR_DESC to result.exceptionOrNull()?.message
+        result.fold(
+            onSuccess = {
+                AnalyticsTracker.track(
+                    INBOX_NOTES_LOADED,
+                    mapOf(KEY_IS_LOADING_MORE to isLoadingMore.toString())
                 )
-                result.exceptionOrNull()?.let {
-                    errorProperties[KEY_ERROR_CONTEXT] = it::class.java.simpleName
-                }
-                errorProperties
+            },
+            onFailure = {
+                AnalyticsTracker.track(
+                    INBOX_NOTES_LOAD_FAILED,
+                    mapOf(
+                        KEY_ERROR_CONTEXT to it::class.java.simpleName,
+                        KEY_ERROR_TYPE to it,
+                        KEY_ERROR_DESC to it.message
+                    )
+                )
             }
-            else -> mapOf(KEY_IS_LOADING_MORE to isLoadingMore.toString())
-        }
-        AnalyticsTracker.track(event, properties)
+        )
     }
 
     private fun trackInboxNoteActionClicked(actionValue: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
@@ -60,8 +60,8 @@ class InboxViewModel @Inject constructor(
 
     private fun trackInboxNotesLoaded(result: Result<Unit>, isLoadingMore: Boolean = false) {
         val event = when {
-            result.isFailure -> INBOX_NOTES_LOADED
-            else -> INBOX_NOTES_LOAD_FAILED
+            result.isFailure -> INBOX_NOTES_LOAD_FAILED
+            else -> INBOX_NOTES_LOADED
         }
         val properties = when {
             result.isFailure -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
@@ -6,6 +6,18 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent.INBOX_NOTES_LOADED
+import com.woocommerce.android.analytics.AnalyticsEvent.INBOX_NOTES_LOAD_FAILED
+import com.woocommerce.android.analytics.AnalyticsEvent.INBOX_NOTE_ACTION
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_INBOX_NOTE_ACTION
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_IS_LOADING_MORE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_INBOX_NOTE_ACTION_DISMISS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_INBOX_NOTE_ACTION_DISMISS_ALL
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_INBOX_NOTE_ACTION_OPEN
 import com.woocommerce.android.ui.inbox.domain.InboxNote
 import com.woocommerce.android.ui.inbox.domain.InboxNote.NoteType.SURVEY
 import com.woocommerce.android.ui.inbox.domain.InboxNote.Status.ACTIONED
@@ -40,12 +52,42 @@ class InboxViewModel @Inject constructor(
     init {
         _inboxState.value = InboxState(isLoading = true)
         viewModelScope.launch {
-            inboxRepository.fetchInboxNotes()
+            val result = inboxRepository.fetchInboxNotes()
+            trackInboxNotesLoaded(result)
             inboxNotesLocalUpdates().collectLatest { _inboxState.value = it }
         }
     }
 
+    private fun trackInboxNotesLoaded(result: Result<Unit>, isLoadingMore: Boolean = false) {
+        val event = when {
+            result.isFailure -> INBOX_NOTES_LOADED
+            else -> INBOX_NOTES_LOAD_FAILED
+        }
+        val properties = when {
+            result.isFailure -> {
+                val errorProperties = mutableMapOf(
+                    KEY_ERROR_TYPE to result.exceptionOrNull(),
+                    KEY_ERROR_DESC to result.exceptionOrNull()?.message
+                )
+                result.exceptionOrNull()?.let {
+                    errorProperties[KEY_ERROR_CONTEXT] = it::class.java.simpleName
+                }
+                errorProperties
+            }
+            else -> mapOf(KEY_IS_LOADING_MORE to isLoadingMore.toString())
+        }
+        AnalyticsTracker.track(event, properties)
+    }
+
+    private fun trackInboxNoteActionClicked(actionValue: String) {
+        AnalyticsTracker.track(
+            INBOX_NOTE_ACTION,
+            mapOf(KEY_INBOX_NOTE_ACTION to actionValue)
+        )
+    }
+
     fun dismissAllNotes() {
+        trackInboxNoteActionClicked(VALUE_INBOX_NOTE_ACTION_DISMISS_ALL)
         viewModelScope.launch {
             inboxRepository.dismissAllNotesForCurrentSite()
         }
@@ -114,6 +156,7 @@ class InboxViewModel @Inject constructor(
     private fun handleInboxNoteAction(actionId: Long, noteId: Long) {
         val clickedNote = inboxState.value?.notes?.firstOrNull { noteId == it.id }
         clickedNote?.let {
+            trackInboxNoteActionClicked(VALUE_INBOX_NOTE_ACTION_OPEN)
             when {
                 it.isSurvey -> markSurveyAsAnswered(clickedNote.id, actionId)
                 else -> openActionUrl(clickedNote, actionId)
@@ -140,6 +183,7 @@ class InboxViewModel @Inject constructor(
     }
 
     private fun dismissNote(noteId: Long) {
+        trackInboxNoteActionClicked(VALUE_INBOX_NOTE_ACTION_DISMISS)
         viewModelScope.launch {
             inboxRepository.dismissNote(noteId)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6261 
<!-- Id number of the GitHub issue this PR addresses. -->

Ready for review but don't merge until the base branch is `trunk`

### Description
Adds tracking to the Inbox screen and interactions over notes following the specification: 
![Screenshot 2022-04-15 at 13 05 14](https://user-images.githubusercontent.com/2663464/163564163-364d146d-e281-45a0-92c8-899cb506e89d.png)

### Testing instructions
Run the app and open the Android logcat filtering by "UTILS" word to see only tracking logs. Then proceed with the test:

1. Tap the inbox notes menu under the more menu. You should see in console the event `*_hub_menu_option_tapped` with the property `option` set to `inbox`. 
2. Open the inbox notes: you should see the event `*_inbox_notes_loaded` in console, with the property `is_loading_more` set to `false`.
3. If there is an error loading the inbox notes, you should see the event `*_inbox_notes_load_failed` in console with the related error if any. This can be tested by removing internet connection and opening Inbox again. 
4. Try to tap on the action button of a note. You should see the event `*_inbox_note_action` in console with the property `open`.
5. Try to tap on dismiss button of a note. You should see the event `*_inbox_note_action` in console with the property `dismiss`.
6. Try to dismiss all the notifications in the view (using the navbar button). You should see the event `*_inbox_note_action` in console with the property `dismiss_all`.
