### PR TITLE
Issue/6493 track failed order creation 9.1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -194,6 +194,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDER_CREATE_BUTTON_TAPPED,
     ORDER_CREATION_SUCCESS,
     ORDER_CREATION_FAILED,
+    ORDER_SYNC_FAILED,
 
     // -- Refunds
     CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrUpdateOrderDraftTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrUpdateOrderDraftTests.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.orders.creation
 
-import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.creation.CreateOrUpdateOrderDraft.OrderDraftUpdateStatus
@@ -35,7 +33,6 @@ class CreateOrUpdateOrderDraftTests : BaseUnitTest() {
     }
     private val orderDraftChanges = MutableStateFlow(Order.EMPTY)
     private val retryTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    private val analyticsTrackerWrapper = mock<AnalyticsTrackerWrapper>()
 
     private val sut: CreateOrUpdateOrderDraft = CreateOrUpdateOrderDraft(
         dispatchers = coroutinesTestRule.testDispatchers,
@@ -135,15 +132,5 @@ class CreateOrUpdateOrderDraftTests : BaseUnitTest() {
         assertThat(updateStatuses.last()).isInstanceOf(OrderDraftUpdateStatus.Succeeded::class.java)
 
         job.cancel()
-    }
-
-    @Test
-    fun `when order sync fails, then error is tracked`() = testBlocking {
-        val badOrder = Order.EMPTY.copy(id = -1)
-        orderCreationRepository.createOrUpdateDraft(badOrder)
-        advanceTimeAndRun(CreateOrUpdateOrderDraft.DEBOUNCE_DURATION_MS)
-
-        verify(orderCreationRepository, times(1)).createOrUpdateDraft(any())
-        verify(analyticsTrackerWrapper, times(1)).track(AnalyticsEvent.ORDER_SYNC_FAILED)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepositoryTest.kt
@@ -1,0 +1,74 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.OrderUpdateStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OrderCreationRepositoryTest : BaseUnitTest() {
+    companion object {
+        const val DEFAULT_ERROR_MESSAGE = "error_message"
+    }
+
+    private lateinit var sut: OrderCreationRepository
+    private lateinit var trackerWrapper: AnalyticsTrackerWrapper
+    private lateinit var orderUpdateStore: OrderUpdateStore
+    private lateinit var selectedSite: SelectedSite
+
+    @Before
+    fun setUp() {
+        trackerWrapper = mock()
+
+        val siteModel = SiteModel()
+        selectedSite = mock {
+            on { get() } doReturn siteModel
+        }
+
+        orderUpdateStore = mock {
+            onBlocking {
+                updateOrder(eq(siteModel), eq(123), any())
+            } doReturn WooResult(
+                WooError(WooErrorType.API_ERROR, BaseRequest.GenericErrorType.NETWORK_ERROR, DEFAULT_ERROR_MESSAGE)
+            )
+        }
+
+        sut = OrderCreationRepository(
+            selectedSite = selectedSite,
+            orderStore = mock(),
+            orderUpdateStore = orderUpdateStore,
+            orderMapper = mock(),
+            dispatchers = coroutinesTestRule.testDispatchers,
+            wooCommerceStore = mock(),
+            analyticsTrackerWrapper = trackerWrapper
+        )
+    }
+
+    @Test
+    fun `when order sync fails, then error is tracked`() = testBlocking {
+        val badOrder = Order.EMPTY.copy(id = 123)
+        sut.createOrUpdateDraft(badOrder)
+
+        verify(trackerWrapper).track(
+            stat = eq(AnalyticsEvent.ORDER_SYNC_FAILED),
+            errorContext = eq(sut.javaClass.simpleName),
+            errorType = eq(WooErrorType.API_ERROR.name),
+            errorDescription = eq(DEFAULT_ERROR_MESSAGE)
+        )
+    }
+}


### PR DESCRIPTION
Closes #6493 by adding tracking of order creation sync failure. A simple way to test this is to change [this line](https://github.com/woocommerce/woocommerce-android/blob/c11b9a5cbe1376532f5a2bc9893168e6442b2312/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt#L66) to set the order id to -1, which will cause the request to fail.

**Note that this targets `release/9.1`.**

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.