### PR TITLE
[Coupons] Use existing dimens value for Compose screens' various dimensions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -182,7 +182,7 @@ private fun CouponListSkeleton() {
                         dimensionResource(id = R.dimen.major_100)
                     )
                     SkeletonView(
-                        dimensionResource(id = R.dimen.major_250),
+                        dimensionResource(id = R.dimen.skeleton_text_small_width),
                         dimensionResource(id = R.dimen.major_125)
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -16,12 +16,12 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
@@ -63,7 +63,7 @@ private fun EmptyCouponList() {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 32.dp),
+            .padding(horizontal = dimensionResource(id = R.dimen.major_200)),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -71,9 +71,12 @@ private fun EmptyCouponList() {
             text = stringResource(id = R.string.coupon_list_empty_heading),
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.h6,
-            modifier = Modifier.padding(start = 24.dp, end = 24.dp)
+            modifier = Modifier.padding(
+                start = dimensionResource(id = R.dimen.major_150),
+                end = dimensionResource(id = R.dimen.major_150)
+            )
         )
-        Spacer(Modifier.size(54.dp))
+        Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
         Image(
             painter = painterResource(id = R.drawable.img_empty_coupon_list),
             contentDescription = null,
@@ -99,10 +102,9 @@ private fun CouponList(
                 onCouponClick = onCouponClick
             )
             Divider(
-                modifier = Modifier
-                    .offset(x = 16.dp),
+                modifier = Modifier.offset(x = dimensionResource(id = R.dimen.major_100)),
                 color = colorResource(id = R.color.divider_color),
-                thickness = 1.dp
+                thickness = dimensionResource(id = R.dimen.minor_10)
             )
         }
     }
@@ -118,7 +120,7 @@ private fun CouponListItem(
     onCouponClick: (Long) -> Unit
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_50)),
         modifier = Modifier
             .fillMaxWidth()
             .clickable(
@@ -127,7 +129,9 @@ private fun CouponListItem(
                 role = Role.Button,
                 onClick = { onCouponClick(coupon.id) }
             )
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_100),
+                vertical = dimensionResource(id = R.dimen.minor_100)),
     ) {
         coupon.code?.let {
             Text(
@@ -162,18 +166,18 @@ private fun CouponListSkeleton() {
         repeat(numberOfInboxSkeletonRows) {
             item {
                 Column(
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_50)),
+                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100), vertical = dimensionResource(id = R.dimen.minor_100))
                 ) {
-                    SkeletonView(80.dp, 20.dp)
-                    SkeletonView(160.dp, 16.dp)
-                    SkeletonView(40.dp, 20.dp)
+                    SkeletonView(dimensionResource(id = R.dimen.skeleton_text_medium_width), dimensionResource(id = R.dimen.major_125))
+                    SkeletonView(dimensionResource(id = R.dimen.skeleton_text_large_width), dimensionResource(id = R.dimen.major_100))
+                    SkeletonView(dimensionResource(id = R.dimen.major_250), dimensionResource(id = R.dimen.major_125))
                 }
                 Divider(
                     modifier = Modifier
-                        .offset(x = 16.dp),
+                        .offset(x = dimensionResource(id = R.dimen.major_100)),
                     color = colorResource(id = R.color.divider_color),
-                    thickness = 1.dp
+                    thickness = dimensionResource(id = R.dimen.minor_10)
                 )
             }
         }
@@ -187,7 +191,7 @@ private fun SearchEmptyList(searchQuery: String) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 32.dp),
+            .padding(horizontal = dimensionResource(id = R.dimen.major_200)),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -195,9 +199,9 @@ private fun SearchEmptyList(searchQuery: String) {
             text = stringResource(id = R.string.empty_message_with_search, searchQuery),
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.h6,
-            modifier = Modifier.padding(start = 24.dp, end = 24.dp)
+            modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_150), end = dimensionResource(id = R.dimen.major_150))
         )
