### PR TITLE
Issue/6438 add unit test manuals screen

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModelTest.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.cardreader.manuals
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import org.junit.Assert.*
-
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Test
 
 class CardReaderManualsViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: CardReaderManualsViewModel
@@ -13,5 +15,73 @@ class CardReaderManualsViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         viewModel = CardReaderManualsViewModel(savedStateHandle)
+    }
+
+    @Test
+    fun `when screen shown, then BBPOS label is displayed`() {
+        val bbposRow = viewModel.manualState.find {
+            it.label == R.string.card_reader_bbpos_manual_card_reader
+        }
+
+        assertThat(bbposRow).isNotNull
+    }
+
+    @Test
+    fun `when user clicks BBPOS reader, then app navigates to BBPOS manual link`() {
+        val bbposRow = viewModel.manualState.find {
+            it.label == R.string.card_reader_bbpos_manual_card_reader
+        }
+
+        bbposRow!!.onManualClicked.invoke()
+
+        assertThat(viewModel.event.value)
+            .isEqualTo(
+                CardReaderManualsViewModel.ManualEvents.NavigateToCardReaderManualLink(
+                    AppUrls.BBPOS_MANUAL_CARD_READER
+                )
+            )
+    }
+
+    @Test
+    fun `when screen shown, then BBPOS icon is displayed`() {
+        val bbposRow = viewModel.manualState.find {
+            it.icon == R.drawable.ic_card_reader_manual
+        }
+
+        assertThat(bbposRow).isNotNull
+    }
+
+    @Test
+    fun `when screen shown, then M2 label is displayed`() {
+        val m2Row = viewModel.manualState.find {
+            it.label == R.string.card_reader_m2_manual_card_reader
+        }
+
+        assertThat(m2Row).isNotNull
+    }
+
+    @Test
+    fun `when user clicks M2 reader, then app navigates to M2 manual link`() {
+        val m2Row = viewModel.manualState.find {
+            it.label == R.string.card_reader_m2_manual_card_reader
+        }
+
+        m2Row!!.onManualClicked.invoke()
+
+        assertThat(viewModel.event.value)
+            .isEqualTo(
+                CardReaderManualsViewModel.ManualEvents.NavigateToCardReaderManualLink(
+                    AppUrls.M2_MANUAL_CARD_READER
+                )
+            )
+    }
+
+    @Test
+    fun `when screen is shown, then M2 icon is displayed`() {
+        val m2Row = viewModel.manualState.find {
+            it.icon == R.drawable.ic_card_reader_manual
+        }
+
+        assertThat(m2Row).isNotNull
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsViewModelTest.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.cardreader.manuals
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import org.junit.Assert.*
+
+import org.junit.Before
+
+class CardReaderManualsViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: CardReaderManualsViewModel
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle()
+
+    @Before
+    fun setUp() {
+        viewModel = CardReaderManualsViewModel(savedStateHandle)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6438
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add unit tests for the CardReaderManualsViewModel.kt
- Tests if the correct label is displayed
- Tests if the app navigates to the correct link based on the label 
- Tests if the correct icon is displayed

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
