### PR TITLE
Add minimum supported plugin version to card reader config

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -148,18 +148,12 @@ class CardReaderOnboardingChecker @Inject constructor(
     private fun isPreferredPluginSupportedInCountry(
         preferredPlugin: PluginWrapper,
         cardReaderConfig: CardReaderConfigForSupportedCountry
-    ) = when (preferredPlugin.type) {
-        WOOCOMMERCE_PAYMENTS -> cardReaderConfig.isExtensionSupported(SupportedExtensionType.WC_PAY)
-        STRIPE_EXTENSION_GATEWAY -> cardReaderConfig.isExtensionSupported(SupportedExtensionType.STRIPE)
-    }
+    ) = cardReaderConfig.isExtensionSupported(preferredPlugin.type.toSupportedExtensionType())
 
     private fun getMinimumSupportedVersionForPlugin(
         preferredPluginType: PluginType,
         cardReaderConfig: CardReaderConfigForSupportedCountry
-    ) = when (preferredPluginType) {
-        WOOCOMMERCE_PAYMENTS -> cardReaderConfig.minSupportedVersionForExtension(SupportedExtensionType.WC_PAY)
-        STRIPE_EXTENSION_GATEWAY -> cardReaderConfig.minSupportedVersionForExtension(SupportedExtensionType.STRIPE)
-    }
+    ) = cardReaderConfig.minSupportedVersionForExtension(preferredPluginType.toSupportedExtensionType())
 
     private fun saveStatementDescriptor(statementDescriptor: String?) {
         val site = selectedSite.get()
@@ -284,6 +278,12 @@ enum class PluginType {
     WOOCOMMERCE_PAYMENTS,
     STRIPE_EXTENSION_GATEWAY
 }
+
+private fun PluginType.toSupportedExtensionType() =
+    when (this) {
+        WOOCOMMERCE_PAYMENTS -> SupportedExtensionType.WC_PAY
+        STRIPE_EXTENSION_GATEWAY -> SupportedExtensionType.STRIPE
+    }
 
 sealed class CardReaderOnboardingState(
     open val preferredPlugin: PluginType? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
-import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
@@ -50,12 +49,6 @@ import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
-
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-const val SUPPORTED_WCPAY_VERSION = "3.2.1"
-
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-const val SUPPORTED_STRIPE_EXTENSION_VERSION = "6.2.0"
 
 const val WCPAY_RECEIPTS_SENDING_SUPPORT_VERSION = "4.0.0"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -6,45 +6,21 @@ import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_O
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_PENDING
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
-import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForSupportedCountry
-import com.woocommerce.android.cardreader.internal.config.SupportedExtensionType
+import com.woocommerce.android.cardreader.internal.config.*
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.prefs.cardreader.InPersonPaymentsCanadaFeatureFlag
 import com.woocommerce.android.ui.prefs.cardreader.StripeExtensionFeatureFlag
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.GenericError
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.NoConnectionError
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.OnboardingCompleted
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.PluginIsNotSupportedInTheCountry
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.PluginUnsupportedVersion
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.SetupNotCompleted
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.StoreCountryNotSupported
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.StripeAccountCountryNotSupported
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.StripeAccountOverdueRequirement
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.StripeAccountPendingRequirement
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.StripeAccountRejected
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.StripeAccountUnderReview
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.WcpayAndStripeActivated
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.WcpayNotActivated
-import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.WcpayNotInstalled
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.*
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.NO_ACCOUNT
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.REJECTED_FRAUD
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.REJECTED_LISTED
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.REJECTED_OTHER
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.REJECTED_TERMS_OF_SERVICE
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.RESTRICTED
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.RESTRICTED_SOON
+import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.*
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType
@@ -127,7 +103,7 @@ class CardReaderOnboardingChecker @Inject constructor(
             STRIPE_EXTENSION_GATEWAY -> throw IllegalStateException("Developer error:`preferredPlugin` should be WCPay")
         }
 
-        if (preferredPlugin.type == STRIPE_EXTENSION_GATEWAY && !cardReaderConfig.isStripeExtensionSupported)
+        if (!isPreferredPluginSupportedInCountry(preferredPlugin, cardReaderConfig))
             return PluginIsNotSupportedInTheCountry(preferredPlugin.type, countryCode!!)
 
         if (!isPluginVersionSupported(
@@ -176,22 +152,20 @@ class CardReaderOnboardingChecker @Inject constructor(
         )
     }
 
+    private fun isPreferredPluginSupportedInCountry(
+        preferredPlugin: PluginWrapper,
+        cardReaderConfig: CardReaderConfigForSupportedCountry
+    ) = when (preferredPlugin.type) {
+        WOOCOMMERCE_PAYMENTS -> cardReaderConfig.isExtensionSupported(SupportedExtensionType.WC_PAY)
+        STRIPE_EXTENSION_GATEWAY -> cardReaderConfig.isExtensionSupported(SupportedExtensionType.STRIPE)
+    }
+
     private fun getMinimumSupportedVersionForPlugin(
         preferredPluginType: PluginType,
         cardReaderConfig: CardReaderConfigForSupportedCountry
-    ): String {
-        return when (preferredPluginType) {
-            WOOCOMMERCE_PAYMENTS -> {
-                cardReaderConfig.supportedExtensions.first {
-                    it.type == SupportedExtensionType.WC_PAY
-                }.supportedSince
-            }
-            STRIPE_EXTENSION_GATEWAY -> {
-                cardReaderConfig.supportedExtensions.firstOrNull {
-                    it.type == SupportedExtensionType.STRIPE
-                }?.supportedSince ?: ""
-            }
-        }
+    ) = when (preferredPluginType) {
+        WOOCOMMERCE_PAYMENTS -> cardReaderConfig.minSupportedVersionForExtension(SupportedExtensionType.WC_PAY)
+        STRIPE_EXTENSION_GATEWAY -> cardReaderConfig.minSupportedVersionForExtension(SupportedExtensionType.STRIPE)
     }
 
     private fun saveStatementDescriptor(statementDescriptor: String?) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -47,6 +47,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
     private val countryCode = "US"
     private val wcPayPluginVersion = "3.3.0"
+    private val wcPayPluginVersionCanada = "4.0.0"
     private val stripePluginVersion = "6.6.0"
 
     @Before
@@ -270,6 +271,22 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
                 .thenReturn(buildStripeExtensionPluginInfo(version = "2.8.1"))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS)).thenReturn(null)
+            whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(
+                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_EXTENSION_GATEWAY)
+            )
+        }
+
+    @Test
+    fun `given store in Canada, when wcpay plugin outdated, then UNSUPPORTED_VERSION returned`() =
+        testBlocking {
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(buildWCPayPluginInfo())
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS)).thenReturn(null)
             whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
 
