### PR TITLE
Fix reviews assert in products UI test

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/SingleProductScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/SingleProductScreen.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.screenshots.products
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.platform.app.InstrumentationRegistry
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.util.CustomMatchers
 import com.woocommerce.android.screenshots.util.ProductData
@@ -47,12 +48,13 @@ class SingleProductScreen : Screen {
         if (product.rating > 0) {
             // Check that "Review" label, actual rating (stars) and reviews count are
             // all direct children of the same container:
+
             Espresso.onView(
                 Matchers.allOf(
                     ViewMatchers.withChild(
                         Matchers.allOf(
                             ViewMatchers.withId(R.id.textPropertyName),
-                            ViewMatchers.withText("Reviews")
+                            ViewMatchers.withText(R.string.product_reviews)
                         )
                     ),
                     ViewMatchers.withChild(
@@ -64,7 +66,7 @@ class SingleProductScreen : Screen {
                     ViewMatchers.withChild(
                         Matchers.allOf(
                             ViewMatchers.withId(R.id.textPropertyValue),
-                            ViewMatchers.withText(product.reviewsCountBeautified)
+                            ViewMatchers.withText(product.getReviewsDescription())
                         )
                     )
                 )
@@ -90,5 +92,14 @@ class SingleProductScreen : Screen {
                 )
             )
         ).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
+
+    private fun ProductData.getReviewsDescription(): String {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return when (this.reviewsCount) {
+            0 -> context.getString(R.string.product_ratings_count_zero)
+            1 -> context.getString(R.string.product_ratings_count_one)
+            else -> context.getString(R.string.product_ratings_count, this.reviewsCount)
+        }
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/DataClasses.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/DataClasses.kt
@@ -51,7 +51,6 @@ data class ProductData(
     val stockStatus = productStatusesMap[stockStatusRaw]
     val price = getPriceDescription()
     val type = productTypesMap[typeRaw]
-    val reviewsCountBeautified = getRatingDescription()
 
     private fun getPriceDescription(): String {
         var price = "Regular price: \$$priceRegularRaw.00"
@@ -66,13 +65,5 @@ data class ProductData(
         }
 
         return price
-    }
-
-    private fun getRatingDescription(): String {
-        return when (reviewsCount) {
-            0 -> ""
-            1 -> "• rated once"
-            else -> "• rated $reviewsCount times"
-        }
     }
 }


### PR DESCRIPTION
### Description
Minor fix to `ProductsUITest`. The test failed because of a change in the product review description.

### Changes

- Created `getReviewsDescription` to use the string resource with the `reviewsCount` to match what the app is doing on [Product.productReviews()](https://github.com/woocommerce/woocommerce-android/blob/6fd4eb72889dfedf5701db42b9d2c66d84c69316/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt#L409)
- Changed Review text match to use the string resource
- Removed unused `getRatingDescription` function

Testing instructions
Run `ProductsUITest` and confirm test passes.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
