### PR TITLE
Extract AndroidX Test Core Dependency Version Declaration

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -281,7 +281,7 @@ dependencies {
 
     // Dependencies for Espresso UI tests
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
-    androidTestImplementation "androidx.test:rules:1.4.0"
+    androidTestImplementation "androidx.test:rules:$androidxTestCoreVersion"
     androidTestImplementation "org.assertj:assertj-core:$assertjVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,6 @@ tasks.register("installGitHooks", Copy) {
 ext {
     fluxCVersion = 'trunk-80df98c29da461f267a9c09bb72653305b17f890'
     glideVersion = '4.12.0'
-    testRunnerVersion = '1.0.1'
     espressoVersion = '3.4.0'
     mockitoKotlinVersion = '4.0.0'
     mockitoVersion = '4.5.1'

--- a/build.gradle
+++ b/build.gradle
@@ -84,24 +84,18 @@ tasks.register("installGitHooks", Copy) {
 ext {
     fluxCVersion = 'trunk-80df98c29da461f267a9c09bb72653305b17f890'
     glideVersion = '4.12.0'
-    espressoVersion = '3.4.0'
-    mockitoKotlinVersion = '4.0.0'
-    mockitoVersion = '4.5.1'
     constraintLayoutVersion = '1.2.0'
     libaddressinputVersion = '0.0.2'
     eventBusVersion = '3.3.1'
     googlePlayCoreVersion = '1.10.3'
     coroutinesVersion = '1.6.1'
     lifecycleVersion = '2.4.1'
-    assertjVersion = '3.11.1'
     aztecVersion = 'v1.3.45'
     flipperVersion = '0.143.0'
     stateMachineVersion = '0.2.0'
     coreKtxVersion = '1.7.0'
     appCompatVersion = '1.4.1'
     materialVersion = '1.5.0'
-    jUnitVersion = '4.13.2'
-    jUnitExtVersion = '1.1.3'
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = "2.3.0"
     mediapickerVersion = 'trunk-d0db2634cf27511bec3ef9b837f9cfe27c5ab601'
@@ -115,7 +109,13 @@ ext {
     composeThemeAdapterVersion = "1.1.8"
 
     // Testing
+    jUnitVersion = '4.13.2'
+    jUnitExtVersion = '1.1.3'
     androidxTestCoreVersion = '1.4.0'
+    assertjVersion = '3.11.1'
+    espressoVersion = '3.4.0'
+    mockitoKotlinVersion = '4.0.0'
+    mockitoVersion = '4.5.1'
 }
 
 // Onboarding and dev env setup tasks

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,9 @@ ext {
     composeAccompanistVersion = "0.23.1"
     lifecycleViewmodelComposeVersion = "2.4.1"
     composeThemeAdapterVersion = "1.1.8"
+
+    // Testing
+    androidxTestCoreVersion = '1.4.0'
 }
 
 // Onboarding and dev env setup tasks

--- a/quicklogin/build.gradle
+++ b/quicklogin/build.gradle
@@ -79,9 +79,9 @@ dependencies {
     implementation "androidx.test.uiautomator:uiautomator:2.2.0"
     implementation "junit:junit:$jUnitVersion"
     implementation "androidx.test.ext:junit:$jUnitExtVersion"
-    implementation "androidx.test:runner:1.4.0"
-    implementation "androidx.test:rules:1.4.0"
-    implementation "androidx.test:core:1.4.0"
+    implementation "androidx.test:runner:$androidxTestCoreVersion"
+    implementation "androidx.test:rules:$androidxTestCoreVersion"
+    implementation "androidx.test:core:$androidxTestCoreVersion"
 }
 
 if (project.hasProperty("debugStoreFile")) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description

As per the documentation and the table list of all the artifacts in the `androidx.test` group, all the below individual test dependencies should be pointing to the same version:
- `androidx.test:core`
- `androidx.test:runner`
- `androidx.test:rules`

Doing that will make it more consistent and easier to update the `android.text` related to core dependencies.

PS: Additionally, as part of this PR all `testing` related dependency version declarations were move to the newly added `Testing` section for grouping purposes.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- CI running both the Unit and UI tests with successfully should be enough.
- Additionally, feel free to run both, the Unit and UI tests, locally to verify success.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
