### PR TITLE
[Hotfix] changing the deprecated runBlockingTest for runTest 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.locale.LocaleProvider
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -19,7 +18,6 @@ import javax.inject.Singleton
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 
-@ExperimentalCoroutinesApi
 @Singleton
 class CurrencyFormatter @Inject constructor(
     private val wcStore: WooCommerceStore,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
@@ -7,7 +7,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.doReturn
@@ -31,7 +33,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
 
     @Test
     fun `when the selected site changes the default currency code updates`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest {
             setupSitesFlow()
             // When the selected site currency code is empty
             var result = formatter.formatAmountWithCurrency(113.7)
@@ -39,7 +41,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
             assertThat(result).doesNotContain("\$US").contains("$")
 
             // When the selected site change to a site with currencyCode ARS
-            advanceTimeBy(1_000)
+            advanceTimeBy(1_100)
             result = formatter.formatAmountWithCurrency(113.7)
             // Then the formatted currency contains ARS
             assertThat(result).contains("ARS")
@@ -53,7 +55,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
 
     @Test
     fun `when fetching site settings are null then retry fetching settings with exponential backoff`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest {
             // First time fetch site setting will return an invalid response error
             // Second time fetch site setting will return an empty success response
             // Third time fetch site setting will return a success response
@@ -93,7 +95,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
             wcStore = wcStore,
             selectedSite = selectedSite,
             localeProvider = localeProvider,
-            appCoroutineScope = TestCoroutineScope(coroutinesTestRule.testDispatcher),
+            appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
             dispatchers = coroutinesTestRule.testDispatchers
         )
     }
@@ -126,7 +128,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
             wcStore = wcStore,
             selectedSite = selectedSite,
             localeProvider = localeProvider,
-            appCoroutineScope = TestCoroutineScope(coroutinesTestRule.testDispatcher),
+            appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
             dispatchers = coroutinesTestRule.testDispatchers
         )
     }


### PR DESCRIPTION
Hotfix changing the deprecated runBlockingTest for runTest in DefaultCurrencyFormatterTest