### PR TITLE
[Coupons] Initial edit screen

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -11,21 +11,6 @@
       <scope name="Tests" level="ERROR" enabled="false" />
     </inspection_tool>
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -11,6 +11,21 @@
       <scope name="Tests" level="ERROR" enabled="false" />
     </inspection_tool>
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
@@ -1,10 +1,13 @@
 package com.woocommerce.android.model
 
+import android.os.Parcelable
 import com.woocommerce.android.extensions.parseGmtDateFromIso8601DateFormat
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.persistence.entity.CouponDataModel
 import java.math.BigDecimal
 import java.util.Date
 
+@Parcelize
 data class Coupon(
     val id: Long,
     val code: String? = null,
@@ -28,8 +31,8 @@ data class Coupon(
     val categories: List<ProductCategory>,
     val excludedCategories: List<ProductCategory>,
     val restrictedEmails: List<String>
-) {
-    sealed class Type(open val value: String) {
+) : Parcelable {
+    sealed class Type(open val value: String) : Parcelable {
         companion object {
             const val PERCENT = "percent"
             const val FIXED_CART = "fixed_cart"
@@ -44,9 +47,17 @@ data class Coupon(
                 }
             }
         }
+
+        @Parcelize
         object Percent : Type(PERCENT)
+
+        @Parcelize
         object FixedCart : Type(FIXED_CART)
+
+        @Parcelize
         object FixedProduct : Type(FIXED_PRODUCT)
+
+        @Parcelize
         data class Custom(override val value: String) : Type(value)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCouponDetailsBinding

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCouponDetailsBinding
@@ -15,6 +16,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CopyCodeEvent
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.ShareCodeEvent
+import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.ShowEditCoupon
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.copyToClipboard
@@ -63,6 +65,9 @@ class CouponDetailsFragment : BaseFragment(R.layout.fragment_coupon_details) {
             when (event) {
                 is CopyCodeEvent -> copyCodeToClipboard(event.couponCode)
                 is ShareCodeEvent -> shareCode(event.shareCodeMessage)
+                is ShowEditCoupon -> findNavController().navigate(
+                    CouponDetailsFragmentDirections.actionCouponDetailsFragmentToEditCouponFragment(event.couponId)
+                )
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> findNavController().navigateUp()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -1,14 +1,36 @@
 package com.woocommerce.android.ui.coupons.details
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -16,9 +38,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.coupons.components.CouponExpirationLabel
-import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.*
+import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponDetailsState
+import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponPerformanceState
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponPerformanceState.Loading
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponPerformanceState.Success
+import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponSummaryUi
 import com.woocommerce.android.util.FeatureFlag
 
 @Composable
@@ -91,18 +115,19 @@ fun CouponDetailsScreen(
                     if (FeatureFlag.COUPONS_M2.isEnabled()) {
                         DropdownMenuItem(onClick = {
                             showMenu = false
+                            onEditButtonClick()
+                        }) {
+                            Text(stringResource(id = R.string.coupon_details_menu_edit))
+                        }
+
+                        DropdownMenuItem(onClick = {
+                            showMenu = false
                             showDeleteDialog = true
                         }) {
                             Text(
                                 stringResource(id = R.string.coupon_details_delete),
                                 color = MaterialTheme.colors.secondary
                             )
-                        }
-                        DropdownMenuItem(onClick = {
-                            showMenu = false
-                            onEditButtonClick()
-                        }) {
-                            Text(stringResource(id = R.string.coupon_details_menu_edit))
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -33,7 +33,8 @@ fun CouponDetailsScreen(
         onBackPress,
         viewModel::onCopyButtonClick,
         viewModel::onShareButtonClick,
-        viewModel::onDeleteButtonClick
+        viewModel::onEditButtonClick,
+        viewModel::onDeleteButtonClick,
     )
 }
 
@@ -44,6 +45,7 @@ fun CouponDetailsScreen(
     onBackPress: () -> Boolean,
     onCopyButtonClick: () -> Unit,
     onShareButtonClick: () -> Unit,
+    onEditButtonClick: () -> Unit,
     onDeleteButtonClick: () -> Unit
 ) {
     Column(
@@ -95,6 +97,12 @@ fun CouponDetailsScreen(
                                 stringResource(id = R.string.coupon_details_delete),
                                 color = MaterialTheme.colors.secondary
                             )
+                        }
+                        DropdownMenuItem(onClick = {
+                            showMenu = false
+                            onEditButtonClick()
+                        }) {
+                            Text(stringResource(id = R.string.coupon_details_menu_edit))
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -63,7 +63,7 @@ fun CouponDetailsScreen(
 }
 
 @Composable
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LongParameterList")
 fun CouponDetailsScreen(
     state: CouponDetailsState,
     onBackPress: () -> Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -178,6 +178,10 @@ class CouponDetailsViewModel @Inject constructor(
         )
     }
 
+    fun onEditButtonClick() {
+        /* TODO */
+    }
+
     data class CouponDetailsState(
         val isLoading: Boolean = false,
         val couponSummary: CouponSummaryUi? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -179,7 +179,9 @@ class CouponDetailsViewModel @Inject constructor(
     }
 
     fun onEditButtonClick() {
-        /* TODO */
+        coupon.value?.id?.let {
+            triggerEvent(ShowEditCoupon(it))
+        }
     }
 
     data class CouponDetailsState(
@@ -223,4 +225,5 @@ class CouponDetailsViewModel @Inject constructor(
 
     data class CopyCodeEvent(val couponCode: String) : MultiLiveEvent.Event()
     data class ShareCodeEvent(val shareCodeMessage: String) : MultiLiveEvent.Event()
+    data class ShowEditCoupon(val couponId: Long) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -7,13 +7,27 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.properties.Delegates.observable
 
 @AndroidEntryPoint
 class EditCouponFragment : BaseFragment() {
     private val viewModel: EditCouponViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Visible(
+            navigationIcon = R.drawable.ic_gridicons_cross_24dp
+        )
+
+    private var screenTitle: String by observable("") { _, oldValue, newValue ->
+        if (oldValue != newValue) {
+            updateActivityTitle()
+        }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -26,4 +40,17 @@ class EditCouponFragment : BaseFragment() {
             }
         }
     }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.viewState.observe(viewLifecycleOwner) {
+            screenTitle = getString(R.string.coupon_edit_screen_title, it.localizedType)
+        }
+    }
+
+    override fun getFragmentTitle() = screenTitle
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.coupons.edit
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class EditCouponFragment : BaseFragment() {
+    private val viewModel: EditCouponViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    EditCouponScreen(viewModel)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponRepository.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.store.CouponStore
 import javax.inject.Inject
@@ -13,7 +14,9 @@ class EditCouponRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val couponStore: CouponStore
 ) {
-    fun observeCoupon(couponId: Long): Flow<Coupon> = couponStore.observeCoupon(selectedSite.get(), couponId)
+    // TODO replace this with the added [getCoupon] function when the last FluxC PR is merged
+    suspend fun getCoupon(couponId: Long): Coupon = couponStore.observeCoupon(selectedSite.get(), couponId)
         .filterNotNull()
         .map { it.toAppModel() }
+        .first()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponRepository.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.coupons.edit
+
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+import org.wordpress.android.fluxc.store.CouponStore
+import javax.inject.Inject
+
+class EditCouponRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val couponStore: CouponStore
+) {
+    fun observeCoupon(couponId: Long): Flow<Coupon> = couponStore.observeCoupon(selectedSite.get(), couponId)
+        .filterNotNull()
+        .map { it.toAppModel() }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponRepository.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.coupons.edit
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.coupons.edit
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun EditCouponScreen(viewModel: EditCouponViewModel) {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -1,7 +1,39 @@
 package com.woocommerce.android.ui.coupons.edit
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons.Filled
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toUpperCase
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.theme.WooTheme
+import java.math.BigDecimal
 
 @Composable
 fun EditCouponScreen(viewModel: EditCouponViewModel) {
@@ -12,5 +44,114 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
 
 @Composable
 fun EditCouponScreen(viewState: EditCouponViewModel.ViewState) {
-    /* TODO */
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .background(color = MaterialTheme.colors.surface)
+            .verticalScroll(scrollState)
+            .fillMaxSize()
+    ) {
+        DetailsSection(viewState)
+        ConditionsSection(viewState)
+        UsageRestrictionsSection(viewState)
+        WCColoredButton(
+            onClick = { /*TODO*/ },
+            text = stringResource(id = R.string.coupon_edit_save_button)
+        )
+    }
+}
+
+@Composable
+private fun DetailsSection(viewState: EditCouponViewModel.ViewState) {
+    val couponDraft = viewState.couponDraft
+    Column(
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_100),
+                vertical = dimensionResource(id = R.dimen.major_100)
+            )
+    ) {
+        Text(
+            text = stringResource(id = R.string.coupon_edit_details_section).toUpperCase(Locale.current),
+            style = MaterialTheme.typography.body2,
+            color = colorResource(id = R.color.color_on_surface_medium)
+        )
+        WCOutlinedTextField(
+            value = couponDraft.amount?.toPlainString().orEmpty(),
+            label = stringResource(id = R.string.coupon_edit_amount_hint, "%"/*TODO*/),
+            onValueChange = { /*TODO*/ },
+            helperText = stringResource(
+                if (couponDraft.type is Coupon.Type.Percent) R.string.coupon_edit_amount_percentage_helper
+                else R.string.coupon_edit_amount_rate_helper
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+        WCOutlinedTextField(
+            value = couponDraft.code.orEmpty(),
+            label = stringResource(id = R.string.coupon_edit_code_hint),
+            onValueChange = { /*TODO*/ },
+            helperText = stringResource(id = R.string.coupon_edit_code_helper),
+            modifier = Modifier.fillMaxWidth()
+        )
+        TextButton(
+            onClick = { /*TODO*/ },
+            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colors.secondary)
+        ) {
+            Text(text = stringResource(id = R.string.coupon_edit_regenerate_coupon).toUpperCase(Locale.current))
+        }
+
+        WCOutlinedButton(
+            onClick = { /*TODO*/ },
+            text = "Edit Description",
+            leadingIcon = {
+                Icon(
+                    imageVector = Filled.Edit,
+                    contentDescription = null,
+                    modifier = Modifier.size(dimensionResource(id = dimen.major_100))
+                )
+            },
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colors.onSurface),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        WCOutlinedSpinner(
+            onClick = { /*TODO*/ },
+            value = couponDraft.dateExpiresGmt?.toString() ?: "None",
+            label = stringResource(id = R.string.coupon_edit_expiry_date)
+        )
+    }
+}
+
+@Composable
+private fun ConditionsSection(viewState: EditCouponViewModel.ViewState) {
+    /*TODO*/
+}
+
+@Composable
+private fun UsageRestrictionsSection(viewState: EditCouponViewModel.ViewState) {
+    /*TODO*/
+}
+
+@Composable
+@Preview
+private fun EditCouponPreview() {
+    WooTheme {
+        EditCouponScreen(
+            viewState = EditCouponViewModel.ViewState(
+                couponDraft = Coupon(
+                    id = 0L,
+                    code = "code",
+                    amount = BigDecimal.TEN,
+                    products = emptyList(),
+                    categories = emptyList(),
+                    excludedProducts = emptyList(),
+                    excludedCategories = emptyList(),
+                    restrictedEmails = emptyList()
+                ),
+                localizedType = "Fixed Rate Discount"
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -1,8 +1,16 @@
 package com.woocommerce.android.ui.coupons.edit
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 
 @Composable
 fun EditCouponScreen(viewModel: EditCouponViewModel) {
+    viewModel.viewState.observeAsState().value?.let {
+        EditCouponScreen(it)
+    }
+}
 
+@Composable
+fun EditCouponScreen(viewState: EditCouponViewModel.ViewState) {
+    /* TODO */
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -125,18 +125,20 @@ private fun DetailsSection(viewState: EditCouponViewModel.ViewState) {
 }
 
 @Composable
+@Suppress("UnusedPrivateMember")
 private fun ConditionsSection(viewState: EditCouponViewModel.ViewState) {
     /*TODO*/
 }
 
 @Composable
+@Suppress("UnusedPrivateMember")
 private fun UsageRestrictionsSection(viewState: EditCouponViewModel.ViewState) {
     /*TODO*/
 }
 
 @Composable
 @Preview
-private fun EditCouponPreview() {
+fun EditCouponPreview() {
     WooTheme {
         EditCouponScreen(
             viewState = EditCouponViewModel.ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
@@ -26,12 +25,12 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
-import com.woocommerce.android.R.dimen
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import java.math.BigDecimal
 
@@ -46,9 +45,14 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
 fun EditCouponScreen(viewState: EditCouponViewModel.ViewState) {
     val scrollState = rememberScrollState()
     Column(
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
         modifier = Modifier
             .background(color = MaterialTheme.colors.surface)
             .verticalScroll(scrollState)
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_100),
+                vertical = dimensionResource(id = R.dimen.major_100)
+            )
             .fillMaxSize()
     ) {
         DetailsSection(viewState)
@@ -56,7 +60,8 @@ fun EditCouponScreen(viewState: EditCouponViewModel.ViewState) {
         UsageRestrictionsSection(viewState)
         WCColoredButton(
             onClick = { /*TODO*/ },
-            text = stringResource(id = R.string.coupon_edit_save_button)
+            text = stringResource(id = R.string.coupon_edit_save_button),
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }
@@ -67,11 +72,7 @@ private fun DetailsSection(viewState: EditCouponViewModel.ViewState) {
     Column(
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
         modifier = Modifier
-            .fillMaxSize()
-            .padding(
-                horizontal = dimensionResource(id = R.dimen.major_100),
-                vertical = dimensionResource(id = R.dimen.major_100)
-            )
+            .fillMaxWidth()
     ) {
         Text(
             text = stringResource(id = R.string.coupon_edit_details_section).toUpperCase(Locale.current),
@@ -95,12 +96,10 @@ private fun DetailsSection(viewState: EditCouponViewModel.ViewState) {
             helperText = stringResource(id = R.string.coupon_edit_code_helper),
             modifier = Modifier.fillMaxWidth()
         )
-        TextButton(
+        WCTextButton(
             onClick = { /*TODO*/ },
-            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colors.secondary)
-        ) {
-            Text(text = stringResource(id = R.string.coupon_edit_regenerate_coupon).toUpperCase(Locale.current))
-        }
+            text = stringResource(id = R.string.coupon_edit_regenerate_coupon)
+        )
 
         WCOutlinedButton(
             onClick = { /*TODO*/ },
@@ -109,7 +108,7 @@ private fun DetailsSection(viewState: EditCouponViewModel.ViewState) {
                 Icon(
                     imageVector = Filled.Edit,
                     contentDescription = null,
-                    modifier = Modifier.size(dimensionResource(id = dimen.major_100))
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.major_100))
                 )
             },
             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colors.onSurface),
@@ -119,7 +118,8 @@ private fun DetailsSection(viewState: EditCouponViewModel.ViewState) {
         WCOutlinedSpinner(
             onClick = { /*TODO*/ },
             value = couponDraft.dateExpiresGmt?.toString() ?: "None",
-            label = stringResource(id = R.string.coupon_edit_expiry_date)
+            label = stringResource(id = R.string.coupon_edit_expiry_date),
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.coupons.edit
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+
+@HiltViewModel
+class EditCouponViewModel(savedStateHandle: SavedStateHandle) : ScopedViewModel(savedStateHandle) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -3,7 +3,10 @@ package com.woocommerce.android.ui.coupons.edit
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
 @HiltViewModel
-class EditCouponViewModel(savedStateHandle: SavedStateHandle) : ScopedViewModel(savedStateHandle) {
+class EditCouponViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -1,12 +1,55 @@
 package com.woocommerce.android.ui.coupons.edit
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getNullableStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class EditCouponViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val editCouponRepository: EditCouponRepository,
+    private val couponUtils: CouponUtils
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: EditCouponFragmentArgs by savedStateHandle.navArgs()
+    private val storedCoupon: Flow<Coupon> = editCouponRepository.observeCoupon(navArgs.couponId)
+        .shareIn(viewModelScope, started = SharingStarted.WhileSubscribed())
+
+    private val couponDraft = savedStateHandle.getNullableStateFlow(viewModelScope, null, Coupon::class.java)
+
+    val viewState = couponDraft
+        .filterNotNull()
+        .map { coupon ->
+            ViewState(
+                couponDraft = coupon,
+                localizedType = coupon.type?.let { couponUtils.localizeType(it) }
+            )
+        }
+        .asLiveData()
+
+    init {
+        if (couponDraft.value == null) {
+            launch {
+                couponDraft.value = storedCoupon.first()
+            }
+        }
+    }
+
+    data class ViewState(
+        val couponDraft: Coupon,
+        val localizedType: String?
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -9,12 +9,10 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -25,8 +23,9 @@ class EditCouponViewModel @Inject constructor(
     private val couponUtils: CouponUtils
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: EditCouponFragmentArgs by savedStateHandle.navArgs()
-    private val storedCoupon: Flow<Coupon> = editCouponRepository.observeCoupon(navArgs.couponId)
-        .shareIn(viewModelScope, started = SharingStarted.WhileSubscribed())
+    private val storedCoupon: Deferred<Coupon> = async {
+        editCouponRepository.getCoupon(navArgs.couponId)
+    }
 
     private val couponDraft = savedStateHandle.getNullableStateFlow(viewModelScope, null, Coupon::class.java)
 
@@ -43,7 +42,7 @@ class EditCouponViewModel @Inject constructor(
     init {
         if (couponDraft.value == null) {
             launch {
-                couponDraft.value = storedCoupon.first()
+                couponDraft.value = storedCoupon.await()
             }
         }
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -18,5 +18,16 @@
         <argument
             android:name="couponId"
             app:argType="long" />
+        <action
+            android:id="@+id/action_couponDetailsFragment_to_editCouponFragment"
+            app:destination="@id/editCouponFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/editCouponFragment"
+        android:name="com.woocommerce.android.ui.coupons.edit.EditCouponFragment"
+        android:label="EditCouponFragment">
+        <argument
+            android:name="couponId"
+            app:argType="long" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_coupons"
+    app:startDestination="@id/couponListFragment">
+    <fragment
+        android:id="@+id/couponListFragment"
+        android:name="com.woocommerce.android.ui.coupons.CouponListFragment"
+        android:label="CouponListFragment">
+        <action
+            android:id="@+id/action_couponListFragment_to_couponDetailsFragment"
+            app:destination="@id/couponDetailsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/couponDetailsFragment"
+        android:name="com.woocommerce.android.ui.coupons.details.CouponDetailsFragment"
+        android:label="CouponDetailsFragment">
+        <argument
+            android:name="couponId"
+            app:argType="long" />
+    </fragment>
+</navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -164,7 +164,7 @@
             app:destination="@id/inboxFragment" />
         <action
             android:id="@+id/action_moreMenu_to_couponListFragment"
-            app:destination="@id/couponListFragment" />
+            app:destination="@id/nav_graph_coupons" />
     </fragment>
     <fragment
         android:id="@+id/feedbackSurveyFragment"
@@ -240,6 +240,8 @@
     <include app:graph="@navigation/nav_graph_product_filters" />
     <include app:graph="@navigation/nav_graph_order_creations" />
     <include app:graph="@navigation/nav_graph_simple_payments" />
+    <include app:graph="@navigation/nav_graph_jetpack_install" />
+    <include app:graph="@navigation/nav_graph_coupons" />
 
     <fragment
         android:id="@+id/infoScreenFragment"
@@ -346,7 +348,6 @@
         android:id="@+id/orderCreationBottomSheetFragment"
         android:name="com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment"
         tools:layout="@layout/dialog_order_creation_bottom_sheet" />
-    <include app:graph="@navigation/nav_graph_jetpack_install" />
     <activity
         android:id="@+id/appSettingsActivity"
         android:name="com.woocommerce.android.ui.prefs.AppSettingsActivity"
@@ -356,20 +357,4 @@
         android:name="com.woocommerce.android.ui.inbox.InboxFragment"
         android:label="InboxFragment"
         tools:layout="@layout/fragment_inbox" />
-    <fragment
-        android:id="@+id/couponListFragment"
-        android:name="com.woocommerce.android.ui.coupons.CouponListFragment"
-        android:label="CouponListFragment">
-        <action
-            android:id="@+id/action_couponListFragment_to_couponDetailsFragment"
-            app:destination="@id/couponDetailsFragment"/>
-    </fragment>
-    <fragment
-        android:id="@+id/couponDetailsFragment"
-        android:name="com.woocommerce.android.ui.coupons.details.CouponDetailsFragment"
-        android:label="CouponDetailsFragment" >
-        <argument
-            android:name="couponId"
-            app:argType="long" />
-    </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1925,6 +1925,7 @@
     <string name="coupon_details_excludes_sale_items">Excludes sale items</string>
     <string name="coupon_details_restricted_emails">Restricted to customers with emails: %1$s</string>
     <string name="coupon_details_menu_edit">Edit Coupon</string>
+    <string name="coupon_edit_screen_title">Edit %1$s</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1924,6 +1924,7 @@
     <string name="coupon_details_allows_free_shipping">Allows free shipping</string>
     <string name="coupon_details_excludes_sale_items">Excludes sale items</string>
     <string name="coupon_details_restricted_emails">Restricted to customers with emails: %1$s</string>
+    <string name="coupon_details_menu_edit">Edit Coupon</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1926,6 +1926,14 @@
     <string name="coupon_details_restricted_emails">Restricted to customers with emails: %1$s</string>
     <string name="coupon_details_menu_edit">Edit Coupon</string>
     <string name="coupon_edit_screen_title">Edit %1$s</string>
+    <string name="coupon_edit_details_section">Coupon Details</string>
+    <string name="coupon_edit_amount_hint">Amount (%1$s)</string>
+    <string name="coupon_edit_amount_percentage_helper">Set the percentage of the discount you want to offer.</string>
+    <string name="coupon_edit_amount_rate_helper">Set the amount of the discount you want to offer.</string>
+    <string name="coupon_edit_code_hint">Coupon Code</string>
+    <string name="coupon_edit_code_helper">Customers need to enter this code to use the coupon.</string>
+    <string name="coupon_edit_regenerate_coupon">Regenerate Coupon Code</string>
+    <string name="coupon_edit_save_button">Save</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>
@@ -2331,4 +2339,5 @@
     <string name="about_automattic_back_icon_description">Back icon</string>
     <string name="about_automattic_app_icon_description">App icon</string>
     <string name="error_generic">An error occurred</string>
+    <string name="coupon_edit_expiry_date">Coupon Expiry Date</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6358 

### Description
This PR adds the screen for editing the coupon, the functionality added so far is:
- Menu item for accessing the edit screen.
- Navigation.
- Fragment and ViewModel and Repository for the edit screen.
- Loading and starting a "coupon draft" from the stored coupon.
- Initial UI for the edit screen (the first part : "coupon details" is almost done UI wise).

### Testing instructions
1. Make sure the coupon beta switch is enabled.
2. Click on More menu.
3. Click on Coupons.
4. Click on one of the coupons.
5. Click on the menu overflow button.
6. Click on Edit coupon.
7. Make sure the navigation works, and the UI loads.
8. Check the screen title, the coupon amount and coupon code contains correct data (the rest is still not handled).

### Images/gif
<img width=400 src="https://user-images.githubusercontent.com/1657201/165876683-911f69cc-2b8d-4165-b3dc-a5ef6d8889d0.png"/>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
