### PR TITLE
Add click events and observers

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFragment.kt
@@ -35,7 +35,8 @@ class CardReaderManualsFragment : BaseFragment() {
 
     override fun onViewCreated(
         view: View,
-        savedInstanceState: Bundle?) {
+        savedInstanceState: Bundle?
+    ) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFragment.kt
@@ -6,13 +6,18 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CardReaderManualsFragment : BaseFragment() {
+    override fun getFragmentTitle() = resources.getString(R.string.settings_card_reader_manuals)
+    private val viewModel: CardReaderManualsViewModel by viewModels()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -28,5 +33,22 @@ class CardReaderManualsFragment : BaseFragment() {
         }
     }
 
-    override fun getFragmentTitle() = resources.getString(R.string.settings_card_reader_manuals)
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is CardReaderManualsViewModel.ManualEvents.NavigateToCardReaderManualLink -> openInBrowser(event.url)
+            }
+        }
+    }
+
+    private fun openInBrowser(url: String) {
+        ChromeCustomTabUtils.launchUrl(requireContext(), url)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
@@ -55,14 +55,14 @@ fun ManualListItem(
         Image(
             painterResource(manualIcon),
             contentDescription = stringResource(R.string.card_reader_icon_content_description),
-            modifier = Modifier
+            modifier
                 .padding(
                     horizontal = dimensionResource(id = R.dimen.major_100),
                     vertical = dimensionResource(id = R.dimen.minor_100)
                 )
         )
         Column(
-            modifier = Modifier
+            modifier
                 .padding(horizontal = dimensionResource(id = R.dimen.major_100))
                 .align(Alignment.CenterVertically)
         ) {
@@ -73,10 +73,11 @@ fun ManualListItem(
 
 @Composable
 fun ManualsList(
-    list: List<CardReaderManualsViewModel.ManualItem>
+    list: List<CardReaderManualsViewModel.ManualItem>,
+    modifier: Modifier = Modifier
 ) {
     LazyColumn(
-        modifier = Modifier
+        modifier
             .background(color = MaterialTheme.colors.surface)
 
     ) {
@@ -89,7 +90,8 @@ fun ManualsList(
                 onManualClick = manual.onManualClicked
             )
             Divider(
-                modifier = Modifier.offset(x = 96.dp),
+                modifier
+                    .offset(x = 96.dp),
                 color = colorResource(id = R.color.divider_color),
                 thickness = dimensionResource(id = R.dimen.minor_10)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModel.kt
@@ -2,7 +2,9 @@ package com.woocommerce.android.ui.cardreader.manuals
 
 import androidx.compose.runtime.toMutableStateList
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -19,14 +21,26 @@ class CardReaderManualsViewModel @Inject constructor(
         ManualItem(
             icon = R.drawable.ic_card_reader_manual,
             label = R.string.card_reader_bbpos_manual_card_reader,
-            onManualClicked = { }
+            onManualClicked = ::onBbposManualClicked
         ),
         ManualItem(
             icon = R.drawable.ic_card_reader_manual,
             label = R.string.card_reader_m2_manual_card_reader,
-            onManualClicked = { }
+            onManualClicked = ::onM2ManualClicked
         )
     )
+
+    private fun onBbposManualClicked() {
+        triggerEvent(ManualEvents.NavigateToCardReaderManualLink(AppUrls.BBPOS_MANUAL_CARD_READER))
+    }
+
+    private fun onM2ManualClicked() {
+        triggerEvent(ManualEvents.NavigateToCardReaderManualLink(AppUrls.M2_MANUAL_CARD_READER))
+    }
+
+    sealed class ManualEvents : MultiLiveEvent.Event() {
+        data class NavigateToCardReaderManualLink(val url: String) : ManualEvents()
+    }
 
     data class ManualItem(
         val icon: Int,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6432

<!-- Id number of the GitHub issue this PR addresses. -->

Merge instructions
- Merge https://github.com/woocommerce/woocommerce-android/pull/6431 and remove `do not merge` label

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds the click event functions to the ViewModel and set up observers on the Fragment.
I have also made a few formatting changes to the Compose Screen modifiers

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
