### PR TITLE
[Shipping Labels] track purchase amount on success event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -217,8 +217,7 @@ class CreateShippingLabelViewModel @Inject constructor(
         mapOf(KEY_STATE to VALUE_STARTED)
     )
 
-    private fun trackPurchaseInitiated(data: List<ShippingRate>, fulfillOrder: Boolean) {
-        val amount = data.sumByBigDecimal { it.price }
+    private fun trackPurchaseInitiated(amount: BigDecimal, fulfillOrder: Boolean) {
         AnalyticsTracker.track(
             AnalyticsEvent.SHIPPING_LABEL_PURCHASE_FLOW,
             mapOf(
@@ -452,7 +451,8 @@ class CreateShippingLabelViewModel @Inject constructor(
     }
 
     private suspend fun purchaseLabels(data: StateMachineData, fulfillOrder: Boolean): Event {
-        trackPurchaseInitiated(data.stepsState.carrierStep.data, fulfillOrder)
+        val amount = data.stepsState.carrierStep.data.sumByBigDecimal { it.price }
+        trackPurchaseInitiated(amount, fulfillOrder)
 
         var result: WooResult<List<ShippingLabel>>
         val duration = measureTimeMillis {
@@ -500,6 +500,7 @@ class CreateShippingLabelViewModel @Inject constructor(
                 AnalyticsEvent.SHIPPING_LABEL_PURCHASE_FLOW,
                 mapOf(
                     KEY_STATE to VALUE_PURCHASE_SUCCEEDED,
+                    KEY_AMOUNT to amount,
                     KEY_TOTAL_DURATION to duration
                 )
             )


### PR DESCRIPTION
### Description
This PR simply adds the amount to the tracked properties with `purchase_succeeded` step.
Check p91TBi-8lZ-p2#comment-9647 for more context.

### Testing instructions
1. Create a shipping label.
2. Check the logcat, and confirm the amount is tracked with the `purchase_succeeded` step.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->