### PR TITLE
Enable the beta switch for coupons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -11,10 +11,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_ADDONS_BETA_FEATURES_SWITCH_TOGGLED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSettingsBetaBinding
-import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
-import com.woocommerce.android.util.PackageUtils
 
 class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -51,10 +51,6 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     }
 
     private fun FragmentSettingsBetaBinding.bindCouponsToggle() {
-        if (!PackageUtils.isDebugBuild()) {
-            switchCouponsToggle.hide()
-            return
-        }
         switchCouponsToggle.isChecked = AppPrefs.isCouponsEnabled
         switchCouponsToggle.setOnCheckedChangeListener { switch, isChecked ->
             settingsListener?.onCouponsOptionChanged(isChecked)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -253,6 +253,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     private fun generateBetaFeaturesTitleList() =
         mutableListOf<String>().apply {
             add(getString(R.string.beta_features_add_ons))
+            add(getString(R.string.beta_features_coupons))
         }
 
     /**


### PR DESCRIPTION
This PR brings back the beta switch for coupons so that it can be tested and released.