### PR TITLE
Add nullcheck on tablayout when setting tab position after delay

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -48,7 +48,6 @@ import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
@@ -171,7 +170,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                 val index = StatsGranularity.values().indexOf(activeGranularity)
                 // Small delay needed to ensure tablayout scrolls to the selected tab if tab is not visible on screen.
                 Handler(Looper.getMainLooper()).postDelayed(
-                    { tabLayout.getTabAt(index)?.select() }, 300
+                    { _tabLayout?.getTabAt(index)?.select() }, 300
                 )
             }
             binding.myStoreStats.loadDashboardStats(activeGranularity)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6487
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
To fix [this issue](https://github.com/woocommerce/woocommerce-android/pull/6320) when navigating back to `My Store` tab a minor delay was introduced when setting selected tab position on `tabLayout`. This delay ensures that the `tablayout` will scroll to the selected tab position. But the delay introduces a `NullPointerException` crash when navigating very fast  between tabs. 

### Testing instructions
To make the app crash: 
- Open the app, select “This Year” tab
- Navigate to More Menu
- Now as fast as you can click on My Store tab and then More Menu. If you are fast enough or your device is slow enough you’ll see the `NullPointer` crash.

Now test this again with the fix. It should not crahs


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
