### PR TITLE
Add env var configuration support for Gradle Enterprise build scans

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -61,8 +61,8 @@ gradleEnterprise {
 
         // Obfuscate personal data
         obfuscation {
-            username { username -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_USERNAME") ?: username.digest('SHA-1') }
-            hostname { _ -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME") ?: "" }
+            username { username -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_USERNAME") ?: username }
+            hostname { hostname -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME") ?: hostname }
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -59,11 +59,13 @@ gradleEnterprise {
         }
         uploadInBackground = System.getenv("CI") == null
 
-        // Obfuscate personal data
-        obfuscation {
-            username { username -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_USERNAME") ?: username }
-            hostname { hostname -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME") ?: hostname }
-            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+        if (!System.getenv().containsKey("CI")) {
+            // Obfuscate personal data unless it's a CI build
+            obfuscation {
+                username { username -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_USERNAME") ?: username }
+                hostname { hostname -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME") ?: hostname }
+                ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+            }
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -70,17 +70,6 @@ gradleEnterprise {
     }
 }
 
-if (System.getenv().containsKey("CI")) {
-    buildCache {
-        remote(HttpBuildCache) {
-            url = "http://10.0.2.215:5071/cache/"
-            allowUntrustedServer = true
-            allowInsecureProtocol = true
-            push = true
-        }
-    }
-}
-
 rootProject.name = 'WCAndroid'
 
 include ':quicklogin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,7 +50,10 @@ gradleEnterprise {
     server = "https://gradle.a8c.com"
     allowUntrustedServer = false
     buildScan {
-        publishAlways()
+        def disableGE = System.getenv("GRADLE_ENTERPRISE_ANALYTICS_DISABLE")
+        if (!(disableGE == "1" || disableGE == "true")) {
+            publishAlways()
+        }
         capture {
             taskInputFiles = true
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -61,8 +61,8 @@ gradleEnterprise {
 
         // Obfuscate personal data
         obfuscation {
-            username { username -> username.digest('SHA-1') }
-            hostname { _ -> "" }
+            username { username -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_USERNAME") ?: username.digest('SHA-1') }
+            hostname { _ -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME") ?: "" }
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
         }
     }


### PR DESCRIPTION
This PR adds support for `GRADLE_ENTERPRISE_ANALYTICS_DISABLE`, `GRADLE_ENTERPRISE_ANALYTICS_USERNAME` & `GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME` env variables and disables build scan obfuscation as requested by @jkmassel.

* If `GRADLE_ENTERPRISE_ANALYTICS_DISABLE` is `true` or `1`, it'll disable GE build scans
* `GRADLE_ENTERPRISE_ANALYTICS_USERNAME` will replace the username that's added to each build scan if it's present
* `GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME` will replace the hostname that's added to each build scan if it's present
* `username` & `hostname` obfuscation is now disabled and will be added to each GE build scan unless `GRADLE_ENTERPRISE_ANALYTICS_USERNAME` or `GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME` env var is present
* **Edit:** It also disables build scan personal data obfuscation for CI builds and removes our custom build caching

**To test**

* Run `./gradlew` and verify that the published build scan includes your `username` & `hostname` (from the `Infrastructure` tab)
* Run `GRADLE_ENTERPRISE_ANALYTICS_DISABLE=true ./gradlew` and verify that it doesn't publish a build scan to GE
* Run `GRADLE_ENTERPRISE_ANALYTICS_USERNAME=example_username GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME=example_hostname ./gradlew` and verify that the `username` & `hostname` in the build scan matches `example_username` & `example_hostname`. (from the `Infrastructure` tab)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
