### PR TITLE
[Coupons] add missing section to the description

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.GregorianCalendar
 import java.util.Locale
+import java.util.TimeZone
 
 /**
  * Method to convert date string from yyyy-MM-dd format to yyyy-MM format
@@ -131,6 +132,24 @@ fun String?.parseFromIso8601DateFormat(locale: Locale = Locale.getDefault()): Da
     return try {
         if (!this.isNullOrEmpty()) {
             val originalFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", locale)
+            return originalFormat.parse(this)
+        }
+        null
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd'T'HH:mm:ss: $this")
+    }
+}
+
+/**
+ * Method to convert month string from yyyy-MM-dd'T'hh:mm:ss format to Date object
+ */
+@Throws(IllegalArgumentException::class)
+fun String?.parseGMTDateFromIso8601DateFormat(locale: Locale = Locale.getDefault()): Date? {
+    return try {
+        if (!this.isNullOrEmpty()) {
+            val originalFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", locale).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
             return originalFormat.parse(this)
         }
         null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
@@ -144,7 +144,7 @@ fun String?.parseFromIso8601DateFormat(locale: Locale = Locale.getDefault()): Da
  * Method to convert month string from yyyy-MM-dd'T'hh:mm:ss format to Date object
  */
 @Throws(IllegalArgumentException::class)
-fun String?.parseGMTDateFromIso8601DateFormat(locale: Locale = Locale.getDefault()): Date? {
+fun String?.parseGmtDateFromIso8601DateFormat(locale: Locale = Locale.getDefault()): Date? {
     return try {
         if (!this.isNullOrEmpty()) {
             val originalFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", locale).apply {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.model
 
-import com.woocommerce.android.extensions.parseGMTDateFromIso8601DateFormat
+import com.woocommerce.android.extensions.parseGmtDateFromIso8601DateFormat
 import org.wordpress.android.fluxc.persistence.entity.CouponDataModel
 import java.math.BigDecimal
 import java.util.Date
@@ -55,11 +55,11 @@ fun CouponDataModel.toAppModel() = Coupon(
     id = coupon.id,
     code = coupon.code,
     amount = coupon.amount?.toBigDecimalOrNull(),
-    dateCreatedGmt = coupon.dateCreatedGmt.parseGMTDateFromIso8601DateFormat(),
-    dateModifiedGmt = coupon.dateModifiedGmt.parseGMTDateFromIso8601DateFormat(),
+    dateCreatedGmt = coupon.dateCreatedGmt.parseGmtDateFromIso8601DateFormat(),
+    dateModifiedGmt = coupon.dateModifiedGmt.parseGmtDateFromIso8601DateFormat(),
     type = coupon.discountType?.let { Coupon.Type.fromString(it) },
     description = coupon.description,
-    dateExpiresGmt = coupon.dateExpiresGmt.parseGMTDateFromIso8601DateFormat(),
+    dateExpiresGmt = coupon.dateExpiresGmt.parseGmtDateFromIso8601DateFormat(),
     usageCount = coupon.usageCount,
     isForIndividualUse = coupon.isForIndividualUse,
     usageLimit = coupon.usageLimit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
@@ -26,7 +26,8 @@ data class Coupon(
     val products: List<Product>,
     val excludedProducts: List<Product>,
     val categories: List<ProductCategory>,
-    val excludedCategories: List<ProductCategory>
+    val excludedCategories: List<ProductCategory>,
+    val restrictedEmails: List<String>
 ) {
     sealed class Type(open val value: String) {
         companion object {
@@ -71,5 +72,6 @@ fun CouponDataModel.toAppModel() = Coupon(
     products = products.map { it.toAppModel() },
     excludedProducts = excludedProducts.map { it.toAppModel() },
     categories = categories.map { it.toAppModel() },
-    excludedCategories = excludedCategories.map { it.toAppModel() }
+    excludedCategories = excludedCategories.map { it.toAppModel() },
+    restrictedEmails = restrictedEmails.map { it.email }
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.model
 
-import com.woocommerce.android.extensions.parseFromIso8601DateFormat
+import com.woocommerce.android.extensions.parseGMTDateFromIso8601DateFormat
 import org.wordpress.android.fluxc.persistence.entity.CouponDataModel
 import java.math.BigDecimal
 import java.util.Date
@@ -55,11 +55,11 @@ fun CouponDataModel.toAppModel() = Coupon(
     id = coupon.id,
     code = coupon.code,
     amount = coupon.amount?.toBigDecimalOrNull(),
-    dateCreatedGmt = coupon.dateCreatedGmt.parseFromIso8601DateFormat(),
-    dateModifiedGmt = coupon.dateModifiedGmt.parseFromIso8601DateFormat(),
+    dateCreatedGmt = coupon.dateCreatedGmt.parseGMTDateFromIso8601DateFormat(),
+    dateModifiedGmt = coupon.dateModifiedGmt.parseGMTDateFromIso8601DateFormat(),
     type = coupon.discountType?.let { Coupon.Type.fromString(it) },
     description = coupon.description,
-    dateExpiresGmt = coupon.dateExpiresGmt.parseFromIso8601DateFormat(),
+    dateExpiresGmt = coupon.dateExpiresGmt.parseGMTDateFromIso8601DateFormat(),
     usageCount = coupon.usageCount,
     isForIndividualUse = coupon.isForIndividualUse,
     usageLimit = coupon.usageLimit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -152,7 +152,9 @@ fun CouponSummarySection(couponSummary: CouponSummaryUi) {
             }
             SummaryLabel(couponSummary.minimumSpending)
             SummaryLabel(couponSummary.maximumSpending)
+            SummaryLabel(couponSummary.usageLimitPerCoupon)
             SummaryLabel(couponSummary.usageLimitPerUser)
+            SummaryLabel(couponSummary.usageLimitPerItems)
             SummaryLabel(couponSummary.expiration)
             SummaryLabel(couponSummary.emailRestrictions)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -141,9 +141,20 @@ fun CouponSummarySection(couponSummary: CouponSummaryUi) {
             )
             SummaryLabel(couponSummary.discountType)
             SummaryLabel(couponSummary.summary)
+            if (couponSummary.isForIndividualUse) {
+                SummaryLabel(stringResource(id = R.string.coupon_details_individual_use_only))
+            }
+            if (couponSummary.isShippingFree) {
+                SummaryLabel(stringResource(id = R.string.coupon_details_allows_free_shipping))
+            }
+            if (couponSummary.areSaleItemsExcluded) {
+                SummaryLabel(stringResource(id = R.string.coupon_details_excludes_sale_items))
+            }
             SummaryLabel(couponSummary.minimumSpending)
             SummaryLabel(couponSummary.maximumSpending)
+            SummaryLabel(couponSummary.usageLimitPerUser)
             SummaryLabel(couponSummary.expiration)
+            SummaryLabel(couponSummary.emailRestrictions)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -61,12 +61,17 @@ class CouponDetailsViewModel @Inject constructor(
             .map { coupon ->
                 CouponSummaryUi(
                     code = coupon.code,
+                    isActive = coupon.dateExpiresGmt?.after(Date()) ?: true,
                     summary = couponUtils.generateSummary(coupon, currencyCode),
+                    isForIndividualUse = coupon.isForIndividualUse ?: false,
+                    isShippingFree = coupon.isShippingFree ?: false,
+                    areSaleItemsExcluded = coupon.areSaleItemsExcluded ?: false,
                     discountType = coupon.type?.let { couponUtils.localizeType(it) },
                     minimumSpending = couponUtils.formatMinimumSpendingInfo(coupon.minimumAmount, currencyCode),
                     maximumSpending = couponUtils.formatMaximumSpendingInfo(coupon.maximumAmount, currencyCode),
-                    isActive = coupon.dateExpiresGmt?.after(Date()) ?: true,
+                    usageLimitPerUser = couponUtils.formatUsageLimitPerUser(coupon.usageLimitPerUser),
                     expiration = coupon.dateExpiresGmt?.let { couponUtils.formatExpirationDate(it) },
+                    emailRestrictions = couponUtils.formatRestrictedEmails(coupon.restrictedEmails)
                 )
             }
     }
@@ -140,10 +145,15 @@ class CouponDetailsViewModel @Inject constructor(
         val code: String?,
         val isActive: Boolean,
         val summary: String,
+        val isForIndividualUse: Boolean,
+        val isShippingFree: Boolean,
+        val areSaleItemsExcluded: Boolean,
         val discountType: String?,
         val minimumSpending: String?,
         val maximumSpending: String?,
+        val usageLimitPerUser: String?,
         val expiration: String?,
+        val emailRestrictions: String?
     )
 
     data class CouponPerformanceUi(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -67,13 +67,6 @@ class CouponDetailsViewModel @Inject constructor(
                     maximumSpending = couponUtils.formatMaximumSpendingInfo(coupon.maximumAmount, currencyCode),
                     isActive = coupon.dateExpiresGmt?.after(Date()) ?: true,
                     expiration = coupon.dateExpiresGmt?.let { couponUtils.formatExpirationDate(it) },
-                    shareCodeMessage = couponUtils.formatSharingMessage(
-                        amount = coupon.amount,
-                        currencyCode = currencyCode,
-                        couponCode = coupon.code,
-                        includedProducts = coupon.products.size,
-                        excludedProducts = coupon.excludedProducts.size
-                    )
                 )
             }
     }
@@ -122,7 +115,15 @@ class CouponDetailsViewModel @Inject constructor(
     }
 
     fun onShareButtonClick() {
-        couponState.value?.couponSummary?.shareCodeMessage?.let {
+        coupon.value?.let { coupon ->
+            couponUtils.formatSharingMessage(
+                amount = coupon.amount,
+                currencyCode = currencyCode,
+                couponCode = coupon.code,
+                includedProducts = coupon.products.size,
+                excludedProducts = coupon.excludedProducts.size
+            )
+        }?.let {
             triggerEvent(ShareCodeEvent(it))
         } ?: run {
             triggerEvent(ShowSnackbar(R.string.coupon_details_share_formatting_failure))
@@ -143,7 +144,6 @@ class CouponDetailsViewModel @Inject constructor(
         val minimumSpending: String?,
         val maximumSpending: String?,
         val expiration: String?,
-        val shareCodeMessage: String?
     )
 
     data class CouponPerformanceUi(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -70,6 +70,8 @@ class CouponDetailsViewModel @Inject constructor(
                     minimumSpending = couponUtils.formatMinimumSpendingInfo(coupon.minimumAmount, currencyCode),
                     maximumSpending = couponUtils.formatMaximumSpendingInfo(coupon.maximumAmount, currencyCode),
                     usageLimitPerUser = couponUtils.formatUsageLimitPerUser(coupon.usageLimitPerUser),
+                    usageLimitPerCoupon = couponUtils.formatUsageLimitPerCoupon(coupon.usageLimit),
+                    usageLimitPerItems = couponUtils.formatUsageLimitPerItems(coupon.limitUsageToXItems),
                     expiration = coupon.dateExpiresGmt?.let { couponUtils.formatExpirationDate(it) },
                     emailRestrictions = couponUtils.formatRestrictedEmails(coupon.restrictedEmails)
                 )
@@ -152,6 +154,8 @@ class CouponDetailsViewModel @Inject constructor(
         val minimumSpending: String?,
         val maximumSpending: String?,
         val usageLimitPerUser: String?,
+        val usageLimitPerCoupon: String?,
+        val usageLimitPerItems: String?,
         val expiration: String?,
         val emailRestrictions: String?
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -61,6 +61,21 @@ class CouponUtils @Inject constructor(
         return resourceProvider.getString(R.string.coupon_details_expiration_date, dateFormat.format(expirationDate))
     }
 
+    fun formatUsageLimitPerUser(usageLimitPerUser: Int?): String? {
+        return usageLimitPerUser?.takeIf { it > 0 }?.let {
+            StringUtils.getQuantityString(
+                resourceProvider = resourceProvider,
+                quantity = it,
+                default = R.string.coupon_details_usage_limit_per_user_multiple,
+                one = R.string.coupon_details_usage_limit_per_user_single
+            )
+        }
+    }
+
+    fun formatRestrictedEmails(restrictedEmails: List<String>): String? {
+        return restrictedEmails.takeIf { it.isNotEmpty() }?.joinToString(", ")
+    }
+
     /*
     - When only specific products or categories are defined: Display "x products" or "x categories"
     - When specific products/categories and exceptions are defined: Display "x products excl. y categories" etc.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -61,15 +61,31 @@ class CouponUtils @Inject constructor(
         return resourceProvider.getString(R.string.coupon_details_expiration_date, dateFormat.format(expirationDate))
     }
 
-    fun formatUsageLimitPerUser(usageLimitPerUser: Int?): String? {
-        return usageLimitPerUser?.takeIf { it > 0 }?.let {
-            StringUtils.getQuantityString(
-                resourceProvider = resourceProvider,
-                quantity = it,
-                default = R.string.coupon_details_usage_limit_per_user_multiple,
-                one = R.string.coupon_details_usage_limit_per_user_single
-            )
-        }
+    fun formatUsageLimitPerUser(usageLimitPerUser: Int?) = usageLimitPerUser?.takeIf { it > 0 }?.let {
+        StringUtils.getQuantityString(
+            resourceProvider = resourceProvider,
+            quantity = it,
+            default = R.string.coupon_details_usage_limit_per_user_multiple,
+            one = R.string.coupon_details_usage_limit_per_user_single
+        )
+    }
+
+    fun formatUsageLimitPerCoupon(usageLimit: Int?) = usageLimit?.takeIf { it > 0 }?.let {
+        StringUtils.getQuantityString(
+            resourceProvider = resourceProvider,
+            quantity = it,
+            default = R.string.coupon_details_usage_limit_per_coupon_multiple,
+            one = R.string.coupon_details_usage_limit_per_coupon_single
+        )
+    }
+
+    fun formatUsageLimitPerItems(usageLimit: Int?) = usageLimit?.takeIf { it > 0 }?.let {
+        StringUtils.getQuantityString(
+            resourceProvider = resourceProvider,
+            quantity = it,
+            default = R.string.coupon_details_usage_limit_per_items_multiple,
+            one = R.string.coupon_details_usage_limit_per_items_single
+        )
     }
 
     fun formatRestrictedEmails(restrictedEmails: List<String>): String? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -73,7 +73,9 @@ class CouponUtils @Inject constructor(
     }
 
     fun formatRestrictedEmails(restrictedEmails: List<String>): String? {
-        return restrictedEmails.takeIf { it.isNotEmpty() }?.joinToString(", ")
+        return restrictedEmails.takeIf { it.isNotEmpty() }?.let { emails ->
+            resourceProvider.getString(R.string.coupon_details_restricted_emails, emails.joinToString(", "))
+        }
     }
 
     /*

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1910,7 +1910,11 @@
     <string name="coupon_details_share_formatting_failure">Unable to generate coupon code sharing message</string>
     <string name="coupons_list_search_hint">Search coupons</string>
     <string name="coupon_details_usage_limit_per_user_multiple">%1$d uses per user</string>
-    <string name="coupon_details_usage_limit_per_user_single">1 use per user</string>
+    <string name="coupon_details_usage_limit_per_user_single">%1$d use per user</string>
+    <string name="coupon_details_usage_limit_per_coupon_multiple">Can be used %1$d times</string>
+    <string name="coupon_details_usage_limit_per_coupon_single">Can be used %1$d time</string>
+    <string name="coupon_details_usage_limit_per_items_multiple">Limited to %1$d items in cart</string>
+    <string name="coupon_details_usage_limit_per_items_single">Limited to %1$d item in cart</string>
     <string name="coupon_details_individual_use_only">Individual use only</string>
     <string name="coupon_details_allows_free_shipping">Allows free shipping</string>
     <string name="coupon_details_excludes_sale_items">Excludes sale items</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1909,6 +1909,8 @@
     <string name="coupon_details_share_coupon_error">Error sharing coupon code.</string>
     <string name="coupon_details_share_formatting_failure">Unable to generate coupon code sharing message</string>
     <string name="coupons_list_search_hint">Search coupons</string>
+    <string name="coupon_details_usage_limit_per_user_multiple">%1$d uses per user</string>
+    <string name="coupon_details_usage_limit_per_user_single">1 use per user</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>
@@ -2314,4 +2316,7 @@
     <string name="about_automattic_back_icon_description">Back icon</string>
     <string name="about_automattic_app_icon_description">App icon</string>
     <string name="error_generic">An error occurred</string>
+    <string name="coupon_details_individual_use_only">Individual use only</string>
+    <string name="coupon_details_allows_free_shipping">Allows free shipping</string>
+    <string name="coupon_details_excludes_sale_items">Excludes sale items</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1911,6 +1911,10 @@
     <string name="coupons_list_search_hint">Search coupons</string>
     <string name="coupon_details_usage_limit_per_user_multiple">%1$d uses per user</string>
     <string name="coupon_details_usage_limit_per_user_single">1 use per user</string>
+    <string name="coupon_details_individual_use_only">Individual use only</string>
+    <string name="coupon_details_allows_free_shipping">Allows free shipping</string>
+    <string name="coupon_details_excludes_sale_items">Excludes sale items</string>
+    <string name="coupon_details_restricted_emails">Restricted to customers with emails: %1$s</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>
@@ -2316,7 +2320,4 @@
     <string name="about_automattic_back_icon_description">Back icon</string>
     <string name="about_automattic_app_icon_description">App icon</string>
     <string name="error_generic">An error occurred</string>
-    <string name="coupon_details_individual_use_only">Individual use only</string>
-    <string name="coupon_details_allows_free_shipping">Allows free shipping</string>
-    <string name="coupon_details_excludes_sale_items">Excludes sale items</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponTestUtils.kt
@@ -18,7 +18,8 @@ object CouponTestUtils {
             categories = emptyList(),
             products = emptyList(),
             excludedProducts = emptyList(),
-            excludedCategories = emptyList()
+            excludedCategories = emptyList(),
+            restrictedEmails = emptyList()
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6325
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the missing items from the coupon description to match iOS behavior, this uses the [PR](https://github.com/woocommerce/woocommerce-ios/pull/6522) as the reference for the different sections.

The last commit c4ad9a1 of the PR fixes an issue with how we were parsing GMT dates, as we weren't specifying the timezone to the `SimpleDateFormat` object, it used by default the device's timezone, which resulted on having all the GMT dates holding an incorrect timezone, I noticed this when the Android was showing `May 30` instead of `May 31` for the expiration of the coupon shown in the screenshot below.
This also fixes an issue that resulted in showing an incorrect expiration status, if the device's timezone is different than GMT (if this is not clear, please let me know and I'll share exact steps to reproduce).
As a side note: this impacts also other parts of the app, I created this [issue](https://github.com/woocommerce/woocommerce-android/issues/6337) to keep track of it.

### Images/gif
| Android | iOS |
| ----- | ----- |
| ![Screenshot_20220421_174431](https://user-images.githubusercontent.com/1657201/164519789-a1aea964-36ab-46f9-b524-5b7cba04e115.png) | ![IMG_561F5EA70115-1](https://user-images.githubusercontent.com/1657201/164516552-cfcfbbd1-8937-44ba-a0e7-99c723c3b404.jpeg) |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
