### PR TITLE
[Coupons] Delete Coupon Functionality

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponRepository.kt
@@ -114,4 +114,21 @@ class CouponRepository @Inject constructor(
                 }
             }
     }
+
+    suspend fun deleteCoupon(couponId: Long): Boolean {
+        val result = store.deleteCoupon(
+            site = site.get(),
+            couponId = couponId
+        )
+
+        return if (result.isError) {
+            WooLog.e(
+                tag = WooLog.T.COUPONS,
+                message = "Coupon deletion failed: ${result.error.message}"
+            )
+            false
+        } else {
+            true
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponRepository.kt
@@ -114,21 +114,4 @@ class CouponRepository @Inject constructor(
                 }
             }
     }
-
-    suspend fun deleteCoupon(couponId: Long): Boolean {
-        val result = store.deleteCoupon(
-            site = site.get(),
-            couponId = couponId
-        )
-
-        return if (result.isError) {
-            WooLog.e(
-                tag = WooLog.T.COUPONS,
-                message = "Coupon deletion failed: ${result.error.message}"
-            )
-            false
-        } else {
-            true
-        }
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.CouponPerformanceReport
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
@@ -33,6 +34,23 @@ class CouponDetailsRepository @Inject constructor(
         return when {
             result.isError -> Result.failure(WooException(result.error))
             else -> Result.success(result.model!!.toAppModel())
+        }
+    }
+
+    suspend fun deleteCoupon(couponId: Long): Boolean {
+        val result = store.deleteCoupon(
+            site = selectedSite.get(),
+            couponId = couponId
+        )
+
+        return if (result.isError) {
+            WooLog.e(
+                tag = WooLog.T.COUPONS,
+                message = "Coupon deletion failed: ${result.error.message}"
+            )
+            false
+        } else {
+            true
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.CouponPerformanceReport
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
@@ -39,7 +39,8 @@ class CouponDetailsRepository @Inject constructor(
     suspend fun deleteCoupon(couponId: Long): Result<Unit> {
         val result = store.deleteCoupon(
             site = selectedSite.get(),
-            couponId = couponId
+            couponId = couponId,
+            trash = false
         )
 
         return when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsRepository.kt
@@ -37,20 +37,15 @@ class CouponDetailsRepository @Inject constructor(
         }
     }
 
-    suspend fun deleteCoupon(couponId: Long): Boolean {
+    suspend fun deleteCoupon(couponId: Long): Result<Unit> {
         val result = store.deleteCoupon(
             site = selectedSite.get(),
             couponId = couponId
         )
 
-        return if (result.isError) {
-            WooLog.e(
-                tag = WooLog.T.COUPONS,
-                message = "Coupon deletion failed: ${result.error.message}"
-            )
-            false
-        } else {
-            true
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            else -> Result.success(Unit)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -29,7 +29,8 @@ fun CouponDetailsScreen(
         couponSummaryState,
         onBackPress,
         viewModel::onCopyButtonClick,
-        viewModel::onShareButtonClick
+        viewModel::onShareButtonClick,
+        viewModel::onDeleteButtonClick
     )
 }
 
@@ -39,7 +40,8 @@ fun CouponDetailsScreen(
     state: CouponDetailsState,
     onBackPress: () -> Boolean,
     onCopyButtonClick: () -> Unit,
-    onShareButtonClick: () -> Unit
+    onShareButtonClick: () -> Unit,
+    onDeleteButtonClick: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -115,7 +117,10 @@ fun CouponDetailsScreen(
                 },
                 confirmButton = {
                     TextButton(
-                        onClick = { showDeleteDialog = false }
+                        onClick = {
+                            showDeleteDialog = false
+                            onDeleteButtonClick()
+                        }
                     ) {
                         Text(
                             stringResource(id = R.string.delete).uppercase(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -117,7 +117,7 @@ class CouponDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun deleteCoupon() {
+    fun onDeleteButtonClick() {
         viewModelScope.launch {
             couponDetailsRepository.deleteCoupon(navArgs.couponId)
                 .onFailure {
@@ -132,10 +132,6 @@ class CouponDetailsViewModel @Inject constructor(
                     triggerEvent(Exit)
                 }
         }
-    }
-
-    fun onDeleteButtonClick() {
-        deleteCoupon()
     }
 
     fun onCopyButtonClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CouponUtils
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -112,6 +113,23 @@ class CouponDetailsViewModel @Inject constructor(
                 CouponPerformanceState.Failure(couponDetails?.usageCount)
             }
             else -> couponPerformanceState
+        }
+    }
+
+    private fun deleteCoupon() {
+        viewModelScope.launch {
+            couponDetailsRepository.deleteCoupon(navArgs.couponId)
+                .onFailure {
+                    WooLog.e(
+                        tag = WooLog.T.COUPONS,
+                        message = "Coupon deletion failed: ${it.message}"
+                    )
+                    triggerEvent(ShowSnackbar(R.string.coupon_details_delete_failure))
+                }
+                .onSuccess {
+                    triggerEvent(ShowSnackbar(R.string.coupon_details_delete_successful))
+                    triggerEvent(Exit)
+                }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.util.WooLog
@@ -122,7 +123,7 @@ class CouponDetailsViewModel @Inject constructor(
                 .onFailure {
                     WooLog.e(
                         tag = WooLog.T.COUPONS,
-                        message = "Coupon deletion failed: ${it.message}"
+                        message = "Coupon deletion failed: ${(it as WooException).error.message}"
                     )
                     triggerEvent(ShowSnackbar(R.string.coupon_details_delete_failure))
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -133,6 +133,10 @@ class CouponDetailsViewModel @Inject constructor(
         }
     }
 
+    fun onDeleteButtonClick() {
+        deleteCoupon()
+    }
+
     fun onCopyButtonClick() {
         couponState.value?.couponSummary?.code?.let {
             triggerEvent(CopyCodeEvent(it))

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1892,6 +1892,8 @@
     <string name="coupon_details_menu_share">Share Coupon</string>
     <string name="coupon_details_delete">Delete Coupon</string>
     <string name="coupon_details_delete_confirmation">Are you sure you want to delete this coupon?</string>
+    <string name="coupon_details_delete_failure">Deleting coupon failed</string>
+    <string name="coupon_details_delete_successful">Coupon deleted</string>
     <string name="coupon_details_performance_loading_failure">Loading coupon performance failed</string>
     <string name="coupon_type_percent">Percentage Discount</string>
     <string name="coupon_type_fixed_cart">Fixed Cart Discount</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.coupons.details
 
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.tools.SelectedSite
@@ -22,6 +23,9 @@ import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCSettingsModel
 import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 
@@ -225,5 +229,45 @@ class CouponDetailsViewModelTest : BaseUnitTest() {
         val performanceUi = (state?.couponPerformanceState as CouponPerformanceState.Success).data
         assertThat(performanceUi.ordersCount).isEqualTo(performanceReport.ordersCount)
         assertThat(performanceUi.formattedAmount).isEqualTo(couponUtils.formatCurrency(performanceReport.amount, "USD"))
+    }
+
+    @Test
+    fun `when coupon deletion is successful, then show success Snackbar and exit`() = testBlocking {
+        setup {
+            whenever(couponDetailsRepository.deleteCoupon(any())).doReturn(
+                Result.success(Unit)
+            )
+        }
+
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        viewModel.event.observeForever {
+            events.add(it)
+        }
+
+        viewModel.onDeleteButtonClick()
+
+        assertThat(events.takeLast(2)).containsExactly(
+            ShowSnackbar(R.string.coupon_details_delete_successful),
+            Exit
+        )
+    }
+
+    @Test
+    fun `when coupon deletion is failed, then show failure Snackbar`() = testBlocking {
+        setup {
+            val error = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN, "")
+            whenever(couponDetailsRepository.deleteCoupon(any())).doReturn(
+                Result.failure(WooException(error))
+            )
+        }
+
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        viewModel.event.observeForever {
+            events.add(it)
+        }
+
+        viewModel.onDeleteButtonClick()
+
+        assertThat(events).contains(ShowSnackbar(R.string.coupon_details_delete_failure))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -21,7 +21,8 @@ object WooLog {
         LOGIN,
         REVIEWS,
         MEDIA,
-        CARD_READER
+        CARD_READER,
+        COUPONS
     }
 
     // Breaking convention to be consistent with org.wordpress.android.util.AppLog


### PR DESCRIPTION
Part of #5534 

Please don't merge before #6316 is merged. 

### Description:
This adds the delete functionality on Coupon Details screen. 

The API call allows the options of (a) moving coupon to Trash, or (b) delete a coupon permanently. To match iOS behavior, here the functionality deletes a coupon permanently.

**Note** about API behavior:
- The API return when wanting to move to trash can be confusing. If we do so, the API returns error `The shop_coupon cannot be deleted`. but the coupon does get moved to trash
- For skipping trash (i.e: force deleting), the API behaves correctly by returning success, and the coupon is deleted permanently.

### To test:
1. Go to Hub menu > Coupons > Select a Coupon
2. Click menu on top right, select "Delete Coupons"
3. Wait until a Snackbar shows up confirming the coupon is deleted
4. Ensure the screen automatically goes back to the Coupons List screen,
5. Ensure that the deleted Coupon is no longer listed,
6. Optionally check in wp-admin and ensure the Coupon no longer exists as well.
7. Also ensure tests succeed in `CouponDetailsViewModelTest`


https://user-images.githubusercontent.com/266376/164966296-ca962d99-5b55-405b-87cd-196fc99f2316.mp4


