### PR TITLE
Issue/6209 order creation fee done button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeFragment.kt
@@ -37,6 +37,8 @@ class OrderCreationFeeFragment :
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
+    private var doneMenuItem: MenuItem? = null
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
@@ -51,6 +53,8 @@ class OrderCreationFeeFragment :
         super.onCreateOptionsMenu(menu, inflater)
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
+        doneMenuItem = menu.findItem(R.id.menu_done)
+        doneMenuItem?.isEnabled = editFeeViewModel.viewStateData.liveData.value!!.isDoneButtonEnabled
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -109,6 +113,9 @@ class OrderCreationFeeFragment :
                 feePercentageCalculatedAmount.isVisible = isChecked
                 feeAmountEditText.isVisible = isChecked.not()
                 feeTypeSwitch.isChecked = isChecked
+            }
+            new.isDoneButtonEnabled.takeIfNotEqualTo(old?.isDoneButtonEnabled) {
+                doneMenuItem?.isEnabled = it
             }
             new.shouldDisplayRemoveFeeButton.takeIfNotEqualTo(old?.shouldDisplayRemoveFeeButton) {
                 removeFeeButton.isVisible = it

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeFragment.kt
@@ -54,7 +54,7 @@ class OrderCreationFeeFragment :
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
-        doneMenuItem?.isEnabled = editFeeViewModel.viewStateData.liveData.value!!.isDoneButtonEnabled
+        doneMenuItem?.isEnabled = editFeeViewModel.viewStateData.liveData.value?.isDoneButtonEnabled ?: false
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModel.kt
@@ -86,10 +86,11 @@ class OrderCreationFeeViewModel @Inject constructor(
         // Only update when isPercentageSelected is enabled
         if (!viewState.isPercentageSelected) return
         val feePercentage = feePercentageRaw.toBigDecimalOrNull() ?: BigDecimal.ZERO
+        val feeAmount = calculateFeePercentage(feePercentage)
         viewState = viewState.copy(
             feePercentage = feePercentage,
-            feeAmount = calculateFeePercentage(feePercentage),
-            isDoneButtonEnabled = feePercentage > BigDecimal.ZERO
+            feeAmount = feeAmount,
+            isDoneButtonEnabled = feeAmount > BigDecimal.ZERO
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModel.kt
@@ -47,7 +47,7 @@ class OrderCreationFeeViewModel @Inject constructor(
                 shouldDisplayPercentageSwitch = false,
                 feeAmount = currentFee,
                 feePercentage = calculatePercentageFromValue(currentFee),
-                isDoneButtonEnabled = currentFee > BigDecimal.ZERO,
+                isDoneButtonEnabled = shouldEnableDoneButtonForAmount(currentFee),
                 shouldDisplayRemoveFeeButton = true
             )
         } ?: run {
@@ -78,7 +78,7 @@ class OrderCreationFeeViewModel @Inject constructor(
         viewState = viewState.copy(
             feeAmount = feeAmount,
             feePercentage = calculatePercentageFromValue(feeAmount),
-            isDoneButtonEnabled = feeAmount > BigDecimal.ZERO
+            isDoneButtonEnabled = shouldEnableDoneButtonForAmount(feeAmount)
         )
     }
 
@@ -90,9 +90,11 @@ class OrderCreationFeeViewModel @Inject constructor(
         viewState = viewState.copy(
             feePercentage = feePercentage,
             feeAmount = feeAmount,
-            isDoneButtonEnabled = feeAmount > BigDecimal.ZERO
+            isDoneButtonEnabled = shouldEnableDoneButtonForAmount(feeAmount)
         )
     }
+
+    private fun shouldEnableDoneButtonForAmount(amount: BigDecimal) = amount != BigDecimal.ZERO
 
     @Parcelize
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModel.kt
@@ -47,6 +47,7 @@ class OrderCreationFeeViewModel @Inject constructor(
                 shouldDisplayPercentageSwitch = false,
                 feeAmount = currentFee,
                 feePercentage = calculatePercentageFromValue(currentFee),
+                isDoneButtonEnabled = currentFee > BigDecimal.ZERO,
                 shouldDisplayRemoveFeeButton = true
             )
         } ?: run {
@@ -76,7 +77,8 @@ class OrderCreationFeeViewModel @Inject constructor(
         if (viewState.isPercentageSelected) return
         viewState = viewState.copy(
             feeAmount = feeAmount,
-            feePercentage = calculatePercentageFromValue(feeAmount)
+            feePercentage = calculatePercentageFromValue(feeAmount),
+            isDoneButtonEnabled = feeAmount > BigDecimal.ZERO
         )
     }
 
@@ -86,7 +88,8 @@ class OrderCreationFeeViewModel @Inject constructor(
         val feePercentage = feePercentageRaw.toBigDecimalOrNull() ?: BigDecimal.ZERO
         viewState = viewState.copy(
             feePercentage = feePercentage,
-            feeAmount = calculateFeePercentage(feePercentage)
+            feeAmount = calculateFeePercentage(feePercentage),
+            isDoneButtonEnabled = feePercentage > BigDecimal.ZERO
         )
     }
 
@@ -95,6 +98,7 @@ class OrderCreationFeeViewModel @Inject constructor(
         val feeAmount: BigDecimal = BigDecimal.ZERO,
         val feePercentage: BigDecimal = BigDecimal.ZERO,
         val isPercentageSelected: Boolean = false,
+        val isDoneButtonEnabled: Boolean = false,
         val shouldDisplayRemoveFeeButton: Boolean = false,
         val shouldDisplayPercentageSwitch: Boolean = false
     ) : Parcelable

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModelTest.kt
@@ -301,7 +301,6 @@ class OrderCreationFeeViewModelTest : BaseUnitTest() {
         assertThat(lastReceivedChange).isTrue
     }
 
-
     @Test
     fun `when fee value start as zero, then set isDoneButtonEnabled to false`() {
         var lastReceivedChange: Boolean? = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreationFeeViewModelTest.kt
@@ -300,4 +300,103 @@ class OrderCreationFeeViewModelTest : BaseUnitTest() {
 
         assertThat(lastReceivedChange).isTrue
     }
+
+
+    @Test
+    fun `when fee value start as zero, then set isDoneButtonEnabled to false`() {
+        var lastReceivedChange: Boolean? = null
+        savedState = OrderCreationFeeFragmentArgs(BigDecimal.ZERO, BigDecimal.ZERO)
+            .initSavedStateHandle()
+        initSut()
+
+        sut.viewStateData.observeForever { _, viewState ->
+            lastReceivedChange = viewState.isDoneButtonEnabled
+        }
+
+        assertThat(lastReceivedChange).isFalse
+    }
+
+    @Test
+    fun `when fee value starts as bigger than zero, then set isDoneButtonEnabled to true`() {
+        var lastReceivedChange: Boolean? = null
+        savedState = OrderCreationFeeFragmentArgs(DEFAULT_ORDER_SUB_TOTAL, DEFAULT_FEE_VALUE)
+            .initSavedStateHandle()
+        initSut()
+
+        sut.viewStateData.observeForever { _, viewState ->
+            lastReceivedChange = viewState.isDoneButtonEnabled
+        }
+
+        assertThat(lastReceivedChange).isTrue
+    }
+
+    @Test
+    fun `when fee value starts as negative amount, then set isDoneButtonEnabled to true`() {
+        var lastReceivedChange: Boolean? = null
+        savedState = OrderCreationFeeFragmentArgs(DEFAULT_ORDER_SUB_TOTAL, BigDecimal(-25))
+            .initSavedStateHandle()
+        initSut()
+
+        sut.viewStateData.observeForever { _, viewState ->
+            lastReceivedChange = viewState.isDoneButtonEnabled
+        }
+
+        assertThat(lastReceivedChange).isTrue
+    }
+
+    @Test
+    fun `when fee amount is set to a negative value, then set isDoneButtonEnabled to true`() {
+        var lastReceivedChange: Boolean? = null
+        savedState = OrderCreationFeeFragmentArgs(DEFAULT_ORDER_SUB_TOTAL, DEFAULT_FEE_VALUE)
+            .initSavedStateHandle()
+        initSut()
+
+        sut.viewStateData.observeForever { _, viewState ->
+            lastReceivedChange = viewState.isDoneButtonEnabled
+        }
+
+        assertThat(lastReceivedChange).isTrue
+
+        sut.onFeeAmountChanged(BigDecimal(-25))
+
+        assertThat(lastReceivedChange).isTrue
+    }
+
+    @Test
+    fun `when fee amount is set to zero, then set isDoneButtonEnabled to false`() {
+        var lastReceivedChange: Boolean? = null
+        savedState = OrderCreationFeeFragmentArgs(DEFAULT_ORDER_SUB_TOTAL, DEFAULT_FEE_VALUE)
+            .initSavedStateHandle()
+        initSut()
+
+        sut.viewStateData.observeForever { _, viewState ->
+            lastReceivedChange = viewState.isDoneButtonEnabled
+        }
+
+        assertThat(lastReceivedChange).isTrue
+
+        sut.onFeeAmountChanged(BigDecimal.ZERO)
+
+        assertThat(lastReceivedChange).isFalse
+    }
+
+    @Test
+    fun `when fee percentage is set to zero, then set isDoneButtonEnabled to false`() {
+        var lastReceivedChange: Boolean? = null
+        savedState = OrderCreationFeeFragmentArgs(DEFAULT_ORDER_SUB_TOTAL, DEFAULT_FEE_VALUE)
+            .initSavedStateHandle()
+        initSut()
+
+        sut.viewStateData.observeForever { _, viewState ->
+            lastReceivedChange = viewState.isDoneButtonEnabled
+        }
+
+        assertThat(lastReceivedChange).isTrue
+
+        sut.onPercentageSwitchChanged(true)
+
+        sut.onFeePercentageChanged("0")
+
+        assertThat(lastReceivedChange).isFalse
+    }
 }


### PR DESCRIPTION
Closes #6209 - previously when adding a fee in order creation, the Done button would be enabled even when the fee is zero. In this situation, tapping "Done" doesn't show any fee added to the order, but the order acts like the fee was added (it syncs remotely and shows the "remove fee" option when you visit the Add Fee screen again).

This PR resolves this by disabling the Done button when the fee is zero.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
