### PR TITLE
Added release notes for coupons

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [**] Variation Detail: Don't clear price on attribute/visibility/inventory change. [https://github.com/woocommerce/woocommerce-android/compare/issue/6345-fix-price-on-variations-2?expand=1]
 - [*] Introduced Location permission rationale dialog in IPP connection flow
-[***] Merchants can now view coupons in their stores by enabling Coupon Management in Experimental Features. [https://github.com/woocommerce/woocommerce-android/pull/6318]
+[***] Merchants can now view coupons in their stores by enabling Coupon Management in Beta Features. [https://github.com/woocommerce/woocommerce-android/pull/6318]
 
 9.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [**] Variation Detail: Don't clear price on attribute/visibility/inventory change. [https://github.com/woocommerce/woocommerce-android/compare/issue/6345-fix-price-on-variations-2?expand=1]
 - [*] Introduced Location permission rationale dialog in IPP connection flow
+[***] Merchants can now view coupons in their stores by enabling Coupon Management in Experimental Features. [https://github.com/woocommerce/woocommerce-android/pull/6318]
 
 9.0
 -----


### PR DESCRIPTION
This PR adds release notes for the coupons feature, which is behind the Beta features. @oguzkocer would it be ok to add this to PR to the current 9.1 release? It just adds some missing release notes. 