### PR TITLE
Extract scrollview out of settings activity and added only where needed

### DIFF
--- a/WooCommerce/src/main/res/layout/activity_app_settings.xml
+++ b/WooCommerce/src/main/res/layout/activity_app_settings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main_content"
     android:layout_width="match_parent"
@@ -12,24 +11,16 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <include
-            layout="@layout/view_toolbar"/>
+        <include layout="@layout/view_toolbar" />
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.core.widget.NestedScrollView
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true">
-
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/nav_host_fragment"
-            android:name="androidx.navigation.fragment.NavHostFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:defaultNavHost="true"
-            app:navGraph="@navigation/nav_graph_settings"/>
-
-    </androidx.core.widget.NestedScrollView>
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph_settings" />
 
 </LinearLayout>
 

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -1,242 +1,246 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?attr/colorSurface"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <View style="@style/Woo.Divider" />
-
-    <!--
-        Help & support
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_help_and_support"
+    <LinearLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:optionTitle="@string/support_help" />
-
-    <LinearLayout
-        android:id="@+id/store_settings_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
+        android:background="?attr/colorSurface"
         android:orientation="vertical">
 
         <View style="@style/Woo.Divider" />
+
         <!--
-                Store Settings
+            Help & support
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_help_and_support"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/support_help" />
+
+        <LinearLayout
+            android:id="@+id/store_settings_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <View style="@style/Woo.Divider" />
+            <!--
+                    Store Settings
+                -->
+            <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_store" />
+            <!--
+                Card Reader
             -->
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/option_card_reader_payments"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:optionTitle="@string/settings_card_reader_payments" />
+
+            <!--
+                Install Jetpack
+            -->
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/option_install_jetpack"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:optionTitle="@string/settings_install_jetpack"
+                tools:visibility="visible" />
+
+        </LinearLayout>
+
+        <View style="@style/Woo.Divider" />
+
+        <!--
+            Notifications (pre- API 26)
+        -->
+        <LinearLayout
+            android:id="@+id/container_notifs_old"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            tools:visibility="visible">
+
+            <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_notifs" />
+
+            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+                android:id="@+id/option_notifs_orders"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:toggleOptionDesc="@string/settings_notifs_orders_detail"
+                app:toggleOptionTitle="@string/settings_notifs_orders" />
+
+            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+                android:id="@+id/option_notifs_tone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:toggleOptionDesc="@string/settings_notifs_tone_detail"
+                app:toggleOptionTitle="@string/settings_notifs_tone" />
+
+            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+                android:id="@+id/option_notifs_reviews"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:toggleOptionDesc="@string/settings_notifs_reviews_detail"
+                app:toggleOptionTitle="@string/settings_notifs_reviews" />
+
+            <View style="@style/Woo.Divider" />
+        </LinearLayout>
+
+        <!--
+            Notifications (API 26+)
+        -->
+        <LinearLayout
+            android:id="@+id/container_notifs_new"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_preferences" />
+
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/option_notifications"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:optionTitle="@string/settings_notifs_device"
+                app:optionValue="@string/settings_notifs_device_detail" />
+
+        </LinearLayout>
+
+        <!--
+            Appearance (App Theme)
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_theme"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/settings_app_theme_title"
+            app:optionValue="@string/settings_app_theme_option_default" />
+
+        <!--
+            Image Optimization
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+            android:id="@+id/option_image_optimization"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:toggleOptionDesc="@string/settings_image_optimization_message"
+            app:toggleOptionTitle="@string/settings_image_optimization_title" />
+
+        <!--
+            Privacy
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_privacy"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/privacy_settings" />
+
+        <View style="@style/Woo.Divider" />
+
+        <!--
+            Beta Features
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_beta_features"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/beta_features"
+            app:optionValue="@string/beta_features_add_ons" />
+
+        <!--
+            Send Feedback
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_send_feedback"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/send_feedback" />
+
+        <View style="@style/Woo.Divider" />
+
+        <!--
+            About
+        -->
         <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/settings_store" />
-        <!--
-            Card Reader
-        -->
-        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-            android:id="@+id/option_card_reader_payments"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:optionTitle="@string/settings_card_reader_payments" />
+            android:text="@string/settings_about" />
 
