### PR TITLE
Fix issue where price was cleared on attribute change

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 9.1
 -----
-
+- [*] Variation Detail: Don't clear price on attribute/visibility/inventory change. [https://github.com/woocommerce/woocommerce-android/compare/issue/6345-fix-price-on-variations-2?expand=1]
 
 9.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -172,8 +172,8 @@ class ProductDetailFragment :
         }
         handleResult<PricingData>(BaseProductEditorFragment.KEY_PRICING_DIALOG_RESULT) {
             viewModel.updateProductDraft(
-                regularPrice = Optional(it.regularPrice),
-                salePrice = Optional(it.salePrice),
+                regularPrice = it.regularPrice,
+                salePrice = it.salePrice,
                 saleStartDate = it.saleStartDate,
                 saleEndDate = it.saleEndDate,
                 isSaleScheduled = it.isSaleScheduled,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -45,7 +45,6 @@ import com.woocommerce.android.ui.products.reviews.ProductReviewsFragment
 import com.woocommerce.android.ui.products.variations.VariationListFragment
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.VariationListData
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.Optional
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -842,8 +842,8 @@ class ProductDetailViewModel @Inject constructor(
         soldIndividually: Boolean? = null,
         stockQuantity: Double? = null,
         backorderStatus: ProductBackorderStatus? = null,
-        regularPrice: Optional<BigDecimal?>? = null,
-        salePrice: Optional<BigDecimal?>? = null,
+        regularPrice: BigDecimal? = viewState.productDraft?.regularPrice,
+        salePrice: BigDecimal? = viewState.productDraft?.salePrice,
         isOnSale: Boolean? = null,
         isVirtual: Boolean? = null,
         isSaleScheduled: Boolean? = null,
@@ -892,16 +892,8 @@ class ProductDetailViewModel @Inject constructor(
                 backorderStatus = backorderStatus ?: product.backorderStatus,
                 stockQuantity = stockQuantity ?: product.stockQuantity,
                 images = images ?: product.images,
-                regularPrice = if (regularPrice != null) {
-                    regularPrice.value
-                } else {
-                    product.regularPrice
-                },
-                salePrice = if (salePrice != null) {
-                    salePrice.value
-                } else {
-                    product.salePrice
-                },
+                regularPrice = regularPrice,
+                salePrice = salePrice,
                 isVirtual = isVirtual ?: product.isVirtual,
                 taxStatus = taxStatus ?: product.taxStatus,
                 taxClass = taxClass ?: product.taxClass,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -34,7 +34,6 @@ import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.ui.products.variations.VariationRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.Optional
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.*
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_VARIATION_IMAGE_
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_VARIATION_VIEW_VARIATION_VISIBILITY_SWITCH_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_ID
-import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.model.ProductVariation

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -200,8 +200,8 @@ class VariationDetailViewModel @Inject constructor(
         remoteVariationId: Long? = null,
         sku: String? = null,
         image: Optional<Image>? = null,
-        regularPrice: BigDecimal? = null,
-        salePrice: BigDecimal? = null,
+        regularPrice: BigDecimal? = viewState.variation?.regularPrice,
+        salePrice: BigDecimal? = viewState.variation?.salePrice,
         saleEndDate: Date? = viewState.variation?.saleEndDateGmt,
         saleStartDate: Date? = viewState.variation?.saleStartDateGmt,
         isSaleScheduled: Boolean? = null,
@@ -229,16 +229,8 @@ class VariationDetailViewModel @Inject constructor(
                     remoteVariationId = remoteVariationId ?: variation.remoteVariationId,
                     sku = sku ?: variation.sku,
                     image = if (image != null) image.value else variation.image,
-                    regularPrice = if (regularPrice isNotEqualTo variation.regularPrice) {
-                        regularPrice
-                    } else {
-                        variation.regularPrice
-                    },
-                    salePrice = if (salePrice isNotEqualTo variation.salePrice) {
-                        salePrice
-                    } else {
-                        variation.salePrice
-                    },
+                    regularPrice = regularPrice,
+                    salePrice = salePrice,
                     saleEndDateGmt = saleEndDate,
                     saleStartDateGmt = saleStartDate,
                     isSaleScheduled = isSaleScheduled ?: variation.isSaleScheduled,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -23,7 +23,6 @@ import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.ui.products.variations.VariationRepository
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.Optional
 import com.woocommerce.android.util.ProductUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
@@ -350,8 +349,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         val updatedRegularPrice = null
         val updatedSalePrice = null
         viewModel.updateProductDraft(
-            regularPrice = Optional(updatedRegularPrice),
-            salePrice = Optional(updatedSalePrice)
+            regularPrice = updatedRegularPrice,
+            salePrice = updatedSalePrice
         )
 
         assertNull(productData?.productDraft?.regularPrice)
@@ -372,8 +371,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         val updatedRegularPrice = BigDecimal.ZERO
         val updatedSalePrice = BigDecimal.ZERO
         viewModel.updateProductDraft(
-            regularPrice = Optional(updatedRegularPrice),
-            salePrice = Optional(updatedSalePrice)
+            regularPrice = updatedRegularPrice,
+            salePrice = updatedSalePrice
         )
 
         assertThat(productData?.productDraft?.regularPrice).isEqualTo(updatedRegularPrice)
@@ -810,6 +809,96 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         assertThat(hasChanges).isTrue
+    }
+
+    @Test
+    fun `given regular price set, when updating inventory, then price remains unchanged`() = testBlocking {
+        doReturn(
+            product.copy(
+                regularPrice = BigDecimal(99)
+            )
+        ).whenever(productRepository).getProductAsync(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        viewModel.updateProductDraft(sku = "E9999999")
+
+        assertThat(viewModel.getProduct().productDraft?.regularPrice).isEqualTo(BigDecimal(99))
+    }
+
+    @Test
+    fun `given sale price set, when updating attributes, then price remains unchanged`() = testBlocking {
+        doReturn(
+            product.copy(
+                salePrice = BigDecimal(99)
+            )
+        ).whenever(productRepository).getProductAsync(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        viewModel.updateProductDraft(sku = "E9999999")
+
+        assertThat(viewModel.getProduct().productDraft?.salePrice).isEqualTo(BigDecimal(99))
+    }
+
+    @Test
+    fun `given regular price greater than 0, when setting price to 0, then price is set to zero`() = testBlocking {
+        doReturn(
+            product.copy(
+                regularPrice = BigDecimal(99)
+            )
+        ).whenever(productRepository).getProductAsync(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        viewModel.updateProductDraft(regularPrice = BigDecimal(0))
+
+        assertThat(viewModel.getProduct().productDraft?.regularPrice).isEqualTo(BigDecimal(0))
+    }
+
+    @Test
+    fun `given sale price greater than 0, when setting price to 0, then price is set to zero`() = testBlocking {
+        doReturn(
+            product.copy(
+                regularPrice = BigDecimal(99)
+            )
+        ).whenever(productRepository).getProductAsync(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        viewModel.updateProductDraft(salePrice = BigDecimal(0))
+
+        assertThat(viewModel.getProduct().productDraft?.salePrice).isEqualTo(BigDecimal(0))
+    }
+
+    @Test
+    fun `given regular price greater than 0, when setting price to null, then price is set to null`() = testBlocking {
+        doReturn(
+            product.copy(
+                regularPrice = BigDecimal(99)
+            )
+        ).whenever(productRepository).getProductAsync(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        viewModel.updateProductDraft(regularPrice = null)
+
+        assertThat(viewModel.getProduct().productDraft?.regularPrice).isNull()
+    }
+
+    @Test
+    fun `given sale price greater than 0, when setting price to null, then price is set to null`() = testBlocking {
+        doReturn(
+            product.copy(
+                regularPrice = BigDecimal(99)
+            )
+        ).whenever(productRepository).getProductAsync(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        viewModel.updateProductDraft(salePrice = null)
+
+        assertThat(viewModel.getProduct().productDraft?.salePrice).isNull()
     }
 
     private val productsDraft

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.products.variations.VariationDetailViewModel.V
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -25,10 +26,12 @@ import org.mockito.kotlin.*
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCProductStore.OnVariationChanged
+import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.ZoneOffset
-import java.util.Date
+import java.util.*
 
+@ExperimentalCoroutinesApi
 class VariationDetailViewModelTest : BaseUnitTest() {
     companion object {
         private val SALE_START_DATE = Date.from(
@@ -37,9 +40,13 @@ class VariationDetailViewModelTest : BaseUnitTest() {
         private val SALE_END_DATE = Date.from(
             LocalDateTime.of(2020, 4, 1, 8, 0).toInstant(ZoneOffset.UTC)
         )
+        private val DUMMY_REGULAR_PRICE = BigDecimal(99)
+        private val DUMMY_SALE_PRICE = BigDecimal(70)
         val TEST_VARIATION = generateVariation().copy(
             saleStartDateGmt = SALE_START_DATE,
-            saleEndDateGmt = SALE_END_DATE
+            saleEndDateGmt = SALE_END_DATE,
+            regularPrice = DUMMY_REGULAR_PRICE,
+            salePrice = DUMMY_SALE_PRICE,
         )
     }
 
@@ -164,6 +171,60 @@ class VariationDetailViewModelTest : BaseUnitTest() {
         errorEvents.emit(emptyList())
 
         assertThat(sut.event.value).isEqualTo(HideImageUploadErrorSnackbar)
+    }
+
+    @Test
+    fun `given regular price set, when updating attributes, then price remains unchanged`() = testBlocking {
+        sut.variationViewStateData.observeForever { _, _ -> }
+
+        sut.onVariationChanged(attributes = emptyArray())
+
+        assertThat(variation!!.regularPrice).isEqualTo(DUMMY_REGULAR_PRICE)
+    }
+
+    @Test
+    fun `given sale price set, when updating attributes, then price remains unchanged`() = testBlocking {
+        sut.variationViewStateData.observeForever { _, _ -> }
+
+        sut.onVariationChanged(attributes = emptyArray())
+
+        assertThat(variation!!.salePrice).isEqualTo(DUMMY_SALE_PRICE)
+    }
+
+    @Test
+    fun `given regular price greater than 0, when setting price to 0, then price is set to zero`() = testBlocking {
+        sut.variationViewStateData.observeForever { _, _ -> }
+
+        sut.onVariationChanged(regularPrice = BigDecimal(0))
+
+        assertThat(variation!!.regularPrice).isEqualTo(BigDecimal(0))
+    }
+
+    @Test
+    fun `given sale price greater than 0, when setting price to 0, then price is set to zero`() = testBlocking {
+        sut.variationViewStateData.observeForever { _, _ -> }
+
+        sut.onVariationChanged(salePrice = BigDecimal(0))
+
+        assertThat(variation!!.salePrice).isEqualTo(BigDecimal(0))
+    }
+
+    @Test
+    fun `given regular price greater than 0, when setting price to null, then price is set to null`() = testBlocking {
+        sut.variationViewStateData.observeForever { _, _ -> }
+
+        sut.onVariationChanged(regularPrice = null)
+
+        assertThat(variation!!.regularPrice).isNull()
+    }
+
+    @Test
+    fun `given sale price greater than 0, when setting price to null, then price is set to null`() = testBlocking {
+        sut.variationViewStateData.observeForever { _, _ -> }
+
+        sut.onVariationChanged(salePrice = null)
+
+        assertThat(variation!!.salePrice).isNull()
     }
 
     private val variation: ProductVariation?


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6345
<!-- Id number of the GitHub issue this PR addresses. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue where price in variation detail gets cleared whenever one of the other values (attributes, visibility and inventory) is changed. This issue was recently introduced in [this PR](https://github.com/woocommerce/woocommerce-android/pull/6039) which fixed another bug related to setting price to 0. This PR hopefully fixes the issue while still supporting setting the price to 0.

Commit https://github.com/woocommerce/woocommerce-android/commit/b0acd149a905f22885c6fa419124a99e510ba2f7 is technically not necessary and doesn't fix anything - it simply makes the code between ProductVariationDetail and ProductDetail consistent.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create a new variable product. Add an attribute like Size.
2. Generate a new variation.
3. On the variation page, tap Add Price and enter a value for the price.
4. Navigate back to the variation page.
5. Tap on Attributes.
6. Change the attribute to a specific value.
7. Navigate back.
8. Notice the price remains unchanged
-----------------

1. Click on the + button in the Products tab and create a new product.
2. Notice that the price section displays "Add Price".
3. Click on the "Add Price" section.
4. Click on the back button.
5. Notice the the menu option is not changed in any way.
6. Click on the "Add price" section again and enter any value in the regular price field and sale price field.
7. If the sale price entered is greater than the regular price, then an error message should be displayed.
8. Enter a regular price value greater than 0 and a sale price value less than the regular price and click on the Back button.
9. Notice the new values are updated correctly. Click on the Update/Save button. View the product page on the web and notice the values displayed correctly as entered.
10. Click on the "Add price" section again and update the regular price to 0 and leave the sale price as empty. Save the product. View the product page on the web and notice the price is displayed as 0.
11. Click on the "Add price" section again and leave the regular price empty and leave the sale price as empty. Save the product. View the product page on the web and notice the price is not displayed and the Add to Cart button is not displayed.
12. Test the above scenarios for a variation of a product.


- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