-        Spacer(Modifier.size(54.dp))
+        Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
         Image(
             painter = painterResource(id = R.drawable.img_empty_search),
             contentDescription = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -131,7 +131,8 @@ private fun CouponListItem(
             )
             .padding(
                 horizontal = dimensionResource(id = R.dimen.major_100),
-                vertical = dimensionResource(id = R.dimen.minor_100)),
+                vertical = dimensionResource(id = R.dimen.minor_100)
+            ),
     ) {
         coupon.code?.let {
             Text(
@@ -167,11 +168,23 @@ private fun CouponListSkeleton() {
             item {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_50)),
-                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100), vertical = dimensionResource(id = R.dimen.minor_100))
+                    modifier = Modifier.padding(
+                        horizontal = dimensionResource(id = R.dimen.major_100),
+                        vertical = dimensionResource(id = R.dimen.minor_100)
+                    )
                 ) {
-                    SkeletonView(dimensionResource(id = R.dimen.skeleton_text_medium_width), dimensionResource(id = R.dimen.major_125))
-                    SkeletonView(dimensionResource(id = R.dimen.skeleton_text_large_width), dimensionResource(id = R.dimen.major_100))
-                    SkeletonView(dimensionResource(id = R.dimen.major_250), dimensionResource(id = R.dimen.major_125))
+                    SkeletonView(
+                        dimensionResource(id = R.dimen.skeleton_text_medium_width),
+                        dimensionResource(id = R.dimen.major_125)
+                    )
+                    SkeletonView(
+                        dimensionResource(id = R.dimen.skeleton_text_large_width),
+                        dimensionResource(id = R.dimen.major_100)
+                    )
+                    SkeletonView(
+                        dimensionResource(id = R.dimen.major_250),
+                        dimensionResource(id = R.dimen.major_125)
+                    )
                 }
                 Divider(
                     modifier = Modifier
@@ -199,7 +212,10 @@ private fun SearchEmptyList(searchQuery: String) {
             text = stringResource(id = R.string.empty_message_with_search, searchQuery),
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.h6,
-            modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_150), end = dimensionResource(id = R.dimen.major_150))
+            modifier = Modifier.padding(
+                start = dimensionResource(id = R.dimen.major_150),
+                end = dimensionResource(id = R.dimen.major_150)
+            )
         )
         Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
         Image(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -9,9 +9,9 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.coupons.components.CouponExpirationLabel
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.*
@@ -97,7 +97,10 @@ fun CouponSummaryHeading(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 16.dp)
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_100),
+                vertical = dimensionResource(id = R.dimen.major_100)
+            )
     ) {
         code?.let {
             Text(
@@ -114,21 +117,21 @@ fun CouponSummaryHeading(
 @Composable
 fun CouponSummarySection(couponSummary: CouponSummaryUi) {
     Surface(
-        elevation = 1.dp,
+        elevation = dimensionResource(id = R.dimen.minor_10),
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 16.dp)
+            .padding(vertical = dimensionResource(id = R.dimen.major_100))
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.padding(16.dp)
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+            modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))
         ) {
             Text(
                 text = stringResource(id = R.string.coupon_details_heading),
                 style = MaterialTheme.typography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.minor_100))
             )
             SummaryLabel(couponSummary.discountType)
             SummaryLabel(couponSummary.summary)
@@ -153,12 +156,12 @@ private fun SummaryLabel(text: String?) {
 @Composable
 private fun CouponPerformanceSection(couponPerformanceState: CouponPerformanceState) {
     Surface(
-        elevation = 1.dp,
+        elevation = dimensionResource(id = R.dimen.minor_10),
         modifier = Modifier
             .fillMaxWidth()
     ) {
         Column(
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))
         ) {
             Text(
                 text = stringResource(id = R.string.coupon_details_performance_heading),
@@ -167,7 +170,7 @@ private fun CouponPerformanceSection(couponPerformanceState: CouponPerformanceSt
                 fontWeight = FontWeight.Bold
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
 
             Row {
                 CouponPerformanceCount(
@@ -190,7 +193,7 @@ private fun CouponPerformanceCount(
     modifier: Modifier = Modifier
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
         modifier = modifier
     ) {
         Text(
@@ -214,7 +217,7 @@ private fun CouponPerformanceAmount(
     modifier: Modifier = Modifier
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
         modifier = modifier
     ) {
         Text(
@@ -223,7 +226,7 @@ private fun CouponPerformanceAmount(
             color = colorResource(id = R.color.color_surface_variant)
         )
         when (couponPerformanceState) {
-            is Loading -> CircularProgressIndicator(modifier = Modifier.size(32.dp))
+            is Loading -> CircularProgressIndicator(modifier = Modifier.size(dimensionResource(id = R.dimen.major_200)))
             else -> {
                 val amount = (couponPerformanceState as? Success)?.data
                     ?.formattedAmount ?: "-"

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -92,6 +92,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="skeleton_text_height_200">@dimen/text_major_75</dimen>
     <dimen name="skeleton_tagview_height">24dp</dimen>
     <dimen name="skeleton_text_button_height">24dp</dimen>
+    <dimen name="skeleton_text_small_width">@dimen/major_250</dimen>
     <dimen name="skeleton_text_medium_width">80dp</dimen>
     <dimen name="skeleton_text_large_width">160dp</dimen>
 

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -92,6 +92,8 @@ so that's the baseline as defined in `major_100`.
     <dimen name="skeleton_text_height_200">@dimen/text_major_75</dimen>
     <dimen name="skeleton_tagview_height">24dp</dimen>
     <dimen name="skeleton_text_button_height">24dp</dimen>
+    <dimen name="skeleton_text_medium_width">80dp</dimen>
+    <dimen name="skeleton_text_large_width">160dp</dimen>
 
     <!-- Corner Radius -->
     <dimen name="corner_radius_small">2dp</dimen>


### PR DESCRIPTION
This replaces hardcoded values in CouponListScreen and CouponDetailsScreen for various dimension parameters, with existing/added parameters in dimens_base file.

### To test:

This doesn't change anything functionality-wise. Run the app and go to Coupons list and Coupon Details screen, make sure nothing looks odd with the design.