### PR TITLE
Fix coupons navigation

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -160,8 +160,7 @@
     <fragment
         android:id="@+id/moreMenu"
         android:name="com.woocommerce.android.ui.moremenu.MoreMenuFragment"
-        android:label="fragment_more_menu"
-        tools:layout="@layout/fragment_more_menu">
+        android:label="fragment_more_menu">
         <action
             android:id="@+id/action_moreMenu_to_reviewList"
             app:destination="@id/reviews" />
@@ -308,7 +307,7 @@
         app:popExitAnim="@anim/activity_fade_out" />
     <action
         android:id="@+id/action_global_login_to_sitePickerFragment"
-        app:destination="@id/sitePickerFragment"/>
+        app:destination="@id/sitePickerFragment" />
     <dialog
         android:id="@+id/productTypesBottomSheetFragment"
         android:name="com.woocommerce.android.ui.products.ProductTypesBottomSheetFragment"
@@ -358,8 +357,7 @@
     <fragment
         android:id="@+id/inboxFragment"
         android:name="com.woocommerce.android.ui.inbox.InboxFragment"
-        android:label="InboxFragment"
-        tools:layout="@layout/fragment_inbox" />
+        android:label="InboxFragment" />
     <fragment
         android:id="@+id/sitePickerFragment"
         android:name="com.woocommerce.android.ui.sitepicker.SitePickerFragment"
@@ -367,8 +365,8 @@
         tools:layout="@layout/fragment_site_picker">
         <argument
             android:name="openedFromLogin"
-            app:argType="boolean"
-            android:defaultValue="true" />
+            android:defaultValue="true"
+            app:argType="boolean" />
     </fragment>
     <fragment
         android:id="@+id/simpleTextEditorFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -3,6 +3,16 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_main">
+
+    <include app:graph="@navigation/nav_graph_orders" />
+    <include app:graph="@navigation/nav_graph_order_filters" />
+    <include app:graph="@navigation/nav_graph_products" />
+    <include app:graph="@navigation/nav_graph_product_filters" />
+    <include app:graph="@navigation/nav_graph_order_creations" />
+    <include app:graph="@navigation/nav_graph_simple_payments" />
+    <include app:graph="@navigation/nav_graph_jetpack_install" />
+    <include app:graph="@navigation/nav_graph_coupons" />
+
     <fragment
         android:id="@+id/dashboard"
         android:name="com.woocommerce.android.ui.mystore.MyStoreFragment"
@@ -232,15 +242,6 @@
             app:destination="@id/reviews"
             app:popUpTo="@+id/moreMenu" />
     </fragment>
-
-    <include app:graph="@navigation/nav_graph_orders" />
-    <include app:graph="@navigation/nav_graph_order_filters" />
-    <include app:graph="@navigation/nav_graph_products" />
-    <include app:graph="@navigation/nav_graph_product_filters" />
-    <include app:graph="@navigation/nav_graph_order_creations" />
-    <include app:graph="@navigation/nav_graph_simple_payments" />
-    <include app:graph="@navigation/nav_graph_jetpack_install" />
-    <include app:graph="@navigation/nav_graph_coupons" />
 
     <fragment
         android:id="@+id/infoScreenFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -239,6 +239,8 @@
     <include app:graph="@navigation/nav_graph_product_filters" />
     <include app:graph="@navigation/nav_graph_order_creations" />
     <include app:graph="@navigation/nav_graph_simple_payments" />
+    <include app:graph="@navigation/nav_graph_jetpack_install" />
+    <include app:graph="@navigation/nav_graph_coupons" />
 
     <fragment
         android:id="@+id/infoScreenFragment"
@@ -348,7 +350,6 @@
         android:id="@+id/orderCreationBottomSheetFragment"
         android:name="com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment"
         tools:layout="@layout/dialog_order_creation_bottom_sheet" />
-    <include app:graph="@navigation/nav_graph_jetpack_install" />
     <activity
         android:id="@+id/appSettingsActivity"
         android:name="com.woocommerce.android.ui.prefs.AppSettingsActivity"


### PR DESCRIPTION
### Description
This PR fixes a crash when navigating to the coupons screen, the cause of the crash is the accidental removal of the `include` statement of the coupons navgraph in this PR #6488.

I also re-organized the code a bit: reformatted it and moved all the `include` statements to the top to be more visible.
And I removed the declarations of the removed layouts.

### Testing instructions
1. Open the app.
2. Click on More.
3. Click on Coupons.
4. Confirm the app doesn't crash.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