@@ -1015,7 +1032,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
         whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-            .thenReturn(buildWCPayPluginInfo(isActive = true))
+            .thenReturn(buildWCPayPluginInfo(isActive = true, version = wcPayPluginVersionCanada))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
             .thenReturn(buildStripeExtensionPluginInfo(isActive = false))
         whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -284,16 +284,18 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `given store in Canada, when wcpay plugin outdated, then UNSUPPORTED_VERSION returned`() =
         testBlocking {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn("CA")
+            whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
+            whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(CardReaderConfigForCanada)
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
-            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildWCPayPluginInfo())
-            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS)).thenReturn(null)
-            whenever(stripeExtensionFeatureFlag.isEnabled()).thenReturn(true)
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(version = wcPayPluginVersion))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY)).thenReturn(null)
 
             val result = checker.getOnboardingState()
 
             assertThat(result).isEqualTo(
-                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_EXTENSION_GATEWAY)
+                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.WOOCOMMERCE_PAYMENTS)
             )
         }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
@@ -11,9 +11,14 @@ sealed class CardReaderConfigForSupportedCountry(
     val countryCode: String,
     val supportedReaders: List<SpecificReader>,
     val paymentMethodType: List<PaymentMethodType>,
-    val isStripeExtensionSupported: Boolean,
     val supportedExtensions: List<SupportedExtension>,
 ) : CardReaderConfig()
