### PR TITLE
Update detekt rules for Composable functions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -126,7 +126,6 @@ private fun logLevelColor(level: WooLog.LogLevel): Int {
 
 @Preview
 @Composable
-@Suppress("MagicNumber")
 fun WooLogViewerScreenPreview() {
     val entries = RollingLogEntries(99).also {
         it.add(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -126,7 +126,7 @@ private fun logLevelColor(level: WooLog.LogLevel): Int {
 
 @Preview
 @Composable
-fun WooLogViewerScreenPreview() {
+private fun WooLogViewerScreenPreview() {
     val entries = RollingLogEntries(99).also {
         it.add(
             RollingLogEntries.LogEntry(WooLog.T.ORDERS, WooLog.LogLevel.v, "Verbose")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/manuals/CardReaderManualsScreen.kt
@@ -100,7 +100,7 @@ fun ManualsList(
 
 @Preview
 @Composable
-fun Preview() {
+private fun Preview() {
     ManualsList(
         list = listOf(
             CardReaderManualsViewModel.ManualItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/animations/SkeletonAnimation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/animations/SkeletonAnimation.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.R
 const val SKELETON_ANIMATION_ALPHA = 0.2F
 
 @Composable
-@SuppressWarnings("MagicNumber")
 fun skeletonAnimationBrush(): Brush {
     val transition = rememberInfiniteTransition()
     val translateAnim by transition.animateFloat(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -208,7 +208,7 @@ fun WCTextButton(
 @Preview(name = "Light mode")
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun ButtonsPreview() {
+private fun ButtonsPreview() {
     WooThemeWithBackground {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -151,7 +151,7 @@ private fun WCOutlinedTextFieldLayout(
 @Preview(name = "Light mode")
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun WCOutlinedTextFieldPreview() {
+private fun WCOutlinedTextFieldPreview() {
     WooThemeWithBackground {
         Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
             WCOutlinedTextField(value = "", label = "Label", onValueChange = {})

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -176,7 +176,7 @@ class NullableBigDecimalTextFieldValueMapper(
 
 @Preview
 @Composable
-fun PreviewTypedTextFields() {
+private fun PreviewTypedTextFields() {
     WooThemeWithBackground {
         Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
             var signedDecimal by remember {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
@@ -74,7 +74,7 @@ fun WCOutlinedSpinner(
 @Preview(name = "Light mode")
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun SpinnerPreview() {
+private fun SpinnerPreview() {
     WooThemeWithBackground {
         var text by remember {
             mutableStateOf("button")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -160,7 +160,6 @@ private fun CouponListItemInfo(
 }
 
 @Composable
-@Suppress("MagicNumber")
 private fun CouponListSkeleton() {
     val numberOfInboxSkeletonRows = 10
     LazyColumn(Modifier.background(color = MaterialTheme.colors.surface)) {
@@ -227,7 +226,6 @@ private fun SearchEmptyList(searchQuery: String) {
 
 @Preview
 @Composable
-@Suppress("MagicNumber")
 fun CouponListPreview() {
     val coupons = listOf(
         CouponListItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -226,7 +226,7 @@ private fun SearchEmptyList(searchQuery: String) {
 
 @Preview
 @Composable
-fun CouponListPreview() {
+private fun CouponListPreview() {
     val coupons = listOf(
         CouponListItem(
             id = 1,
@@ -255,12 +255,12 @@ fun CouponListPreview() {
 
 @Preview
 @Composable
-fun CouponListEmptyPreview() {
+private fun CouponListEmptyPreview() {
     EmptyCouponList()
 }
 
 @Preview
 @Composable
-fun CouponListSkeletonPreview() {
+private fun CouponListSkeletonPreview() {
     CouponListSkeleton()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -64,7 +64,6 @@ fun CouponDetailsScreen(
 }
 
 @Composable
-@Suppress("LongMethod", "LongParameterList")
 fun CouponDetailsScreen(
     state: CouponDetailsState,
     onBackPress: () -> Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -95,7 +95,6 @@ fun EditCouponScreen(
     }
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun DetailsSection(
     viewState: EditCouponViewModel.ViewState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -194,7 +194,7 @@ private fun DescriptionButton(description: String?, onButtonClicked: () -> Unit)
 
 @Composable
 @Preview
-fun EditCouponPreview() {
+private fun EditCouponPreview() {
     WooTheme {
         EditCouponScreen(
             viewState = EditCouponViewModel.ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxScreen.kt
@@ -343,7 +343,7 @@ private fun InboxNoteButtonsSkeleton() {
 
 @Preview
 @Composable
-fun InboxPreview(@PreviewParameter(SampleInboxProvider::class, 1) state: InboxState) {
+private fun InboxPreview(@PreviewParameter(SampleInboxProvider::class, 1) state: InboxState) {
     InboxScreen(state)
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxScreen.kt
@@ -238,7 +238,6 @@ fun InboxNoteTextAction(inboxAction: InboxNoteActionUi) {
 }
 
 @Composable
-@SuppressWarnings("MagicNumber")
 fun InboxNoteSurveyAction(inboxAction: InboxNoteActionUi) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
@@ -265,7 +264,6 @@ fun InboxNoteSurveyAction(inboxAction: InboxNoteActionUi) {
 }
 
 @Composable
-@Suppress("MagicNumber")
 fun InboxSkeletons() {
     val numberOfInboxSkeletonRows = 4
     LazyColumn {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -77,7 +77,6 @@ fun MoreMenuScreen(viewModel: MoreMenuViewModel) {
 
 @ExperimentalFoundationApi
 @Composable
-@Suppress("LongMethod")
 fun MoreMenuScreen(
     state: MoreMenuViewState,
     onSwitchStore: () -> Unit,
@@ -317,7 +316,6 @@ fun MoreMenuBadge(badgeCount: Int) {
 @ExperimentalFoundationApi
 @Preview
 @Composable
-@Suppress("MagicNumber")
 fun MoreMenuPreview() {
     val state = MoreMenuViewState(
         moreMenuItems = listOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -316,7 +316,7 @@ fun MoreMenuBadge(badgeCount: Int) {
 @ExperimentalFoundationApi
 @Preview
 @Composable
-fun MoreMenuPreview() {
+private fun MoreMenuPreview() {
     val state = MoreMenuViewState(
         moreMenuItems = listOf(
             MenuUiButton(VIEW_ADMIN, string.more_menu_button_woo_admin, drawable.ic_more_menu_wp_admin),

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -3,14 +3,14 @@ build:
 
 complexity:
   LargeClass:
-    excludes: ['**/test/**']
+    excludes: [ '**/test/**' ]
   LongParameterList:
     ignoreDefaultParameters: true
-    ignoreAnnotated: ['Inject', 'Composable']
+    ignoreAnnotated: [ 'Inject', 'Composable' ]
   TooManyFunctions:
     active: false
   LongMethod:
-    ignoreAnnotated: ['Composable']
+    ignoreAnnotated: [ 'Composable' ]
 
 formatting:
   active: true
@@ -25,6 +25,8 @@ style:
     ignoreAnnotated: [ 'Module' ]
   MagicNumber:
     ignoreAnnotated: [ 'Composable' ]
+  UnusedPrivateMember:
+    ignoreAnnotated: [ 'Preview' ]
 
 naming:
   FunctionNaming:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -6,9 +6,11 @@ complexity:
     excludes: ['**/test/**']
   LongParameterList:
     ignoreDefaultParameters: true
-    ignoreAnnotated: ['Inject']
+    ignoreAnnotated: ['Inject', 'Composable']
   TooManyFunctions:
     active: false
+  LongMethod:
+    ignoreAnnotated: ['Composable']
 
 formatting:
   active: true
@@ -21,8 +23,9 @@ style:
   UnnecessaryAbstractClass:
     active: true
     ignoreAnnotated: [ 'Module' ]
+  MagicNumber:
+    ignoreAnnotated: [ 'Composable' ]
 
 naming:
   FunctionNaming:
     ignoreAnnotated: [ 'Composable' ]
-


### PR DESCRIPTION
### Description
This PR disables the Detekt checks: `LongMethod`, `LongParameterList` and `MagicNumber` for `Composable` functions, and disables `UnusedPrivateMember` for `Preview` functions.
I found myself suppressing those checks frequently lately, and I think those checks don't make sense for Composables:
1. `LongMethod`: Composable functions tend to be long, and still not complicated, as they just "declare" UI: for example a `Column` with multiple sections shouldn't have to be split in two parts, and still `detekt` would complain about it.
2. `LongParameterList`: Composable functions tend to have a long list of parameters, that's how we can make them customizable for all cases, and how we can `hoist` the state by adding callbacks for the different actions a component can have.
3. `MagicNumber`: This might be subjective, but IMO in Compose we shoudln't require people to create constants for literal values everywhere: dimensions, animation durations..., if you check the official compose samples, you'll find them using numbers directly everywhere too. 
4. `UnusedPrivateMember`: when marking `Preview` functions as private, `detekt` complain about having an unused member, where having them as private is better to avoid cluttering the auto-complete with unwanted suggestions.

Detekt has an official document about Compose: https://detekt.dev/docs/introduction/compose, I didn't follow the guidelines to the letter, we can discuss the subject, and have what makes sense for us.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
