### PR TITLE
[Hub menu] Prevent multiple fast clicks on menu from opening multiple sections

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+9.1
+-----
+- [*] Fixed an issue in hub menu where tapping multiple menu buttons at once breaks navigation. [https://github.com/woocommerce/woocommerce-android/pull/6289]
+
 9.0
 -----
 - [*] Fixes a bug that caused the scheduled sale dates of a product to be different than the selected dates. [https://github.com/woocommerce/woocommerce-android/pull/6188]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MenuUiButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MenuUiButton.kt
@@ -9,7 +9,7 @@ data class MenuUiButton(
     @DrawableRes val icon: Int,
     val badgeCount: Int = 0,
     val isEnabled: Boolean = true,
-    val onClick: () -> Unit = {},
+    val onClick: (MenuButtonType) -> Unit = {},
 )
 
 enum class MenuButtonType {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenu.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenu.kt
@@ -97,7 +97,7 @@ fun MoreMenu(
                     text = item.text,
                     iconDrawable = item.icon,
                     badgeCount = item.badgeCount,
-                    onClick = item.onClick
+                    onClick = { item.onClick(item.type) }
                 )
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5992
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

On the more menu screen, when someone taps various different menu buttons quickly, we want the app to only care about the latest tap. This prevents opening multiple sections at once, which can break back navigation (as shown [on this video](https://video.wordpress.com/v/y4xWFyHQ) on #5992).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to hub menu,
2. Tap multiple menu items as fast as possible,
3. Ensure that only the last tapped item is opened,
4. Once it is opened, tap back, and ensure that the hub menu is shown again.

### Video
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/266376/163787450-014fee13-0a6c-413e-9c8e-2a0e84b6823d.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
