### PR TITLE
Clean-up around Fragments and base classes API improvements.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.TopLevelFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collect
 
 @AndroidEntryPoint
 class AnalyticsFragment :

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.base
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.ui.dialog.WooDialog
@@ -19,25 +20,26 @@ open class BaseFragment : Fragment, BaseFragmentView {
 
     open val activityAppBarStatus: AppBarStatus = AppBarStatus.Visible()
 
+    @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
         savedInstanceState?.let {
             activity?.title = it.getString(KEY_TITLE)
         }
     }
 
+    @CallSuper
     override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
         outState.putString(KEY_TITLE, getFragmentTitle())
     }
 
+    @CallSuper
     override fun onHiddenChanged(hidden: Boolean) {
-        super.onHiddenChanged(hidden)
         if (!hidden) {
             updateActivityTitle()
         }
     }
 
+    @CallSuper
     override fun onResume() {
         super.onResume()
         updateActivityTitle()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -91,8 +91,6 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         val binding = CardReaderConnectDialogBinding.bind(view)
         initMultipleReadersFoundRecyclerView(binding)
         initObservers(binding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
@@ -25,8 +25,6 @@ class CardReaderWelcomeDialogFragment : DialogFragment(R.layout.card_reader_welc
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         val binding = CardReaderWelcomeDialogBinding.bind(view)
         initObservers(binding)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -58,10 +58,7 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         val binding = CardReaderPaymentDialogBinding.bind(view)
-
         initObservers(binding)
         initViewModel()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/statuschecker/CardReaderStatusCheckerDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/statuschecker/CardReaderStatusCheckerDialogFragment.kt
@@ -25,8 +25,6 @@ class CardReaderStatusCheckerDialogFragment : DialogFragment(R.layout.card_reade
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         initObservers()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/tutorial/CardReaderTutorialDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/tutorial/CardReaderTutorialDialogFragment.kt
@@ -42,8 +42,6 @@ class CardReaderTutorialDialogFragment : DialogFragment(R.layout.card_reader_tut
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         val binding = CardReaderTutorialDialogBinding.bind(view)
 
         binding.viewPager.adapter = CardReaderTutorialAdapter(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/tutorial/CardReaderTutorialViewPagerItemFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/tutorial/CardReaderTutorialViewPagerItemFragment.kt
@@ -15,8 +15,6 @@ import org.wordpress.android.util.DisplayUtils
  */
 class CardReaderTutorialViewPagerItemFragment : Fragment(R.layout.fragment_card_reader_tutorial_viewpager_item) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         arguments?.let { args ->
             val binding = FragmentCardReaderTutorialViewpagerItemBinding.bind(view)
             binding.labelTextView.setText(args.getInt(ARG_LABEL_ID))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -41,8 +41,6 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         val binding = CardReaderUpdateDialogBinding.bind(view)
 
         initObservers(binding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InfoScreenFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InfoScreenFragment.kt
@@ -20,8 +20,6 @@ class InfoScreenFragment : Fragment(R.layout.fragment_info_screen) {
     private val navArgs: InfoScreenFragmentArgs by navArgs()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         setHasOptionsMenu(true)
 
         val binding = FragmentInfoScreenBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -32,7 +32,6 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment(R.layout.fragme
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
 
         val binding = FragmentFeedbackCompletedBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -44,7 +44,6 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment(R.layout.fragment_
     private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
 
         _binding = FragmentFeedbackSurveyBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackBenefitsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackBenefitsDialog.kt
@@ -26,8 +26,6 @@ class JetpackBenefitsDialog : DialogFragment(R.layout.dialog_jetpack_benefits) {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         // Specify transition animations
         dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -54,8 +54,6 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         // Specify transition animations
         dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallStartDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallStartDialog.kt
@@ -29,8 +29,6 @@ class JetpackInstallStartDialog : DialogFragment(R.layout.dialog_jetpack_install
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         // Specify transition animations
         dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
@@ -81,8 +81,6 @@ class LoginDiscoveryErrorFragment : Fragment(layout.fragment_login_discovery_err
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         setHasOptionsMenu(true)
 
         val binding = FragmentLoginDiscoveryErrorBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
@@ -46,8 +46,6 @@ class LoginJetpackRequiredFragment : Fragment(R.layout.fragment_login_jetpack_re
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         val binding = FragmentLoginJetpackRequiredBinding.bind(view)
         val btnBinding = binding.epilogueButtonBar
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -97,8 +97,6 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         setHasOptionsMenu(true)
 
         val binding = FragmentLoginNoJetpackBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
@@ -47,7 +47,6 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
 
         val binding = FragmentLoginNoWpcomAccountFoundBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -31,8 +31,6 @@ class LoginPrologueFragment : Fragment(R.layout.fragment_login_prologue) {
     private var prologueFinishedListener: PrologueFinishedListener? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         val binding = FragmentLoginPrologueBinding.bind(view)
 
         binding.buttonLoginStore.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueViewPagerItemFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueViewPagerItemFragment.kt
@@ -36,8 +36,6 @@ class LoginPrologueViewPagerItemFragment : Fragment(R.layout.fragment_login_prol
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         arguments?.let { args ->
             val binding = FragmentLoginPrologueViewpagerItemBinding.bind(view)
             binding.textView.setText(args.getInt(ARG_STRING_ID))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginSiteCheckErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginSiteCheckErrorFragment.kt
@@ -49,8 +49,6 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.fragment_login_site_check_
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         setHasOptionsMenu(true)
         activity?.title = getString(R.string.log_in)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptFragment.kt
@@ -66,8 +66,6 @@ class MagicLinkInterceptFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         retryButton = view.findViewById(R.id.login_open_email_client)
         retryContainer = view.findViewById(R.id.login_magic_link_container)
         retryButton?.text = getString(R.string.retry)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -48,7 +48,6 @@ import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -7,6 +7,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
@@ -68,6 +69,7 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
      */
     abstract fun saveChanges(): Boolean
 
+    @CallSuper
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
@@ -76,17 +78,20 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
         }
     }
 
+    @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
     }
 
+    @CallSuper
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
     }
 
+    @CallSuper
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
         updateDoneMenuItem()
@@ -107,6 +112,7 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
         sharedViewModel.start()
     }
 
+    @CallSuper
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
@@ -123,6 +129,7 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
         doneMenuItem?.isVisible = hasChanges()
     }
 
+    @CallSuper
     override fun onRequestAllowBackPress(): Boolean {
         return if (hasChanges()) {
             confirmDiscard()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
@@ -15,8 +15,6 @@ class LicensesFragment : Fragment(R.layout.fragment_licenses) {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         val binding = FragmentLicensesBinding.bind(view)
 
         context?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -54,8 +54,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
     @Suppress("ForbiddenComment", "LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         _binding = FragmentSettingsMainBinding.bind(view)
 
         presenter.takeView(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -27,8 +27,6 @@ class PrivacySettingsFragment : Fragment(R.layout.fragment_settings_privacy), Pr
     @Inject lateinit var presenter: PrivacySettingsContract.Presenter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         presenter.takeView(this)
 
         val binding = FragmentSettingsPrivacyBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -11,7 +11,9 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.Observer
@@ -27,6 +28,7 @@ abstract class BaseProductFragment : BaseFragment, BackPressListener {
 
     protected val viewModel: ProductDetailViewModel by hiltNavGraphViewModels(R.id.nav_graph_products)
 
+    @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -58,6 +60,7 @@ abstract class BaseProductFragment : BaseFragment, BackPressListener {
         )
     }
 
+    @CallSuper
     override fun onStop() {
         super.onStop()
         WooDialog.onCleared()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ImageViewerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ImageViewerFragment.kt
@@ -49,8 +49,6 @@ class ImageViewerFragment : Fragment(R.layout.fragment_image_viewer), RequestLis
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         _binding = FragmentImageViewerBinding.bind(view)
 
         loadImage()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -350,14 +350,10 @@ class ProductDetailFragment :
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_product_detail_fragment, menu)
-
-        super.onCreateOptionsMenu(menu, inflater)
     }
 
     @SuppressLint("ResourceAsColor")
     override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
-
         // change the font color of the trash menu item to red, and only show it if it should be enabled
         with(menu.findItem(R.id.menu_trash_product)) {
             if (this == null) return@with

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.settings
 
+import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithResult
@@ -18,12 +19,14 @@ abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
+    @CallSuper
     override fun onStop() {
         super.onStop()
         WooDialog.onCleared()
         activity?.let { ActivityUtils.hideKeyboard(it) }
     }
 
+    @CallSuper
     override fun onRequestAllowBackPress(): Boolean {
         if (hasChanges()) {
             // we only want to return to the previous screen if the changes are valid, which means if they're

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
@@ -24,8 +24,6 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
     private val navArgs: RenameAttributeFragmentArgs by navArgs()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         _binding = FragmentRenameAttributeBinding.bind(view)
         requireActivity().title = getString(R.string.product_rename_attribute)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -42,7 +42,6 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
         val binding = FeatureAnnouncementDialogFragmentBinding.bind(view)
 
         viewModel.setAnnouncementData(navArgs.announcement)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateFlow.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.SavedStateHandle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.widgets
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.CallSuper
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.R
@@ -14,9 +15,8 @@ import org.wordpress.android.util.DisplayUtils
  * sheet on large landscape tablets.
  */
 open class WCBottomSheetDialogFragment : BottomSheetDialogFragment() {
+    @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         if (DisplayUtils.isXLargeTablet(requireContext()) && DisplayUtils.isLandscape(requireContext())) {
             dialog?.setOnShowListener {
                 val dialog = it as BottomSheetDialog


### PR DESCRIPTION
Minor Improvements to base fragment classes and code clean-up related to Fragments. 

### Description
This PR adds the following improvements specific to Fragment classes:
* Deletes redundant `super.onViewCreated()` calls as those hook methods' bodies are empty (which is quite confusing in Android).
* Annotates hook methods in base classes which contain custom logic with `@CallSuper`. This prevents unconscious misusage of those base fragment classes by reminding to call the super implementation of the base method. This was introduced in: `BaseFragment `, `BaseOrderEditingFragment`, `BaseProductFragment`, `BaseProductSettingsFragment`, and `WCBottomSheetDialogFragment`.
* Removed unused imports.

### Testing instructions
There are no user-facing changes. This is a pure code clean-up PR. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