+
+fun CardReaderConfigForSupportedCountry.isExtensionSupported(type: SupportedExtensionType) =
+    supportedExtensions.any { it.type == type }
+
+fun CardReaderConfigForSupportedCountry.minSupportedVersionForExtension(type: SupportedExtensionType) =
+    supportedExtensions.first { it.type == type }.supportedSince
 
 object CardReaderConfigForUnsupportedCountry : CardReaderConfig()
 
@@ -21,6 +26,7 @@ data class SupportedExtension(
     val type: SupportedExtensionType,
     val supportedSince: String,
 )
+
 enum class SupportedExtensionType {
     WC_PAY, STRIPE
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
@@ -12,8 +12,15 @@ sealed class CardReaderConfigForSupportedCountry(
     val supportedReaders: List<SpecificReader>,
     val paymentMethodType: List<PaymentMethodType>,
     val isStripeExtensionSupported: Boolean,
-    val minimumSupportedVersionWCPay: String,
-    val minimumSupportedVersionStripeExtension: String
+    val supportedExtensions: List<SupportedExtension>,
 ) : CardReaderConfig()
 
 object CardReaderConfigForUnsupportedCountry : CardReaderConfig()
+
+data class SupportedExtension(
+    val type: SupportedExtensionType,
+    val supportedSince: String,
+)
+enum class SupportedExtensionType {
+    WC_PAY, STRIPE
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfig.kt
@@ -5,12 +5,15 @@ import com.woocommerce.android.cardreader.connection.SpecificReader
 
 sealed class CardReaderConfig
 
+@Suppress("LongParameterList")
 sealed class CardReaderConfigForSupportedCountry(
     val currency: String,
     val countryCode: String,
     val supportedReaders: List<SpecificReader>,
     val paymentMethodType: List<PaymentMethodType>,
     val isStripeExtensionSupported: Boolean,
+    val minimumSupportedVersionWCPay: String,
+    val minimumSupportedVersionStripeExtension: String
 ) : CardReaderConfig()
 
 object CardReaderConfigForUnsupportedCountry : CardReaderConfig()

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
@@ -12,8 +12,10 @@ object CardReaderConfigForCanada : CardReaderConfigForSupportedCountry(
         PaymentMethodType.INTERAC_PRESENT
     ),
     isStripeExtensionSupported = false,
-    minimumSupportedVersionWCPay = "4.0.0",
-    // Empty string is temporary here. As soon as support stripe extension in Canada,
-    // we replace this with the actual version.
-    minimumSupportedVersionStripeExtension = ""
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.0.0"
+        ),
+    ),
 )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
@@ -11,7 +11,6 @@ object CardReaderConfigForCanada : CardReaderConfigForSupportedCountry(
         PaymentMethodType.CARD_PRESENT,
         PaymentMethodType.INTERAC_PRESENT
     ),
-    isStripeExtensionSupported = false,
     supportedExtensions = listOf(
         SupportedExtension(
             type = SupportedExtensionType.WC_PAY,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForCanada.kt
@@ -11,5 +11,9 @@ object CardReaderConfigForCanada : CardReaderConfigForSupportedCountry(
         PaymentMethodType.CARD_PRESENT,
         PaymentMethodType.INTERAC_PRESENT
     ),
-    isStripeExtensionSupported = false
+    isStripeExtensionSupported = false,
+    minimumSupportedVersionWCPay = "4.0.0",
+    // Empty string is temporary here. As soon as support stripe extension in Canada,
+    // we replace this with the actual version.
+    minimumSupportedVersionStripeExtension = ""
 )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
@@ -8,5 +8,7 @@ object CardReaderConfigForUSA : CardReaderConfigForSupportedCountry(
     countryCode = "US",
     supportedReaders = listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2),
     paymentMethodType = listOf(PaymentMethodType.CARD_PRESENT),
-    isStripeExtensionSupported = true
+    isStripeExtensionSupported = true,
+    minimumSupportedVersionWCPay = "3.2.1",
+    minimumSupportedVersionStripeExtension = "6.2.0"
 )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
