### PR TITLE
Gradle Enterprise: Obfuscate personal data

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -55,6 +55,13 @@ gradleEnterprise {
             taskInputFiles = true
         }
         uploadInBackground = System.getenv("CI") == null
+
+        // Obfuscate personal data
+        obfuscation {
+            username { username -> username.digest('SHA-1') }
+            hostname { _ -> "" }
+            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+        }
     }
 }
 


### PR DESCRIPTION
By default, build scans collect some personal data which makes me uncomfortable. I don't think this data is particularly useful for us, but in the odd case that we need to identify builds by a certain user, a unique hash does the job as well as a full username. So, this PR completely removes the `hostname` & `ipAddress` and replaces the `username` with a `SHA1` encryption of it.

I believe this information will be more than enough for us, but if for some reason we need more information, we can always add it back.

Here is the documentation that covers this and Gradle Enterprise in general: https://docs.gradle.com/enterprise/gradle-plugin/
Here is the API documentation: https://docs.gradle.com/enterprise/gradle-plugin/api/com/gradle/scan/plugin/BuildScanDataObfuscation.html

**To test:**

* Testing is not necessary, but the changes can be verified by running `./gradlew`, opening the build scan link and navigating to the `Infrastructure` section.