### PR TITLE
[Coupons] Display amount unformatted for custom discount types

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -23,7 +23,7 @@ class CouponUtils @Inject constructor(
     }
 
     fun generateSummary(coupon: Coupon, currencyCode: String?): String {
-        val amount = formatDiscount(coupon.amount, coupon.type, currencyCode)
+        val amount = coupon.amount?.let { formatDiscount(it, coupon.type, currencyCode) }.orEmpty()
         val affectedArticles = formatAffectedArticles(
             coupon.products.size,
             coupon.excludedProducts.size,
@@ -144,13 +144,14 @@ class CouponUtils @Inject constructor(
     }
 
     private fun formatDiscount(
-        amount: BigDecimal?,
+        amount: BigDecimal,
         couponType: Coupon.Type?,
         currencyCode: String?
     ): String {
         return when (couponType) {
-            Coupon.Type.Percent -> "$amount%"
-            else -> formatCurrency(amount, currencyCode)
+            Coupon.Type.Percent -> "${amount.toPlainString()}%"
+            Coupon.Type.FixedCart, Coupon.Type.FixedProduct -> formatCurrency(amount, currencyCode)
+            else -> amount.toPlainString()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6467 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates logic of formatting the coupon's amount to display the amount unformatted for custom coupon types.

### Testing instructions
1. Create a coupon with a custom type (if you use WooCommerce subscriptions, it will add some custom types automatically).
2. Open the coupon list in the app.
3. Confirm the amount of this coupon is unformatted.
4. Open the coupon details.
5. Confirm the amount is unformatted as well.

### Images/gif
<img width="398" alt="Screen Shot 2022-05-09 at 13 37 47" src="https://user-images.githubusercontent.com/1657201/167411444-55c9c3d4-849a-423b-8663-3dd43b29d291.png">
<img width="398" alt="Screen Shot 2022-05-09 at 13 38 22" src="https://user-images.githubusercontent.com/1657201/167411459-6ddf3216-a8b1-49f7-a416-6da873e07bea.png">
up


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
