### PR TITLE
Issue/6424 add compose screen UI elements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFragment.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.prefs.cardreader.hub.ManualsScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFragment.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.prefs.cardreader.hub.ManualsScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -22,7 +23,7 @@ class CardReaderManualsFragment : BaseFragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 WooThemeWithBackground {
-                    CardReaderManualsScreen()
+                    ManualsScreen()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.woocommerce.android.R
 
@@ -89,7 +88,7 @@ fun ManualsList(
                 onManualClick = manual.onManualClicked
             )
             Divider(
-                modifier = Modifier.offset(x = 96.dp),
+                modifier = Modifier.offset(dimensionResource(id = R.dimen.card_reader_manuals_divider)),
                 color = colorResource(id = R.color.divider_color),
                 thickness = dimensionResource(id = R.dimen.minor_10)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
@@ -17,10 +17,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsViewModel
@@ -29,7 +29,6 @@ import com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsViewModel
 fun ManualsScreen(
     cardReaderManualsViewModel: CardReaderManualsViewModel = viewModel()
 ) {
-
     ManualsList(
         list = cardReaderManualsViewModel.manualState
     )
@@ -55,12 +54,16 @@ fun ManualListItem(
     ) {
         Image(
             painterResource(manualIcon),
-            contentDescription = null,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            contentDescription = stringResource(R.string.card_reader_icon_content_description),
+            modifier = Modifier
+                .padding(
+                    horizontal = dimensionResource(id = R.dimen.major_100),
+                    vertical = dimensionResource(id = R.dimen.minor_100)
+                )
         )
         Column(
             modifier = Modifier
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
                 .align(Alignment.CenterVertically)
         ) {
             Text(text = manualLabel)
@@ -86,10 +89,9 @@ fun ManualsList(
                 onManualClick = manual.onManualClicked
             )
             Divider(
-                modifier = Modifier
-                    .offset(x = 96.dp),
+                modifier = Modifier.offset(x = dimensionResource(id = R.dimen.major_100)),
                 color = colorResource(id = R.color.divider_color),
-                thickness = 1.dp
+                thickness = dimensionResource(id = R.dimen.minor_10)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
@@ -1,8 +1,96 @@
-package com.woocommerce.android.ui.cardreader.manuals
+package com.woocommerce.android.ui.prefs.cardreader.hub
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsViewModel
 
 @Composable
-fun CardReaderManualsScreen() {
-    // TODO add Jetpack Compose UI here
+fun ManualsScreen(
+    cardReaderManualsViewModel: CardReaderManualsViewModel = viewModel()
+) {
+
+    ManualsList(
+        list = cardReaderManualsViewModel.manualState
+    )
+}
+
+@Composable
+fun ManualListItem(
+    manualLabel: String,
+    manualIcon: Int,
+    onManualClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier
+            .fillMaxWidth()
+            .clickable(
+                enabled = true,
+                onClickLabel = null,
+                role = Role.Button,
+                onClick = onManualClick
+            )
+
+    ) {
+        Image(
+            painterResource(manualIcon),
+            contentDescription = null,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .align(Alignment.CenterVertically)
+        ) {
+            Text(text = manualLabel)
+        }
+    }
+}
+
+@Composable
+fun ManualsList(
+    list: List<CardReaderManualsViewModel.ManualItem>
+) {
+    LazyColumn(
+        modifier = Modifier
+            .background(color = MaterialTheme.colors.surface)
+
+    ) {
+        items(
+            items = list
+        ) { manual ->
+            ManualListItem(
+                manualLabel = stringResource(id = manual.label),
+                manualIcon = manual.icon,
+                onManualClick = manual.onManualClicked
+            )
+            Divider(
+                modifier = Modifier
+                    .offset(x = 96.dp),
+                color = colorResource(id = R.color.divider_color),
+                thickness = 1.dp
+            )
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.prefs.cardreader.hub
+package com.woocommerce.android.ui.cardreader.manuals
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -21,9 +21,9 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsViewModel
 
 @Composable
 fun ManualsScreen(
@@ -89,7 +89,7 @@ fun ManualsList(
                 onManualClick = manual.onManualClicked
             )
             Divider(
-                modifier = Modifier.offset(x = dimensionResource(id = R.dimen.major_100)),
+                modifier = Modifier.offset(x = 96.dp),
                 color = colorResource(id = R.color.divider_color),
                 thickness = dimensionResource(id = R.dimen.minor_10)
             )

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -121,6 +121,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="progress_bar_mid">56dp</dimen>
     <dimen name="progress_bar_large">91dp</dimen>
     <dimen name="whats_new_dialog_heading_top_margin">64dp</dimen>
+    <dimen name="card_reader_manuals_divider">96dp</dimen>
 
     <!-- More Menu dimens -->
     <dimen name="more_menu_button_height">190dp</dimen>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- These dimensions are calculated starting with a baseline, then defined as a percentage of
+<?xml version="1.0" encoding="utf-8"?><!-- These dimensions are calculated starting with a baseline, then defined as a percentage of
 that baseline. The percentage doesn't have to be exact, it's main purpose it to describe
 the relationship of the dimension to the baseline. So < 100 would be smaller and > 100 would
 be larger.
@@ -121,7 +120,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="progress_bar_mid">56dp</dimen>
     <dimen name="progress_bar_large">91dp</dimen>
     <dimen name="whats_new_dialog_heading_top_margin">64dp</dimen>
-    <dimen name="card_reader_manuals_divider">96dp</dimen>
+    <dimen name="card_reader_manuals_divider">105dp</dimen>
 
     <!-- More Menu dimens -->
     <dimen name="more_menu_button_height">190dp</dimen>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -915,6 +915,7 @@
     <string name="card_reader_bbpos_manual_card_reader">BBPOS Chipper Card Reader Manual</string>
     <string name="card_reader_m2_manual_card_reader">Stripe M2 Card Reader Manual</string>
     <string name="card_reader_wisepad_3_manual_card_reader">WisePad 3 Card Reader Manual</string>
+    <string name="card_reader_icon_content_description">Card Reader Image</string>
 
     <!--
             Card Reader Interac refund


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6424 
<!-- Id number of the GitHub issue this PR addresses. -->

Merge instructions
- Merge https://github.com/woocommerce/woocommerce-android/pull/6427 and remove `do not merge` label

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the Compose elements to the CardReaderScreen.kt

The video can be seen below and it's based on [this other branch](https://github.com/woocommerce/woocommerce-android/tree/card-reader-manuals-test) ( where I was running tests:

![Screen Capture on 2022-05-03 at 17-32-57](https://user-images.githubusercontent.com/30724184/166570328-bb53e5c3-36c5-4a65-af28-b851dd73cc3d.gif)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
