### PR TITLE
Issue/6390 order creation SKU and price

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionFragment.kt
@@ -88,8 +88,7 @@ class OrderCreationProductSelectionFragment :
             ?: ProductListAdapter(
                 clickListener = { id, _ -> productListViewModel.onProductSelected(id) },
                 loadMoreListener = this@OrderCreationProductSelectionFragment,
-                currencyFormatter = currencyFormatter,
-                showSku = true
+                currencyFormatter = currencyFormatter
             ).also { productsList.adapter = it }
         adapter.submitList(products)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionFragment.kt
@@ -88,7 +88,8 @@ class OrderCreationProductSelectionFragment :
             ?: ProductListAdapter(
                 clickListener = { id, _ -> productListViewModel.onProductSelected(id) },
                 loadMoreListener = this@OrderCreationProductSelectionFragment,
-                currencyFormatter = currencyFormatter
+                currencyFormatter = currencyFormatter,
+                showSku = true
             ).also { productsList.adapter = it }
         adapter.submitList(products)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreationProductSelectionFragment.kt
@@ -24,10 +24,12 @@ import com.woocommerce.android.ui.orders.creation.products.OrderCreationProductS
 import com.woocommerce.android.ui.orders.creation.products.OrderCreationProductSelectionViewModel.ViewState
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.ui.products.ProductListAdapter
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class OrderCreationProductSelectionFragment :
@@ -41,6 +43,8 @@ class OrderCreationProductSelectionFragment :
     private val skeletonView = SkeletonView()
     private var searchMenuItem: MenuItem? = null
     private var searchView: SearchView? = null
+
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -83,7 +87,8 @@ class OrderCreationProductSelectionFragment :
             .let { it as? ProductListAdapter }
             ?: ProductListAdapter(
                 clickListener = { id, _ -> productListViewModel.onProductSelected(id) },
-                loadMoreListener = this@OrderCreationProductSelectionFragment
+                loadMoreListener = this@OrderCreationProductSelectionFragment,
+                currencyFormatter = currencyFormatter
             ).also { productsList.adapter = it }
         adapter.submitList(products)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListAdapter.kt
