### PR TITLE
[Coupons] Add option to add/edit description

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
@@ -1,0 +1,63 @@
+package com.woocommerce.android.ui.common.texteditor
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorViewModel.SimpleTextEditorResult
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SimpleTextEditorFragment : BaseFragment(), BackPressListener {
+    companion object {
+        const val SIMPLE_TEXT_EDITOR_RESULT = "text-editor-result"
+    }
+
+    private val viewModel: SimpleTextEditorViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        setHasOptionsMenu(true)
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    SimpleTextEditorScreen(viewModel)
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ExitWithResult<*> -> {
+                    val data = event.data as SimpleTextEditorResult
+                    val key = "$SIMPLE_TEXT_EDITOR_RESULT${data.requestCode?.toString().orEmpty()}"
+                    navigateBackWithResult(key, data.text)
+                }
+                is Exit -> findNavController().navigateUp()
+            }
+        }
+    }
+
+    override fun onRequestAllowBackPress(): Boolean {
+        viewModel.onBackPressed()
+        return false
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
@@ -18,6 +18,14 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
+/**
+ * A screen that shows a TextField in full-screen, to allow editing and returning a simple text.
+ *
+ * To configure the screen, pass an instance of [SimpleTextEditorFragmentArgs] during the navigation.
+ *
+ * The result is returned using the key:
+ *   "{[SIMPLE_TEXT_EDITOR_RESULT]}{[SimpleTextEditorFragmentArgs.requestCode] if present}".
+ */
 @AndroidEntryPoint
 class SimpleTextEditorFragment : BaseFragment(), BackPressListener {
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorViewModel.SimpleTextEditorResult
@@ -24,6 +25,7 @@ class SimpleTextEditorFragment : BaseFragment(), BackPressListener {
     }
 
     private val viewModel: SimpleTextEditorViewModel by viewModels()
+    private val navArgs: SimpleTextEditorFragmentArgs by navArgs()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         setHasOptionsMenu(true)
@@ -55,6 +57,8 @@ class SimpleTextEditorFragment : BaseFragment(), BackPressListener {
             }
         }
     }
