### PR TITLE
Issue/6497 add preview manuals screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.woocommerce.android.R
 
@@ -95,4 +96,28 @@ fun ManualsList(
             )
         }
     }
+}
+
+@Preview
+@Composable
+fun Preview() {
+    ManualsList(
+        list = listOf(
+            CardReaderManualsViewModel.ManualItem(
+                icon = R.drawable.ic_chipper_reader,
+                label = R.string.card_reader_bbpos_manual_card_reader,
+                onManualClicked = { }
+            ),
+            CardReaderManualsViewModel.ManualItem(
+                icon = R.drawable.ic_m2_reader,
+                label = R.string.card_reader_m2_manual_card_reader,
+                onManualClicked = { }
+            ),
+            CardReaderManualsViewModel.ManualItem(
+                icon = R.drawable.ic_wisepad3_reader,
+                label = R.string.card_reader_wisepad_3_manual_card_reader,
+                onManualClicked = { }
+            )
+        )
+    )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6497 
<!-- Id number of the GitHub issue this PR addresses. -->

Merge Instructions: 

- Merge #6474 and remove `do not merge` label

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add the @Preview function to the CardReaderManualsScreen.kt file as suggested [here](https://github.com/woocommerce/woocommerce-android/pull/6474#issuecomment-1122505400)

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

![Screen Shot 2022-05-11 at 9 04 50 AM](https://user-images.githubusercontent.com/30724184/167857570-57eadc75-447b-450e-907e-a24cb341a96c.png)

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
