### PR TITLE
Adding data class and list function to the ViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModel.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.cardreader.manuals
 
+import androidx.compose.runtime.toMutableStateList
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -9,5 +11,27 @@ import javax.inject.Inject
 class CardReaderManualsViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    // TODO add manuals screen logic here
+
+    private val _manualState = getManualItems().toMutableStateList()
+    val manualState: List<ManualItem>
+        get() = _manualState
+
+    private fun getManualItems(): List<ManualItem> = listOf(
+        ManualItem(
+            icon = R.drawable.ic_card_reader_manual,
+            label = R.string.card_reader_bbpos_manual_card_reader,
+            onManualClicked = { }
+        ),
+        ManualItem(
+            icon = R.drawable.ic_card_reader_manual,
+            label = R.string.card_reader_m2_manual_card_reader,
+            onManualClicked = { }
+        )
+    )
+
+    data class ManualItem(
+        val icon: Int,
+        val label: Int,
+        val onManualClicked: () -> Unit
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModel.kt
@@ -11,7 +11,6 @@ import javax.inject.Inject
 class CardReaderManualsViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-
     private val _manualState = getManualItems().toMutableStateList()
     val manualState: List<ManualItem>
         get() = _manualState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.cardreader.manuals
 
-import androidx.compose.runtime.toMutableStateList
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -11,9 +10,7 @@ import javax.inject.Inject
 class CardReaderManualsViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    private val _manualState = getManualItems().toMutableStateList()
-    val manualState: List<ManualItem>
-        get() = _manualState
+    val manualState = getManualItems()
 
     private fun getManualItems(): List<ManualItem> = listOf(
         ManualItem(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6425 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds the business logic for the Manual Screen to the ViewModel

-Data class
-Data source function (list of manuals)

(the click events mentioned in the issue will be submitted in a separate PR)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
