### PR TITLE
4952 cardreader battery level seems to be out dated

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 9.2
 -----
-
+- [*] In-Person Payments: update the reader's battery level when it's changed on the card reader's details screen
 
 9.1
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 9.2
 -----
 - [*] In-Person Payments: update the reader's battery level when it's changed on the card reader's details screen
-- [*] IPP. Optimization: in cases when onboarding is not completed, we show the details about what's wrong right away, without refetching the status
+- [*] In-Person Payments: In cases when IPP onboarding is not completed, we show the details about what's wrong right away, without making a network call
 - [*] Fixed a bug that caused decimal values to be rounded when the decimal separator was a comma [https://github.com/woocommerce/woocommerce-android/pull/6426]
 - [*] Most of the fields in order detail now support long press to copy to the clipboard [https://github.com/woocommerce/woocommerce-android/pull/6430]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/detail/CardReaderDetailFragment.kt
@@ -94,61 +94,60 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
 
     private fun observeViewState(binding: FragmentCardReaderDetailBinding) {
         viewModel.viewStateData.observe(
-            viewLifecycleOwner,
-            { state ->
-                makeStateVisible(binding, state)
-                when (state) {
-                    is ConnectedState -> {
-                        with(binding.readerConnectedState) {
-                            UiHelpers.setTextOrHide(enforcedUpdateTv, state.enforceReaderUpdate)
-                            enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
-                            with(readerNameTv) {
-                                UiHelpers.setTextOrHide(this, state.readerName)
-                                setOnLongClickListener { state.onReaderNameLongClick(); true }
-                                expandHitArea(0, dpToPx(requireContext(), HIT_AREA_EXPANSION_DP))
-                            }
-                            UiHelpers.setTextOrHide(readerBatteryTv, state.readerBattery)
-                            UiHelpers.setTextOrHide(readerFirmwareVersionTv, state.readerFirmwareVersion)
-                            UiHelpers.setTextOrHide(primaryActionBtn, state.primaryButtonState?.text)
-                            primaryActionBtn.setOnClickListener { state.primaryButtonState?.onActionClicked?.invoke() }
-                            UiHelpers.setTextOrHide(secondaryActionBtn, state.secondaryButtonState?.text)
-                            secondaryActionBtn.setOnClickListener {
-                                state.secondaryButtonState?.onActionClicked?.invoke()
-                            }
-                            binding.readerConnectedState.enforcedUpdateTv.setDrawableColor(
-                                color.warning_banner_foreground_color
-                            )
-                            with(cardReaderDetailLearnMoreTv.root) {
-                                movementMethod = LinkMovementMethod.getInstance()
-                                UiHelpers.setTextOrHide(this, state.learnMoreLabel)
-                                setOnClickListener { state.onLearnMoreClicked.invoke() }
-                            }
+            viewLifecycleOwner
+        ) { state ->
+            makeStateVisible(binding, state)
+            when (state) {
+                is ConnectedState -> {
+                    with(binding.readerConnectedState) {
+                        UiHelpers.setTextOrHide(enforcedUpdateTv, state.enforceReaderUpdate)
+                        enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
+                        with(readerNameTv) {
+                            UiHelpers.setTextOrHide(this, state.readerName)
+                            setOnLongClickListener { state.onReaderNameLongClick(); true }
+                            expandHitArea(0, dpToPx(requireContext(), HIT_AREA_EXPANSION_DP))
+                        }
+                        UiHelpers.setTextOrHide(readerBatteryTv, state.readerBattery)
+                        UiHelpers.setTextOrHide(readerFirmwareVersionTv, state.readerFirmwareVersion)
+                        UiHelpers.setTextOrHide(primaryActionBtn, state.primaryButtonState?.text)
+                        primaryActionBtn.setOnClickListener { state.primaryButtonState?.onActionClicked?.invoke() }
+                        UiHelpers.setTextOrHide(secondaryActionBtn, state.secondaryButtonState?.text)
+                        secondaryActionBtn.setOnClickListener {
+                            state.secondaryButtonState?.onActionClicked?.invoke()
+                        }
+                        binding.readerConnectedState.enforcedUpdateTv.setDrawableColor(
+                            color.warning_banner_foreground_color
+                        )
+                        with(cardReaderDetailLearnMoreTv.root) {
+                            movementMethod = LinkMovementMethod.getInstance()
+                            UiHelpers.setTextOrHide(this, state.learnMoreLabel)
+                            setOnClickListener { state.onLearnMoreClicked.invoke() }
                         }
                     }
-                    is NotConnectedState -> {
-                        with(binding.readerDisconnectedState) {
-                            UiHelpers.setTextOrHide(cardReaderDetailConnectHeaderLabel, state.headerLabel)
-                            UiHelpers.setImageOrHideInLandscape(cardReaderDetailIllustration, state.illustration)
-                            UiHelpers.setTextOrHide(cardReaderDetailFirstHintLabel, state.firstHintLabel)
-                            UiHelpers.setTextOrHide(cardReaderDetailFirstHintNumberLabel, state.firstHintNumber)
-                            UiHelpers.setTextOrHide(cardReaderDetailSecondHintLabel, state.secondHintLabel)
-                            UiHelpers.setTextOrHide(cardReaderDetailSecondHintNumberLabel, state.secondHintNumber)
-                            UiHelpers.setTextOrHide(cardReaderDetailThirdHintLabel, state.thirdHintLabel)
-                            UiHelpers.setTextOrHide(cardReaderDetailThirdHintNumberLabel, state.thirdHintNumber)
-                            UiHelpers.setTextOrHide(cardReaderDetailConnectBtn, state.connectBtnLabel)
-                            cardReaderDetailConnectBtn.setOnClickListener { state.onPrimaryActionClicked.invoke() }
-                            with(cardReaderDetailLearnMoreTv.root) {
-                                movementMethod = LinkMovementMethod.getInstance()
-                                UiHelpers.setTextOrHide(this, state.learnMoreLabel)
-                                setOnClickListener { state.onLearnMoreClicked.invoke() }
-                            }
+                }
+                is NotConnectedState -> {
+                    with(binding.readerDisconnectedState) {
+                        UiHelpers.setTextOrHide(cardReaderDetailConnectHeaderLabel, state.headerLabel)
+                        UiHelpers.setImageOrHideInLandscape(cardReaderDetailIllustration, state.illustration)
+                        UiHelpers.setTextOrHide(cardReaderDetailFirstHintLabel, state.firstHintLabel)
+                        UiHelpers.setTextOrHide(cardReaderDetailFirstHintNumberLabel, state.firstHintNumber)
+                        UiHelpers.setTextOrHide(cardReaderDetailSecondHintLabel, state.secondHintLabel)
+                        UiHelpers.setTextOrHide(cardReaderDetailSecondHintNumberLabel, state.secondHintNumber)
+                        UiHelpers.setTextOrHide(cardReaderDetailThirdHintLabel, state.thirdHintLabel)
+                        UiHelpers.setTextOrHide(cardReaderDetailThirdHintNumberLabel, state.thirdHintNumber)
+                        UiHelpers.setTextOrHide(cardReaderDetailConnectBtn, state.connectBtnLabel)
+                        cardReaderDetailConnectBtn.setOnClickListener { state.onPrimaryActionClicked.invoke() }
+                        with(cardReaderDetailLearnMoreTv.root) {
+                            movementMethod = LinkMovementMethod.getInstance()
+                            UiHelpers.setTextOrHide(this, state.learnMoreLabel)
+                            setOnClickListener { state.onLearnMoreClicked.invoke() }
                         }
                     }
-                    Loading -> {
-                    }
-                }.exhaustive
-            }
-        )
+                }
+                Loading -> {
+                }
+            }.exhaustive
+        }
     }
 
     private fun initResultHandlers() {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus
@@ -24,6 +25,7 @@ interface CardReaderManager {
     val readerStatus: StateFlow<CardReaderStatus>
     val softwareUpdateStatus: Flow<SoftwareUpdateStatus>
     val softwareUpdateAvailability: Flow<SoftwareUpdateAvailability>
+    val batteryStatus: Flow<CardReaderBatteryStatus>
     val displayBluetoothCardReaderMessages: Flow<BluetoothCardReaderMessages>
 
     fun initialize()

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/CardReaderBatteryStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/CardReaderBatteryStatus.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.cardreader.connection.event
+
+import com.stripe.stripeterminal.external.models.BatteryStatus.CRITICAL
+import com.stripe.stripeterminal.external.models.BatteryStatus.LOW
+import com.stripe.stripeterminal.external.models.BatteryStatus.NOMINAL
+import com.stripe.stripeterminal.external.models.BatteryStatus.UNKNOWN
+
+sealed class CardReaderBatteryStatus {
+    data class StatusChanged(
+        val batteryLevel: Float,
+        val batteryStatus: BatteryStatus,
+        val isCharging: Boolean
+    ) : CardReaderBatteryStatus()
+
+    object Warning : CardReaderBatteryStatus()
+    object Unknown : CardReaderBatteryStatus()
+}
+
+enum class BatteryStatus {
+    UNKNOWN,
+    CRITICAL,
+    LOW,
+    NOMINAL,
+}
+
+internal fun com.stripe.stripeterminal.external.models.BatteryStatus.toLocalBatteryStatus() =
+    when (this) {
+        UNKNOWN -> BatteryStatus.UNKNOWN
+        CRITICAL -> BatteryStatus.CRITICAL
+        LOW -> BatteryStatus.LOW
+        NOMINAL -> BatteryStatus.NOMINAL
+    }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -53,6 +53,8 @@ internal class CardReaderManagerImpl(
 
     override val softwareUpdateAvailability = connectionManager.softwareUpdateAvailability
 
+    override val batteryStatus = connectionManager.batteryStatus
+
     override val displayBluetoothCardReaderMessages = connectionManager.displayBluetoothCardReaderMessages
 
     override fun initialize() {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.cardreader.internal.connection
 
 import com.stripe.stripeterminal.external.callable.BluetoothReaderListener
 import com.stripe.stripeterminal.external.callable.Cancelable
+import com.stripe.stripeterminal.external.models.BatteryStatus
 import com.stripe.stripeterminal.external.models.ReaderDisplayMessage
 import com.stripe.stripeterminal.external.models.ReaderEvent
 import com.stripe.stripeterminal.external.models.ReaderInputOptions
@@ -10,8 +11,13 @@ import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages.CardReaderNoMessage
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus.StatusChanged
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus.Unknown
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus.Warning
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
+import com.woocommerce.android.cardreader.connection.event.toLocalBatteryStatus
 import com.woocommerce.android.cardreader.internal.LOG_TAG
 import com.woocommerce.android.cardreader.internal.payments.AdditionalInfoMapper
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,8 +35,11 @@ internal class BluetoothReaderListenerImpl(
         MutableStateFlow<SoftwareUpdateAvailability>(SoftwareUpdateAvailability.NotAvailable)
     val updateAvailabilityEvents = _updateAvailabilityEvents.asStateFlow()
 
-    private val _displayMessagesEvent = MutableStateFlow<BluetoothCardReaderMessages>(CardReaderNoMessage)
-    val displayMessagesEvent = _displayMessagesEvent.asStateFlow()
+    private val _displayMessagesEvents = MutableStateFlow<BluetoothCardReaderMessages>(CardReaderNoMessage)
+    val displayMessagesEvents = _displayMessagesEvents.asStateFlow()
+
+    private val _batteryStatusEvents = MutableStateFlow<CardReaderBatteryStatus>(Unknown)
+    val batteryStatusEvents = _batteryStatusEvents.asStateFlow()
 
     var cancelUpdateAction: Cancelable? = null
 
@@ -65,6 +74,19 @@ internal class BluetoothReaderListenerImpl(
 
     override fun onReportLowBatteryWarning() {
         logWrapper.d(LOG_TAG, "onReportLowBatteryWarning")
+        _batteryStatusEvents.value = Warning
+    }
+
+    override fun onBatteryLevelUpdate(batteryLevel: Float, batteryStatus: BatteryStatus, isCharging: Boolean) {
+        logWrapper.d(
+            LOG_TAG,
+            "onBatteryLevelUpdate: batteryStatus: $batteryStatus, batteryLevel: $batteryLevel, isCharging: $isCharging"
+        )
+        _batteryStatusEvents.value = StatusChanged(
+            batteryLevel,
+            batteryStatus.toLocalBatteryStatus(),
+            isCharging,
+        )
     }
 
     override fun onReportReaderEvent(event: ReaderEvent) {
@@ -73,13 +95,13 @@ internal class BluetoothReaderListenerImpl(
 
     override fun onRequestReaderDisplayMessage(message: ReaderDisplayMessage) {
         logWrapper.d(LOG_TAG, "onRequestReaderDisplayMessage: $message")
-        _displayMessagesEvent.value = BluetoothCardReaderMessages
+        _displayMessagesEvents.value = BluetoothCardReaderMessages
             .CardReaderDisplayMessage(additionalInfoMapper.map(message))
     }
 
     override fun onRequestReaderInput(options: ReaderInputOptions) {
         logWrapper.d(LOG_TAG, "onRequestReaderInput: $options")
-        _displayMessagesEvent.value = BluetoothCardReaderMessages.CardReaderInputMessage(options.toString())
+        _displayMessagesEvents.value = BluetoothCardReaderMessages.CardReaderInputMessage(options.toString())
     }
 
     fun resetConnectionState() {
@@ -88,6 +110,6 @@ internal class BluetoothReaderListenerImpl(
     }
 
     fun resetDisplayMessage() {
-        _displayMessagesEvent.value = CardReaderNoMessage
+        _displayMessagesEvents.value = CardReaderNoMessage
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.coroutines.resume
@@ -30,7 +29,8 @@ internal class ConnectionManager(
 ) {
     val softwareUpdateStatus = bluetoothReaderListener.updateStatusEvents
     val softwareUpdateAvailability = bluetoothReaderListener.updateAvailabilityEvents
-    val displayBluetoothCardReaderMessages = bluetoothReaderListener.displayMessagesEvent
+    val batteryStatus = bluetoothReaderListener.batteryStatusEvents
+    val displayBluetoothCardReaderMessages = bluetoothReaderListener.displayMessagesEvents
 
     fun discoverReaders(isSimulated: Boolean, cardReaderTypesToDiscover: CardReaderTypesToDiscover) =
         discoverReadersAction.discoverReaders(isSimulated).map { state ->

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImplTest.kt
@@ -4,7 +4,13 @@ import com.stripe.stripeterminal.external.models.ReaderDisplayMessage
 import com.stripe.stripeterminal.external.models.ReaderInputOptions
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.event.BatteryStatus.CRITICAL
+import com.woocommerce.android.cardreader.connection.event.BatteryStatus.LOW
+import com.woocommerce.android.cardreader.connection.event.BatteryStatus.NOMINAL
+import com.woocommerce.android.cardreader.connection.event.BatteryStatus.UNKNOWN
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus.StatusChanged
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus.Warning
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatusErrorType
@@ -109,5 +115,86 @@ class BluetoothReaderListenerImplTest {
         // THEN
         assertThat(listener.displayMessagesEvents.value)
             .isEqualTo(BluetoothCardReaderMessages.CardReaderInputMessage(options.toString()))
+    }
+
+    @Test
+    fun `given NOMINAL status, when on battery level update called, then new battery status is emitted`() {
+        // WHEN
+        val batteryLevel = 0.3F
+        val batteryStatus = com.stripe.stripeterminal.external.models.BatteryStatus.NOMINAL
+        val isCharging = true
+        listener.onBatteryLevelUpdate(batteryLevel, batteryStatus, isCharging)
+
+        // THEN
+        assertThat(listener.batteryStatusEvents.value).isEqualTo(
+            StatusChanged(
+                batteryLevel,
+                NOMINAL,
+                isCharging,
+            )
+        )
+    }
+
+    @Test
+    fun `given LOW status, when on battery level update called, then new battery status is emitted`() {
+        // WHEN
+        val batteryLevel = 0.3F
+        val batteryStatus = com.stripe.stripeterminal.external.models.BatteryStatus.LOW
+        val isCharging = true
+        listener.onBatteryLevelUpdate(batteryLevel, batteryStatus, isCharging)
+
+        // THEN
+        assertThat(listener.batteryStatusEvents.value).isEqualTo(
+            StatusChanged(
+                batteryLevel,
+                LOW,
+                isCharging,
+            )
+        )
+    }
+
+    @Test
+    fun `given CRITICAL status, when on battery level update called, then new battery status is emitted`() {
+        // WHEN
+        val batteryLevel = 0.3F
+        val batteryStatus = com.stripe.stripeterminal.external.models.BatteryStatus.CRITICAL
+        val isCharging = true
+        listener.onBatteryLevelUpdate(batteryLevel, batteryStatus, isCharging)
+
+        // THEN
+        assertThat(listener.batteryStatusEvents.value).isEqualTo(
+            StatusChanged(
+                batteryLevel,
+                CRITICAL,
+                isCharging,
+            )
+        )
+    }
+
+    @Test
+    fun `given UNKNOWN status, when on battery level update called, then new battery status is emitted`() {
+        // WHEN
+        val batteryLevel = 0.3F
+        val batteryStatus = com.stripe.stripeterminal.external.models.BatteryStatus.UNKNOWN
+        val isCharging = true
+        listener.onBatteryLevelUpdate(batteryLevel, batteryStatus, isCharging)
+
+        // THEN
+        assertThat(listener.batteryStatusEvents.value).isEqualTo(
+            StatusChanged(
+                batteryLevel,
+                UNKNOWN,
+                isCharging,
+            )
+        )
+    }
+
+    @Test
+    fun `when on report low battery warning called, then warning battery status is emitted`() {
+        // WHEN
+        listener.onReportLowBatteryWarning()
+
+        // THEN
+        assertThat(listener.batteryStatusEvents.value).isEqualTo(Warning)
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImplTest.kt
@@ -96,7 +96,7 @@ class BluetoothReaderListenerImplTest {
         listener.onRequestReaderDisplayMessage(ReaderDisplayMessage.REMOVE_CARD)
 
         // THEN
-        assertThat(listener.displayMessagesEvent.value)
+        assertThat(listener.displayMessagesEvents.value)
             .isEqualTo(BluetoothCardReaderMessages.CardReaderDisplayMessage(REMOVE_CARD))
     }
 
@@ -107,7 +107,7 @@ class BluetoothReaderListenerImplTest {
         listener.onRequestReaderInput(options)
 
         // THEN
-        assertThat(listener.displayMessagesEvent.value)
+        assertThat(listener.displayMessagesEvents.value)
             .isEqualTo(BluetoothCardReaderMessages.CardReaderInputMessage(options.toString()))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4952
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR utilizes a feature of the SDK v2.7.0 that adds callback that invokes when a reader's batter status changes 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Collect to the reader via settings
* Wait 10 minutes (yes, the SDK claims that it updates it once per 10 minutes)
* Notice that battery level dropped

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
