### PR TITLE
[Coupons] hide the feature on release versions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -11,8 +11,10 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_ADDONS_BETA_FEATURES_SWITCH_TOGGLED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSettingsBetaBinding
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
+import com.woocommerce.android.util.PackageUtils
 
 class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     companion object {
@@ -49,6 +51,10 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     }
 
     private fun FragmentSettingsBetaBinding.bindCouponsToggle() {
+        if (!PackageUtils.isDebugBuild()) {
+            switchCouponsToggle.hide()
+            return
+        }
         switchCouponsToggle.isChecked = AppPrefs.isCouponsEnabled
         switchCouponsToggle.setOnCheckedChangeListener { switch, isChecked ->
             settingsListener?.onCouponsOptionChanged(isChecked)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -253,7 +253,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     private fun generateBetaFeaturesTitleList() =
         mutableListOf<String>().apply {
             add(getString(R.string.beta_features_add_ons))
-            add(getString(R.string.beta_features_coupons))
         }
 
     /**


### PR DESCRIPTION
### Description
This PR simply hides the coupons beta toggle on release versions.

### Testing instructions
Test the release build, and confirm the beta toggle is hidden in the screen "Beta features"


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