-        <!--
-            Install Jetpack
-        -->
         <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-            android:id="@+id/option_install_jetpack"
+            android:id="@+id/option_about"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:optionTitle="@string/settings_install_jetpack"
+            app:optionTitle="@string/app_name" />
+
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_whats_new"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:visibility="gone"
+            app:optionTitle="@string/settings_whats_new"
             tools:visibility="visible" />
 
-    </LinearLayout>
-
-    <View style="@style/Woo.Divider" />
-
-    <!--
-        Notifications (pre- API 26)
-    -->
-    <LinearLayout
-        android:id="@+id/container_notifs_old"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        tools:visibility="visible">
-
-        <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_licenses"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/settings_notifs" />
-
-        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-            android:id="@+id/option_notifs_orders"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:toggleOptionDesc="@string/settings_notifs_orders_detail"
-            app:toggleOptionTitle="@string/settings_notifs_orders" />
-
-        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-            android:id="@+id/option_notifs_tone"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:toggleOptionDesc="@string/settings_notifs_tone_detail"
-            app:toggleOptionTitle="@string/settings_notifs_tone" />
-
-        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-            android:id="@+id/option_notifs_reviews"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:toggleOptionDesc="@string/settings_notifs_reviews_detail"
-            app:toggleOptionTitle="@string/settings_notifs_reviews" />
+            app:optionTitle="@string/settings_licenses" />
 
         <View style="@style/Woo.Divider" />
-    </LinearLayout>
 
-    <!--
-        Notifications (API 26+)
-    -->
-    <LinearLayout
-        android:id="@+id/container_notifs_new"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+        <com.woocommerce.android.ui.prefs.WCSettingsButton
+            android:id="@+id/btn_option_logout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/settings_preferences" />
+            android:text="@string/settings_signout" />
 
-        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-            android:id="@+id/option_notifications"
+        <View style="@style/Woo.Divider" />
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:optionTitle="@string/settings_notifs_device"
-            app:optionValue="@string/settings_notifs_device_detail" />
+            android:layout_margin="@dimen/major_100"
+            android:orientation="horizontal">
 
+            <ImageView
+                android:id="@+id/imageHeart"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:importantForAccessibility="no"
+                android:paddingStart="@dimen/major_100"
+                android:paddingEnd="0dp"
+                android:scaleType="center"
+                app:srcCompat="@drawable/ic_gridicons_heart_outline" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/settingsHiring"
+                style="@style/Woo.TextView.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_margin="@dimen/minor_00"
+                android:gravity="center_vertical"
+                android:paddingStart="@dimen/major_100"
+                android:paddingEnd="@dimen/major_100"
+                android:text="@string/settings_hiring"
+                tools:text="Made with love by Automattic. We're hiring!" />
+        </LinearLayout>
     </LinearLayout>
-
-    <!--
-        Appearance (App Theme)
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_theme"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/settings_app_theme_title"
-        app:optionValue="@string/settings_app_theme_option_default" />
-
-    <!--
-        Image Optimization
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-        android:id="@+id/option_image_optimization"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:toggleOptionDesc="@string/settings_image_optimization_message"
-        app:toggleOptionTitle="@string/settings_image_optimization_title" />
-
-    <!--
-        Privacy
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_privacy"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/privacy_settings" />
-
-    <View style="@style/Woo.Divider" />
-
-    <!--
-        Beta Features
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_beta_features"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/beta_features"
-        app:optionValue="@string/beta_features_add_ons" />
-
-    <!--
-        Send Feedback
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_send_feedback"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/send_feedback" />
-
-    <View style="@style/Woo.Divider" />
-
-    <!--
-        About
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/settings_about" />
-
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_about"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/app_name" />
-
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_whats_new"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/settings_whats_new"
-        android:visibility="gone"
-        tools:visibility="visible"  />
-
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_licenses"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/settings_licenses" />
-
-    <View style="@style/Woo.Divider" />
-
-    <com.woocommerce.android.ui.prefs.WCSettingsButton
-        android:id="@+id/btn_option_logout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/settings_signout" />
-
-    <View style="@style/Woo.Divider" />
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100"
-        android:orientation="horizontal">
-
-        <ImageView
-            android:id="@+id/imageHeart"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:importantForAccessibility="no"
-            android:paddingStart="@dimen/major_100"
-            android:paddingEnd="0dp"
-            android:scaleType="center"
-            app:srcCompat="@drawable/ic_gridicons_heart_outline" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/settingsHiring"
-            style="@style/Woo.TextView.Caption"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_margin="@dimen/minor_00"
-            android:gravity="center_vertical"
-            android:paddingStart="@dimen/major_100"
-            android:paddingEnd="@dimen/major_100"
-            android:text="@string/settings_hiring"
-            tools:text="Made with love by Automattic. We're hiring!" />
-    </LinearLayout>
-</LinearLayout>
+</ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -1,176 +1,179 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?attr/colorSurface">
+    android:layout_height="match_parent">
 
