### PR TITLE
Fix issues when filtering by custom date range between today and toda…

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
@@ -2,15 +2,13 @@ package com.woocommerce.android.ui.orders.filters.data
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.DateUtils
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class OrderFiltersRepository @Inject constructor(
     private val appSharedPrefs: AppPrefsWrapper,
-    private val selectedSite: SelectedSite,
-    private val dateUtils: DateUtils
+    private val selectedSite: SelectedSite
 ) {
     fun setSelectedFilters(
         filterCategory: OrderListFilterCategory,
@@ -41,8 +39,8 @@ class OrderFiltersRepository @Inject constructor(
         selectedSite.getIfExists()?.let {
             appSharedPrefs.setOrderFilterCustomDateRange(
                 it.id,
-                dateUtils.getDateInMillisAtTheStartOfTheDay(startDateMillis),
-                dateUtils.getDateInMillisAtTheEndOfTheDay(endDateMillis)
+                startDateMillis,
+                endDateMillis
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
@@ -2,13 +2,15 @@ package com.woocommerce.android.ui.orders.filters.data
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.DateUtils
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class OrderFiltersRepository @Inject constructor(
     private val appSharedPrefs: AppPrefsWrapper,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val dateUtils: DateUtils
 ) {
     fun setSelectedFilters(
         filterCategory: OrderListFilterCategory,
@@ -39,8 +41,8 @@ class OrderFiltersRepository @Inject constructor(
         selectedSite.getIfExists()?.let {
             appSharedPrefs.setOrderFilterCustomDateRange(
                 it.id,
-                startDateMillis,
-                endDateMillis
+                dateUtils.getDateInMillisAtTheStartOfTheDay(startDateMillis),
+                dateUtils.getDateInMillisAtTheEndOfTheDay(endDateMillis)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetWCOrderListDescriptorWithFilters.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetWCOrderListDescriptorWithFilters.kt
@@ -48,10 +48,14 @@ class GetWCOrderListDescriptorWithFilters @Inject constructor(
                 var afterDate: String? = null
                 var beforeDate: String? = null
                 if (customDateRange.first > 0) {
-                    afterDate = dateUtils.toIso8601Format(customDateRange.first)
+                    afterDate = dateUtils.toIso8601Format(
+                        dateUtils.getDateInMillisAtTheStartOfTheDay(customDateRange.first)
+                    )
                 }
                 if (customDateRange.second > 0) {
-                    beforeDate = dateUtils.toIso8601Format(customDateRange.second)
+                    beforeDate = dateUtils.toIso8601Format(
+                        dateUtils.getDateInMillisAtTheEndOfTheDay(customDateRange.second)
+                    )
                 }
                 Pair(afterDate, beforeDate)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -295,6 +295,29 @@ class DateUtils @Inject constructor(
     }
 
     /**
+     * Returns the same date received as parameter in millis at the end of the day: 23:59:59
+     */
+    fun getDateInMillisAtTheEndOfTheDay(dateMillis: Long): Long =
+        Calendar.getInstance(Locale.getDefault()).apply {
+            timeInMillis = dateMillis
+            set(Calendar.SECOND, getMaximum(Calendar.SECOND))
+            set(Calendar.MINUTE, getMaximum(Calendar.MINUTE))
+            set(Calendar.HOUR_OF_DAY, getMaximum(Calendar.HOUR_OF_DAY))
+        }.timeInMillis
+
+    /**
+     * Returns the same date received as parameter in millis at the start of the day: 00:00:00
+     */
+    fun getDateInMillisAtTheStartOfTheDay(dateMillis: Long): Long =
+        Calendar.getInstance(Locale.getDefault()).apply {
+            timeInMillis = dateMillis
+            clear(Calendar.MILLISECOND)
+            clear(Calendar.SECOND)
+            clear(Calendar.MINUTE)
+            set(Calendar.HOUR_OF_DAY, ZERO)
+        }.timeInMillis
+
+    /**
      * Returns a date time in millis with the date for current day at 00:00:00
      */
     fun getDateForTodayAtTheStartOfTheDay(): Long =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5637 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The custom range filter doesn't show the correct results when selecting only today's date or the range of a previous date to today's date.

To Reproduce
Steps to reproduce the behavior:

### Testing instructions
- Create some orders today
- Go to Orders screen to get list of orders
- Filter by "Today" - Today's orders displayed [OK]
- Filter by Custom range: "Today's date -1 " to "Today's date" - Orders should be displayed
- Filter by Custom range: "Today's date" to "Today's date" - Should display same orders as "Today" filter.

### Images/gif


https://user-images.githubusercontent.com/2663464/165339720-8cbf4a40-b895-4c04-9c29-2931217afdff.mp4

