### PR TITLE
Issue/6203 add card reader manuals tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
@@ -54,6 +54,9 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
+                is CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderManualsScreen -> {
+                    findNavController().navigateSafely(R.id.action_cardReaderHubFragment_to_cardReaderManualsFragment)
+                }
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.InPersonPaymentsCanadaFeatureFlag
+import com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsFeatureFlag
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
@@ -24,6 +25,7 @@ import javax.inject.Inject
 class CardReaderHubViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
+    private val cardReaderManualsFeatureFlag: CardReaderManualsFeatureFlag,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val selectedSite: SelectedSite,
 ) : ScopedViewModel(savedState) {
@@ -82,6 +84,15 @@ class CardReaderHubViewModel @Inject constructor(
                     )
                 )
             }
+            if (cardReaderManualsFeatureFlag.isEnabled()) {
+                add(
+                    CardReaderHubListItemViewState(
+                        icon = R.drawable.ic_card_reader_manual,
+                        label = UiString.UiStringRes(R.string.settings_card_reader_manuals),
+                        onItemClicked = ::onCardReaderManualsClicked
+                    )
+                )
+            }
         }.toImmutableList()
     )
 
@@ -107,10 +118,15 @@ class CardReaderHubViewModel @Inject constructor(
         triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.WISEPAD_3_MANUAL_CARD_READER))
     }
 
+    private fun onCardReaderManualsClicked() {
+        triggerEvent(CardReaderHubEvents.NavigateToCardReaderManualsScreen)
+    }
+
     sealed class CardReaderHubEvents : MultiLiveEvent.Event() {
         data class NavigateToCardReaderDetail(val cardReaderFlowParam: CardReaderFlowParam) : CardReaderHubEvents()
         data class NavigateToPurchaseCardReaderFlow(val url: String) : CardReaderHubEvents()
         data class NavigateToManualCardReaderFlow(val url: String) : CardReaderHubEvents()
+        object NavigateToCardReaderManualsScreen : CardReaderHubEvents()
     }
 
     sealed class CardReaderHubViewState {

--- a/WooCommerce/src/main/res/navigation/nav_graph_card_reader_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_card_reader_flow.xml
@@ -68,6 +68,9 @@
         <action
             android:id="@+id/action_cardReaderHubFragment_to_cardReaderDetailFragment"
             app:destination="@id/cardReaderDetailFragment" />
+        <action
+            android:id="@+id/action_cardReaderHubFragment_to_cardReaderManualsFragment"
+            app:destination="@id/cardReaderManualsFragment" />
     </fragment>
     <fragment
         android:id="@+id/cardReaderDetailFragment"
@@ -169,4 +172,8 @@
             app:argType="com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam$PaymentOrRefund"
             app:nullable="false" />
     </dialog>
+    <fragment
+        android:id="@+id/cardReaderManualsFragment"
+        android:name="com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsFragment"
+        android:label="CardReaderManualsFragment" />
 </navigation>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.InPersonPaymentsCanadaFeatureFlag
+import com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsFeatureFlag
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
@@ -22,6 +23,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 class CardReaderHubViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: CardReaderHubViewModel
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag = mock()
+    private val cardReaderManualsFeatureFlag: CardReaderManualsFeatureFlag = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock {
         on(it.getCardReaderPreferredPlugin(any(), any(), any()))
             .thenReturn(WOOCOMMERCE_PAYMENTS)
@@ -294,6 +296,12 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     private fun initViewModel() {
-        viewModel = CardReaderHubViewModel(savedState, inPersonPaymentsCanadaFeatureFlag, appPrefsWrapper, selectedSite)
+        viewModel = CardReaderHubViewModel(
+            savedState,
+            inPersonPaymentsCanadaFeatureFlag,
+            cardReaderManualsFeatureFlag,
+            appPrefsWrapper,
+            selectedSite
+        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -295,6 +295,46 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
             )
     }
 
+    @Test
+    fun `given manuals is enabled, when screen shown, then manuals row is displayed`() {
+        whenever(cardReaderManualsFeatureFlag.isEnabled()).thenReturn(true)
+        initViewModel()
+
+        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
+            .anyMatch {
+                it.icon == R.drawable.ic_card_reader_manual &&
+                    it.label == UiString.UiStringRes(R.string.settings_card_reader_manuals)
+            }
+    }
+
+    @Test
+    fun `given manuals disabled, when screen shown, then manuals row is not displayed`() {
+        whenever(cardReaderManualsFeatureFlag.isEnabled()).thenReturn(false)
+        initViewModel()
+
+        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
+            .noneMatch {
+                it.icon == R.drawable.ic_card_reader_manual &&
+                    it.label == UiString.UiStringRes(R.string.settings_card_reader_manuals)
+            }
+    }
+
+    @Test
+    fun `given manuals enabled, when user clicks on manuals row, then app navigates to manuals screen`() {
+        whenever(cardReaderManualsFeatureFlag.isEnabled()).thenReturn(true)
+        initViewModel()
+
+        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
+            .find {
+                it.label == UiString.UiStringRes(R.string.settings_card_reader_manuals)
+            }!!.onItemClicked.invoke()
+
+        assertThat(viewModel.event.value)
+            .isEqualTo(
+                CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderManualsScreen
+            )
+    }
+
     private fun initViewModel() {
         viewModel = CardReaderHubViewModel(
             savedState,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6203 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an action to the Nav_graph_card_reader_flow to go from the reader hub to the manuals page.
Adds the Card Reader Manuals tab to the Reader Hud screen and hides it under a feature flag to be available under debug build only. 
Consequently, this PR also adds the CardReaderManualsFeatureFlag as a parameter to the CardReaderHubViewModelTest.kt

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
**1st scenario:**

- run the app in debug (use a store that has IPP enabled)
- Go to the Menu -> Settings -> In Person Payments Tab 
- Make sure the Card Reader Manuals tab is displayed
- Click on it
- Make sure both the BBPOS and M2 readers tabs are displayed
- Click on each of the reader manuals and make sure they redirect to the PDF download of each one

**2nd Scenario:** 

- Run the app on release
- Go to the Menu -> Settings -> In Person Payments screen 
- Make sure the Card Reader Manuals tab is not displayed

**Please note:**

The icons will be replaced by the correct icons once they are provided by the design team. This will change the alignment of the text. This should be revisited when issue #6146 is addressed and the label and icons are amended. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

**Release:**

![release](https://user-images.githubusercontent.com/30724184/166998219-123fcc4c-42b1-460c-ad4e-cf9dcef7e456.gif)

**Debug**

![debug](https://user-images.githubusercontent.com/30724184/166998510-824a2f83-bcea-40db-a03a-fb3a8c9783cf.gif)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