@@ -5,9 +5,11 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.woocommerce.android.databinding.ProductListItemBinding
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.util.CurrencyFormatter
 
 class GroupedProductListAdapter(
-    private val onItemDeleted: (product: Product) -> Unit
+    private val onItemDeleted: (product: Product) -> Unit,
+    private val currencyFormatter: CurrencyFormatter
 ) : ListAdapter<Product, ProductItemViewHolder>(ProductItemDiffCallback) {
     init {
         setHasStableIds(true)
@@ -28,7 +30,7 @@ class GroupedProductListAdapter(
     override fun onBindViewHolder(holder: ProductItemViewHolder, position: Int) {
         val product = getItem(position)
 
-        holder.bind(product)
+        holder.bind(product, currencyFormatter)
         holder.setOnDeleteClickListener(product, onItemDeleted)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -78,9 +78,9 @@ class GroupedProductListFragment : BaseFragment(R.layout.fragment_grouped_produc
             viewLifecycleOwner,
             Observer { event ->
                 when (event) {
-                    is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                    is Exit -> findNavController().navigateUp()
-                    is ExitWithResult<*> -> {
+                    is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                    is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                    is MultiLiveEvent.Event.ExitWithResult<*> -> {
                         navigateBackWithResult(viewModel.getKeyForGroupedProductListType(), event.data as List<*>)
                     }
                     is ProductNavigationTarget -> navigator.navigate(this, event)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
@@ -25,12 +26,13 @@ import javax.inject.Inject
 class GroupedProductListFragment : BaseFragment(R.layout.fragment_grouped_product_list), BackPressListener {
     @Inject lateinit var navigator: ProductNavigator
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     val viewModel: GroupedProductListViewModel by viewModels()
 
     private val skeletonView = SkeletonView()
     private val productListAdapter: GroupedProductListAdapter by lazy {
-        GroupedProductListAdapter(viewModel::onProductDeleted)
+        GroupedProductListAdapter(viewModel::onProductDeleted, currencyFormatter)
     }
 
     private var _binding: FragmentGroupedProductListBinding? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -34,9 +34,8 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
 
     fun bind(
         product: Product,
-        currencyFormatter: CurrencyFormatter? = null,
-        isActivated: Boolean = false,
-        showSku: Boolean = false
+        currencyFormatter: CurrencyFormatter,
+        isActivated: Boolean = false
     ) {
         viewBinding.root.isActivated = isActivated
 
@@ -60,7 +59,7 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
         }
 
         with(viewBinding.productSku) {
-            if (showSku && product.sku.isNotEmpty()) {
+            if (product.sku.isNotEmpty()) {
                 visibility = View.VISIBLE
                 text = context.getString(R.string.orderdetail_product_lineitem_sku_value, product.sku)
             } else {
@@ -123,7 +122,7 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
     private fun getProductStockStatusPriceText(
         context: Context,
         product: Product,
-        currencyFormatter: CurrencyFormatter?
+        currencyFormatter: CurrencyFormatter
     ): String {
         val statusHtml = product.status?.let {
             when {
@@ -142,7 +141,7 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
         val stock = getStockText(product)
         val stockAndStatus = if (statusHtml != null) "$statusHtml $bullet $stock" else stock
 
-        return if (product.price != null && currencyFormatter != null) {
+        return if (product.price != null) {
             val fmtPrice = currencyFormatter.formatCurrency(product.price)
             "$stockAndStatus $bullet $fmtPrice"
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -68,6 +68,18 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
             }
         }
 
+        showProductImage(product, viewBinding)
+
+        ViewCompat.setTransitionName(
+            viewBinding.root,
+            String.format(
+                context.getString(R.string.order_card_transition_name),
+                product.remoteId
+            )
+        )
+    }
+
+    private fun showProductImage(product: Product, viewBinding: ProductListItemBinding) {
         val firstImage = product.firstImageUrl
         val size: Int
         when {
@@ -96,14 +108,6 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
             height = size
             width = size
         }
-
-        ViewCompat.setTransitionName(
-            viewBinding.root,
-            String.format(
-                context.getString(R.string.order_card_transition_name),
-                product.remoteId
-            )
-        )
     }
 
     fun setOnDeleteClickListener(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -58,6 +58,15 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
             }
         }
 
+        with(viewBinding.productSku) {
+            if (product.sku.isNotEmpty()) {
+                visibility = View.VISIBLE
+                text = product.sku
+            } else {
+                visibility = View.GONE
+            }
+        }
+
         val firstImage = product.firstImageUrl
         val size: Int
         when {
@@ -159,11 +168,11 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
         }
 
         val stockStatus = if (statusHtml != null) "$statusHtml $bullet $stock" else stock
-        if (product.price != null && currencyFormatter != null) {
+        return if (product.price != null && currencyFormatter != null) {
             val fmtPrice = currencyFormatter.formatCurrency(product.price)
-            return "$stockStatus $bullet $fmtPrice"
+            "$stockStatus $bullet $fmtPrice"
         } else {
-            return stockStatus
+            stockStatus
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -35,7 +35,8 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
     fun bind(
         product: Product,
         currencyFormatter: CurrencyFormatter? = null,
-        isActivated: Boolean = false
+        isActivated: Boolean = false,
+        showSku: Boolean = false
     ) {
         viewBinding.root.isActivated = isActivated
 
@@ -59,9 +60,9 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
         }
 
         with(viewBinding.productSku) {
-            if (product.sku.isNotEmpty()) {
+            if (showSku && product.sku.isNotEmpty()) {
                 visibility = View.VISIBLE
-                text = product.sku
+                text = context.getString(R.string.orderdetail_product_lineitem_sku_value, product.sku)
             } else {
                 visibility = View.GONE
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -139,7 +139,19 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
             }
         }
 
-        val stock = when (product.stockStatus) {
+        val stock = getStockText(product)
+        val stockAndStatus = if (statusHtml != null) "$statusHtml $bullet $stock" else stock
+
+        return if (product.price != null && currencyFormatter != null) {
+            val fmtPrice = currencyFormatter.formatCurrency(product.price)
+            "$stockAndStatus $bullet $fmtPrice"
+        } else {
+            stockAndStatus
+        }
+    }
+
+    private fun getStockText(product: Product): String {
+        return when (product.stockStatus) {
             InStock -> {
                 if (product.productType == VARIABLE) {
                     if (product.numVariations > 0) {
@@ -170,14 +182,6 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
             else -> {
                 product.stockStatus.value
             }
-        }
-
-        val stockStatus = if (statusHtml != null) "$statusHtml $bullet $stock" else stock
-        return if (product.price != null && currencyFormatter != null) {
-            val fmtPrice = currencyFormatter.formatCurrency(product.price)
-            "$stockStatus $bullet $fmtPrice"
-        } else {
-            stockStatus
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -9,12 +9,14 @@ import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_LIST_PRODUCT_TAP
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ProductListItemBinding
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.util.CurrencyFormatter
 
 typealias OnProductClickListener = (remoteProductId: Long, sharedView: View?) -> Unit
 
 class ProductListAdapter(
     private inline val clickListener: OnProductClickListener? = null,
-    private val loadMoreListener: OnLoadMoreListener
+    private val loadMoreListener: OnLoadMoreListener,
+    private val currencyFormatter: CurrencyFormatter? = null
 ) : ListAdapter<Product, ProductItemViewHolder>(ProductItemDiffCallback) {
     // allow the selection library to track the selections of the user
     var tracker: SelectionTracker<Long>? = null
@@ -38,7 +40,7 @@ class ProductListAdapter(
     override fun onBindViewHolder(holder: ProductItemViewHolder, position: Int) {
         val product = getItem(position)
 
-        holder.bind(product, tracker?.isSelected(product.remoteId) ?: false)
+        holder.bind(product, currencyFormatter, isActivated = tracker?.isSelected(product.remoteId) ?: false)
 
         holder.itemView.setOnClickListener {
             AnalyticsTracker.track(PRODUCT_LIST_PRODUCT_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -41,7 +41,8 @@ class ProductListAdapter(
     override fun onBindViewHolder(holder: ProductItemViewHolder, position: Int) {
         val product = getItem(position)
 
-        holder.bind(product,
+        holder.bind(
+            product,
             currencyFormatter,
             isActivated = tracker?.isSelected(product.remoteId) ?: false,
             showSku = showSku

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -16,8 +16,7 @@ typealias OnProductClickListener = (remoteProductId: Long, sharedView: View?) ->
 class ProductListAdapter(
     private inline val clickListener: OnProductClickListener? = null,
     private val loadMoreListener: OnLoadMoreListener,
-    private val currencyFormatter: CurrencyFormatter? = null,
-    private val showSku: Boolean = false
+    private val currencyFormatter: CurrencyFormatter
 ) : ListAdapter<Product, ProductItemViewHolder>(ProductItemDiffCallback) {
     // allow the selection library to track the selections of the user
     var tracker: SelectionTracker<Long>? = null
@@ -44,8 +43,7 @@ class ProductListAdapter(
         holder.bind(
             product,
             currencyFormatter,
-            isActivated = tracker?.isSelected(product.remoteId) ?: false,
-            showSku = showSku
+            isActivated = tracker?.isSelected(product.remoteId) ?: false
         )
 
         holder.itemView.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -16,7 +16,8 @@ typealias OnProductClickListener = (remoteProductId: Long, sharedView: View?) ->
 class ProductListAdapter(
     private inline val clickListener: OnProductClickListener? = null,
     private val loadMoreListener: OnLoadMoreListener,
-    private val currencyFormatter: CurrencyFormatter? = null
+    private val currencyFormatter: CurrencyFormatter? = null,
+    private val showSku: Boolean = false
 ) : ListAdapter<Product, ProductItemViewHolder>(ProductItemDiffCallback) {
     // allow the selection library to track the selections of the user
     var tracker: SelectionTracker<Long>? = null
@@ -40,7 +41,11 @@ class ProductListAdapter(
     override fun onBindViewHolder(holder: ProductItemViewHolder, position: Int) {
         val product = getItem(position)
 
-        holder.bind(product, currencyFormatter, isActivated = tracker?.isSelected(product.remoteId) ?: false)
+        holder.bind(product,
+            currencyFormatter,
+            isActivated = tracker?.isSelected(product.remoteId) ?: false,
+            showSku = showSku
+        )
 
         holder.itemView.setOnClickListener {
             AnalyticsTracker.track(PRODUCT_LIST_PRODUCT_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductFilterScreen
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductSortingBottomSheet
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
@@ -65,6 +66,7 @@ class ProductListFragment :
     }
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     private var _productAdapter: ProductListAdapter? = null
     private val productAdapter: ProductListAdapter
@@ -98,7 +100,11 @@ class ProductListFragment :
         setupObservers(viewModel)
         setupResultHandlers()
         ViewGroupCompat.setTransitionGroup(binding.productsRefreshLayout, true)
-        _productAdapter = ProductListAdapter(::onProductClick, this)
+        _productAdapter = ProductListAdapter(
+            ::onProductClick,
+            loadMoreListener = this,
+            currencyFormatter = currencyFormatter
+        )
         binding.productsRecycler.layoutManager = LinearLayoutManager(requireActivity())
         binding.productsRecycler.adapter = productAdapter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -36,12 +37,16 @@ class ProductSelectionListFragment :
     OnQueryTextListener,
     OnActionExpandListener {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     val viewModel: ProductSelectionListViewModel by viewModels()
 
     private var tracker: SelectionTracker<Long>? = null
     private val productSelectionListAdapter: ProductListAdapter by lazy {
-        ProductListAdapter(loadMoreListener = this)
+        ProductListAdapter(
+            loadMoreListener = this,
+            currencyFormatter = currencyFormatter
+        )
     }
 
     private val skeletonView = SkeletonView()

--- a/WooCommerce/src/main/res/layout/product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_list_item.xml
@@ -66,8 +66,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/minor_00"
-            tools:text="Out of stock this is a really long version to see what happens when we move o"
-            tools:visibility="visible" />
+            tools:text="Out of stock this is a really long version to see what happens when we move o" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/productSku"
+            style="@style/Woo.ListItem.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/minor_00"
+            tools:text="SKU" />
     </LinearLayout>
 
     <ImageButton


### PR DESCRIPTION
Closes #6390 by adding product price and SKU to the order creation product list. Note there was some discussion [here](https://github.com/woocommerce/woocommerce-android/issues/6390#issuecomment-1125121316) about showing price & SKU on the main product list, and that can be easily done if we decide to do that, ~~but I chose to only change the order creation product list.~~

Also, after the above changes were made,  we were getting "long method" and "complex fun" warnings in `ProductItemViewHolder`  so I corrected those in this PR, too.

![Screenshot_20220512_150322](https://user-images.githubusercontent.com/3903757/168151277-1e77e310-83af-40d2-83a7-26cf38418464.png)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
