### PR TITLE
Updates BBPOs card reader manual link 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -55,7 +55,7 @@ object AppUrls {
     const val WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY = "https://woocommerce.com/products/hardware/"
 
     const val BBPOS_MANUAL_CARD_READER =
-        "https://developer.bbpos.com/quick_start_guide/Chipper%202X%20BT%20Quick%20Start%20Guide.pdf"
+        "https://stripe.com/files/docs/terminal/c2xbt_product_sheet.pdf"
     const val M2_MANUAL_CARD_READER = "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf"
     const val WISEPAD_3_MANUAL_CARD_READER = "https://stripe.com/files/docs/terminal/wp3_product_sheet.pdf"
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6365
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The BBPOs card reader manual link is currently returning a 404 error because it seems to have been moved behind a login page. Following this convo p1650664840720759-slack-C025A8VV728 this PR replaces the old link in the AppsUrl.kt file with the correct link provided by Stripe:

https://stripe.com/files/docs/terminal/c2xbt_product_sheet.pdf

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the Settings Page
- Click on IPP tab
- Click on the BBPOS Chipper Card Reader Manual tab 
- confirm the link works. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->