### PR TITLE
Build debuggable apks on CI installable builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -651,7 +651,7 @@ platform :android do
     gradle(
       task: "assemble",
       flavor: "Jalapeno",
-      build_type: "Release"
+      build_type: "Debug"
     )
 
     upload_path = upload_to_s3(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates BuildKite fastlane to build debuggable apks instead of release apks. This has several benefits
- feature flags in development are enabled - PR reviewers don't need to build the apk locally
- PR reviewers can use debugger to modify values of variables etc. without building the app locally

The only downside is that R8 is disabled on debuggable builds -> R8 related issues will be discovered later in the development process. However, considering that R8 related issues are very rare and PR reviewers will save significant amount of time, the costs outweight the benefits. 

Jeremy suggested we could also build both versions of the app  - I'm not sure if it'd increase time before a PR can be merged or if it has other consequences, so I haven't included this approach in this PR - we can add it later.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Download the installable build and make sure it's debuggable.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
