### PR TITLE
Add select site feature for quicklogin script

### DIFF
--- a/quicklogin/build.gradle
+++ b/quicklogin/build.gradle
@@ -59,6 +59,7 @@ android {
 
         buildConfigField "String", "QUICK_LOGIN_WP_EMAIL", "\"${project.getProperties().get("quickLoginWpEmail")}\""
         buildConfigField "String", "QUICK_LOGIN_WP_PASSWORD", "\"${project.getProperties().get("quickLoginWpPassword")}\""
+        buildConfigField "String", "QUICK_LOGIN_WP_SITE", "\"${project.getProperties().get("quickLoginWpSite")}\""
     }
 
     compileOptions {

--- a/quicklogin/src/main/kotlin/com/woocommerce/android/quicklogin/QuickLoginWordpress.kt
+++ b/quicklogin/src/main/kotlin/com/woocommerce/android/quicklogin/QuickLoginWordpress.kt
@@ -39,11 +39,12 @@ class QuickLoginWordpress {
         enterEmail()
         enterPassword()
         enterSecondFactorIfNeeded()
+        selectSiteIfProvided()
     }
 
     private fun verifyEmailAndPassword() {
-        if (BuildConfig.QUICK_LOGIN_WP_EMAIL.isNullOrBlank() ||
-            BuildConfig.QUICK_LOGIN_WP_PASSWORD.isNullOrBlank()
+        if (BuildConfig.QUICK_LOGIN_WP_EMAIL.isBlank() ||
+            BuildConfig.QUICK_LOGIN_WP_PASSWORD.isBlank()
         ) {
             exitFlowWithMessage("WP Email or password is not set. Look into quicklogin/woo_login.sh-example")
         }
@@ -118,6 +119,29 @@ class QuickLoginWordpress {
         continueButton.click()
 
         device.wait(Until.findObject(By.res(DEBUG_PACKAGE_NAME, "site_list_container")), LONG_TIMEOUT)
+    }
+
+    private fun selectSiteIfProvided() {
+        if (BuildConfig.QUICK_LOGIN_WP_SITE.isBlank().not()) {
+            device
+                .wait(Until.findObject(By.res(DEBUG_PACKAGE_NAME, "site_list_container")), TIMEOUT)
+                ?: return
+
+            val selectedSite = device.wait(
+                Until.findObject(
+                    By.text(BuildConfig.QUICK_LOGIN_WP_SITE)
+                ),
+                TIMEOUT
+            )
+
+            val doneButton = device
+                .wait(Until.findObject(By.res(DEBUG_PACKAGE_NAME, "button_primary")), TIMEOUT)
+
+            selectedSite.click()
+            doneButton.click()
+
+            device.wait(Until.findObject(By.res(DEBUG_PACKAGE_NAME, "bottom_nav")), LONG_TIMEOUT)
+        }
     }
 
     private fun exitFlowWithMessage(message: String) {

--- a/quicklogin/woo_login.sh
+++ b/quicklogin/woo_login.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-# PASS WORDPRESS_EMAIL and WORDPRESS_PASSWORD as env variable to the script
+# PASS WORDPRESS_EMAIL, WORDPRESS_SITE and WORDPRESS_PASSWORD as env variable to the script
 # Optionally pass path to your adb: ADB_PATH
-# Example: ADB_PATH=~/Library/Android/sdk/platform-tools/adb WORDPRESS_EMAIL=my_wp_email@gmail.com  WORDPRESS_PASSWORD=my_pasword_1_# ./quicklogin/woo_login.sh
+# Example: ADB_PATH=~/Library/Android/sdk/platform-tools/adb WORDPRESS_EMAIL=my_wp_email@gmail.com  WORDPRESS_PASSWORD=my_pasword_1_# WORDPRESS_SITE=my_wordpress_site ./quicklogin/woo_login.sh
 
 if [[ "$ADB_PATH" ]]; then
   adbPath="$ADB_PATH"

--- a/quicklogin/woo_login.sh
+++ b/quicklogin/woo_login.sh
@@ -17,7 +17,8 @@ eval $adbPath shell pm clear $packageName
 ./gradlew installWasabiDebug
 ./gradlew :quicklogin:installDebug \
 -PquickLoginWpEmail="$WORDPRESS_EMAIL" \
--PquickLoginWpPassword="$WORDPRESS_PASSWORD"
+-PquickLoginWpPassword="$WORDPRESS_PASSWORD" \
+-PquickLoginWpSite="$WORDPRESS_SITE"
 
 eval $adbPath shell am instrument -w -r -e debug false -e class 'com.woocommerce.android.quicklogin.QuickLoginWordpress' $packageName.quicklogin/androidx.test.runner.AndroidJUnitRunner
 eval $adbPath shell am start -n $packageName/com.woocommerce.android.ui.main.MainActivity


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6454
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a possibility to point to a site that should be selected during quicklogin script execution.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### TC1 Check for selecting site

1. Run the quicklogin script with `WORDPRESS_SITE` variable, e.g.
```shell
WORDPRESS_EMAIL=wojtek.zieba@automattic.com  WORDPRESS_PASSWORD=mypassword WORDPRESS_SITE=wziebatests.com ./quicklogin/woo_login.sh
```
2. See that site has been selected and after quicklogin finishes, you can see the main screen (dashboard).

#### TC2 Check for regression
1. Run the quicklogin script without `WORDPRESS_SITE` variable, e.g.
```shell
WORDPRESS_EMAIL=wojtek.zieba@automattic.com  WORDPRESS_PASSWORD=mypassword ./quicklogin/woo_login.sh
```
2. See that script works as before and ends up on the site selection screen.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
