### PR TITLE
Show a toast when /refund call is happening in the background after Interac refund success

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -464,7 +464,15 @@ class IssueRefundViewModel @Inject constructor(
                     )
                 )
 
-                triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_error))
+                if (isInteracRefund()) {
+                    triggerEvent(
+                        ShowSnackbar(
+                            R.string.card_reader_interac_refund_notifying_backend_about_successful_refund_failed
+                        )
+                    )
+                } else {
+                    triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_error))
+                }
             } else {
                 AnalyticsTracker.track(
                     REFUND_CREATE_SUCCESS,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -405,6 +405,9 @@ class IssueRefundViewModel @Inject constructor(
     // TODO Refactor this method in a follow up PR
     @Suppress("ComplexMethod", "LongMethod")
     fun refund() {
+        if (isInteracRefund()) {
+            triggerEvent(ShowSnackbar(R.string.card_reader_interac_refund_notifying_backend_about_successful_refund))
+        }
         launch {
             val resultCall = async(dispatchers.io) {
                 return@async when (commonState.refundType) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -66,7 +66,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCGatewayStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCRefundStore
@@ -402,94 +404,112 @@ class IssueRefundViewModel @Inject constructor(
        For non-Interac refund -> Process the refund (Entire refund logic lives in the backend)
        For Interac refund -> Update the backend of the successful refund. The actual refund happens on the client-side
      */
-    // TODO Refactor this method in a follow up PR
-    @Suppress("ComplexMethod", "LongMethod")
     fun refund() {
+        triggerUIMessageIfRefundIsInterac()
+        launch {
+            val result = initiateRefund()
+            if (result.isError) {
+                trackRefundError(result)
+                triggerUIMessage()
+            } else {
+                trackRefundSuccess(result)
+                updateRefundSummaryStateWithOrderNote()
+                triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_successful))
+                triggerEvent(Exit)
+            }
+        }
+    }
+
+    private fun triggerUIMessageIfRefundIsInterac() {
         if (isInteracRefund()) {
             triggerEvent(ShowSnackbar(R.string.card_reader_interac_refund_notifying_backend_about_successful_refund))
         }
-        launch {
-            val resultCall = async(dispatchers.io) {
-                return@async when (commonState.refundType) {
-                    ITEMS -> {
-                        val allItems = mutableListOf<WCRefundItem>()
-                        refundItems.value?.let {
-                            it.forEach { item -> allItems.add(item.toDataModel()) }
-                        }
+    }
 
-                        val selectedShipping = refundShippingLines.value?.filter {
-                            refundByItemsState.selectedShippingLines
-                                ?.contains(it.shippingLine.itemId)
-                                ?: false
-                        }
-                        selectedShipping?.forEach { allItems.add(it.toDataModel()) }
-
-                        val selectedFees = refundFeeLines.value?.filter {
-                            refundByItemsState.selectedFeeLines
-                                ?.contains(it.feeLine.id)
-                                ?: false
-                        }
-                        selectedFees?.forEach { allItems.add(it.toDataModel()) }
-
-                        refundStore.createItemsRefund(
-                            selectedSite.get(),
-                            order.id,
-                            refundSummaryState.refundReason ?: "",
-                            true,
-                            gateway.supportsRefunds,
-                            items = allItems
-                        )
+    private suspend fun initiateRefund(): WooResult<WCRefundModel> {
+        val result = async(dispatchers.io) {
+            return@async when (commonState.refundType) {
+                ITEMS -> {
+                    val allItems = mutableListOf<WCRefundItem>()
+                    refundItems.value?.let {
+                        it.forEach { item -> allItems.add(item.toDataModel()) }
                     }
-                    AMOUNT -> {
-                        refundStore.createAmountRefund(
-                            selectedSite.get(),
-                            order.id,
-                            commonState.refundTotal,
-                            refundSummaryState.refundReason ?: "",
-                            gateway.supportsRefunds
-                        )
+
+                    val selectedShipping = refundShippingLines.value?.filter {
+                        refundByItemsState.selectedShippingLines
+                            ?.contains(it.shippingLine.itemId)
+                            ?: false
                     }
+                    selectedShipping?.forEach { allItems.add(it.toDataModel()) }
+
+                    val selectedFees = refundFeeLines.value?.filter {
+                        refundByItemsState.selectedFeeLines
+                            ?.contains(it.feeLine.id)
+                            ?: false
+                    }
+                    selectedFees?.forEach { allItems.add(it.toDataModel()) }
+
+                    refundStore.createItemsRefund(
+                        selectedSite.get(),
+                        order.id,
+                        refundSummaryState.refundReason ?: "",
+                        true,
+                        gateway.supportsRefunds,
+                        items = allItems
+                    )
+                }
+                AMOUNT -> {
+                    refundStore.createAmountRefund(
+                        selectedSite.get(),
+                        order.id,
+                        commonState.refundTotal,
+                        refundSummaryState.refundReason ?: "",
+                        gateway.supportsRefunds
+                    )
                 }
             }
+        }
+        return result.await()
+    }
 
-            val result = resultCall.await()
-            if (result.isError) {
-                AnalyticsTracker.track(
-                    REFUND_CREATE_FAILED,
-                    mapOf(
-                        AnalyticsTracker.KEY_ORDER_ID to order.id,
-                        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
-                        AnalyticsTracker.KEY_ERROR_TYPE to result.error.type.toString(),
-                        AnalyticsTracker.KEY_ERROR_DESC to result.error.message
-                    )
+    private fun trackRefundError(result: WooResult<WCRefundModel>) {
+        AnalyticsTracker.track(
+            REFUND_CREATE_FAILED,
+            mapOf(
+                AnalyticsTracker.KEY_ORDER_ID to order.id,
+                AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+                AnalyticsTracker.KEY_ERROR_TYPE to result.error.type.toString(),
+                AnalyticsTracker.KEY_ERROR_DESC to result.error.message
+            )
+        )
+    }
+
+    private fun triggerUIMessage() {
+        if (isInteracRefund()) {
+            triggerEvent(
+                ShowSnackbar(
+                    R.string.card_reader_interac_refund_notifying_backend_about_successful_refund_failed
                 )
+            )
+        } else {
+            triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_error))
+        }
+    }
 
-                if (isInteracRefund()) {
-                    triggerEvent(
-                        ShowSnackbar(
-                            R.string.card_reader_interac_refund_notifying_backend_about_successful_refund_failed
-                        )
-                    )
-                } else {
-                    triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_error))
-                }
-            } else {
-                AnalyticsTracker.track(
-                    REFUND_CREATE_SUCCESS,
-                    mapOf(
-                        AnalyticsTracker.KEY_ORDER_ID to order.id,
-                        AnalyticsTracker.KEY_ID to result.model?.id
-                    )
-                )
+    private fun trackRefundSuccess(result: WooResult<WCRefundModel>) {
+        AnalyticsTracker.track(
+            REFUND_CREATE_SUCCESS,
+            mapOf(
+                AnalyticsTracker.KEY_ORDER_ID to order.id,
+                AnalyticsTracker.KEY_ID to result.model?.id
+            )
+        )
+    }
 
-                refundSummaryState.refundReason?.let { reason ->
-                    if (reason.isNotBlank()) {
-                        addOrderNote(reason)
-                    }
-                }
-
-                triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_successful))
-                triggerEvent(Exit)
+    private suspend fun updateRefundSummaryStateWithOrderNote() {
+        refundSummaryState.refundReason?.let { reason ->
+            if (reason.isNotBlank()) {
+                addOrderNote(reason)
             }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -937,6 +937,7 @@
     <string name="card_reader_interac_refund_order_refunded_refund_cancelled">The order is already refunded</string>
     <string name="card_reader_interac_refund_refund_payment_hint">Tap or insert to refund</string>
     <string name="card_reader_interac_refund_notifying_backend_about_successful_refund">Updating backend about the successful refund</string>
+    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund_failed">Something went wrong while updating the backend.</string>
     <!--
         Card Reader Payments
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -936,8 +936,8 @@
     <string name="card_reader_interac_refund_refund_failed_cancelled">Refund cancelled</string>
     <string name="card_reader_interac_refund_order_refunded_refund_cancelled">The order is already refunded</string>
     <string name="card_reader_interac_refund_refund_payment_hint">Tap or insert to refund</string>
-    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund">Updating backend about the successful refund</string>
-    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund_failed">Something went wrong while updating the backend</string>
+    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund">Updating your store with the refund information</string>
+    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund_failed">Something went wrong while updating the refund information</string>
     <!--
         Card Reader Payments
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -936,6 +936,7 @@
     <string name="card_reader_interac_refund_refund_failed_cancelled">Refund cancelled</string>
     <string name="card_reader_interac_refund_order_refunded_refund_cancelled">The order is already refunded</string>
     <string name="card_reader_interac_refund_refund_payment_hint">Tap or insert to refund</string>
+    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund">Updating backend about the successful refund</string>
     <!--
         Card Reader Payments
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -937,7 +937,7 @@
     <string name="card_reader_interac_refund_order_refunded_refund_cancelled">The order is already refunded</string>
     <string name="card_reader_interac_refund_refund_payment_hint">Tap or insert to refund</string>
     <string name="card_reader_interac_refund_notifying_backend_about_successful_refund">Updating backend about the successful refund</string>
-    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund_failed">Something went wrong while updating the backend.</string>
+    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund_failed">Something went wrong while updating the backend</string>
     <!--
         Card Reader Payments
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -936,8 +936,8 @@
     <string name="card_reader_interac_refund_refund_failed_cancelled">Refund cancelled</string>
     <string name="card_reader_interac_refund_order_refunded_refund_cancelled">The order is already refunded</string>
     <string name="card_reader_interac_refund_refund_payment_hint">Tap or insert to refund</string>
-    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund">Updating your store with the refund information</string>
-    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund_failed">Something went wrong while updating the refund information</string>
+    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund">Applying refund to order</string>
+    <string name="card_reader_interac_refund_notifying_backend_about_successful_refund_failed">Something went wrong while applying the refund</string>
     <!--
         Card Reader Payments
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -202,7 +202,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given interac refund, when making "capture_terminal_payment", then trigger updating backend snackbar`() {
+    fun `given interac refund, when initiating refund, then trigger updating backend snackbar`() {
         testBlocking {
             val chargeId = "charge_id"
             val cardBrand = "visa"
@@ -236,7 +236,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given non-interac refund, when "capture_terminal_payment", then don't trigger updating backend snackbar`() {
+    fun `given non-interac refund, when initiating refund, then don't trigger updating backend snackbar`() {
         testBlocking {
             val chargeId = "charge_id"
             val cardBrand = "visa"
@@ -270,7 +270,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given interac refund, when "capture_terminal_payment" fails, then trigger updating backend failed snackbar`() {
+    fun `given interac refund, when initiating refund fails, then trigger updating backend failed snackbar`() {
         testBlocking {
             val chargeId = "charge_id"
             val cardBrand = "visa"
@@ -321,7 +321,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given non-interac refund, when "capture_terminal_payment" fails, then don't trigger update failed snackbar`() {
+    fun `given non-interac refund, when initiating refund fails, then don't trigger update failed snackbar`() {
         testBlocking {
             val chargeId = "charge_id"
             val cardBrand = "visa"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -24,6 +24,10 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCGatewayStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCRefundStore
@@ -260,6 +264,159 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             assertThat(events.any()).isNotEqualTo(
                 MultiLiveEvent.Event.ShowSnackbar(
                     R.string.card_reader_interac_refund_notifying_backend_about_successful_refund
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `given interac refund, when "capture_terminal_payment" fails, then trigger updating backend failed snackbar`() {
+        testBlocking {
+            val chargeId = "charge_id"
+            val cardBrand = "visa"
+            val cardLast4 = "1234"
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[{\"key\"=\"_charge_id\", \"value\"=\"$chargeId\"}]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = cardBrand,
+                    cardLast4 = cardLast4,
+                    paymentMethodType = "interac_present"
+                )
+            )
+            whenever(resourceProvider.getString(R.string.order_refunds_manual_refund))
+                .thenReturn("Credit/Debit card")
+            whenever(
+                refundStore.createItemsRefund(
+                    site = any(),
+                    orderId = any(),
+                    reason = any(),
+                    restockItems = any(),
+                    autoRefund = any(),
+                    items = any()
+                )
+            ).thenReturn(
+                WooResult(
+                    error = WooError(
+                        type = WooErrorType.GENERIC_ERROR,
+                        original = BaseRequest.GenericErrorType.NETWORK_ERROR
+                    )
+                )
+            )
+
+            initViewModel()
+            val events = mutableListOf<MultiLiveEvent.Event>()
+            viewModel.event.observeForever { events.add(it) }
+            viewModel.refund()
+
+            assertThat(events[1]).isEqualTo(
+                MultiLiveEvent.Event.ShowSnackbar(
+                    R.string.card_reader_interac_refund_notifying_backend_about_successful_refund_failed
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `given non-interac refund, when "capture_terminal_payment" fails, then don't trigger update failed snackbar`() {
+        testBlocking {
+            val chargeId = "charge_id"
+            val cardBrand = "visa"
+            val cardLast4 = "1234"
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[{\"key\"=\"_charge_id\", \"value\"=\"$chargeId\"}]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = cardBrand,
+                    cardLast4 = cardLast4,
+                    paymentMethodType = "card_present"
+                )
+            )
+            whenever(resourceProvider.getString(R.string.order_refunds_manual_refund))
+                .thenReturn("Credit/Debit card")
+            whenever(
+                refundStore.createItemsRefund(
+                    site = any(),
+                    orderId = any(),
+                    reason = any(),
+                    restockItems = any(),
+                    autoRefund = any(),
+                    items = any()
+                )
+            ).thenReturn(
+                WooResult(
+                    error = WooError(
+                        type = WooErrorType.GENERIC_ERROR,
+                        original = BaseRequest.GenericErrorType.NETWORK_ERROR
+                    )
+                )
+            )
+
+            initViewModel()
+            val events = mutableListOf<MultiLiveEvent.Event>()
+            viewModel.event.observeForever { events.add(it) }
+            viewModel.refund()
+
+            assertThat(events.any()).isNotEqualTo(
+                MultiLiveEvent.Event.ShowSnackbar(
+                    R.string.card_reader_interac_refund_notifying_backend_about_successful_refund_failed
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `given non-interac refund, when refund() fails, then trigger failed snackbar`() {
+        testBlocking {
+            val chargeId = "charge_id"
+            val cardBrand = "visa"
+            val cardLast4 = "1234"
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[{\"key\"=\"_charge_id\", \"value\"=\"$chargeId\"}]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = cardBrand,
+                    cardLast4 = cardLast4,
+                    paymentMethodType = "card_present"
+                )
+            )
+            whenever(resourceProvider.getString(R.string.order_refunds_manual_refund))
+                .thenReturn("Credit/Debit card")
+            whenever(
+                refundStore.createItemsRefund(
+                    site = any(),
+                    orderId = any(),
+                    reason = any(),
+                    restockItems = any(),
+                    autoRefund = any(),
+                    items = any()
+                )
+            ).thenReturn(
+                WooResult(
+                    error = WooError(
+                        type = WooErrorType.GENERIC_ERROR,
+                        original = BaseRequest.GenericErrorType.NETWORK_ERROR
+                    )
+                )
+            )
+
+            initViewModel()
+            val events = mutableListOf<MultiLiveEvent.Event>()
+            viewModel.event.observeForever { events.add(it) }
+            viewModel.refund()
+
+            assertThat(events.first()).isEqualTo(
+                MultiLiveEvent.Event.ShowSnackbar(
+                    R.string.order_refunds_amount_refund_error
                 )
             )
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6415 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Show a toast informing the merchant that we are updating the backend about the successful Interac refund when the /refund call is happening in the background after the Interac refund success. Without this toast message, the merchant might get confused as to what is happening since it takes a few milliseconds or in some cases couple of seconds to finish the /refund call.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
## Interac refund
1. Collect Interac payment from an order eligible for IPP.
2. Try to refund the above order with the same Interac card.
3. After the Interac refund is successful, ensure you see a toast message indicating that the backend is being updated


## Non-Interac refund
1. Collect Non-Interac payment from an order eligible for IPP.
2. Try to refund the above order.
3. Ensure you don't see a toast message indicating that the backend is being updated.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

**Before**

https://user-images.githubusercontent.com/1331230/166218706-70097c24-e148-43ba-a6db-516af8d78094.mp4 


**After**

https://user-images.githubusercontent.com/1331230/166219289-762558d8-3d71-40d3-acf2-200dee57e322.mp4









- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
