### PR TITLE
[Coupons] Edit code

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -22,8 +22,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toLowerCase
 import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
@@ -104,11 +106,13 @@ private fun DetailsSection(
             color = colorResource(id = R.color.color_on_surface_medium)
         )
         AmountField(viewState.couponDraft.amount, viewState.amountUnit, viewState.couponDraft.type, onAmountChanged)
+        // Coupon code field: display code uppercased, but always return it lowercased
         WCOutlinedTextField(
-            value = couponDraft.code.orEmpty(),
+            value = couponDraft.code.orEmpty().toUpperCase(Locale.current),
             label = stringResource(id = string.coupon_edit_code_hint),
-            onValueChange = onCouponCodeChanged,
+            onValueChange = { onCouponCodeChanged(it.toLowerCase(Locale.current)) },
             helperText = stringResource(id = string.coupon_edit_code_helper),
+            keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
             modifier = Modifier.fillMaxWidth()
         )
         WCTextButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -95,6 +96,7 @@ private fun DetailsSection(
     onRegenerateCodeClick: () -> Unit
 ) {
     val couponDraft = viewState.couponDraft
+    val focusManager = LocalFocusManager.current
     Column(
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
         modifier = Modifier
@@ -116,7 +118,10 @@ private fun DetailsSection(
             modifier = Modifier.fillMaxWidth()
         )
         WCTextButton(
-            onClick = onRegenerateCodeClick,
+            onClick = {
+                focusManager.clearFocus()
+                onRegenerateCodeClick()
+            },
             text = stringResource(id = R.string.coupon_edit_regenerate_coupon)
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -46,7 +46,8 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
     viewModel.viewState.observeAsState().value?.let {
         EditCouponScreen(
             viewState = it,
-            onAmountChanged = viewModel::onAmountChanged
+            onAmountChanged = viewModel::onAmountChanged,
+            onCouponCodeChanged = viewModel::onCouponCodeChanged
         )
     }
 }
@@ -54,7 +55,8 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
 @Composable
 fun EditCouponScreen(
     viewState: EditCouponViewModel.ViewState,
-    onAmountChanged: (BigDecimal?) -> Unit
+    onAmountChanged: (BigDecimal?) -> Unit = {},
+    onCouponCodeChanged: (String) -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -68,7 +70,7 @@ fun EditCouponScreen(
             )
             .fillMaxSize()
     ) {
-        DetailsSection(viewState, onAmountChanged)
+        DetailsSection(viewState, onAmountChanged, onCouponCodeChanged)
         ConditionsSection(viewState)
         UsageRestrictionsSection(viewState)
         WCColoredButton(
@@ -84,7 +86,8 @@ fun EditCouponScreen(
 @Composable
 private fun DetailsSection(
     viewState: EditCouponViewModel.ViewState,
-    onAmountChanged: (BigDecimal?) -> Unit
+    onAmountChanged: (BigDecimal?) -> Unit,
+    onCouponCodeChanged: (String) -> Unit
 ) {
     val couponDraft = viewState.couponDraft
     Column(
@@ -101,7 +104,7 @@ private fun DetailsSection(
         WCOutlinedTextField(
             value = couponDraft.code.orEmpty(),
             label = stringResource(id = string.coupon_edit_code_hint),
-            onValueChange = { /*TODO*/ },
+            onValueChange = onCouponCodeChanged,
             helperText = stringResource(id = string.coupon_edit_code_helper),
             modifier = Modifier.fillMaxWidth()
         )
@@ -182,8 +185,7 @@ fun EditCouponPreview() {
                 localizedType = "Fixed Rate Discount",
                 amountUnit = "%",
                 hasChanges = true
-            ),
-            onAmountChanged = {}
+            )
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -47,7 +47,8 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
         EditCouponScreen(
             viewState = it,
             onAmountChanged = viewModel::onAmountChanged,
-            onCouponCodeChanged = viewModel::onCouponCodeChanged
+            onCouponCodeChanged = viewModel::onCouponCodeChanged,
+            onRegenerateCodeClick = viewModel::onRegenerateCodeClick
         )
     }
 }
@@ -56,7 +57,8 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
 fun EditCouponScreen(
     viewState: EditCouponViewModel.ViewState,
     onAmountChanged: (BigDecimal?) -> Unit = {},
-    onCouponCodeChanged: (String) -> Unit = {}
+    onCouponCodeChanged: (String) -> Unit = {},
+    onRegenerateCodeClick: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -70,7 +72,7 @@ fun EditCouponScreen(
             )
             .fillMaxSize()
     ) {
-        DetailsSection(viewState, onAmountChanged, onCouponCodeChanged)
+        DetailsSection(viewState, onAmountChanged, onCouponCodeChanged, onRegenerateCodeClick)
         ConditionsSection(viewState)
         UsageRestrictionsSection(viewState)
         WCColoredButton(
@@ -87,7 +89,8 @@ fun EditCouponScreen(
 private fun DetailsSection(
     viewState: EditCouponViewModel.ViewState,
     onAmountChanged: (BigDecimal?) -> Unit,
-    onCouponCodeChanged: (String) -> Unit
+    onCouponCodeChanged: (String) -> Unit,
+    onRegenerateCodeClick: () -> Unit
 ) {
     val couponDraft = viewState.couponDraft
     Column(
@@ -109,7 +112,7 @@ private fun DetailsSection(
             modifier = Modifier.fillMaxWidth()
         )
         WCTextButton(
-            onClick = { /*TODO*/ },
+            onClick = onRegenerateCodeClick,
             text = stringResource(id = R.string.coupon_edit_regenerate_coupon)
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -73,6 +73,13 @@ class EditCouponViewModel @Inject constructor(
         }
     }
 
+    fun onRegenerateCodeClick() {
+        val newCode = couponUtils.generateRandomCode()
+        couponDraft.update {
+            it?.copy(code = newCode)
+        }
+    }
+
     data class ViewState(
         val couponDraft: Coupon,
         val localizedType: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -67,6 +67,12 @@ class EditCouponViewModel @Inject constructor(
         }
     }
 
+    fun onCouponCodeChanged(code: String) {
+        couponDraft.update {
+            it?.copy(code = code)
+        }
+    }
+
     data class ViewState(
         val couponDraft: Coupon,
         val localizedType: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -220,6 +220,7 @@ class CouponUtils @Inject constructor(
      * Generate a random coupon code following the same logic as Core
      * https://github.com/woocommerce/woocommerce/blob/2e60d47a019a6e35f066f3ef43a56c0e761fc8e3/includes/admin/class-wc-admin-assets.php#L295
      */
+    @Suppress("MagicNumber")
     fun generateRandomCode(): String {
         val availableCharacters = "abcdefghjkmnpqrstuvwxyz23456789".toCharArray()
         val codeLength = 8

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -221,7 +221,7 @@ class CouponUtils @Inject constructor(
      * https://github.com/woocommerce/woocommerce/blob/2e60d47a019a6e35f066f3ef43a56c0e761fc8e3/includes/admin/class-wc-admin-assets.php#L295
      */
     fun generateRandomCode(): String {
-        val availableCharacters = "ABCDEFGHJKMNPQRSTUVWXYZ23456789".toCharArray()
+        val availableCharacters = "abcdefghjkmnpqrstuvwxyz23456789".toCharArray()
         val codeLength = 8
         return String(
             (1..codeLength).map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -215,4 +215,18 @@ class CouponUtils @Inject constructor(
             )
         } else ""
     }
+
+    /**
+     * Generate a random coupon code following the same logic as Core
+     * https://github.com/woocommerce/woocommerce/blob/2e60d47a019a6e35f066f3ef43a56c0e761fc8e3/includes/admin/class-wc-admin-assets.php#L295
+     */
+    fun generateRandomCode(): String {
+        val availableCharacters = "ABCDEFGHJKMNPQRSTUVWXYZ23456789".toCharArray()
+        val codeLength = 8
+        return String(
+            (1..codeLength).map {
+                availableCharacters.random()
+            }.toCharArray()
+        )
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6475 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Please don't merge until #6462 is merged.

### Description
This PR adds support for editing the coupons code, and for generating a random code.
A note regarding the casing of the code, as the API seems to be sending the codes always lowercased, the result is always saved lowercased, but still to align with Core's code editor, we uppercase the code in the text field.

### Testing instructions
1. Make sure the coupons beta toggle is enabled.
2. Open the app, and click on More, then coupons.
3. Open the coupon details.
4. Click on the menu button, then click on Edit.
5. Make some manual changes to the code.
6. Confirm the text is always uppercased.
7. Click on Regenerate code, and confirm it generates a random code that has 8 characters.
8. Confirm the "Save button" is displayed whenever the code is different.

### Images/gif
https://user-images.githubusercontent.com/1657201/167482269-87c673b4-f157-4991-af0e-63f186ce785c.mov

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