+
+    override fun getFragmentTitle(): String = navArgs.screenTitle
 
     override fun onRequestAllowBackPress(): Boolean {
         viewModel.onBackPressed()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorScreen.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.common.texteditor
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SimpleTextEditorScreen(viewModel: SimpleTextEditorViewModel) {
+    val viewState by viewModel.viewState.observeAsState()
+    SimpleTextEditorScreen(viewState?.text, viewModel::onTextChanged)
+}
+
+@Composable
+fun SimpleTextEditorScreen(text: String?, onTextChanged: (String) -> Unit) {
+    TextField(value = text.orEmpty(), onValueChange = onTextChanged, modifier = Modifier.fillMaxSize())
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorScreen.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.common.texteditor
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -10,10 +13,18 @@ import androidx.compose.ui.Modifier
 @Composable
 fun SimpleTextEditorScreen(viewModel: SimpleTextEditorViewModel) {
     val viewState by viewModel.viewState.observeAsState()
-    SimpleTextEditorScreen(viewState?.text, viewModel::onTextChanged)
+    SimpleTextEditorScreen(viewState?.text, viewState?.hint, viewModel::onTextChanged)
 }
 
 @Composable
-fun SimpleTextEditorScreen(text: String?, onTextChanged: (String) -> Unit) {
-    TextField(value = text.orEmpty(), onValueChange = onTextChanged, modifier = Modifier.fillMaxSize())
+fun SimpleTextEditorScreen(text: String?, hint: String?, onTextChanged: (String) -> Unit) {
+    TextField(
+        value = text.orEmpty(),
+        onValueChange = onTextChanged,
+        placeholder = {
+            Text(hint.orEmpty())
+        },
+        colors = TextFieldDefaults.textFieldColors(backgroundColor = MaterialTheme.colors.surface),
+        modifier = Modifier.fillMaxSize()
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
@@ -20,6 +20,7 @@ class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle
     val viewState = textLiveData.map {
         ViewState(
             text = it,
+            hint = navArgs.hint,
             hasChanges = it != navArgs.currentText
         )
     }
@@ -43,6 +44,7 @@ class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle
 
     data class ViewState(
         val text: String,
+        val hint: String,
         val hasChanges: Boolean
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
@@ -1,0 +1,53 @@
+package com.woocommerce.android.ui.common.texteditor
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.map
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle) : ScopedViewModel(savedState) {
+    companion object {
+        private const val TEXT_KEY = "text"
+    }
+
+    private val navArgs: SimpleTextEditorFragmentArgs by savedState.navArgs()
+    private val textLiveData = savedState.getLiveData<String>(TEXT_KEY, navArgs.currentText)
+    val viewState = textLiveData.map {
+        ViewState(
+            text = it,
+            hasChanges = it != navArgs.currentText
+        )
+    }
+
+    fun onTextChanged(text: String) {
+        textLiveData.value = text
+    }
+
+    fun onBackPressed() {
+        val event = viewState.value?.takeIf { it.hasChanges }?.let { viewState ->
+            ExitWithResult(
+                SimpleTextEditorResult(
+                    text = viewState.text,
+                    requestCode = navArgs.requestCode.takeIf { it != -1 }
+                )
+            )
+        } ?: Exit
+
+        triggerEvent(event)
+    }
+
+    data class ViewState(
+        val text: String,
+        val hasChanges: Boolean
+    )
+
+    data class SimpleTextEditorResult(
+        val text: String,
+        val requestCode: Int?
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -8,7 +8,9 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
@@ -44,11 +46,24 @@ class EditCouponFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
+        handleResults()
     }
 
     private fun setupObservers() {
         viewModel.viewState.observe(viewLifecycleOwner) {
             screenTitle = getString(R.string.coupon_edit_screen_title, it.localizedType)
+        }
+
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is EditCouponNavigationTarget -> EditCouponNavigator.navigate(this, event)
+            }
+        }
+    }
+
+    private fun handleResults() {
+        handleResult<String>(SimpleTextEditorFragment.SIMPLE_TEXT_EDITOR_RESULT) {
+            viewModel.onDescriptionChanged(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.coupons.edit
+
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+
+sealed class EditCouponNavigationTarget : Event() {
+    data class OpenDescriptionEditor(val currentDescription: String?) : EditCouponNavigationTarget()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.coupons.edit
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
+
+object EditCouponNavigator {
+    fun navigate(fragment: Fragment, target: EditCouponNavigationTarget) {
+        val navController = fragment.findNavController()
+        when (target) {
+            is OpenDescriptionEditor -> navController.navigate(
+                NavGraphMainDirections.actionGlobalSimpleTextEditorFragment(target.currentDescription)
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
@@ -3,15 +3,22 @@ package com.woocommerce.android.ui.coupons.edit
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
 
 object EditCouponNavigator {
     fun navigate(fragment: Fragment, target: EditCouponNavigationTarget) {
         val navController = fragment.findNavController()
         when (target) {
-            is OpenDescriptionEditor -> navController.navigate(
-                NavGraphMainDirections.actionGlobalSimpleTextEditorFragment(target.currentDescription)
-            )
+            is OpenDescriptionEditor -> {
+                navController.navigate(
+                    NavGraphMainDirections.actionGlobalSimpleTextEditorFragment(
+                        currentText = target.currentDescription,
+                        screenTitle = fragment.getString(R.string.coupon_edit_description_editor_title),
+                        hint = fragment.getString(R.string.coupon_edit_add_description_hint)
+                    )
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -80,6 +80,10 @@ class EditCouponViewModel @Inject constructor(
         }
     }
 
+    fun onDescriptionButtonClick() {
+        TODO()
+    }
+
     data class ViewState(
         val couponDraft: Coupon,
         val localizedType: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.coupons.CouponRepository
+import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -81,7 +82,13 @@ class EditCouponViewModel @Inject constructor(
     }
 
     fun onDescriptionButtonClick() {
-        TODO()
+        triggerEvent(OpenDescriptionEditor(couponDraft.value?.description))
+    }
+
+    fun onDescriptionChanged(description: String) {
+        couponDraft.update {
+            it?.copy(description = description)
+        }
     }
 
     data class ViewState(

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -357,4 +357,20 @@
         android:name="com.woocommerce.android.ui.inbox.InboxFragment"
         android:label="InboxFragment"
         tools:layout="@layout/fragment_inbox" />
+    <fragment
+        android:id="@+id/simpleTextEditorFragment"
+        android:name="com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment"
+        android:label="SimpleTextEditorFragment">
+        <argument
+            android:name="currentText"
+            app:argType="string"
+            app:nullable="true" />
+        <argument
+            android:name="requestCode"
+            android:defaultValue="-1"
+            app:argType="integer" />
+    </fragment>
+    <action
+        android:id="@+id/action_global_simpleTextEditorFragment"
+        app:destination="@id/simpleTextEditorFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -366,6 +366,12 @@
             app:argType="string"
             app:nullable="true" />
         <argument
+            android:name="screenTitle"
+            app:argType="string" />
+        <argument
+            android:name="hint"
+            app:argType="string" />
+        <argument
             android:name="requestCode"
             android:defaultValue="-1"
             app:argType="integer" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1963,6 +1963,9 @@
     <string name="coupon_edit_code_helper">Customers need to enter this code to use the coupon.</string>
     <string name="coupon_edit_regenerate_coupon">Regenerate Coupon Code</string>
     <string name="coupon_edit_save_button">Save</string>
+    <string name="coupon_edit_expiry_date">Coupon Expiry Date</string>
+    <string name="coupon_edit_add_description">Add Description (Optional)</string>
+    <string name="coupon_edit_edit_description">Edit Description</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>
@@ -2368,5 +2371,4 @@
     <string name="about_automattic_back_icon_description">Back icon</string>
     <string name="about_automattic_app_icon_description">App icon</string>
     <string name="error_generic">An error occurred</string>
-    <string name="coupon_edit_expiry_date">Coupon Expiry Date</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1966,6 +1966,8 @@
     <string name="coupon_edit_expiry_date">Coupon Expiry Date</string>
     <string name="coupon_edit_add_description">Add Description (Optional)</string>
     <string name="coupon_edit_edit_description">Edit Description</string>
+    <string name="coupon_edit_description_editor_title">Coupon Description</string>
+    <string name="coupon_edit_add_description_hint">Add the description of the coupon.</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModelTests.kt
@@ -1,0 +1,81 @@
+package com.woocommerce.android.ui.common.texteditor
+
+import com.woocommerce.android.initSavedStateHandle
+import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorViewModel.SimpleTextEditorResult
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SimpleTextEditorViewModelTests : BaseUnitTest() {
+    private lateinit var viewModel: SimpleTextEditorViewModel
+
+    private val defaultArgs = SimpleTextEditorFragmentArgs(
+        currentText = "text",
+        screenTitle = "title",
+        hint = "hint"
+    )
+
+    fun setup(args: SimpleTextEditorFragmentArgs = defaultArgs) {
+        viewModel = SimpleTextEditorViewModel(args.initSavedStateHandle())
+    }
+
+    @Test
+    fun `when the screen is loaded, then init viewstate correctly`() {
+        setup()
+
+        val state = viewModel.viewState.captureValues().last()
+
+        assertThat(state.text).isEqualTo(defaultArgs.currentText)
+        assertThat(state.hint).isEqualTo(defaultArgs.hint)
+        assertThat(state.hasChanges).isFalse
+    }
+
+    @Test
+    fun `when the text is edited, then update viewstate`() {
+        setup()
+
+        viewModel.onTextChanged("new text")
+        val state = viewModel.viewState.captureValues().last()
+
+        assertThat(state.text).isEqualTo("new text")
+        assertThat(state.hasChanges).isTrue
+    }
+
+    @Test
+    fun `given there are no changes, when back is pressed, then exit without any result`() {
+        setup()
+
+        viewModel.onBackPressed()
+        val event = viewModel.event.captureValues().last()
+
+        assertThat(event).isEqualTo(Exit)
+    }
+
+    @Test
+    fun `given there are text changes, when back is pressed, then exit with result`() {
+        setup()
+
+        viewModel.viewState.observeForever { }
+        viewModel.onTextChanged("new text")
+        viewModel.onBackPressed()
+        val event = viewModel.event.captureValues().last()
+
+        assertThat(event).isEqualTo(ExitWithResult(SimpleTextEditorResult(text = "new text", requestCode = null)))
+    }
+
+    @Test
+    fun `given a request code was passed, when back is pressed, then exit with result`() {
+        setup(defaultArgs.copy(requestCode = 1))
+
+        viewModel.viewState.observeForever { }
+        viewModel.onTextChanged("new text")
+        viewModel.onBackPressed()
+        val event = viewModel.event.captureValues().last()
+
+        @Suppress("UNCHECKED_CAST")
+        assertThat((event as ExitWithResult<SimpleTextEditorResult>).data.requestCode).isEqualTo(1)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModelTests.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.coupons.CouponRepository
 import com.woocommerce.android.ui.coupons.CouponTestUtils
+import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.util.CurrencyFormatter
@@ -137,4 +138,36 @@ class EditCouponViewModelTests : BaseUnitTest() {
 
         assertThat(state.couponDraft.code).isEqualTo(generatedCode)
     }
+
+    @Test
+    fun `when description button is clicked, then open description editor`() = testBlocking {
+        setup()
+
+        viewModel.onDescriptionButtonClick()
+
+        val event = viewModel.event.captureValues().last()
+        assertThat(event).isEqualTo(OpenDescriptionEditor(storedCoupon.description))
+    }
+
+    @Test
+    fun `when description changes, then update coupon draft`() = testBlocking {
+        setup()
+
+        viewModel.onDescriptionChanged("description")
+
+        val state = viewModel.viewState.captureValues().last()
+        assertThat(state.couponDraft.description).isEqualTo("description")
+    }
+
+    @Test
+    fun `given there are description changes, when description button is clicked, then open description editor`() =
+        testBlocking {
+            setup()
+
+            viewModel.onDescriptionChanged("description")
+            viewModel.onDescriptionButtonClick()
+
+            val event = viewModel.event.captureValues().last()
+            assertThat(event).isEqualTo(OpenDescriptionEditor("description"))
+        }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5535 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the option to add/edit the description of the coupon.
I decided to add a reusable screen called `SimpleTextEditorFragment` similar to what we are doing with `AztecEditorFragment`, we can reuse this screen for some parts in order creation (customer note uses a similar design), I decided also to avoid using a `done` in the menu, a `back` action is considered as a positive action, similar to what we are doing with `AztecEditorFragment`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<img width="260" alt="Screen Shot 2022-05-11 at 12 10 56" src="https://user-images.githubusercontent.com/1657201/167836259-e5bd4bcd-fa4c-47cc-84f1-a57d8d5c2433.png"> <img width="260" alt="Screen Shot 2022-05-11 at 12 11 09" src="https://user-images.githubusercontent.com/1657201/167836264-1e30a865-24f5-4919-991e-a191b6bf3dc3.png"> <img width="260" alt="Screen Shot 2022-05-11 at 12 11 17" src="https://user-images.githubusercontent.com/1657201/167836265-a3a62293-376d-4562-a166-bcea13cce657.png">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
