### PR TITLE
[Coupons] edit free shipping toggle

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Switch.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Switch.kt
@@ -1,0 +1,66 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchColors
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+private fun defaultSwitchColors(): SwitchColors =
+    SwitchDefaults.colors(checkedThumbColor = MaterialTheme.colors.primary)
+
+@Composable
+fun WCSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: SwitchColors = defaultSwitchColors()
+) {
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        colors = colors
+    )
+}
+
+@Composable
+fun WCSwitch(
+    text: String,
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: SwitchColors = defaultSwitchColors()
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.subtitle1
+        )
+        WCSwitch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled,
+            interactionSource = interactionSource,
+            colors = colors
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -43,6 +43,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.ui.coupons.edit.EditCouponViewModel.ViewState
 import java.math.BigDecimal
 
 @Composable
@@ -53,7 +54,8 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
             onAmountChanged = viewModel::onAmountChanged,
             onCouponCodeChanged = viewModel::onCouponCodeChanged,
             onRegenerateCodeClick = viewModel::onRegenerateCodeClick,
-            onDescriptionButtonClick = viewModel::onDescriptionButtonClick
+            onDescriptionButtonClick = viewModel::onDescriptionButtonClick,
+            onFreeShippingChanged = viewModel::onFreeShippingChanged
         )
     }
 }
@@ -64,7 +66,8 @@ fun EditCouponScreen(
     onAmountChanged: (BigDecimal?) -> Unit = {},
     onCouponCodeChanged: (String) -> Unit = {},
     onRegenerateCodeClick: () -> Unit = {},
-    onDescriptionButtonClick: () -> Unit = {}
+    onDescriptionButtonClick: () -> Unit = {},
+    onFreeShippingChanged: (Boolean) -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -83,7 +86,8 @@ fun EditCouponScreen(
             onAmountChanged = onAmountChanged,
             onCouponCodeChanged = onCouponCodeChanged,
             onRegenerateCodeClick = onRegenerateCodeClick,
-            onDescriptionButtonClick = onDescriptionButtonClick
+            onDescriptionButtonClick = onDescriptionButtonClick,
+            onFreeShippingChanged = onFreeShippingChanged
         )
         ConditionsSection(viewState)
         UsageRestrictionsSection(viewState)
@@ -99,11 +103,12 @@ fun EditCouponScreen(
 @Suppress("LongMethod")
 @Composable
 private fun DetailsSection(
-    viewState: EditCouponViewModel.ViewState,
+    viewState: ViewState,
     onAmountChanged: (BigDecimal?) -> Unit,
     onCouponCodeChanged: (String) -> Unit,
     onRegenerateCodeClick: () -> Unit,
-    onDescriptionButtonClick: () -> Unit
+    onDescriptionButtonClick: () -> Unit,
+    onFreeShippingChanged: (Boolean) -> Unit
 ) {
     val couponDraft = viewState.couponDraft
     val focusManager = LocalFocusManager.current
@@ -144,7 +149,7 @@ private fun DetailsSection(
         WCSwitch(
             text = stringResource(id = R.string.coupon_edit_free_shipping),
             checked = viewState.couponDraft.isShippingFree ?: false,
-            onCheckedChange = {},
+            onCheckedChange = onFreeShippingChanged,
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -100,7 +100,7 @@ fun EditCouponScreen(
     }
 }
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LongParameterList")
 @Composable
 private fun DetailsSection(
     viewState: ViewState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
+import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import java.math.BigDecimal
@@ -140,6 +141,12 @@ private fun DetailsSection(
             label = stringResource(id = R.string.coupon_edit_expiry_date),
             modifier = Modifier.fillMaxWidth()
         )
+        WCSwitch(
+            text = stringResource(id = R.string.coupon_edit_free_shipping),
+            checked = viewState.couponDraft.isShippingFree ?: false,
+            onCheckedChange = {},
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 
@@ -203,6 +210,7 @@ fun EditCouponPreview() {
                     id = 0L,
                     code = "code",
                     amount = BigDecimal.TEN,
+                    isShippingFree = true,
                     productIds = emptyList(),
                     categoryIds = emptyList(),
                     excludedProductIds = emptyList(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -91,6 +91,12 @@ class EditCouponViewModel @Inject constructor(
         }
     }
 
+    fun onFreeShippingChanged(value: Boolean) {
+        couponDraft.update {
+            it?.copy(isShippingFree = value)
+        }
+    }
+
     data class ViewState(
         val couponDraft: Coupon,
         val localizedType: String?,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1967,6 +1967,7 @@
     <string name="coupon_edit_edit_description">Edit Description</string>
     <string name="coupon_edit_description_editor_title">Coupon Description</string>
     <string name="coupon_edit_add_description_hint">Add the description of the coupon.</string>
+    <string name="coupon_edit_free_shipping">Include Free Shipping?</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModelTests.kt
@@ -170,4 +170,15 @@ class EditCouponViewModelTests : BaseUnitTest() {
             val event = viewModel.event.captureValues().last()
             assertThat(event).isEqualTo(OpenDescriptionEditor("description"))
         }
+
+    @Test
+    fun `when free shipping toggle changes, then update coupon draft`() = testBlocking {
+        storedCoupon = storedCoupon.copy(isShippingFree = false)
+        setup()
+
+        viewModel.onFreeShippingChanged(true)
+
+        val state = viewModel.viewState.captureValues().last()
+        assertThat(state.couponDraft.isShippingFree).isTrue()
+    }
 }


### PR DESCRIPTION
Closes: #6521

### Description
This PR simply adds support for changing the state of the "free shipping" toggle.

As the default colors of the material switch are different from what we use in the app, I created a wrapper around the default `Switch` with our default colors, and I also added a variant that uses a Row with a Text to make adding the most common format easier.

### Testing instructions
1. Make sure coupons beta feature flag is enabled.
2. Open a coupon in the app.
3. Click on the menu, then "edit"
4. Toggle on and off the "include free shipping" switch.
5. Confirm the "Save" button state changes when the value is different than what we had



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
