### PR TITLE
Add numeric badge to the bottom bar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -626,8 +626,8 @@ class MainActivity :
         binding.bottomNav.setOrderBadgeCount(0)
     }
 
-    private fun showMoreMenuBadge(show: Boolean) {
-        binding.bottomNav.showMoreMenuBadge(show)
+    private fun showMoreMenuBadge(count: Int) {
+        binding.bottomNav.showMoreMenuBadge(count)
     }
 
     override fun onNavItemSelected(navPos: BottomNavigationPosition) {
@@ -727,7 +727,7 @@ class MainActivity :
         }
 
         viewModel.unseenReviewsCount.observe(this) { count ->
-            showMoreMenuBadge(count > 0)
+            showMoreMenuBadge(count)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -111,16 +111,20 @@ class MainBottomNavigationView @JvmOverloads constructor(
         assignNavigationListeners(true)
     }
 
-    fun showMoreMenuBadge(show: Boolean) {
-        moreMenuBadge.isVisible = show
+    fun showMoreMenuBadge(count: Int) {
+        showBadge(moreMenuBadge, count)
     }
 
     fun setOrderBadgeCount(count: Int) {
+        showBadge(ordersBadge, count)
+    }
+
+    private fun showBadge(badgeDrawable: BadgeDrawable, count: Int) {
         if (count > 0) {
-            ordersBadge.number = count
-            ordersBadge.isVisible = true
+            badgeDrawable.number = count
+            badgeDrawable.isVisible = true
         } else {
-            ordersBadge.isVisible = false
+            badgeDrawable.isVisible = false
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6105 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
To keep the bottom navigation badges more consistent, we'll the notification badge with a number in the same persistent way we do for orders tab.

In the More menu case, it should be the total number of notifications within the view. When tapping on the reviews menu item I think the review should stay unread until the merchant actually goes in and reads the review itself or marks them all as read (I think this is how it currently works) When an item is marked as read it will then be subtracted from the badge and cleared when there are no notifications left.

### Testing instructions
Add a couple product reviews and see how the numeric badge is displayed in the more menu bottom tab
Check that the badge behaves as described previously. 

### Images/gif


https://user-images.githubusercontent.com/2663464/167136106-99a6dd13-8670-4c44-8d12-18c0ebd13b0c.mp4


- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