@@ -9,6 +9,14 @@ object CardReaderConfigForUSA : CardReaderConfigForSupportedCountry(
     supportedReaders = listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2),
     paymentMethodType = listOf(PaymentMethodType.CARD_PRESENT),
     isStripeExtensionSupported = true,
-    minimumSupportedVersionWCPay = "3.2.1",
-    minimumSupportedVersionStripeExtension = "6.2.0"
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "3.2.1"
+        ),
+    ),
 )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigForUSA.kt
@@ -8,7 +8,6 @@ object CardReaderConfigForUSA : CardReaderConfigForSupportedCountry(
     countryCode = "US",
     supportedReaders = listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2),
     paymentMethodType = listOf(PaymentMethodType.CARD_PRESENT),
-    isStripeExtensionSupported = true,
     supportedExtensions = listOf(
         SupportedExtension(
             type = SupportedExtensionType.STRIPE,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6315 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
IPP In Canada must support Interac refunds and Interac refund support was added in WCPay 4.0.0. We need 4.0.0 as the minimum plugin version for supporting IPP in Canada whereas for the US plugin version 3.2.1 works fine as the US doesn't have Interac refunds.

To support this use case and for any other countries, we add in the future. Moving the logic which checks the minimum plugin version into the Card reader config class so that configuring the plugin according to the country becomes easy and maintainable. This PR does exactly that.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Store in Canada and Stripe extension activated
1. WooCommerce store setup in Canada
2. Try to collect IPP by going into the order detail screen and tapping the "collect payment" button.
3. Notice the onboarding checks fails and show Stripe extension not supported in Canada error.

## Store in Canada and WCPay extension (< 4.0.0) activated
1. WooCommerce store setup in Canada
2. WCPay version < 4.0.0 is installed and activated.
3. Try to collect IPP by going into the order detail screen and tapping the "collect payment" button.
4. Notice the onboarding checks fails and show the WCPay extension is outdated.

## Store in Canada and WCPay extension (>= 4.0.0) activated
1. WooCommerce store setup in Canada
2. WCPay version >= 4.0.0 is installed and activated.
3. Try to collect IPP by going into the order detail screen and tapping the "collect payment" button.
4. Notice the onboarding checks passes and you are able to collect payment successfully.

## Store in US and Stripe extension (< 6.2.0) activated
1. WooCommerce store set up in the US
2. Stripe extension version < 6.2.0 is installed and activated.
3. Try to collect IPP by going into the order detail screen and tapping the "collect payment" button.
4. Notice the onboarding checks fails and show the Stripe extension is outdated.

## Store in US and Stripe extension (>= 6.2.0) activated
1. WooCommerce store set up in the US
2. Stripe extension version >= 6.2.0 is installed and activated.
3. Try to collect IPP by going into the order detail screen and tapping the "collect payment" button.
4. Notice the onboarding checks passes and you are able to collect the payment successfully.

## Store in US and WCPay extension (< 3.2.1) activated
1. WooCommerce store set up in the US
2. Stripe extension version < 3.2.1 is installed and activated.
3. Try to collect IPP by going into the order detail screen and tapping the "collect payment" button.
4. Notice the onboarding checks fails with an outdated WCPay extension error.

## Store in US and WCPay extension (>= 3.2.1) activated
1. WooCommerce store set up in the US
2. Stripe extension version >= 3.2.1 is installed and activated.
3. Try to collect IPP by going into the order detail screen and tapping the "collect payment" button.
4. Notice the onboarding checks passes and you are able to collect payment successfully.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
