### PR TITLE
remove "usd" from the amount too small error message

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -967,7 +967,7 @@
     <string name="card_reader_payment_failed_server_error_state">No connection to server</string>
     <string name="card_reader_payment_failed_collecting_payment_timed_out_state">Card declined</string>
     <string name="card_reader_payment_failed_unexpected_error_state">Sorry, this payment couldn\’t be processed</string>
-    <string name="card_reader_payment_failed_amount_too_small">Amount must be at least $0.50 usd</string>
+    <string name="card_reader_payment_failed_amount_too_small">Amount must be at least $0.50</string>
     <string name="card_reader_payment_failed_temporary">Trying again may succeed</string>
     <string name="card_reader_payment_failed_fraud">Try another means of payment</string>
     <string name="card_reader_payment_failed_generic">Payment was declined for an unspecified reason</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6374 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes "USD" from the `amount_too_small` error message. This is done because showing "USD" in the error message doesn't make sense in Canada and we are using the same string resource for both the countries.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create an order with an amount < 0.50$
2. Try to collect IPP from the above-created order.
3. Ensure the error message doesn't contain "USD" in it.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<table>
  <tr>
    <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
<td><img src=https://user-images.githubusercontent.com/1331230/165434149-d0f26ef0-45b2-4b4d-9b7f-01df8a4ac00a.png width=350px height=650px/></td>
<td><img src=https://user-images.githubusercontent.com/1331230/165434384-456ac747-c92c-4ae9-bda4-e867f6739a15.png width=350px height=650px/></td>
  </tr>
 </table>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
