### PR TITLE
Hide out of stock products from the order creation product selector

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
@@ -35,8 +35,8 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
     val productListData: LiveData<List<Product>> = productList.map { products ->
         products.filter {
             it.isPurchasable &&
-            it.status == PUBLISH &&
-            it.stockStatus != ProductStockStatus.OutOfStock
+                it.status == PUBLISH &&
+                it.stockStatus != ProductStockStatus.OutOfStock
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.ShowProductVariations
 import com.woocommerce.android.ui.products.ProductListRepository
 import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
+import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -32,7 +33,11 @@ class OrderCreationProductSelectionViewModel @Inject constructor(
 
     private val productList = MutableLiveData<List<Product>>()
     val productListData: LiveData<List<Product>> = productList.map { products ->
-        products.filter { it.isPurchasable && it.status == PUBLISH }
+        products.filter {
+            it.isPurchasable &&
+            it.status == PUBLISH &&
+            it.stockStatus != ProductStockStatus.OutOfStock
+        }
     }
 
     val isSearchActive


### PR DESCRIPTION
Order creation currently enables adding out of stock products to the order, which _may_ be a bug. Please see this Slack discussion p1650046727648959-slack-CGPNUU63E

This PR excludes out of stock products from the product selection list, but I've marked it as "do not merge" until we have more clarity about whether or not this is a bug.