### PR TITLE
nick/coupon-list-skeleton-alpha

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/animations/SkeletonAnimation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/animations/SkeletonAnimation.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.Dp
 import com.woocommerce.android.R
 
-const val SKELETON_ANIMATION_ALPHA = 0.15F
+const val SKELETON_ANIMATION_ALPHA = 0.20F
 
 @Composable
 fun skeletonAnimationBrush(): Brush {


### PR DESCRIPTION
This is a minor tweak to the skeleton alpha in the coupon list. To my eyes, the 0.15 alpha is too subtle:


https://user-images.githubusercontent.com/3903757/165312485-945b7472-1390-4fdb-8c93-34265b80a3f9.mp4

Simply changing it to 0.20 makes it more obvious:


https://user-images.githubusercontent.com/3903757/165312556-0bb3e9a3-0b95-4302-bab7-e70f4a02eed2.mp4

@JorgeMucientes Totally up to you whether you think this is a worthwhile change.