### PR TITLE
Issue/6146 remove manuals feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
@@ -51,9 +51,6 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
-                is CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow -> {
-                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
-                }
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderManualsScreen -> {
                     findNavController().navigateSafely(R.id.action_cardReaderHubFragment_to_cardReaderManualsFragment)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
@@ -66,34 +66,10 @@ class CardReaderHubViewModel @Inject constructor(
             ),
             CardReaderHubListItemViewState(
                 icon = R.drawable.ic_card_reader_manual,
-                label = UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader),
-                onItemClicked = ::onBbposManualCardReaderClicked
-            ),
-            CardReaderHubListItemViewState(
-                icon = R.drawable.ic_card_reader_manual,
-                label = UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader),
-                onItemClicked = ::onM2ManualCardReaderClicked
+                label = UiString.UiStringRes(R.string.settings_card_reader_manuals),
+                onItemClicked = ::onCardReaderManualsClicked
             )
-        ).apply {
-            if (inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
-                add(
-                    CardReaderHubListItemViewState(
-                        icon = R.drawable.ic_card_reader_manual,
-                        label = UiString.UiStringRes(R.string.card_reader_wisepad_3_manual_card_reader),
-                        onItemClicked = ::onWisePad3ManualCardReaderClicked
-                    )
-                )
-            }
-            if (cardReaderManualsFeatureFlag.isEnabled()) {
-                add(
-                    CardReaderHubListItemViewState(
-                        icon = R.drawable.ic_card_reader_manual,
-                        label = UiString.UiStringRes(R.string.settings_card_reader_manuals),
-                        onItemClicked = ::onCardReaderManualsClicked
-                    )
-                )
-            }
-        }.toImmutableList()
+        )
     )
 
     val viewStateData: LiveData<CardReaderHubViewState> = viewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
@@ -79,18 +79,6 @@ class CardReaderHubViewModel @Inject constructor(
         triggerEvent(CardReaderHubEvents.NavigateToPurchaseCardReaderFlow(cardReaderPurchaseUrl))
     }
 
