### PR TITLE
Save as draft improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.R
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -9,10 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_VIEW_INVE
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.extensions.addIfNotEmpty
-import com.woocommerce.android.extensions.fastStripHtml
-import com.woocommerce.android.extensions.filterNotEmpty
-import com.woocommerce.android.extensions.isSet
+import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewGroupedProducts
@@ -488,8 +486,7 @@ class ProductDetailCardBuilder(
 
     private fun Product.title(): ProductProperty {
         val name = this.name.fastStripHtml()
-        val badgeText = if (this.status != ProductStatus.PUBLISH) this.status?.stringResource else null
-        val badgeColor = if (this.status != ProductStatus.PUBLISH) this.status?.colorResource else null
+        val (badgeText, badgeColor) = this.status?.getBadgeResources() ?: Pair(null, null)
         return Editable(
             hint = string.product_detail_title_hint,
             text = name,
@@ -652,5 +649,14 @@ class ProductDetailCardBuilder(
         return missingPriceVariation?.let {
             ProductProperty.Warning(resources.getString(string.variation_detail_price_warning))
         }
+    }
+}
+
+fun ProductStatus.getBadgeResources(): Pair<Int?, Int?> {
+    return when (this) {
+        ProductStatus.PUBLISH -> Pair(null, null)
+        ProductStatus.DRAFT -> Pair(string.product_status_draft, R.color.product_status_badge_draft)
+        ProductStatus.PENDING -> Pair(string.product_status_pending, R.color.product_status_badge_pending)
+        ProductStatus.PRIVATE -> Pair(string.product_status_privately_published, R.color.product_status_badge_draft)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -486,7 +486,7 @@ class ProductDetailCardBuilder(
 
     private fun Product.title(): ProductProperty {
         val name = this.name.fastStripHtml()
-        val (badgeText, badgeColor) = this.status?.getBadgeResources() ?: Pair(null, null)
+        val (badgeText, badgeColor) = this.status.getBadgeResources()
         return Editable(
             hint = string.product_detail_title_hint,
             text = name,
@@ -652,11 +652,12 @@ class ProductDetailCardBuilder(
     }
 }
 
-fun ProductStatus.getBadgeResources(): Pair<Int?, Int?> {
-    return when (this) {
+fun ProductStatus?.getBadgeResources(): Pair<Int?, Int?> {
+    return if (this == null) Pair(null, null)
+    else when (this) {
         ProductStatus.PUBLISH -> Pair(null, null)
-        ProductStatus.DRAFT -> Pair(string.product_status_draft, R.color.product_status_badge_draft)
         ProductStatus.PENDING -> Pair(string.product_status_pending, R.color.product_status_badge_pending)
         ProductStatus.PRIVATE -> Pair(string.product_status_privately_published, R.color.product_status_badge_draft)
+        else -> Pair(this.stringResource, R.color.product_status_badge_draft)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -488,9 +488,13 @@ class ProductDetailCardBuilder(
 
     private fun Product.title(): ProductProperty {
         val name = this.name.fastStripHtml()
+        val badgeText = if (this.status != ProductStatus.PUBLISH) this.status?.stringResource else null
+        val badgeColor = if (this.status != ProductStatus.PUBLISH) this.status?.colorResource else null
         return Editable(
-            string.product_detail_title_hint,
-            name,
+            hint = string.product_detail_title_hint,
+            text = name,
+            badgeText = badgeText,
+            badgeColor = badgeColor,
             onTextChanged = viewModel::onProductTitleChanged
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -284,16 +284,6 @@ class ProductDetailFragment :
             binding.imageGallery.showProductImages(product.images, this)
         }
 
-        // show status badge for unpublished products
-        product.status?.let { status ->
-            if (status != ProductStatus.PUBLISH && viewModel.isAddFlowEntryPoint.not()) {
-                binding.frameStatusBadge.show()
-                binding.textStatusBadge.text = status.toLocalizedString(requireActivity())
-            } else {
-                binding.frameStatusBadge.hide()
-            }
-        }
-
         binding.productDetailAddMoreButton.setOnClickListener {
             // TODO: add tracking events here
             viewModel.onEditProductCardClicked(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -187,11 +187,11 @@ class ProductDetailViewModel @Inject constructor(
             val isNotPublishedUnderCreation = isProductUnderCreation &&
                 productDraft.status != PUBLISH &&
                 productDraft.status != PRIVATE
-            val showSaveOptionAsPrincipal = hasChanges && (isNotPublishedUnderCreation || !isProductUnderCreation)
+            val showSaveOptionAsActionWithText = hasChanges && (isNotPublishedUnderCreation || !isProductUnderCreation)
             val isProductPublished = productDraft.status == PUBLISH
             val isProductPublishedOrPrivate = isProductPublished || productDraft.status == PRIVATE
             MenuButtonsState(
-                saveOption = showSaveOptionAsPrincipal,
+                saveOption = showSaveOptionAsActionWithText,
                 saveAsDraftOption = canBeSavedAsDraft,
                 publishOption = !isProductPublishedOrPrivate || isProductUnderCreation,
                 viewProductOption = isProductPublished && !isProductUnderCreation,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -184,10 +184,12 @@ class ProductDetailViewModel @Inject constructor(
             val canBeSavedAsDraft = isAddFlowEntryPoint &&
                 !isProductStoredAtSite &&
                 productDraft.status != DRAFT
+            val isNotPublishedUnderCreation = isProductUnderCreation && productDraft.status != PUBLISH
+            val showSaveOptionAsPrincipal = hasChanges && (isNotPublishedUnderCreation || !isProductUnderCreation)
             val isProductPublished = productDraft.status == PUBLISH
             val isProductPublishedOrPrivate = isProductPublished || productDraft.status == PRIVATE
             MenuButtonsState(
-                saveOption = hasChanges && !canBeSavedAsDraft,
+                saveOption = showSaveOptionAsPrincipal,
                 saveAsDraftOption = canBeSavedAsDraft,
                 publishOption = !isProductPublishedOrPrivate || isProductUnderCreation,
                 viewProductOption = isProductPublished && !isProductUnderCreation,
@@ -731,18 +733,13 @@ class ProductDetailViewModel @Inject constructor(
         else string.product_detail_save_product_success
 
     private fun pickAddProductRequestSnackbarText(productWasAdded: Boolean, requestedProductStatus: ProductStatus) =
-        if (productWasAdded) {
-            if (requestedProductStatus == DRAFT) {
-                string.product_detail_publish_product_draft_success
-            } else {
-                string.product_detail_publish_product_success
-            }
-        } else {
-            if (requestedProductStatus == DRAFT) {
-                string.product_detail_publish_product_draft_error
-            } else {
-                string.product_detail_publish_product_error
-            }
+        when {
+            productWasAdded && requestedProductStatus == DRAFT -> string.product_detail_publish_product_draft_success
+            productWasAdded && requestedProductStatus == PUBLISH -> string.product_detail_publish_product_success
+            productWasAdded -> string.product_detail_save_product_success
+            !productWasAdded && requestedProductStatus == DRAFT -> string.product_detail_publish_product_draft_error
+            !productWasAdded && requestedProductStatus == PUBLISH -> string.product_detail_publish_product_error
+            else -> string.product_detail_save_product_error
         }
 
     private fun trackPublishing(it: Product) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -184,7 +184,9 @@ class ProductDetailViewModel @Inject constructor(
             val canBeSavedAsDraft = isAddFlowEntryPoint &&
                 !isProductStoredAtSite &&
                 productDraft.status != DRAFT
-            val isNotPublishedUnderCreation = isProductUnderCreation && productDraft.status != PUBLISH
+            val isNotPublishedUnderCreation = isProductUnderCreation &&
+                productDraft.status != PUBLISH &&
+                productDraft.status != PRIVATE
             val showSaveOptionAsPrincipal = hasChanges && (isNotPublishedUnderCreation || !isProductUnderCreation)
             val isProductPublished = productDraft.status == PUBLISH
             val isProductPublishedOrPrivate = isProductPublished || productDraft.status == PRIVATE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -734,15 +734,22 @@ class ProductDetailViewModel @Inject constructor(
         if (isProductPublishedOrSaved) string.product_detail_publish_product_success
         else string.product_detail_save_product_success
 
-    private fun pickAddProductRequestSnackbarText(productWasAdded: Boolean, requestedProductStatus: ProductStatus) =
-        when {
-            productWasAdded && requestedProductStatus == DRAFT -> string.product_detail_publish_product_draft_success
-            productWasAdded && requestedProductStatus == PUBLISH -> string.product_detail_publish_product_success
+    private fun pickAddProductRequestSnackbarText(
+        productWasAdded: Boolean,
+        requestedProductStatus: ProductStatus
+    ): Int {
+        val isDraftStatus = requestedProductStatus == DRAFT
+        val isPublishStatus = requestedProductStatus == PUBLISH
+        val failedAddingProduct = !productWasAdded
+        return when {
+            productWasAdded && isDraftStatus -> string.product_detail_publish_product_draft_success
+            productWasAdded && isPublishStatus -> string.product_detail_publish_product_success
+            failedAddingProduct && isDraftStatus -> string.product_detail_publish_product_draft_error
+            failedAddingProduct && isPublishStatus -> string.product_detail_publish_product_error
             productWasAdded -> string.product_detail_save_product_success
-            !productWasAdded && requestedProductStatus == DRAFT -> string.product_detail_publish_product_draft_error
-            !productWasAdded && requestedProductStatus == PUBLISH -> string.product_detail_publish_product_error
             else -> string.product_detail_save_product_error
         }
+    }
 
     private fun trackPublishing(it: Product) {
         val properties = mapOf("product_type" to it.productType.value.toLowerCase(Locale.ROOT))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStatus.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import android.content.Context
-import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
@@ -12,12 +11,11 @@ import java.util.Locale
  */
 enum class ProductStatus(
     @StringRes val stringResource: Int = 0,
-    val value: String = "",
-    @ColorRes val colorResource: Int = R.color.product_status_badge_draft,
+    val value: String = ""
 ) {
     PUBLISH(R.string.product_status_published, CoreProductStatus.PUBLISH.value),
-    DRAFT(R.string.product_status_draft, CoreProductStatus.DRAFT.value, R.color.product_status_badge_draft),
-    PENDING(R.string.product_status_pending, CoreProductStatus.PENDING.value, R.color.product_status_badge_pending),
+    DRAFT(R.string.product_status_draft, CoreProductStatus.DRAFT.value),
+    PENDING(R.string.product_status_pending, CoreProductStatus.PENDING.value),
     PRIVATE(R.string.product_status_private, CoreProductStatus.PRIVATE.value);
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStatus.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import android.content.Context
+import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
@@ -9,10 +10,14 @@ import java.util.Locale
 /**
  * Similar to PostStatus except only draft, pending, private, and publish are supported
  */
-enum class ProductStatus(@StringRes val stringResource: Int = 0, val value: String = "") {
+enum class ProductStatus(
+    @StringRes val stringResource: Int = 0,
+    val value: String = "",
+    @ColorRes val colorResource: Int = R.color.product_status_badge_draft,
+) {
     PUBLISH(R.string.product_status_published, CoreProductStatus.PUBLISH.value),
-    DRAFT(R.string.product_status_draft, CoreProductStatus.DRAFT.value),
-    PENDING(R.string.product_status_pending, CoreProductStatus.PENDING.value),
+    DRAFT(R.string.product_status_draft, CoreProductStatus.DRAFT.value, R.color.product_status_badge_draft),
+    PENDING(R.string.product_status_pending, CoreProductStatus.PENDING.value, R.color.product_status_badge_pending),
     PRIVATE(R.string.product_status_private, CoreProductStatus.PRIVATE.value);
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyEditableView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyEditableView.kt
@@ -1,12 +1,15 @@
 package com.woocommerce.android.ui.products
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.text.Editable
 import android.util.AttributeSet
 import android.view.View
 import android.widget.EditText
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.core.widget.doAfterTextChanged
+import com.google.android.material.textview.MaterialTextView
 import com.woocommerce.android.R
 
 class WCProductPropertyEditableView @JvmOverloads constructor(
@@ -16,6 +19,7 @@ class WCProductPropertyEditableView @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs, defStyle) {
     private val view = View.inflate(context, R.layout.product_property_editable_view_layout, this)
     private val editableText = view.findViewById<EditText>(R.id.editText)
+    private val badgeTextView = view.findViewById<MaterialTextView>(R.id.badgeTextView)
 
     // Flag to check if [EditText] already has a [EditText.doAfterTextChanged] defined to avoid multiple callbacks
     private var isTextChangeListenerActive: Boolean = false
@@ -33,6 +37,17 @@ class WCProductPropertyEditableView @JvmOverloads constructor(
         if (isFocused) {
             editableText.requestFocus()
         }
+    }
+
+    fun showBadge(badgeTextRes: Int, badgeColorRes: Int) {
+        badgeTextView.visibility = View.VISIBLE
+        badgeTextView.backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(context, badgeColorRes))
+        badgeTextView.setText(badgeTextRes)
+    }
+
+    fun hideBadge() {
+        badgeTextView.visibility = View.GONE
+        badgeTextView.text = ""
     }
 
     fun setOnTextChangedListener(cb: (text: Editable?) -> Unit) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.models
 
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
@@ -75,6 +76,8 @@ sealed class ProductProperty(val type: Type) {
         val text: String = "",
         var shouldFocus: Boolean = false,
         var isReadOnly: Boolean = false,
+        @StringRes val badgeText: Int? = null,
+        @ColorRes val badgeColor: Int? = null,
         val onTextChanged: ((String) -> Unit)? = null
     ) : ProductProperty(EDITABLE)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/EditableViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/EditableViewHolder.kt
@@ -19,5 +19,11 @@ class EditableViewHolder(parent: ViewGroup) : ProductPropertyViewHolder(
         }
 
         editableView.show(hint, item.text, item.shouldFocus, item.isReadOnly)
+
+        if (item.badgeText != null && item.badgeColor != null) {
+            editableView.showBadge(item.badgeText, item.badgeColor)
+        } else {
+            editableView.hideBadge()
+        }
     }
 }

--- a/WooCommerce/src/main/res/drawable/product_detail_status_badge.xml
+++ b/WooCommerce/src/main/res/drawable/product_detail_status_badge.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
     <solid
-        android:color="@color/color_on_surface_medium"/>
-    <corners android:radius="2dp"/>
+        android:color="@android:color/white"/>
+    <corners android:radius="4dp"/>
 </shape>

--- a/WooCommerce/src/main/res/layout/fragment_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_detail.xml
@@ -71,31 +71,6 @@
 
                     </FrameLayout>
 
-                    <FrameLayout
-                        android:id="@+id/frameStatusBadge"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="start|bottom"
-                        android:paddingBottom="@dimen/major_100"
-                        android:visibility="gone"
-                        tools:visibility="visible">
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/textStatusBadge"
-                            style="@style/Woo.TextView.Body2"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="bottom"
-                            android:background="@drawable/product_detail_status_badge"
-                            android:textColor="@color/color_on_primary_high"
-                            android:gravity="center"
-                            android:paddingStart="@dimen/minor_100"
-                            android:paddingTop="@dimen/minor_50"
-                            android:paddingEnd="@dimen/minor_100"
-                            android:paddingBottom="@dimen/minor_50"
-                            tools:text="Private" />
-                    </FrameLayout>
-
                     <View
                         style="@style/Woo.Divider"
                         android:layout_gravity="bottom" />

--- a/WooCommerce/src/main/res/layout/product_property_editable_view_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_editable_view_layout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -24,16 +23,33 @@
         android:importantForAutofill="no"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/divider"
+        app:layout_constraintEnd_toStartOf="@+id/badgeTextView"
         app:layout_constraintStart_toStartOf="parent"
+        tools:text="Hoodie" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/badgeTextView"
+        style="@style/Woo.TextView.Body2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/product_detail_status_badge"
+        android:paddingStart="@dimen/major_75"
+        android:paddingEnd="@dimen/major_75"
+        android:paddingTop="@dimen/minor_50"
+        android:paddingBottom="@dimen/minor_50"
+        android:textColor="@color/woo_gray_80"
+        android:layout_marginTop="@dimen/minor_100"
+        app:layout_constraintTop_toTopOf="@+id/editText"
         app:layout_constraintEnd_toEndOf="parent"
-        tools:text="Hoodie"/>
+        android:visibility="gone"
+        tools:text="Private" />
 
     <View
         android:id="@+id/divider"
         style="@style/Woo.Divider"
         android:layout_marginStart="@dimen/minor_00"
-        app:layout_constraintTop_toBottomOf="@id/editText"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@id/editText" />
 </merge>

--- a/WooCommerce/src/main/res/layout/product_property_editable_view_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_editable_view_layout.xml
@@ -11,7 +11,7 @@
         android:layout_marginBottom="@dimen/minor_100"
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginEnd="@dimen/major_100"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:paddingStart="0dp"
         android:paddingEnd="0dp"

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -135,7 +135,11 @@
     <color name="product_status_fg_other">@color/woo_blue_50</color>
     <color name="product_status_fg_pending">@color/woo_orange_50</color>
     <color name="product_filer_bg_selected">@color/color_primary_surface</color>
-
+    <!--
+        Product Status Badge
+    -->
+    <color name="product_status_badge_draft">@color/woo_gray_5</color>
+    <color name="product_status_badge_pending">@color/woo_orange_10</color>
     <!--
         Aztec Editor
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1795,6 +1795,7 @@
     <string name="product_publish_draft_dialog_title">Saving draft</string>
     <string name="product_publish_dialog_message" translatable="false">@string/product_update_dialog_message</string>
     <string name="product_detail_publish_product_error">Error publishing product</string>
+    <string name="product_detail_save_product_error">Cannot update product</string>
     <string name="product_detail_publish_product_success">Product published</string>
     <string name="product_detail_publish_product_draft_error">Error saving product draft</string>
     <string name="product_detail_publish_product_draft_success">Product draft saved</string>

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -22,6 +22,7 @@
     <color name="woo_blue_50">#2271B1</color>
 
     <color name="woo_orange_5">#F7DCC6</color>
+    <color name="woo_orange_10">#FFBF86</color>
     <color name="woo_orange_30">#E68B28</color>
     <color name="woo_orange_50">#B26200</color>
     <color name="woo_orange_70">#351F04</color>


### PR DESCRIPTION
Closes: #6363 

### Description
When saving the product as a draft and pending review, update the add product status badge position and aim for cross-platform consistency.

| Draft | Pending review | Draft long title | Pending review long title |
| ----- | --------------- |  ----- | --------------- |
| ![android-product-new-product-with-description](https://user-images.githubusercontent.com/18119390/165144233-1d96cd38-2a58-4e8d-ab13-5a56cb7f2b34.jpg) | ![android-product-new-product-with-description (2)](https://user-images.githubusercontent.com/18119390/165144230-437c8329-fd3d-45bf-8ea4-e8a3ef9eceff.jpg) | ![android-product-new-product-with-description (1)](https://user-images.githubusercontent.com/18119390/165144219-f5d86299-5667-4172-9bc0-a778a0ef5acb.jpg) | ![android-product-new-product-with-description](https://user-images.githubusercontent.com/18119390/165144240-03e663f2-190c-467a-8334-e71f04cd6ff4.png) |

### Testing instructions
1. Go to Products > Add new product ("+" at the bottom right).
2. Add a title, description, and price.
3. Check that the title has no status badge.
4. Change the status to a draft by going to More > Product settings > Status > Draft.
5. Check that the draft badge it's visible beside the title and matches the design in Figma
6. Change the status to a pending review by going to More > Product settings > Status > Pending review.
7. Check that the pending review badge it's visible beside the title and matches the design in Figma

### Images/gif


https://user-images.githubusercontent.com/18119390/165178143-83a0c0e7-90e8-44b7-aef2-5790bbea74f3.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