-    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-        android:id="@+id/switchSendStats"
-        android:paddingTop="@dimen/minor_00"
-        android:paddingBottom="@dimen/minor_00"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:toggleOptionTitle="@string/settings_send_stats"
-        app:toggleOptionIcon="@drawable/ic_stats_24dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        android:background="?attr/colorSurface">
 
-    <View
-        android:id="@+id/divider1"
-        style="@style/Woo.Divider.TitleAligned"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/switchSendStats"/>
+        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+            android:id="@+id/switchSendStats"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/minor_00"
+            android:paddingBottom="@dimen/minor_00"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:toggleOptionIcon="@drawable/ic_stats_24dp"
+            app:toggleOptionTitle="@string/settings_send_stats" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/privacy_share_info"
-        style="@style/Woo.TextView.Body2"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/minor_00"
-        android:layout_marginTop="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
-        android:text="@string/settings_send_stats_detail"
-        app:layout_constraintStart_toStartOf="@+id/divider1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider1"/>
+        <View
+            android:id="@+id/divider1"
+            style="@style/Woo.Divider.TitleAligned"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/switchSendStats" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/buttonLearnMore"
-        style="@style/Woo.Button.TextButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/major_100"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/minor_100"
-        android:paddingEnd="0dp"
-        android:paddingStart="0dp"
-        android:text="@string/learn_more"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/privacy_share_info"/>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/privacy_share_info"
+            style="@style/Woo.TextView.Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_00"
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/settings_send_stats_detail"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/divider1"
+            app:layout_constraintTop_toBottomOf="@+id/divider1" />
 
-    <View
-        android:id="@+id/divider2"
-        style="@style/Woo.Divider.TitleAligned"
-        android:layout_marginTop="@dimen/minor_100"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/buttonLearnMore"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonLearnMore"
+            style="@style/Woo.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:paddingStart="0dp"
+            android:paddingEnd="0dp"
+            android:text="@string/learn_more"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/privacy_share_info" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/privacy_policy_info"
-        style="@style/Woo.TextView.Body2"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/minor_00"
-        android:layout_marginTop="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
-        android:text="@string/settings_privacy_detail"
-        app:layout_constraintStart_toStartOf="@+id/divider2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider2"
-        app:layout_constraintBottom_toTopOf="@+id/buttonPrivacyPolicy"/>
+        <View
+            android:id="@+id/divider2"
+            style="@style/Woo.Divider.TitleAligned"
+            android:layout_marginTop="@dimen/minor_100"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/buttonLearnMore" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/buttonPrivacyPolicy"
-        style="@style/Woo.Button.TextButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/major_100"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/minor_100"
-        android:paddingEnd="0dp"
-        android:paddingStart="0dp"
-        android:text="@string/settings_privacy_policy"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/privacy_policy_info"/>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/privacy_policy_info"
+            style="@style/Woo.TextView.Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_00"
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/settings_privacy_detail"
+            app:layout_constraintBottom_toTopOf="@+id/buttonPrivacyPolicy"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/divider2"
+            app:layout_constraintTop_toBottomOf="@+id/divider2" />
 
