### PR TITLE
Compose: add reusable components for common views

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.compose.component
 
+import android.content.res.Configuration
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -202,7 +203,8 @@ fun WCTextButton(
     }
 }
 
-@Preview
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ButtonsPreview() {
     WooThemeWithBackground {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -45,7 +45,9 @@ fun WCColoredButton(
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     colors: ButtonColors = ButtonDefaults.buttonColors(
         backgroundColor = MaterialTheme.colors.secondary,
-        contentColor = MaterialTheme.colors.onPrimary
+        contentColor = MaterialTheme.colors.onPrimary,
+        disabledBackgroundColor = MaterialTheme.colors.secondary.copy(alpha = 0.38f),
+        disabledContentColor = MaterialTheme.colors.onPrimary
     ),
     content: @Composable RowScope.() -> Unit
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -201,7 +201,6 @@ fun WCTextButton(
     }
 }
 
-
 @Preview
 @Composable
 fun ButtonsPreview() {
@@ -216,7 +215,10 @@ fun ButtonsPreview() {
             WCColoredButton(onClick = {}) {
                 Text("Button")
             }
-            WCColoredButton(onClick = {}, enabled = false) {
+            WCColoredButton(
+                onClick = {},
+                enabled = false
+            ) {
                 Text("Disabled Button")
             }
             WCColoredButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -54,7 +55,7 @@ fun WCColoredButton(
         elevation = null,
         interactionSource = interactionSource,
         contentPadding = contentPadding,
-        modifier = modifier,
+        modifier = modifier.defaultMinSize(minHeight = dimensionResource(id = R.dimen.min_tap_target)),
     ) {
         ProvideTextStyle(
             value = MaterialTheme.typography.subtitle2
@@ -115,7 +116,7 @@ fun WCOutlinedButton(
         colors = colors,
         contentPadding = contentPadding,
         interactionSource = interactionSource,
-        modifier = modifier
+        modifier = modifier.defaultMinSize(minHeight = dimensionResource(id = R.dimen.min_tap_target)),
     ) {
         ProvideTextStyle(
             value = MaterialTheme.typography.subtitle2
@@ -191,7 +192,7 @@ fun WCTextButton(
 ) {
     TextButton(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.defaultMinSize(minHeight = dimensionResource(id = R.dimen.min_tap_target)),
         enabled = enabled,
         contentPadding = contentPadding,
         interactionSource = interactionSource,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -1,0 +1,255 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonColors
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.ProvideTextStyle
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toUpperCase
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun WCColoredButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    colors: ButtonColors = ButtonDefaults.buttonColors(
+        backgroundColor = MaterialTheme.colors.secondary,
+        contentColor = MaterialTheme.colors.onPrimary
+    ),
+    content: @Composable RowScope.() -> Unit
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        colors = colors,
+        elevation = null,
+        interactionSource = interactionSource,
+        contentPadding = contentPadding,
+        modifier = modifier,
+    ) {
+        ProvideTextStyle(
+            value = MaterialTheme.typography.subtitle2
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+fun WCColoredButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    colors: ButtonColors = ButtonDefaults.buttonColors(
+        backgroundColor = MaterialTheme.colors.secondary,
+        contentColor = MaterialTheme.colors.onPrimary
+    )
+) {
+    WCColoredButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        colors = colors
+    ) {
+        if (leadingIcon != null) {
+            leadingIcon()
+            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+        }
+        Text(text = text)
+        if (trailingIcon != null) {
+            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+            trailingIcon()
+        }
+    }
+}
+
+@Composable
+fun WCOutlinedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    colors: ButtonColors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colors.secondary),
+    content: @Composable RowScope.() -> Unit
+) {
+    OutlinedButton(
+        onClick = onClick,
+        enabled = enabled,
+        colors = colors,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        modifier = modifier
+    ) {
+        ProvideTextStyle(
+            value = MaterialTheme.typography.subtitle2
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+fun WCOutlinedButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    colors: ButtonColors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colors.secondary),
+) {
+    WCOutlinedButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        colors = colors
+    ) {
+        if (leadingIcon != null) {
+            leadingIcon()
+            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+        }
+        Text(text = text)
+        if (trailingIcon != null) {
+            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+            trailingIcon()
+        }
+    }
+}
+
+@Composable
+fun WCTextButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
+    colors: ButtonColors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colors.secondary),
+    content: @Composable RowScope.() -> Unit
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        colors = colors,
+        content = content
+    )
+}
+
+@Composable
+fun WCTextButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    allCaps: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
+    colors: ButtonColors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colors.secondary),
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        colors = colors
+    ) {
+        Text(text = text.let { if (allCaps) it.toUpperCase(Locale.current) else it })
+    }
+}
+
+
+@Preview
+@Composable
+fun ButtonsPreview() {
+    WooThemeWithBackground {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            WCColoredButton(onClick = {}) {
+                Text("Button")
+            }
+            WCColoredButton(onClick = {}, enabled = false) {
+                Text("Disabled Button")
+            }
+            WCColoredButton(
+                onClick = {},
+                text = "Button With icon",
+                leadingIcon = {
+                    Icon(imageVector = Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp))
+                },
+                trailingIcon = {
+                    Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
+            )
+
+            WCOutlinedButton(onClick = {}) {
+                Text(text = "Outlined Button")
+            }
+            WCOutlinedButton(onClick = {}, enabled = false) { Text(text = "Disabled Outlined Button") }
+
+            WCOutlinedButton(
+                onClick = {},
+                text = "Outlined Button with icon",
+                leadingIcon = {
+                    Icon(imageVector = Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp))
+                },
+                trailingIcon = {
+                    Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
+            )
+
+            WCTextButton(onClick = {}) {
+                Text(text = "Text button")
+            }
+            WCTextButton(onClick = {}, text = "Text Button")
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -54,7 +54,8 @@ fun WCOutlinedTextField(
             Text(
                 text = helperText,
                 style = MaterialTheme.typography.caption,
-                color = if (!isError) colorResource(id = R.color.color_on_surface_medium) else MaterialTheme.colors.error,
+                color = if (!isError) colorResource(id = R.color.color_on_surface_medium)
+                else MaterialTheme.colors.error,
                 modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
             )
         }
@@ -80,4 +81,3 @@ fun WCOutlinedTextFieldPreview() {
         }
     }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -1,0 +1,83 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldColors
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+/**
+ * An [OutlinedTextField] that displays an optional helper text below the field.
+ */
+@Composable
+fun WCOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    helperText: String? = null,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
+) {
+    Column(modifier = modifier) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = {
+                Text(text = label)
+            },
+            enabled = enabled,
+            readOnly = readOnly,
+            modifier = Modifier.fillMaxWidth(),
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            isError = isError,
+            colors = colors,
+        )
+        if (!helperText.isNullOrEmpty()) {
+            Text(
+                text = helperText,
+                style = MaterialTheme.typography.caption,
+                color = if (!isError) colorResource(id = R.color.color_on_surface_medium) else MaterialTheme.colors.error,
+                modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun WCOutlinedTextFieldPreview() {
+    WooThemeWithBackground {
+        Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            WCOutlinedTextField(value = "", label = "Label", onValueChange = {})
+            WCOutlinedTextField(value = "Value", label = "Label", onValueChange = {})
+            WCOutlinedTextField(value = "Value", label = "Label", onValueChange = {}, enabled = false)
+            WCOutlinedTextField(value = "Value", label = "Label", onValueChange = {}, helperText = "Helper Text")
+            WCOutlinedTextField(
+                value = "Value",
+                label = "Label",
+                onValueChange = {},
+                helperText = "Helper Text",
+                isError = true
+            )
+        }
+    }
+}
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.compose.component
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -62,7 +63,8 @@ fun WCOutlinedTextField(
     }
 }
 
-@Preview
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun WCOutlinedTextFieldPreview() {
     WooThemeWithBackground {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.compose.component
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,6 +12,10 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -31,19 +37,27 @@ fun WCOutlinedSpinner(
     enabled: Boolean = true
 ) {
     Column(modifier = modifier) {
-        OutlinedTextField(
-            value = value,
-            onValueChange = {},
-            label = {
-                Text(text = label)
-            },
-            readOnly = true,
-            trailingIcon = {
-                Icon(painter = painterResource(id = R.drawable.ic_arrow_drop_down), contentDescription = null)
-            },
-            enabled = enabled,
-            modifier = modifier.clickable(onClick = onClick, enabled = enabled)
-        )
+        Box {
+            OutlinedTextField(
+                value = value,
+                onValueChange = {},
+                label = {
+                    Text(text = label)
+                },
+                readOnly = true,
+                trailingIcon = {
+                    Icon(painter = painterResource(id = R.drawable.ic_arrow_drop_down), contentDescription = null)
+                },
+                enabled = enabled,
+                modifier = modifier
+                    .focusable(false)
+            )
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .clickable(enabled = enabled, onClick = onClick)
+            )
+        }
         if (!helperText.isNullOrEmpty()) {
             Text(
                 text = helperText,
@@ -59,11 +73,19 @@ fun WCOutlinedSpinner(
 @Composable
 fun SpinnerPreview() {
     WooThemeWithBackground {
+        var text by remember {
+            mutableStateOf("button")
+        }
         Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
             WCOutlinedSpinner(onClick = { /*TODO*/ }, value = "", label = "Label")
             WCOutlinedSpinner(onClick = { /*TODO*/ }, value = "Value", label = "Label")
-            WCOutlinedSpinner(onClick = { /*TODO*/ }, value = "Value", label = "Label", helperText = "Helper Text")
-            WCOutlinedSpinner(onClick = { /*TODO*/ }, value = "Value", label = "Label", enabled = false)
+            WCOutlinedSpinner(
+                onClick = { /*TODO*/ },
+                value = "Value",
+                label = "Label",
+                helperText = "Helper Text"
+            )
+            WCOutlinedSpinner(onClick = { text = "clicked" }, value = text, label = "Label", enabled = true)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
@@ -52,6 +52,7 @@ fun WCOutlinedSpinner(
                 modifier = modifier
                     .focusable(false)
             )
+            // Capture and consume click events, this makes the text field non-focusable too.
             Box(
                 modifier = Modifier
                     .matchParentSize()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.compose.component
 
+import android.content.res.Configuration
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
@@ -70,7 +71,8 @@ fun WCOutlinedSpinner(
     }
 }
 
-@Preview
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun SpinnerPreview() {
     WooThemeWithBackground {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.R.color
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun WCOutlinedSpinner(
+    onClick: () -> Unit,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+    helperText: String? = null,
+    enabled: Boolean = true
+) {
+    Column(modifier = modifier) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = {},
+            label = {
+                Text(text = label)
+            },
+            readOnly = true,
+            trailingIcon = {
+                Icon(painter = painterResource(id = R.drawable.ic_arrow_drop_down), contentDescription = null)
+            },
+            enabled = enabled,
+            modifier = modifier.clickable(onClick = onClick, enabled = enabled)
+        )
+        if (!helperText.isNullOrEmpty()) {
+            Text(
+                text = helperText,
+                style = MaterialTheme.typography.caption,
+                color = colorResource(id = color.color_on_surface_medium),
+                modifier = Modifier.padding(horizontal = dimensionResource(id = dimen.major_100))
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SpinnerPreview() {
+    WooThemeWithBackground {
+        Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            WCOutlinedSpinner(onClick = { /*TODO*/ }, value = "", label = "Label")
+            WCOutlinedSpinner(onClick = { /*TODO*/ }, value = "Value", label = "Label")
+            WCOutlinedSpinner(onClick = { /*TODO*/ }, value = "Value", label = "Label", helperText = "Helper Text")
+            WCOutlinedSpinner(onClick = { /*TODO*/ }, value = "Value", label = "Label", enabled = false)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/theme/Theme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/theme/Theme.kt
@@ -7,6 +7,20 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import com.google.android.material.composethemeadapter.createMdcTheme
 
+/**
+ * This theme should be used to support light/dark colors if the composable root of the view tree
+ * does not support the use of contentColor.
+ * @see <a href="https://developer.android.com/jetpack/compose/themes/material#content-color</a> for more details
+ */
+@Composable
+fun WooThemeWithBackground(
+    content: @Composable () -> Unit
+) {
+    WooTheme {
+        SurfacedContent(content)
+    }
+}
+
 @Composable
 fun WooTheme(
     content: @Composable () -> Unit
@@ -36,28 +50,6 @@ private fun BaseWooTheme(
         typography = typography ?: MaterialTheme.typography,
         shapes = shapes ?: MaterialTheme.shapes,
         content = content
-    )
-}
-
-/**
- * This theme should be used to support light/dark colors if the composable root of the view tree
- * does not support the use of contentColor.
- * @see <a href="https://developer.android.com/jetpack/compose/themes/material#content-color</a> for more details
- */
-@Composable
-fun WooThemeWithBackground(
-    content: @Composable () -> Unit
-) {
-    val (colors, typography, shapes) = createMdcTheme(
-        context = LocalContext.current,
-        layoutDirection = LocalLayoutDirection.current
-    )
-
-    BaseWooTheme(
-        colors = colors,
-        typography = typography,
-        shapes = shapes,
-        content = { SurfacedContent(content) },
     )
 }
 


### PR DESCRIPTION
### Description
After starting the work on #6358, I noticed that the default material choices give sometimes different results than what we want to achieve, so to avoid repeating the code to adjust the views, I tried to add some implementations for the common views that we use in the app:
1. OutlinedTextField
2. Buttons
3. OutlinedSpinner

Please feel free to be nitpicky as you want, we need to get this right, and the smallest remarks would be helpful.

### Testing instructions
Just check the preview in Android Studio, and confirm they match the design of previous widgets we have in the app, you can also test the components using the interactive mode of the preview.

Alternatively, add them to some Compose screens and test them on device.

### Images/gif
<img width="400" alt="Screen Shot 2022-04-28 at 18 37 47" src="https://user-images.githubusercontent.com/1657201/165823897-5ffa8555-1d74-4675-98c1-b4f8fde16f42.png">
<img width="400" alt="Screen Shot 2022-04-28 at 18 38 22" src="https://user-images.githubusercontent.com/1657201/165823901-0af4a9fa-1c35-401b-9373-7c571a5b8ddd.png">
<img width="400" alt="Screen Shot 2022-04-28 at 18 38 11" src="https://user-images.githubusercontent.com/1657201/165823904-5716452f-2caa-4717-9c8f-15faf0fcfd55.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
