### PR TITLE
Issue/6392 auto focus order creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/EditTextExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/EditTextExt.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.extensions
+
+import android.widget.EditText
+import org.wordpress.android.util.ActivityUtils
+
+/**
+ * Useful for showing the soft keyboard when the user enters a fragment
+ */
+fun EditText.showKeyboardWithDelay(delayMs: Long = DEFAULT_KEYBOARD_DELAY) {
+    requestFocus()
+    postDelayed(
+        {
+            ActivityUtils.showKeyboard(this)
+        }, delayMs
+    )
+}
+
+private const val DEFAULT_KEYBOARD_DELAY = 500L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreationFeeBinding
 import com.woocommerce.android.extensions.drop
 import com.woocommerce.android.extensions.filterNotNull
+import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel
@@ -44,6 +45,10 @@ class OrderCreationFeeFragment :
             bindViews()
             observeEvents()
             observeViewStateData()
+
+            if (savedInstanceState == null) {
+                feeAmountEditText.editText.showKeyboardWithDelay()
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/notes/OrderCreationCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/notes/OrderCreationCustomerNoteFragment.kt
@@ -10,6 +10,7 @@ import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditCustomerOrderNoteBinding
+import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel
 
@@ -29,6 +30,7 @@ class OrderCreationCustomerNoteFragment : BaseFragment(R.layout.fragment_edit_cu
         _binding = FragmentEditCustomerOrderNoteBinding.bind(view)
         if (savedInstanceState == null) {
             binding.customerOrderNoteEditor.setText(sharedViewModel.currentDraft.customerNote)
+            binding.customerOrderNoteEditor.showKeyboardWithDelay()
         }
         binding.customerOrderNoteEditor.doAfterTextChanged {
             if (::doneMenuItem.isInitialized) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderCreationShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderCreationShippingFragment.kt
@@ -36,6 +36,10 @@ class OrderCreationShippingFragment : BaseFragment(R.layout.fragment_order_creat
         val binding = FragmentOrderCreationShippingBinding.bind(view)
         binding.initUi()
         setupObservers(binding)
+
+        if (savedInstanceState == null) {
+            binding.amountEditText.editText.showKeyboardWithDelay()
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -64,8 +68,6 @@ class OrderCreationShippingFragment : BaseFragment(R.layout.fragment_order_creat
         removeShippingButton.setOnClickListener {
             viewModel.onRemoveShippingClicked()
         }
-
-        amountEditText.editText.showKeyboardWithDelay()
     }
 
     private fun setupObservers(binding: FragmentOrderCreationShippingBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderCreationShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderCreationShippingFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreationShippingBinding
 import com.woocommerce.android.extensions.drop
 import com.woocommerce.android.extensions.filterNotNull
+import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel
@@ -63,6 +64,8 @@ class OrderCreationShippingFragment : BaseFragment(R.layout.fragment_order_creat
         removeShippingButton.setOnClickListener {
             viewModel.onRemoveShippingClicked()
         }
+
+        amountEditText.editText.showKeyboardWithDelay()
     }
 
     private fun setupObservers(binding: FragmentOrderCreationShippingBinding) {


### PR DESCRIPTION
Closes #6392 by automatically showing the soft keyboard when entering the order creation shipping, fee, and customer note screens. 

Note that the issue only mentions shipping, but I assumed if we want to show the keyboard there we'd want to in other screens as well. I chose not to automatically show the keyboard when entering the customer detail screen because I wasn't convinced the user would want the customer first name focused, but I could easily be convinced otherwise.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.