### PR TITLE
Crash removing products in Order Creation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] In-Person Payments: In cases when IPP onboarding is not completed, we show the details about what's wrong right away, without making a network call
 - [*] Fixed a bug that caused decimal values to be rounded when the decimal separator was a comma [https://github.com/woocommerce/woocommerce-android/pull/6426]
 - [*] Most of the fields in order detail now support long press to copy to the clipboard [https://github.com/woocommerce/woocommerce-android/pull/6430]
+- [*] Fixed a crash when trying to remove an unsynchronized product in a new synced order [https://github.com/woocommerce/woocommerce-android/pull/6459]
 
 9.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -62,6 +62,7 @@ class OrderCreationProductsAdapter(
         }
 
         fun bind(productModel: ProductUIModel) {
+            binding.root.isEnabled = productModel.item.isSynced()
             binding.productName.text = productModel.item.name
             binding.stepperView.isMinusButtonEnabled = isQuantityButtonsEnabled
             binding.stepperView.isPlusButtonEnabled = isQuantityButtonsEnabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -184,6 +184,8 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onProductClicked(item: Order.Item) {
+        // Don't show details if the product is not synced yet
+        if (!item.isSynced()) return
         triggerEvent(ShowProductDetails(item))
     }
 
@@ -348,6 +350,7 @@ class OrderCreationViewModel @Inject constructor(
     ) : Parcelable {
         @IgnoredOnParcel
         val canCreateOrder: Boolean = !willUpdateOrderDraft && !isUpdatingOrderDraft && !showOrderUpdateSnackbar
+
         @IgnoredOnParcel
         val isIdle: Boolean = !isUpdatingOrderDraft && !willUpdateOrderDraft
     }
@@ -360,3 +363,5 @@ data class ProductUIModel(
     val stockQuantity: Double,
     val stockStatus: ProductStockStatus
 )
+
+fun Order.Item.isSynced() = this.itemId != 0L

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
@@ -672,6 +672,38 @@ class OrderCreationViewModelTest : BaseUnitTest() {
         assertThat(viewState.canCreateOrder).isTrue
     }
 
+    @Test
+    fun `when hitting a product that is not synced then do nothing`() {
+        var lastReceivedEvent: Event? = null
+        sut.event.observeForever {
+            lastReceivedEvent = it
+        }
+
+        val orderItem = Order.Item.EMPTY
+        sut.onProductClicked(orderItem)
+
+        assertThat(lastReceivedEvent).isNull()
+    }
+
+    @Test
+    fun `when hitting a product that is synced then show product details`() {
+        var lastReceivedEvent: Event? = null
+        sut.event.observeForever {
+            lastReceivedEvent = it
+        }
+
+        val orderItem = createOrderItem()
+        sut.onProductClicked(orderItem)
+
+        assertThat(lastReceivedEvent).isNotNull
+        lastReceivedEvent
+            .run { this as? ShowProductDetails }
+            ?.let { showProductDetailsEvent ->
+                val currentOrderItem = showProductDetailsEvent.item
+                assertThat(currentOrderItem).isEqualTo(orderItem)
+            } ?: fail("Last event should be of ShowProductDetails type")
+    }
+
     private fun createSut() {
         sut = OrderCreationViewModel(
             savedState = savedState,


### PR DESCRIPTION
Closes: #6456

### Description
When adding a product to an Order in a slow connection, if we select the product before the Order is synced with the API and try to remove this product after the Order is synced, the app will crash because the **product itemId not synced** (0) will not match with the **product itemId synced**. To prevent this, now the app shows the product detail only to synced items.

### Testing instructions

1. Go to Orders -> Tap on (+) -> Create new order
2. Tap on Add product
3. Select a product, and before the Order is synced, tap on the product again
4. Check that the product is not clickable until the Order is synced.
5. Run tests in OrderCreationViewModelTest

### Images/gif

https://user-images.githubusercontent.com/18119390/167167188-39884664-df97-46e1-88ca-583ba769893c.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.