### PR TITLE
[Coupons] Edit amount

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Coupon.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.parseFromIso8601DateFormat
 import com.woocommerce.android.extensions.parseGmtDateFromIso8601DateFormat
 import kotlinx.parcelize.Parcelize
@@ -34,6 +35,30 @@ data class Coupon(
     val excludedCategories: List<ProductCategory>,
     val restrictedEmails: List<String>
 ) : Parcelable {
+    @Suppress("ComplexMethod")
+    fun isSameCoupon(otherCoupon: Coupon): Boolean {
+        return id == otherCoupon.id &&
+            code == otherCoupon.code &&
+            amount isEqualTo otherCoupon.amount &&
+            type == otherCoupon.type &&
+            description == otherCoupon.description &&
+            dateExpires == otherCoupon.dateExpires &&
+            usageCount == otherCoupon.usageCount &&
+            isForIndividualUse == otherCoupon.isForIndividualUse &&
+            usageLimit == otherCoupon.usageLimit &&
+            usageLimitPerUser == otherCoupon.usageLimitPerUser &&
+            limitUsageToXItems == otherCoupon.limitUsageToXItems &&
+            isShippingFree == otherCoupon.isShippingFree &&
+            areSaleItemsExcluded == otherCoupon.areSaleItemsExcluded &&
+            minimumAmount == otherCoupon.minimumAmount &&
+            maximumAmount == otherCoupon.maximumAmount &&
+            products == otherCoupon.products &&
+            excludedProducts == otherCoupon.excludedProducts &&
+            categories == otherCoupon.categories &&
+            excludedCategories == otherCoupon.excludedCategories &&
+            restrictedEmails == otherCoupon.restrictedEmails
+    }
+
     sealed class Type(open val value: String) : Parcelable {
         companion object {
             fun fromDataModel(dataType: CouponEntity.DiscountType): Type {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -1,19 +1,30 @@
 package com.woocommerce.android.ui.compose.component
 
 import android.content.res.Configuration
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldColors
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -34,9 +45,19 @@ fun WCOutlinedTextField(
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
     isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
 ) {
-    Column(modifier = modifier) {
+    WCOutlinedTextFieldLayout(
+        modifier = modifier,
+        helperText = helperText,
+        isError = isError
+    ) {
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
@@ -50,7 +71,137 @@ fun WCOutlinedTextField(
             trailingIcon = trailingIcon,
             isError = isError,
             colors = colors,
+            visualTransformation = visualTransformation,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            interactionSource = interactionSource
         )
+    }
+}
+
+@Composable
+fun WCOutlinedTextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    helperText: String? = null,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
+) {
+    WCOutlinedTextFieldLayout(
+        modifier = modifier,
+        helperText = helperText,
+        isError = isError
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = {
+                Text(text = label)
+            },
+            enabled = enabled,
+            readOnly = readOnly,
+            modifier = Modifier.fillMaxWidth(),
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            isError = isError,
+            colors = colors,
+            visualTransformation = visualTransformation,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            interactionSource = interactionSource
+        )
+    }
+
+}
+
+@Composable
+fun <T> WCOutlinedTextField(
+    value: T,
+    onValueChange: (T) -> Unit,
+    label: String,
+    parseText: (String) -> T,
+    parseValue: (T) -> String,
+    modifier: Modifier = Modifier,
+    preAdjustText: (TextFieldValue) -> TextFieldValue = { it },
+    helperText: String? = null,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
+) {
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(parseValue(value)))
+    }
+
+    LaunchedEffect(value) {
+        println("LaunchedEffect")
+        if (value != parseText(textFieldValue.text)) {
+            val text = parseValue(value)
+            textFieldValue = TextFieldValue(text, selection = TextRange(text.length))
+        }
+    }
+
+    WCOutlinedTextField(
+        value = textFieldValue,
+        onValueChange = onValueChange@{ updatedValue ->
+            val adjustedText = preAdjustText(updatedValue)
+            runCatching { parseText(adjustedText.text) }
+                .onSuccess {
+                    textFieldValue = adjustedText
+                    onValueChange(it)
+                }
+        },
+        label = label,
+        modifier = modifier,
+        helperText = helperText,
+        enabled = enabled,
+        readOnly = readOnly,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        isError = isError,
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        interactionSource = interactionSource,
+        colors = colors
+    )
+}
+
+@Composable
+private fun WCOutlinedTextFieldLayout(
+    helperText: String? = null,
+    isError: Boolean = false,
+    modifier: Modifier,
+    textField: @Composable () -> Unit
+) {
+    Column(modifier = modifier) {
+        textField()
         if (!helperText.isNullOrEmpty()) {
             Text(
                 text = helperText,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -170,6 +170,7 @@ fun <T> WCOutlinedTextField(
         mutableStateOf(TextFieldValue(parseValue(value)))
     }
 
+    // Monitor value changes, and update text if it's different
     LaunchedEffect(value) {
         if (value != parseText(textFieldValue.text)) {
             val text = parseValue(value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -140,8 +140,8 @@ fun WCOutlinedTextField(
  *        will be ignored.
  * @param parseValue determines how the [T] values should be represented in text.
  * @param preAdjustText an optional function that allows making modifications to the text before parsing it.
- *        This can be useful for cases where we want to disallow empty values, or we want to have advanced handling for
- *        decimals...
+ *        This can be useful for cases when we want to filter the allowed characters, or for advanced text manipulations
+ *        (such as: disallowing empty values, advanced decimal formatting...)
  */
 @Composable
 fun <T> WCOutlinedTextField(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -14,15 +14,10 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextFieldColors
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -130,86 +125,6 @@ fun WCOutlinedTextField(
             interactionSource = interactionSource
         )
     }
-}
-
-/**
- * A generic [OutlinedTextField] that accepts a typed value of type [T], and have a listener that emits values of the
- * same type.
- *
- * @param parseText parses the entered text into a value of type [T], if this throws any exception, the text change
- *        will be ignored.
- * @param parseValue determines how the [T] values should be represented in text.
- * @param preAdjustText an optional function that allows making modifications to the text before parsing it.
- *        This can be useful for cases when we want to filter the allowed characters, or for advanced text manipulations
- *        (such as: disallowing empty values, advanced decimal formatting...)
- */
-@Composable
-fun <T> WCOutlinedTextField(
-    value: T,
-    onValueChange: (T) -> Unit,
-    label: String,
-    parseText: (String) -> T,
-    parseValue: (T) -> String,
-    modifier: Modifier = Modifier,
-    preAdjustText: (String) -> String = { it },
-    helperText: String? = null,
-    enabled: Boolean = true,
-    readOnly: Boolean = false,
-    leadingIcon: @Composable (() -> Unit)? = null,
-    trailingIcon: @Composable (() -> Unit)? = null,
-    isError: Boolean = false,
-    visualTransformation: VisualTransformation = VisualTransformation.None,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    keyboardActions: KeyboardActions = KeyboardActions.Default,
-    singleLine: Boolean = true,
-    maxLines: Int = Int.MAX_VALUE,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
-) {
-    var textFieldValue by remember {
-        mutableStateOf(TextFieldValue(parseValue(value)))
-    }
-
-    // Monitor value changes, and update text if it's different
-    LaunchedEffect(value) {
-        if (value != parseText(textFieldValue.text)) {
-            val text = parseValue(value)
-            textFieldValue = TextFieldValue(text, selection = TextRange(text.length))
-        }
-    }
-
-    WCOutlinedTextField(
-        value = textFieldValue,
-        onValueChange = onValueChange@{ updatedValue ->
-            val adjustedText = preAdjustText(updatedValue.text)
-            runCatching { parseText(adjustedText) }
-                .onSuccess {
-                    textFieldValue = TextFieldValue(
-                        text = adjustedText,
-                        // Update selection to preserve cursor position after text adjustments
-                        selection = TextRange(
-                            updatedValue.selection.start + adjustedText.length - updatedValue.text.length
-                        )
-                    )
-                    onValueChange(it)
-                }
-        },
-        label = label,
-        modifier = modifier,
-        helperText = helperText,
-        enabled = enabled,
-        readOnly = readOnly,
-        leadingIcon = leadingIcon,
-        trailingIcon = trailingIcon,
-        isError = isError,
-        visualTransformation = visualTransformation,
-        keyboardOptions = keyboardOptions,
-        keyboardActions = keyboardActions,
-        singleLine = singleLine,
-        maxLines = maxLines,
-        interactionSource = interactionSource,
-        colors = colors
-    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -151,7 +151,7 @@ fun <T> WCOutlinedTextField(
     parseText: (String) -> T,
     parseValue: (T) -> String,
     modifier: Modifier = Modifier,
-    preAdjustText: (TextFieldValue) -> TextFieldValue = { it },
+    preAdjustText: (String) -> String = { it },
     helperText: String? = null,
     enabled: Boolean = true,
     readOnly: Boolean = false,
@@ -181,10 +181,16 @@ fun <T> WCOutlinedTextField(
     WCOutlinedTextField(
         value = textFieldValue,
         onValueChange = onValueChange@{ updatedValue ->
-            val adjustedText = preAdjustText(updatedValue)
-            runCatching { parseText(adjustedText.text) }
+            val adjustedText = preAdjustText(updatedValue.text)
+            runCatching { parseText(adjustedText) }
                 .onSuccess {
-                    textFieldValue = adjustedText
+                    textFieldValue = TextFieldValue(
+                        text = adjustedText,
+                        // Update selection to preserve cursor position after text adjustments
+                        selection = TextRange(
+                            updatedValue.selection.start + adjustedText.length - updatedValue.text.length
+                        )
+                    )
                     onValueChange(it)
                 }
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -81,6 +81,9 @@ fun WCOutlinedTextField(
     }
 }
 
+/**
+ * An [OutlinedTextField] that displays an optional helper text below the field.
+ */
 @Composable
 fun WCOutlinedTextField(
     value: TextFieldValue,
@@ -130,6 +133,17 @@ fun WCOutlinedTextField(
 
 }
 
+/**
+ * A generic [OutlinedTextField] that accepts a typed value of type [T], and have a listener that emits values of the
+ * same type.
+ *
+ * @param parseText parses the entered text into a value of type [T], if this throws any exception, the text change
+ *        will be ignored.
+ * @param parseValue determines how the [T] values should be represented in text.
+ * @param preAdjustText an optional function that allows making modifications to the text before parsing it.
+ *        This can be useful for cases where we want to disallow empty values, or we want to have advanced handling for
+ *        decimals...
+ */
 @Composable
 fun <T> WCOutlinedTextField(
     value: T,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -130,7 +130,6 @@ fun WCOutlinedTextField(
             interactionSource = interactionSource
         )
     }
-
 }
 
 /**
@@ -172,7 +171,6 @@ fun <T> WCOutlinedTextField(
     }
 
     LaunchedEffect(value) {
-        println("LaunchedEffect")
         if (value != parseText(textFieldValue.text)) {
             val text = parseValue(value)
             textFieldValue = TextFieldValue(text, selection = TextRange(text.length))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -1,0 +1,196 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.TextFieldColors
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import java.math.BigDecimal
+
+/**
+ * A generic [OutlinedTextField] that accepts a typed value of type [T], and have a listener that emits values of the
+ * same type.
+ *
+ * @param valueMapper the [TextFieldValueMapper] to use with this field.
+ */
+@Composable
+fun <T> WCOutlinedTypedTextField(
+    value: T,
+    onValueChange: (T) -> Unit,
+    label: String,
+    valueMapper: TextFieldValueMapper<T>,
+    modifier: Modifier = Modifier,
+    helperText: String? = null,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
+) {
+    var currentValue by remember {
+        mutableStateOf(value)
+    }
+    // Monitor the passed value using the remember's key
+    var textFieldValue by remember(value != currentValue) {
+        currentValue = value
+        mutableStateOf(TextFieldValue(valueMapper.printValue(value)))
+    }
+
+    WCOutlinedTextField(
+        value = textFieldValue,
+        onValueChange = onValueChange@{ updatedValue ->
+            val transformedText = valueMapper.transformText(textFieldValue.text, updatedValue.text)
+            runCatching { valueMapper.parseText(transformedText) }
+                .onSuccess {
+                    textFieldValue = TextFieldValue(
+                        text = transformedText,
+                        // Update selection to preserve cursor position after text transformations
+                        selection = TextRange(
+                            updatedValue.selection.start + transformedText.length - updatedValue.text.length
+                        )
+                    )
+                    currentValue = it
+                    onValueChange(it)
+                }
+        },
+        label = label,
+        modifier = modifier,
+        helperText = helperText,
+        enabled = enabled,
+        readOnly = readOnly,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        isError = isError,
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        interactionSource = interactionSource,
+        colors = colors
+    )
+}
+
+/**
+ * Handles the mapping between the values of type [T] and their text representation, when used in a
+ * typed [WCOutlinedTypedTextField].
+ */
+interface TextFieldValueMapper<T> {
+    /**
+     * Parse the passed [text] into a value of type [T].
+     * When this throws an [Exception], the last text edit will be reverted.
+     */
+    @Throws(Exception::class)
+    fun parseText(text: String): T
+
+    /**
+     * Returns a String representation of the instance [value], as it should be printed to the text field.
+     */
+    fun printValue(value: T): String
+
+    /**
+     * Handles any text transformations before parsing the text.
+     * This can be useful for cases when we want to filter the allowed characters, or for advanced text manipulations
+     * (such as: disallowing empty values, advanced decimal formatting...)
+     */
+    fun transformText(oldText: String, newText: String): String = newText
+}
+
+class BigDecimalTextFieldValueMapper(
+    private val supportsNegativeValue: Boolean = true
+) : TextFieldValueMapper<BigDecimal> {
+    override fun parseText(text: String): BigDecimal = text.toBigDecimal()
+    override fun printValue(value: BigDecimal): String = value.toPlainString()
+    override fun transformText(oldText: String, newText: String): String {
+        val clearedText = if (!supportsNegativeValue) newText.filter { it != '-' } else newText
+        return when {
+            clearedText.isEmpty() || clearedText == "-" -> "0"
+            clearedText.matches("^-?0+\\d".toRegex()) ->
+                // Delete any leading 0s, since this field can't be cleared
+                clearedText.replace("^(-?)0+".toRegex(), "$1")
+            clearedText.toBigDecimalOrNull() != null -> clearedText
+            else -> oldText
+        }
+    }
+}
+
+class NullableBigDecimalTextFieldValueMapper(
+    private val supportsNegativeValue: Boolean = true
+) : TextFieldValueMapper<BigDecimal?> {
+    override fun parseText(text: String): BigDecimal? = text.toBigDecimalOrNull()
+    override fun printValue(value: BigDecimal?): String = value?.toPlainString().orEmpty()
+    override fun transformText(oldText: String, newText: String): String {
+        val clearedText = if (!supportsNegativeValue) newText.filter { it != '-' } else newText
+        return when {
+            clearedText.isEmpty() || clearedText == "-" || clearedText == "." -> clearedText
+            clearedText.toBigDecimalOrNull() != null -> clearedText
+            else -> oldText
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewTypedTextFields() {
+    WooThemeWithBackground {
+        Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            var signedDecimal by remember {
+                mutableStateOf(BigDecimal.ZERO)
+            }
+
+            WCOutlinedTypedTextField(
+                value = signedDecimal,
+                onValueChange = { signedDecimal = it },
+                label = "Signed BigDecimal",
+                valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = true),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            )
+
+            var nonSignedDecimal by remember {
+                mutableStateOf(BigDecimal.ZERO)
+            }
+            WCOutlinedTypedTextField(
+                value = nonSignedDecimal,
+                onValueChange = { nonSignedDecimal = it },
+                label = "Non-signed BigDecimal",
+                valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            )
+
+            var optionalDecimal by remember {
+                mutableStateOf<BigDecimal?>(null)
+            }
+            WCOutlinedTypedTextField(
+                value = optionalDecimal,
+                onValueChange = { optionalDecimal = it },
+                label = "Optional BigDecimal",
+                valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = true),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -79,7 +79,7 @@ fun <T> WCOutlinedTypedTextField(
                                 .coerceIn(0, transformedText.length)
                         )
                     )
-                    if (currentValue != it) {
+                    if (!valueMapper.equals(currentValue, it)) {
                         currentValue = it
                         onValueChange(it)
                     }
@@ -126,6 +126,19 @@ interface TextFieldValueMapper<T> {
      * (such as: disallowing empty values, advanced decimal formatting...)
      */
     fun transformText(oldText: String, newText: String): String = newText
+
+    /**
+     * Checks whether the old value that the text field had [oldValue] equals the [newValue]
+     * The Text field won't emit changes until the values are different
+     */
+    fun equals(oldValue: T, newValue: T): Boolean {
+        return if (oldValue is Comparable<*> && newValue != null) {
+            @Suppress("UNCHECKED_CAST")
+            (oldValue as Comparable<Any>).compareTo(newValue) == 0
+        } else {
+            oldValue == newValue
+        }
+    }
 }
 
 class BigDecimalTextFieldValueMapper(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -74,7 +74,8 @@ fun <T> WCOutlinedTypedTextField(
                         text = transformedText,
                         // Update selection to preserve cursor position after text transformations
                         selection = TextRange(
-                            updatedValue.selection.start + transformedText.length - updatedValue.text.length
+                            (updatedValue.selection.start + transformedText.length - updatedValue.text.length)
+                                .coerceIn(0, transformedText.length)
                         )
                     )
                     if (currentValue != it) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -63,6 +63,10 @@ fun <T> WCOutlinedTypedTextField(
     WCOutlinedTextField(
         value = textFieldValue,
         onValueChange = onValueChange@{ updatedValue ->
+            if (updatedValue.text == textFieldValue.text) {
+                textFieldValue = updatedValue
+                return@onValueChange
+            }
             val transformedText = valueMapper.transformText(textFieldValue.text, updatedValue.text)
             runCatching { valueMapper.parseText(transformedText) }
                 .onSuccess {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -77,8 +77,10 @@ fun <T> WCOutlinedTypedTextField(
                             updatedValue.selection.start + transformedText.length - updatedValue.text.length
                         )
                     )
-                    currentValue = it
-                    onValueChange(it)
+                    if (currentValue != it) {
+                        currentValue = it
+                        onValueChange(it)
+                    }
                 }
         },
         label = label,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -72,6 +72,7 @@ fun <T> WCOutlinedTypedTextField(
                 .onSuccess {
                     textFieldValue = TextFieldValue(
                         text = transformedText,
+                        composition = updatedValue.composition,
                         // Update selection to preserve cursor position after text transformations
                         selection = TextRange(
                             (updatedValue.selection.start + transformedText.length - updatedValue.text.length)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -17,7 +17,12 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -22,15 +22,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.model.Coupon.Type
 import com.woocommerce.android.model.Coupon.Type.Percent
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
@@ -96,28 +95,7 @@ private fun DetailsSection(
             style = MaterialTheme.typography.body2,
             color = colorResource(id = R.color.color_on_surface_medium)
         )
-        WCOutlinedTextField(
-            value = couponDraft.amount ?: BigDecimal.ZERO,
-            label = stringResource(id = string.coupon_edit_amount_hint, viewState.amountUnit),
-            parseText = { it.toBigDecimal() },
-            parseValue = { it.toPlainString() },
-            preAdjustText = { value ->
-                when {
-                    value.text.isEmpty() -> TextFieldValue("0", selection = TextRange(1))
-                    value.text.matches(Regex("^0\\d")) -> value.copy(text = value.text.trimStart('0'))
-                    else -> value.copy(text = value.text.filter { it != '-' })
-                }
-            },
-            onValueChange = onAmountChanged,
-            helperText = stringResource(
-                if (couponDraft.type is Percent) string.coupon_edit_amount_percentage_helper
-                else string.coupon_edit_amount_rate_helper
-            ),
-            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
-            //  (https://issuetracker.google.com/issues/209835363)
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
+        AmountField(viewState.couponDraft.amount, viewState.amountUnit, viewState.couponDraft.type, onAmountChanged)
         WCOutlinedTextField(
             value = couponDraft.code.orEmpty(),
             label = stringResource(id = string.coupon_edit_code_hint),
@@ -163,6 +141,32 @@ private fun ConditionsSection(viewState: EditCouponViewModel.ViewState) {
 @Suppress("UnusedPrivateMember")
 private fun UsageRestrictionsSection(viewState: EditCouponViewModel.ViewState) {
     /*TODO*/
+}
+
+@Composable
+private fun AmountField(amount: BigDecimal?, amountUnit: String, type: Type?, onAmountChanged: (BigDecimal?) -> Unit) {
+    WCOutlinedTextField(
+        value = amount ?: BigDecimal.ZERO,
+        label = stringResource(id = string.coupon_edit_amount_hint, amountUnit),
+        parseText = { it.toBigDecimal() },
+        parseValue = { it.toPlainString() },
+        preAdjustText = { text ->
+            when {
+                text.isEmpty() -> "0"
+                text.matches(Regex("^0\\d")) -> text.trimStart('0')
+                else -> text.filter { it != '-' }
+            }
+        },
+        onValueChange = onAmountChanged,
+        helperText = stringResource(
+            if (type is Percent) string.coupon_edit_amount_percentage_helper
+            else string.coupon_edit_amount_rate_helper
+        ),
+        // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+        //  (https://issuetracker.google.com/issues/209835363)
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        modifier = Modifier.fillMaxWidth()
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -101,11 +101,11 @@ private fun DetailsSection(
             label = stringResource(id = string.coupon_edit_amount_hint, viewState.amountUnit),
             parseText = { it.toBigDecimal() },
             parseValue = { it.toPlainString() },
-            preAdjustText = {
+            preAdjustText = { value ->
                 when {
-                    it.text.isEmpty() -> TextFieldValue("0", selection = TextRange(1))
-                    it.text.matches(Regex("^0\\d")) -> it.copy(text = it.text.trimStart('0'))
-                    else -> it
+                    value.text.isEmpty() -> TextFieldValue("0", selection = TextRange(1))
+                    value.text.matches(Regex("^0\\d")) -> value.copy(text = value.text.trimStart('0'))
+                    else -> value.copy(text = value.text.filter { it != '-' })
                 }
             },
             onValueChange = onAmountChanged,
@@ -113,6 +113,8 @@ private fun DetailsSection(
                 if (couponDraft.type is Percent) string.coupon_edit_amount_percentage_helper
                 else string.coupon_edit_amount_rate_helper
             ),
+            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+            //  (https://issuetracker.google.com/issues/209835363)
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier.fillMaxWidth()
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -31,10 +31,12 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.Coupon.Type
 import com.woocommerce.android.model.Coupon.Type.Percent
+import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import java.math.BigDecimal
@@ -145,18 +147,10 @@ private fun UsageRestrictionsSection(viewState: EditCouponViewModel.ViewState) {
 
 @Composable
 private fun AmountField(amount: BigDecimal?, amountUnit: String, type: Type?, onAmountChanged: (BigDecimal?) -> Unit) {
-    WCOutlinedTextField(
+    WCOutlinedTypedTextField(
         value = amount ?: BigDecimal.ZERO,
         label = stringResource(id = string.coupon_edit_amount_hint, amountUnit),
-        parseText = { it.toBigDecimal() },
-        parseValue = { it.toPlainString() },
-        preAdjustText = { text ->
-            when {
-                text.isEmpty() -> "0"
-                text.matches(Regex("^0\\d")) -> text.trimStart('0')
-                else -> text.filter { it != '-' }
-            }
-        },
+        valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = true),
         onValueChange = onAmountChanged,
         helperText = stringResource(
             if (type is Percent) string.coupon_edit_amount_percentage_helper

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -79,6 +79,7 @@ fun EditCouponScreen(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun DetailsSection(
     viewState: EditCouponViewModel.ViewState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -82,7 +82,7 @@ private fun DetailsSection(viewState: EditCouponViewModel.ViewState) {
         )
         WCOutlinedTextField(
             value = couponDraft.amount?.toPlainString().orEmpty(),
-            label = stringResource(id = R.string.coupon_edit_amount_hint, "%"/*TODO*/),
+            label = stringResource(id = R.string.coupon_edit_amount_hint, viewState.amountUnit),
             onValueChange = { /*TODO*/ },
             helperText = stringResource(
                 if (couponDraft.type is Coupon.Type.Percent) R.string.coupon_edit_amount_percentage_helper
@@ -154,6 +154,7 @@ fun EditCouponPreview() {
                     restrictedEmails = emptyList()
                 ),
                 localizedType = "Fixed Rate Discount",
+                amountUnit = "%",
                 hasChanges = true
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -61,7 +61,8 @@ fun EditCouponScreen(viewState: EditCouponViewModel.ViewState) {
         WCColoredButton(
             onClick = { /*TODO*/ },
             text = stringResource(id = R.string.coupon_edit_save_button),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            enabled = viewState.hasChanges
         )
     }
 }
@@ -152,7 +153,8 @@ fun EditCouponPreview() {
                     excludedCategories = emptyList(),
                     restrictedEmails = emptyList()
                 ),
-                localizedType = "Fixed Rate Discount"
+                localizedType = "Fixed Rate Discount",
+                hasChanges = true
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -16,7 +16,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -56,6 +58,12 @@ class EditCouponViewModel @Inject constructor(
             launch {
                 couponDraft.value = storedCoupon.await()
             }
+        }
+    }
+
+    fun onAmountChanged(value: BigDecimal?) {
+        couponDraft.update {
+            it!!.copy(amount = value)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -36,7 +36,8 @@ class EditCouponViewModel @Inject constructor(
         .map { coupon ->
             ViewState(
                 couponDraft = coupon,
-                localizedType = coupon.type?.let { couponUtils.localizeType(it) }
+                localizedType = coupon.type?.let { couponUtils.localizeType(it) },
+                hasChanges = coupon != storedCoupon.await()
             )
         }
         .asLiveData()
@@ -51,6 +52,7 @@ class EditCouponViewModel @Inject constructor(
 
     data class ViewState(
         val couponDraft: Coupon,
-        val localizedType: String?
+        val localizedType: String?,
+        val hasChanges: Boolean
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -63,7 +63,7 @@ class EditCouponViewModel @Inject constructor(
 
     fun onAmountChanged(value: BigDecimal?) {
         couponDraft.update {
-            it!!.copy(amount = value)
+            it?.copy(amount = value)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -48,7 +48,7 @@ class EditCouponViewModel @Inject constructor(
                 couponDraft = coupon,
                 localizedType = coupon.type?.let { couponUtils.localizeType(it) },
                 amountUnit = if (coupon.type == Coupon.Type.Percent) "%" else currencyCode,
-                hasChanges = coupon != storedCoupon.await()
+                hasChanges = !coupon.isSameCoupon(storedCoupon.await())
             )
         }
         .asLiveData()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModelTest.kt
@@ -7,7 +7,9 @@ import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.coupons.CouponRepository
 import com.woocommerce.android.ui.coupons.CouponTestUtils
-import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.*
+import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponDetailsState
+import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponPerformanceState
+import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponPerformanceUi
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.InlineClassesAnswer
@@ -21,7 +23,14 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCSettingsModel
 import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5536 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds support for editing the coupon's amount, and the list of changes is:
1. Add a `hasChanges` property to the ViewModel, and update the Save button depending on its value.
2. Update the amount unit depending on the coupon type.
3. Add some overloads for WCOutlinedTextField to support more advanced scenarios, and a specific component version that allows typed values.
4. Handle the amount edition.

### Testing instructions
1. Make sure the coupons beta toggle is enabled.
2. Open the app, then click on More menu, then coupons.
3. Click on one of the coupons.
4. Click on Menu, then select "edit".
5. Confirm the "Save" button is disabled.
6. Update the content of the amount field.
7. Make sure to test the field properly: handling of cursor position, allowed characters, backspace behavior...
8. Confirm that the "Save" button gets enabled when the amount is different than what the coupon had.

### Images/gif
https://user-images.githubusercontent.com/1657201/167250737-fa40579b-081e-4aab-95eb-02ce540a24de.mov

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