-    private fun onBbposManualCardReaderClicked() {
-        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.BBPOS_MANUAL_CARD_READER))
-    }
-
-    private fun onM2ManualCardReaderClicked() {
-        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.M2_MANUAL_CARD_READER))
-    }
-
-    private fun onWisePad3ManualCardReaderClicked() {
-        triggerEvent(CardReaderHubEvents.NavigateToManualCardReaderFlow(AppUrls.WISEPAD_3_MANUAL_CARD_READER))
-    }
-
     private fun onCardReaderManualsClicked() {
         triggerEvent(CardReaderHubEvents.NavigateToCardReaderManualsScreen)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.InPersonPaymentsCanadaFeatureFlag
-import com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsFeatureFlag
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
@@ -18,14 +17,12 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import okhttp3.internal.toImmutableList
 import javax.inject.Inject
 
 @HiltViewModel
 class CardReaderHubViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
-    private val cardReaderManualsFeatureFlag: CardReaderManualsFeatureFlag,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val selectedSite: SelectedSite,
 ) : ScopedViewModel(savedState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModel.kt
@@ -86,7 +86,6 @@ class CardReaderHubViewModel @Inject constructor(
     sealed class CardReaderHubEvents : MultiLiveEvent.Event() {
         data class NavigateToCardReaderDetail(val cardReaderFlowParam: CardReaderFlowParam) : CardReaderHubEvents()
         data class NavigateToPurchaseCardReaderFlow(val url: String) : CardReaderHubEvents()
-        data class NavigateToManualCardReaderFlow(val url: String) : CardReaderHubEvents()
         object NavigateToCardReaderManualsScreen : CardReaderHubEvents()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsFeatureFlag.kt
@@ -1,8 +1,0 @@
-package com.woocommerce.android.ui.cardreader.manuals
-
-import com.woocommerce.android.util.FeatureFlag
-import javax.inject.Inject
-
-class CardReaderManualsFeatureFlag @Inject constructor() {
-    fun isEnabled() = FeatureFlag.CARD_READER_MANUALS.isEnabled(null)
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -12,7 +12,6 @@ enum class FeatureFlag {
     ORDER_FILTERS,
     ANALYTICS_HUB,
     IN_PERSON_PAYMENTS_CANADA,
-    CARD_READER_MANUALS,
     MORE_MENU_INBOX,
     COUPONS_M2;
 
@@ -26,7 +25,6 @@ enum class FeatureFlag {
             ORDER_FILTERS,
             ANALYTICS_HUB,
             IN_PERSON_PAYMENTS_CANADA,
-            CARD_READER_MANUALS,
             MORE_MENU_INBOX,
             COUPONS_M2 -> PackageUtils.isDebugBuild()
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -912,9 +912,9 @@
         -->
     <string name="card_reader_manage_card_reader">Manage Card Reader</string>
     <string name="card_reader_purchase_card_reader">Order Card Reader</string>
-    <string name="card_reader_bbpos_manual_card_reader">BBPOS Chipper Card Reader Manual</string>
-    <string name="card_reader_m2_manual_card_reader">Stripe M2 Card Reader Manual</string>
-    <string name="card_reader_wisepad_3_manual_card_reader">WisePad 3 Card Reader Manual</string>
+    <string name="card_reader_bbpos_manual_card_reader">BBPOS Chipper™ 2X BT</string>
+    <string name="card_reader_m2_manual_card_reader">Stripe M2 Card Reader</string>
+    <string name="card_reader_wisepad_3_manual_card_reader">WisePad 3 Card Reader</string>
     <string name="card_reader_icon_content_description">Card Reader Image</string>
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -912,9 +912,9 @@
         -->
     <string name="card_reader_manage_card_reader">Manage Card Reader</string>
     <string name="card_reader_purchase_card_reader">Order Card Reader</string>
-    <string name="card_reader_bbpos_manual_card_reader">BBPOS Chipper™ 2X BT</string>
-    <string name="card_reader_m2_manual_card_reader">Stripe M2 Card Reader</string>
-    <string name="card_reader_wisepad_3_manual_card_reader">WisePad 3 Card Reader</string>
+    <string name="card_reader_bbpos_manual_card_reader" translatable="false">BBPOS Chipper™ 2X BT</string>
+    <string name="card_reader_m2_manual_card_reader" translatable="false">Stripe M2</string>
+    <string name="card_reader_wisepad_3_manual_card_reader" translatable="false">WisePad 3</string>
     <string name="card_reader_icon_content_description">Card Reader Image</string>
 
     <!--

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.InPersonPaymentsCanadaFeatureFlag
-import com.woocommerce.android.ui.cardreader.manuals.CardReaderManualsFeatureFlag
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
@@ -23,7 +22,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 class CardReaderHubViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: CardReaderHubViewModel
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag = mock()
-    private val cardReaderManualsFeatureFlag: CardReaderManualsFeatureFlag = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock {
         on(it.getCardReaderPreferredPlugin(any(), any(), any()))
             .thenReturn(WOOCOMMERCE_PAYMENTS)
@@ -76,82 +74,11 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when screen shown, then bbpos manual card reader row present`() {
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .anyMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader)
-            }
-    }
-
-    @Test
     fun `when screen shown, then manual card reader row icon is present`() {
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
                 it.icon == R.drawable.ic_card_reader_manual
             }
-    }
-
-    @Test
-    fun `when screen shown, then m2 manual card reader row present`() {
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .anyMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader) &&
-                    it.icon == R.drawable.ic_card_reader_manual
-            }
-    }
-
-    @Test
-    fun `when screen shown, then bbpos chipper manual card reader row present`() {
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .anyMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader) &&
-                    it.icon == R.drawable.ic_card_reader_manual
-            }
-    }
-
-    @Test
-    fun `given ipp canada enabled, when screen shown, then wisepad manual card reader row present`() {
-        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
-        initViewModel()
-
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .anyMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_wisepad_3_manual_card_reader) &&
-                    it.icon == R.drawable.ic_card_reader_manual
-            }
-    }
-
-    @Test
-    fun `given ipp canada disabled, when screen shown, then wisepad manual card reader row not present`() {
-        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(false)
-        initViewModel()
-
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .noneMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_wisepad_3_manual_card_reader) &&
-                    it.icon == R.drawable.ic_card_reader_manual
-            }
-    }
-
-    @Test
-    fun `when screen shown, then bbpos manual card reader row present on third position`() {
-        val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-        assertThat(rows[2].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader))
-    }
-
-    @Test
-    fun `when screen shown, then m2 manual card reader row present at fourth last`() {
-        val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-        assertThat(rows[3].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader))
-    }
-
-    @Test
-    fun `given ipp canada enabled, when screen shown, then wisepade manual card reader row present at fourth last`() {
-        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
-        initViewModel()
-
-        val rows = (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-        assertThat(rows[4].label).isEqualTo(UiString.UiStringRes(R.string.card_reader_wisepad_3_manual_card_reader))
     }
 
     @Test
@@ -248,57 +175,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when user clicks on bbpos manual card reader, then app opens external webview with bbpos link`() {
-        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-            .find {
-                it.label == UiString.UiStringRes(R.string.card_reader_bbpos_manual_card_reader)
-            }!!.onItemClicked.invoke()
-
-        assertThat(viewModel.event.value)
-            .isEqualTo(
-                CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow(
-                    AppUrls.BBPOS_MANUAL_CARD_READER
-                )
-            )
-    }
-
-    @Test
-    fun `when user clicks on m2 manual card reader, then app opens external webview with m2 link`() {
-        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-            .find {
-                it.label == UiString.UiStringRes(R.string.card_reader_m2_manual_card_reader)
-            }!!.onItemClicked.invoke()
-
-        assertThat(viewModel.event.value)
-            .isEqualTo(
-                CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow(
-                    AppUrls.M2_MANUAL_CARD_READER
-                )
-            )
-    }
-
-    @Test
-    fun `given ipp canada enabled, when user clicks on wp3 manual card reader, then app opens webview with wp3 link`() {
-        whenever(inPersonPaymentsCanadaFeatureFlag.isEnabled()).thenReturn(true)
-        initViewModel()
-
-        (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
-            .find {
-                it.label == UiString.UiStringRes(R.string.card_reader_wisepad_3_manual_card_reader)
-            }!!.onItemClicked.invoke()
-
-        assertThat(viewModel.event.value)
-            .isEqualTo(
-                CardReaderHubViewModel.CardReaderHubEvents.NavigateToManualCardReaderFlow(
-                    AppUrls.WISEPAD_3_MANUAL_CARD_READER
-                )
-            )
-    }
-
-    @Test
-    fun `given manuals is enabled, when screen shown, then manuals row is displayed`() {
-        whenever(cardReaderManualsFeatureFlag.isEnabled()).thenReturn(true)
-        initViewModel()
+    fun ` when screen shown, then manuals row is displayed`() {
 
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
@@ -308,21 +185,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given manuals disabled, when screen shown, then manuals row is not displayed`() {
-        whenever(cardReaderManualsFeatureFlag.isEnabled()).thenReturn(false)
-        initViewModel()
-
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .noneMatch {
-                it.icon == R.drawable.ic_card_reader_manual &&
-                    it.label == UiString.UiStringRes(R.string.settings_card_reader_manuals)
-            }
-    }
-
-    @Test
-    fun `given manuals enabled, when user clicks on manuals row, then app navigates to manuals screen`() {
-        whenever(cardReaderManualsFeatureFlag.isEnabled()).thenReturn(true)
-        initViewModel()
+    fun `when user clicks on manuals row, then app navigates to manuals screen`() {
 
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
             .find {
@@ -339,7 +202,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         viewModel = CardReaderHubViewModel(
             savedState,
             inPersonPaymentsCanadaFeatureFlag,
-            cardReaderManualsFeatureFlag,
             appPrefsWrapper,
             selectedSite
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -176,7 +176,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
     @Test
     fun ` when screen shown, then manuals row is displayed`() {
-
         assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
             .anyMatch {
                 it.icon == R.drawable.ic_card_reader_manual &&
@@ -186,7 +185,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when user clicks on manuals row, then app navigates to manuals screen`() {
-
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
             .find {
                 it.label == UiString.UiStringRes(R.string.settings_card_reader_manuals)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6146 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR:

- Removes the individual manual tabs from the IPP Hub screen and click events for those tabs
- Removes the Feature Flag hiding the Card Reader Manuals Tab on the IPP hub screen
- Removes the Feature flag Const from the FeatureFlag class
- Removes the CardReaderManualsFeatureFlag file
- Removes the CardReaderManualsFeatureFlag from the CardReaderHubViewModelTest.kt 
- Removes the tests related to the individual manual tabs CardReaderHubViewModelTest.kt 
- Removes the word `manual` from the reader's strings (context p1651755490484779-slack-CGPNUU63E) 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**Scenario 1**
- Run the app in debug
- Open a store that has IPP enabled
- Go to Menu - Settings - IPP
- Make sure the Manuals tab is displayed
- Click on the manuals tab
- make sure all three readers (BBPOS, M2 and WP3) are displayed
- Click on each one and make sure it navigates to the respective manual PDF downloads

**Scenario 2**

- Run the app in Release
- Open a store that has IPP enabled
- Go to Menu - Settings - IPP
- Make sure the Manuals tab is displayed
- Click on the manuals tab
- make sure only two readers (BBPOS & M2 ) are displayed
- Click on each one and make sure it navigates to the respective manual PDF downloads

### Images/gif

### IPP Screen (debug)

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/168627065-6ade6f26-b9a5-49eb-8f5a-b47565e41082.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/168626513-5aec83f7-62a2-408c-ab1a-c7c6c7f31b62.png" width="350"/> |

### Manuals Screen

| Release | Debug |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/168635465-dc745ebc-f29c-4d7f-821c-8e767ac827e6.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/168635516-035ffb8a-8658-488f-8ec9-a709cf9cdec4.png" width="350"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->