### PR TITLE
Issue/6135 order bottom sheet tablet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderCreationBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderCreationBottomSheetFragment.kt
@@ -4,13 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.databinding.DialogOrderCreationBottomSheetBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.OrderCreationAction.CREATE_ORDER
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.OrderCreationAction.SIMPLE_PAYMENT
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 
-class OrderCreationBottomSheetFragment : BottomSheetDialogFragment() {
+class OrderCreationBottomSheetFragment : WCBottomSheetDialogFragment() {
     companion object {
         const val KEY_ORDER_CREATION_ACTION_RESULT = "key_order_creation_action_result"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
@@ -8,7 +8,6 @@ import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogProductDetailBottomSheetListBinding
 import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.ProductDetailBottomSheetUiItem

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
@@ -13,10 +13,11 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogProductDetailBottomSheetListBinding
 import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.ProductDetailBottomSheetUiItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ProductDetailBottomSheetFragment : BottomSheetDialogFragment() {
+class ProductDetailBottomSheetFragment : WCBottomSheetDialogFragment() {
     val viewModel: ProductDetailViewModel by hiltNavGraphViewModels(R.id.nav_graph_products)
 
     private lateinit var productDetailBottomSheetAdapter: ProductDetailBottomSheetAdapter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortingFragment.kt
@@ -7,15 +7,15 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.databinding.DialogProductListSortingBinding
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ProductSortingFragment : BottomSheetDialogFragment() {
+class ProductSortingFragment : WCBottomSheetDialogFragment() {
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     private val viewModel: ProductSortingViewModel by viewModels()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -16,11 +16,12 @@ import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.Prod
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ProductTypesBottomSheetFragment : BottomSheetDialogFragment() {
+class ProductTypesBottomSheetFragment : WCBottomSheetDialogFragment() {
     companion object {
         const val KEY_PRODUCT_TYPE_RESULT = "key_product_type_result"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogProductDetailBottomSheetListBinding
 import com.woocommerce.android.extensions.navigateBackWithResult

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/AddProductDownloadBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/AddProductDownloadBottomSheetFragment.kt
@@ -11,7 +11,6 @@ import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogProductAddDownloadableFileBinding
 import com.woocommerce.android.mediapicker.MediaPickerUtil.processDeviceMediaResult
@@ -20,7 +19,10 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDownloadDetails
 import com.woocommerce.android.ui.products.ProductNavigator
-import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel.*
+import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel.PickFileFromDevice
+import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel.PickFileFromMedialLibrary
+import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel.UploadFile
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.DEVICE
@@ -29,7 +31,7 @@ import org.wordpress.android.mediapicker.ui.MediaPickerActivity
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class AddProductDownloadBottomSheetFragment : BottomSheetDialogFragment() {
+class AddProductDownloadBottomSheetFragment : WCBottomSheetDialogFragment() {
     @Inject lateinit var navigator: ProductNavigator
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var mediaPickerSetupFactory: MediaPickerSetup.Factory

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
@@ -9,16 +9,15 @@ import org.wordpress.android.util.DisplayUtils
 
 /**
  * The default behavior of a bottom sheet in landscape causes it to be cut off after the first item,
- * which makes sense for phones but not tablets since there's usually plenty of room to show more
- * items. This simple BottomSheetDialogFragment wrapper resolves this by showing the entire sheet on
- * landscape tablets.
+ * which makes sense for phones but not large tablets since there's usually plenty of room to show
+ * more items. This simple BottomSheetDialogFragment wrapper resolves this by showing the entire
+ * sheet on large landscape tablets.
  */
 open class WCBottomSheetDialogFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val isTablet = DisplayUtils.isTablet(requireContext()) || DisplayUtils.isXLargeTablet(requireContext())
-        if (isTablet && DisplayUtils.isLandscape(requireContext())) {
+        if (DisplayUtils.isXLargeTablet(requireContext()) && DisplayUtils.isLandscape(requireContext())) {
             dialog?.setOnShowListener {
                 val dialog = it as BottomSheetDialog
                 dialog.findViewById<View>(R.id.design_bottom_sheet)?.let { sheet ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.widgets
+
+import android.os.Bundle
+import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.woocommerce.android.R
+import org.wordpress.android.util.DisplayUtils
+
+/**
+ * The default behavior of a bottom sheet in landscape causes it to be cut off after the first item,
+ * which makes sense for phones but not tablets since there's usually plenty of room to show more
+ * items. This simple BottomSheetDialogFragment wrapper resolves this by showing the entire sheet on
+ * landscape tablets.
+ */
+
+open class WCBottomSheetDialogFragment : BottomSheetDialogFragment() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val isTablet = DisplayUtils.isTablet(requireContext()) || DisplayUtils.isXLargeTablet(requireContext())
+        if (isTablet && DisplayUtils.isLandscape(requireContext())) {
+            dialog?.setOnShowListener {
+                val dialog = it as BottomSheetDialog
+                dialog.findViewById<View>(R.id.design_bottom_sheet)?.let { sheet ->
+                    dialog.behavior.peekHeight = sheet.height
+                    sheet.parent.parent.requestLayout()
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.util.DisplayUtils
  * items. This simple BottomSheetDialogFragment wrapper resolves this by showing the entire sheet on
  * landscape tablets.
  */
-
 open class WCBottomSheetDialogFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)


### PR DESCRIPTION
Fixes #6135 - In landscape, bottom sheet fragments default to showing a single item, requiring the user to scroll to see more. This makes sense on phones and perhaps smaller tablets, but on larger tablets there's usually enough space to show more items.

This PR addresses this by adding a `BottomSheetFragment` descendant which automatically shows the entire sheet on large landscape tablets for these bottom sheets:

* Order list
* Product list
* Product detail
* Product sorting
* Product downloads

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
