### PR TITLE
Show selected tab when restoring state in MyStore

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -162,6 +162,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         viewModel.activeStatsGranularity.observe(viewLifecycleOwner) { activeGranularity ->
             if (tabLayout.getTabAt(tabLayout.selectedTabPosition)?.tag != activeGranularity) {
                 val index = StatsGranularity.values().indexOf(activeGranularity)
+                // Small delay needed to ensure tablayout scrolls to the selected if tab is not visible on screen.
                 Handler(Looper.getMainLooper()).postDelayed(
                     { tabLayout.getTabAt(index)?.select() }, 300
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.mystore
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.View
 import android.view.ViewGroup.LayoutParams
 import androidx.core.view.children
@@ -21,7 +23,11 @@ import com.woocommerce.android.R.attr
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentMyStoreBinding
-import com.woocommerce.android.extensions.*
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.scrollStartEvents
+import com.woocommerce.android.extensions.setClickableText
+import com.woocommerce.android.extensions.startHelpActivity
+import com.woocommerce.android.extensions.verticalOffsetChanges
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
@@ -32,7 +38,11 @@ import com.woocommerce.android.ui.mystore.MyStoreViewModel.OrderState
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.RevenueStatsViewState
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.TopPerformersViewState
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.VisitorStatsViewState
-import com.woocommerce.android.util.*
+import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
@@ -42,7 +52,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.NetworkUtils
-import java.util.*
+import java.util.Calendar
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -152,7 +162,9 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         viewModel.activeStatsGranularity.observe(viewLifecycleOwner) { activeGranularity ->
             if (tabLayout.getTabAt(tabLayout.selectedTabPosition)?.tag != activeGranularity) {
                 val index = StatsGranularity.values().indexOf(activeGranularity)
-                tabLayout.getTabAt(index)?.select()
+                Handler(Looper.getMainLooper()).postDelayed(
+                    { tabLayout.getTabAt(index)?.select() }, 300
+                )
             }
             binding.myStoreStats.loadDashboardStats(activeGranularity)
             binding.myStoreTopPerformers.onDateGranularityChanged(activeGranularity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -162,7 +162,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         viewModel.activeStatsGranularity.observe(viewLifecycleOwner) { activeGranularity ->
             if (tabLayout.getTabAt(tabLayout.selectedTabPosition)?.tag != activeGranularity) {
                 val index = StatsGranularity.values().indexOf(activeGranularity)
-                // Small delay needed to ensure tablayout scrolls to the selected if tab is not visible on screen.
+                // Small delay needed to ensure tablayout scrolls to the selected tab if tab is not visible on screen.
                 Handler(Looper.getMainLooper()).postDelayed(
                     { tabLayout.getTabAt(index)?.select() }, 300
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -157,7 +157,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         setupStateObservers()
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "MagicNumber")
     private fun setupStateObservers() {
         viewModel.activeStatsGranularity.observe(viewLifecycleOwner) { activeGranularity ->
             if (tabLayout.getTabAt(tabLayout.selectedTabPosition)?.tag != activeGranularity) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5784 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

There is a bug when restoring selected tab state for Home Screen. This is specially noticeable when we select  "This year" tab. When navigating back to Home screen the previously selected tab is properly restored but it might not be visible. 

### Testing instructions
- Open My Store tab and select "This Year" tab. 
- Navigate to another tab like "More Menu" 
- Navigate back to My Store tab and see how "This Year" tab is selected and **visible**

### Images/gif

**Before**

https://user-images.githubusercontent.com/2663464/164430394-1250c7b4-57d6-4bfd-bd6c-aebe4bbf9a8e.mp4

**After**

https://user-images.githubusercontent.com/2663464/164430094-5a380b4f-663d-4abb-b9d6-ed490bf92ec9.mp4



