### PR TITLE
Use comma decimal separator in Currency Edit Text

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -282,7 +282,7 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
                 updatedText
             } else text
 
-            _value.value = text?.toString()?.toBigDecimalOrNull()
+            _value.value = text?.toString()?.replace(decimalSeparator, ".")?.toBigDecimalOrNull()
             if (text != null) {
                 // Trim any leading unwanted zeros
                 val cleanedText = text.trimStart('-').trimStart('0')


### PR DESCRIPTION
Closes: #6213

### Description
`toBigDecimalOrNull` returns `null` when using a different decimal separator than `.`  I updated the code to replace the current decimal separator with `.` before converting the value to BigDecimal.

### Testing instructions

- In wp-admin, go to WooCommerce > Settings > Currency options > Decimal separator and set it to , (comma).

#### 1) Testing shipping

1. In the app, go to the Order tab and create a new order.
2. Tap "Add shipping".
3. Enter an amount with a decimal value (e.g. $1,23) and tap "Done."
4. Check that in the new order screen Shipping matches the amount entered (e.g $1,23).

---------------------
#### 2) Testing fees

1. In the app, go to the Order tab and create a new order.
2. Tap "Fees".
3. Enter an amount with a decimal value (e.g. $1,23) and tap "Done."
4. Check that in the new order screen Fees matches the amount entered (e.g $1,23).


### Images/gif

https://user-images.githubusercontent.com/18119390/166502333-24fa7bba-3ebe-492d-9122-bbc1056fd57f.mp4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
