### PR TITLE
Fix No wild card import error in ProductDetailCardBuilder

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -10,7 +10,10 @@ import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_VIEW_INVE
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.extensions.*
+import com.woocommerce.android.extensions.addIfNotEmpty
+import com.woocommerce.android.extensions.fastStripHtml
+import com.woocommerce.android.extensions.filterNotEmpty
+import com.woocommerce.android.extensions.isSet
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewGroupedProducts


### PR DESCRIPTION
Summary
==========
Fix trunk detekt `NoWildCardImport` error introduced in https://github.com/woocommerce/woocommerce-android/pull/6369.

How to Test
==========
1. Run detekt issues and verify everything is green.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
