### PR TITLE
Exclude `Automattic-Tracks-Android` from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,4 @@ updates:
       - dependency-name: "org.wordpress:fluxc"
       - dependency-name: "org.wordpress.fluxc.plugins:woocommerce"
       - dependency-name: "org.wordpress:login"
+      - dependency-name: "com.automattic:Automattic-Tracks-Android"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,7 @@ updates:
       # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
       # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968
       - dependency-name: "com.github.tomakehurst:wiremock"
-      # Our libraries that are stored in S3 have a custom versioning scheme which doesn't work with
-      # dependapot.
+      # Our libraries that are stored in S3 have a custom versioning scheme which doesn't work with Dependabot.
       - dependency-name: "org.wordpress:utils"
       - dependency-name: "org.wordpress:fluxc"
       - dependency-name: "org.wordpress.fluxc.plugins:woocommerce"


### PR DESCRIPTION
As `Automattic-Tracks-Android` is now hosted on S3 and follows a custom versioning scheme, we shouldn't allow Dependabot to create PRs with bumps. 