### PR TITLE
Use shared Gradle dependency cache from dependency catalog

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Note that as the script is sourced not run directly, the shebang line will be ignored
+# Note that as the script is sourced, not run directly, the shebang line will be ignored
 # See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
 
 set -e

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Note that as the script is sourced not run directly, the shebang line will be ignored
+# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+
+set -e
+
+restore_gradle_dependency_cache || true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.1.0
+    - automattic/bash-cache#save-and-restore-gradle-dependency-cache
 
 steps:
   - label: "checkstyle"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#save-and-restore-gradle-dependency-cache
+    - automattic/bash-cache#2.4.0
 
 steps:
   - label: "checkstyle"


### PR DESCRIPTION
### Description
This PR adds a `pre-command` Buildkite hook which restores the our global Gradle dependency cache we create from https://github.com/Automattic/android-dependency-catalog/ project. It uses the `restore_gradle_dependency_cache` script introduced in https://github.com/Automattic/bash-cache-buildkite-plugin/pull/25 which includes more information about how our caching works. Errors during cache restoration will not halt the builds since it's optional.

~**Note that https://github.com/Automattic/bash-cache-buildkite-plugin/pull/25 needs to be merged and a new `bash-cache-buildkite-plugin` release needs to be created before this PR can be merged.**~

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* [The network tab in PR's `Installable Build`'s Gradle scan](https://gradle.a8c.com/s/e3e6jpobqfe3a/performance/network-activity) indicate that `177.3 MiB` data was downloaded.
* [The network tab from `release/9.2`'s `Installable Build`'s Gradle scan](https://gradle.a8c.com/s/u3sdwq45m3zws/performance/network-activity) indicate that `407.1 MiB` data was downloaded.

Even though these scans are not based on the same base commit, it's a good enough indication that the cache was correctly utilized. The build logs also show that the cache was restored successfully.

Note that, since https://github.com/Automattic/android-dependency-catalog/ does not yet have most WCAndroid dependencies, the cache that's restored is only a partial match.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