-    <View
-        android:id="@+id/divider3"
-        style="@style/Woo.Divider.TitleAligned"
-        android:layout_marginTop="@dimen/minor_100"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonPrivacyPolicy"
+            style="@style/Woo.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:paddingStart="0dp"
+            android:paddingEnd="0dp"
+            android:text="@string/settings_privacy_policy"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/privacy_policy_info" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/privacy_tracking_info"
-        style="@style/Woo.TextView.Body2"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/minor_00"
-        android:layout_marginTop="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
-        android:text="@string/settings_tracking"
-        app:layout_constraintStart_toStartOf="@+id/divider3"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider3"/>
+        <View
+            android:id="@+id/divider3"
+            style="@style/Woo.Divider.TitleAligned"
+            android:layout_marginTop="@dimen/minor_100"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/buttonTracking"
-        style="@style/Woo.Button.TextButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/major_100"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/minor_100"
-        android:layout_marginBottom="@dimen/minor_100"
-        android:paddingEnd="0dp"
-        android:paddingStart="0dp"
-        android:text="@string/learn_more"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/privacy_tracking_info"/>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/privacy_tracking_info"
+            style="@style/Woo.TextView.Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_00"
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/settings_tracking"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/divider3"
+            app:layout_constraintTop_toBottomOf="@+id/divider3" />
 
-    <View
-        android:id="@+id/divider4"
-        style="@style/Woo.Divider"
-        android:layout_marginTop="@dimen/minor_100"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/buttonTracking"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonTracking"
+            style="@style/Woo.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/minor_100"
+            android:paddingStart="0dp"
+            android:paddingEnd="0dp"
+            android:text="@string/learn_more"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/privacy_tracking_info" />
 
-    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-        android:id="@+id/switchCrashReporting"
-        android:paddingTop="@dimen/minor_00"
-        android:paddingBottom="@dimen/minor_00"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:toggleOptionIcon="@drawable/ic_gridicons_bug"
-        app:toggleOptionTitle="@string/settings_crash_reporting"
-        app:layout_constraintTop_toBottomOf="@id/divider4"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        <View
+            android:id="@+id/divider4"
+            style="@style/Woo.Divider"
+            android:layout_marginTop="@dimen/minor_100"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/buttonTracking" />
 
-    <View
-        android:id="@+id/divider5"
-        style="@style/Woo.Divider.TitleAligned"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/switchCrashReporting"/>
+        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+            android:id="@+id/switchCrashReporting"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/minor_00"
+            android:paddingBottom="@dimen/minor_00"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider4"
+            app:toggleOptionIcon="@drawable/ic_gridicons_bug"
+            app:toggleOptionTitle="@string/settings_crash_reporting" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/textCrashReporting"
-        style="@style/Woo.TextView.Body2"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/minor_00"
-        android:layout_marginTop="@dimen/major_100"
-        android:layout_marginBottom="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
-        android:text="@string/settings_crash_reporting_detail"
-        app:layout_constraintStart_toStartOf="@+id/divider5"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/divider5"
-        app:layout_constraintBottom_toTopOf="@+id/divider6"/>
+        <View
+            android:id="@+id/divider5"
+            style="@style/Woo.Divider.TitleAligned"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/switchCrashReporting" />
 
-    <View
-        android:id="@+id/divider6"
-        style="@style/Woo.Divider"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textCrashReporting"
+            style="@style/Woo.TextView.Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_00"
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
+            android:text="@string/settings_crash_reporting_detail"
+            app:layout_constraintBottom_toTopOf="@+id/divider6"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/divider5"
+            app:layout_constraintTop_toBottomOf="@id/divider5" />
+
+        <View
+            android:id="@+id/divider6"
+            style="@style/Woo.Divider"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6299 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Removes scroll view from settings activity and adds it to the child fragments where needed. The reasons for this change are detailed in the issue description #6299 

### Images/gif

This screen recording was done using a small device with 5" screen. For the sake of making the video short, I only opened the screen that need scrolling behavior to check that everything looks as expected. But please navigate to all settings sections when testing this, just in case I missed any screen that might need scrolling and doesn't have it already. 

https://user-images.githubusercontent.com/2663464/165110220-95af08ac-bbee-4abf-aa7b-326ab2f99ba4.mp4

