### PR TITLE
Issue/5997 Bulk variations update: bottom sheet picker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -481,6 +481,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     PRODUCT_VARIANTS_PULLED_TO_REFRESH,
     PRODUCT_VARIANTS_LOADED,
     PRODUCT_VARIANTS_LOAD_ERROR,
+    PRODUCT_VARIANTS_BULK_UPDATE_TAPPED,
 
     // -- Product images
     PRODUCT_IMAGE_ADDED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -161,7 +161,6 @@ class VariationListFragment :
 
         viewModel.variationList.observe(viewLifecycleOwner) {
             showVariations(it, viewModel.viewStateLiveData.liveData.value?.parentProduct)
-//            requireActivity().invalidateOptionsMenu()
         }
 
         viewModel.event.observe(viewLifecycleOwner) { event ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -11,7 +11,6 @@ import android.view.View.VISIBLE
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -155,15 +154,15 @@ class VariationListFragment :
             new.isProgressDialogShown?.takeIfNotEqualTo(old?.isProgressDialogShown) {
                 showProgressDialog(it, R.string.variation_create_dialog_title)
             }
-        }
-
-        viewModel.variationList.observe(
-            viewLifecycleOwner,
-            Observer {
-                showVariations(it, viewModel.viewStateLiveData.liveData.value?.parentProduct)
+            new.isVariationsOptionsMenuEnabled.takeIfNotEqualTo(old?.isVariationsOptionsMenuEnabled) {
                 requireActivity().invalidateOptionsMenu()
             }
-        )
+        }
+
+        viewModel.variationList.observe(viewLifecycleOwner) {
+            showVariations(it, viewModel.viewStateLiveData.liveData.value?.parentProduct)
+//            requireActivity().invalidateOptionsMenu()
+        }
 
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.Transformations
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_VARIANTS_BULK_UPDATE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_VARIATION_VIEW_VARIATION_DETAIL_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_ID
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.track
@@ -88,6 +89,14 @@ class VariationListViewModel @Inject constructor(
 
     fun onLoadMoreRequested(remoteProductId: Long) {
         loadVariations(remoteProductId, loadMore = true)
+    }
+
+
+    fun onBulkUpdateClicked() {
+        track(PRODUCT_VARIANTS_BULK_UPDATE_TAPPED)
+        variationList.value?.let { variations ->
+            triggerEvent(ShowBulkUpdateAttrPicker(variations))
+        }
     }
 
     fun onItemClick(variation: ProductVariation) {
@@ -201,10 +210,11 @@ class VariationListViewModel @Inject constructor(
             if (fetchedVariations.isNullOrEmpty()) {
                 if (!loadMore) {
                     _variationList.value = emptyList()
-                    viewState = viewState.copy(isEmptyViewVisible = true)
+                    viewState = viewState.copy(isEmptyViewVisible = true, isVariationsOptionsMenuEnabled = false)
                 }
             } else {
                 _variationList.value = combineData(fetchedVariations)
+                viewState = viewState.copy(isVariationsOptionsMenuEnabled = true)
             }
         } else {
             triggerEvent(ShowSnackbar(string.offline_error))
@@ -245,7 +255,8 @@ class VariationListViewModel @Inject constructor(
         val isEmptyViewVisible: Boolean? = null,
         val isWarningVisible: Boolean? = null,
         val isProgressDialogShown: Boolean? = null,
-        val parentProduct: Product? = null
+        val parentProduct: Product? = null,
+        val isVariationsOptionsMenuEnabled: Boolean = false,
     ) : Parcelable
 
     @Parcelize
@@ -254,5 +265,10 @@ class VariationListViewModel @Inject constructor(
     ) : Parcelable
 
     data class ShowVariationDetail(val variation: ProductVariation) : Event()
+
+    /**
+     * Represents event responsible for displaying [VariationsBulkUpdateAttrPickerDialog].
+     */
+    data class ShowBulkUpdateAttrPicker(val variationsToUpdate: List<ProductVariation>): Event()
     object ShowAddAttributeView : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -91,7 +91,6 @@ class VariationListViewModel @Inject constructor(
         loadVariations(remoteProductId, loadMore = true)
     }
 
-
     fun onBulkUpdateClicked() {
         track(PRODUCT_VARIANTS_BULK_UPDATE_TAPPED)
         variationList.value?.let { variations ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateAttrPickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateAttrPickerDialog.kt
@@ -1,0 +1,100 @@
+package com.woocommerce.android.ui.products.variations
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.View.GONE
+import android.view.View.VISIBLE
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_DRAGGING
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HALF_EXPANDED
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentVariationsBulkUpdateAttrPickerBinding
+import com.woocommerce.android.ui.products.variations.VariationsBulkUpdateAttrPickerViewModel.RegularPriceState
+import com.woocommerce.android.ui.products.variations.VariationsBulkUpdateAttrPickerViewModel.ViewState
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
+
+private const val DEFAULT_BG_DIM = 0.32F
+private const val KEY_EXTRA_SHEET_STATE = "key_sheet_state"
+
+class VariationsBulkUpdateAttrPickerDialog : WCBottomSheetDialogFragment() {
+    private var _binding: FragmentVariationsBulkUpdateAttrPickerBinding? = null
+    private val binding get() = _binding!!
+
+    private val sheetCallback by lazy {
+        object : BottomSheetCallback() {
+            override fun onStateChanged(bottomSheet: View, newState: Int) = renderInternalSheetState(newState)
+            override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
+        }
+    }
+    private val viewModel: VariationsBulkUpdateAttrPickerViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentVariationsBulkUpdateAttrPickerBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val bottomSheetBehavior = getSheetBehavior()
+        binding.collapsedStateHeader.setOnClickListener { bottomSheetBehavior.state = STATE_EXPANDED }
+        binding.fullscreenStateToolbar.setNavigationOnClickListener { dismiss() }
+
+        bottomSheetBehavior.apply {
+            isFitToContents = false
+            addBottomSheetCallback(sheetCallback)
+            halfExpandedRatio = 0.5f
+            state = savedInstanceState?.getInt(KEY_EXTRA_SHEET_STATE, STATE_HALF_EXPANDED) ?: STATE_HALF_EXPANDED
+        }
+        dialog?.window?.setDimAmount(DEFAULT_BG_DIM)
+        renderInternalSheetState(bottomSheetBehavior.state)
+        lifecycleScope.launchWhenStarted {
+            viewModel.viewState.collect { newState ->
+                renderViewState(newState)
+            }
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putInt(KEY_EXTRA_SHEET_STATE, getSheetBehavior().state)
+        super.onSaveInstanceState(outState)
+    }
+
+    private fun renderViewState(newState: ViewState) {
+        binding.priceSubtitle.text = when (newState.regularPriceState) {
+            RegularPriceState.None -> getString(R.string.variations_bulk_update_dialog_price_none)
+            RegularPriceState.Mixed -> getString(R.string.variations_bulk_update_dialog_price_mixed)
+            is RegularPriceState.Value -> newState.regularPriceState.price
+        }
+    }
+
+    private fun renderInternalSheetState(bottomSheetState: Int) {
+        when (bottomSheetState) {
+            STATE_EXPANDED -> {
+                getSheetBehavior().isFitToContents = false
+                dialog?.window?.setDimAmount(0F)
+                binding.collapsedStateHeader.visibility = GONE
+                binding.fullscreenStateToolbar.visibility = VISIBLE
+            }
+            STATE_DRAGGING -> {
+                dialog?.window?.setDimAmount(DEFAULT_BG_DIM)
+                binding.collapsedStateHeader.visibility = VISIBLE
+                binding.fullscreenStateToolbar.visibility = GONE
+            }
+            STATE_COLLAPSED, STATE_HALF_EXPANDED -> {
+                dialog?.window?.setDimAmount(DEFAULT_BG_DIM)
+                binding.collapsedStateHeader.visibility = VISIBLE
+                binding.fullscreenStateToolbar.visibility = GONE
+            }
+        }
+    }
+
+    private fun getSheetBehavior() = (dialog as BottomSheetDialog).behavior
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateAttrPickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateAttrPickerDialog.kt
@@ -56,7 +56,7 @@ class VariationsBulkUpdateAttrPickerDialog : WCBottomSheetDialogFragment() {
         dialog?.window?.setDimAmount(DEFAULT_BG_DIM)
         renderInternalSheetState(bottomSheetBehavior.state)
         lifecycleScope.launchWhenStarted {
-            viewModel.viewState.collect { newState ->
+            viewModel.viewState.observe(viewLifecycleOwner) { newState ->
                 renderViewState(newState)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateAttrPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateAttrPickerViewModel.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.products.variations
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Responsible for calculating view state - [ProductVariation] attribute subtitles
+ * which are represented by [RegularPriceState] class.
+ */
+class VariationsBulkUpdateAttrPickerViewModel(
+    savedState: SavedStateHandle,
+) : ScopedViewModel(savedState) {
+    private val args: VariationsBulkUpdateAttrPickerDialogArgs by savedState.navArgs()
+
+    private val _viewState = MutableStateFlow(ViewState())
+    val viewState: StateFlow<ViewState> = _viewState
+
+    init {
+        val regularPriceState = calculateRegularPriceState(args.variationsToUpdate)
+        _viewState.value = viewState.value.copy(regularPriceState = regularPriceState)
+    }
+
+    private fun calculateRegularPriceState(variations: Array<ProductVariation>): RegularPriceState {
+        val prices = variations.map { it.regularPrice }
+        return when {
+            prices.isEmpty() -> RegularPriceState.None
+            prices.distinct().size == 1 ->
+                RegularPriceState.Value(variations.map { it.priceWithCurrency }.first() ?: "")
+            else -> RegularPriceState.Mixed
+        }
+    }
+
+    data class ViewState(
+        val regularPriceState: RegularPriceState = RegularPriceState.None
+    )
+
+    sealed class RegularPriceState {
+        object None : RegularPriceState()
+        object Mixed : RegularPriceState()
+        data class Value(val price: String) : RegularPriceState()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateAttrPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateAttrPickerViewModel.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.ui.products.variations
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.ui.products.variations.VariationsBulkUpdateAttrPickerViewModel.RegularPriceState
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Responsible for calculating view state - [ProductVariation] attribute subtitles
@@ -17,11 +19,11 @@ class VariationsBulkUpdateAttrPickerViewModel(
     private val args: VariationsBulkUpdateAttrPickerDialogArgs by savedState.navArgs()
 
     private val _viewState = MutableStateFlow(ViewState())
-    val viewState: StateFlow<ViewState> = _viewState
+    val viewState: LiveData<ViewState> = _viewState.asLiveData()
 
     init {
         val regularPriceState = calculateRegularPriceState(args.variationsToUpdate)
-        _viewState.value = viewState.value.copy(regularPriceState = regularPriceState)
+        _viewState.value = _viewState.value.copy(regularPriceState = regularPriceState)
     }
 
     private fun calculateRegularPriceState(variations: Array<ProductVariation>): RegularPriceState {

--- a/WooCommerce/src/main/res/layout/fragment_variations_bulk_update_attr_picker.xml
+++ b/WooCommerce/src/main/res/layout/fragment_variations_bulk_update_attr_picker.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ui.main.MainActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/fullscreen_state_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        app:navigationIcon="@drawable/ic_close"
+        app:navigationIconTint="@color/color_icon">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/fullscreen_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="12dp"
+            android:paddingRight="12dp"
+            android:text="@string/variations_bulk_update_dialog_title"
+            android:textColor="@color/color_on_surface_high"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            tools:ignore="RtlHardcoded" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/collapsed_state_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackground"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/variations_bulk_update_dialog_title"
+            android:textColor="@color/color_on_surface_high"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/variations_bulk_update_dialog_subtitle"
+            android:textColor="@color/color_on_surface_medium"
+            android:textSize="14sp" />
+    </androidx.appcompat.widget.LinearLayoutCompat>
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/divider_color" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="14dp"
+            android:paddingVertical="12dp"
+            android:text="@string/variations_bulk_update_dialog_price_section_title"
+            android:textColor="@color/color_on_surface_medium"
+            android:textSize="16sp" />
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:id="@+id/regular_price"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            android:orientation="vertical"
+            android:paddingVertical="12dp">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/price_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="16dp"
+                android:text="@string/variations_bulk_update_dialog_regular_price_label"
+                android:textColor="@color/color_on_surface_high"
+                android:textSize="16sp" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/price_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="16dp"
+                android:textColor="@color/color_on_surface_medium"
+                android:textSize="14sp"
+                tools:text="$8.00" />
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/divider_color" />
+
+        <View
+            android:id="@+id/bottom_spacer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.appcompat.widget.LinearLayoutCompat>
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/WooCommerce/src/main/res/layout/fragment_variations_bulk_update_attr_picker.xml
+++ b/WooCommerce/src/main/res/layout/fragment_variations_bulk_update_attr_picker.xml
@@ -11,22 +11,11 @@
         android:id="@+id/fullscreen_state_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        style="@style/Widget.Woo.Toolbar"
         android:animateLayoutChanges="true"
         app:navigationIcon="@drawable/ic_close"
-        app:navigationIconTint="@color/color_icon">
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/fullscreen_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingLeft="12dp"
-            android:paddingRight="12dp"
-            android:text="@string/variations_bulk_update_dialog_title"
-            android:textColor="@color/color_on_surface_high"
-            android:textSize="20sp"
-            android:textStyle="bold"
-            tools:ignore="RtlHardcoded" />
-    </com.google.android.material.appbar.MaterialToolbar>
+        app:navigationIconTint="@color/color_icon"
+        app:title="@string/variations_bulk_update_dialog_title" />
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/collapsed_state_header"
@@ -34,7 +23,7 @@
         android:layout_height="wrap_content"
         android:background="?selectableItemBackground"
         android:orientation="vertical"
-        android:padding="16dp">
+        android:padding="@dimen/major_100">
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/title"
@@ -42,7 +31,7 @@
             android:layout_height="wrap_content"
             android:text="@string/variations_bulk_update_dialog_title"
             android:textColor="@color/color_on_surface_high"
-            android:textSize="20sp"
+            android:textSize="@dimen/text_major_25"
             android:textStyle="bold" />
 
         <androidx.appcompat.widget.AppCompatTextView
@@ -51,7 +40,7 @@
             android:layout_height="wrap_content"
             android:text="@string/variations_bulk_update_dialog_subtitle"
             android:textColor="@color/color_on_surface_medium"
-            android:textSize="14sp" />
+            android:textSize="@dimen/text_minor_100" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 
     <androidx.appcompat.widget.LinearLayoutCompat
@@ -61,17 +50,17 @@
 
         <View
             android:layout_width="match_parent"
-            android:layout_height="1dp"
+            android:layout_height="@dimen/minor_10"
             android:background="@color/divider_color" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingHorizontal="14dp"
-            android:paddingVertical="12dp"
+            android:paddingHorizontal="@dimen/major_85"
+            android:paddingVertical="@dimen/major_75"
             android:text="@string/variations_bulk_update_dialog_price_section_title"
             android:textColor="@color/color_on_surface_medium"
-            android:textSize="16sp" />
+            android:textSize="@dimen/text_minor_125" />
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:id="@+id/regular_price"
@@ -81,30 +70,30 @@
             android:clickable="true"
             android:focusable="true"
             android:orientation="vertical"
-            android:paddingVertical="12dp">
+            android:paddingVertical="@dimen/major_75">
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/price_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingHorizontal="16dp"
+                android:paddingHorizontal="@dimen/major_100"
                 android:text="@string/variations_bulk_update_dialog_regular_price_label"
                 android:textColor="@color/color_on_surface_high"
-                android:textSize="16sp" />
+                android:textSize="@dimen/text_minor_125" />
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/price_subtitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingHorizontal="16dp"
+                android:paddingHorizontal="@dimen/major_100"
                 android:textColor="@color/color_on_surface_medium"
-                android:textSize="14sp"
+                android:textSize="@dimen/text_minor_100"
                 tools:text="$8.00" />
         </androidx.appcompat.widget.LinearLayoutCompat>
 
         <View
             android:layout_width="match_parent"
-            android:layout_height="1dp"
+            android:layout_height="@dimen/minor_10"
             android:background="@color/divider_color" />
 
         <View

--- a/WooCommerce/src/main/res/menu/menu_variation_list_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_variation_list_fragment.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_bulk_update"
+        android:title="@string/variation_list_menu_bulk_update"
+        android:visible="false"
+        app:showAsAction="never" />
+
+</menu>

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -107,7 +107,23 @@
                 android:defaultValue="false"
                 app:argType="boolean" />
         </action>
+        <action
+            android:id="@+id/action_variationListFragment_to_variationsBulkUpdateAttrPickerFragment"
+            app:destination="@id/variationsBulkUpdateAttrPickerFragment" >
+            <argument
+                android:name="variationsToUpdate"
+                app:argType="com.woocommerce.android.model.ProductVariation[]" />
+        </action>
+
     </fragment>
+    <dialog
+        android:id="@+id/variationsBulkUpdateAttrPickerFragment"
+        android:name="com.woocommerce.android.ui.products.variations.VariationsBulkUpdateAttrPickerDialog"
+        android:label="variationsBulkUpdateAttrPickerFragment">
+        <argument
+            android:name="variationsToUpdate"
+            app:argType="com.woocommerce.android.model.ProductVariation[]" />
+    </dialog>
     <fragment
         android:id="@+id/attributeListFragment"
         android:name="com.woocommerce.android.ui.products.variations.attributes.AttributeListFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1456,7 +1456,17 @@
     <string name="variation_created_title">Variation Created</string>
     <string name="variation_create_dialog_title">Generating variation</string>
     <string name="variation_confirm_delete">Do you want to delete this Variation?</string>
+    <string name="variation_list_menu_bulk_update">Bulk update…</string>
 
+    <!--
+        Variations bulk update
+    -->
+    <string name="variations_bulk_update_dialog_title">Bulk update</string>
+    <string name="variations_bulk_update_dialog_subtitle">Choose a value to update</string>
+    <string name="variations_bulk_update_dialog_price_section_title">Price</string>
+    <string name="variations_bulk_update_dialog_regular_price_label">Regular price</string>
+    <string name="variations_bulk_update_dialog_price_none">None</string>
+    <string name="variations_bulk_update_dialog_price_mixed">Mixed</string>
     <!--
         Product images
     -->


### PR DESCRIPTION
Note: this PR implements the #5997 partially and targets the base feature branch.

### Description
* Added menu on `VariationListFragment` screen with the "Bulk update..." option. The menu is displayed after the variations are loaded.
* Added new analytics event - `PRODUCT_VARIANTS_BULK_UPDATE_TAPPED`, tracked on "Bulk update..."  clicks.
* Implemented a `BottomSheetDialogFragment` acting as `ProductVariation` attrs picker (for now only containing regular price attr). The bottom sheet is expandable to the fullscreen view too.
* Implemented `VariationsBulkUpdateAttrPickerViewModel` class. It is responsible for calculating view state of the bottom sheet picker - if the product variations attribute groups have: the same values, mixed, or no values - as required by the UI design.

### Testing instructions
1. Open product details and go to "Variations" list (product must have variations defined). 
2. After variations are loaded click the "Bulk update..." menu item.
3. The bottom sheet should appear.

### Visual changes
| Light mode  | Dark mode |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/4527432/168664454-b4e2e564-9d27-4186-a374-36b582f7d8cb.mp4"/>  | <video src="https://user-images.githubusercontent.com/4527432/168664486-31c70320-7126-4e92-a8bf-833a4edb9225.mp4">  |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
👆🏼 This will be added with the final PR targeting the trunk branch.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
