### PR TITLE
Adjust Order EMPTY static field to contain the most recent DateTime possible

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -233,9 +233,9 @@ data class Order(
     fun getProductIds() = items.map { it.productId }
 
     fun isEmpty() = this.copy(
-            dateCreated = DEFAULT_EMPTY_ORDER.dateCreated,
-            dateModified = DEFAULT_EMPTY_ORDER.dateModified
-        ) == DEFAULT_EMPTY_ORDER
+        dateCreated = DEFAULT_EMPTY_ORDER.dateCreated,
+        dateModified = DEFAULT_EMPTY_ORDER.dateModified
+    ) == DEFAULT_EMPTY_ORDER
 
     sealed class Status(val value: String) : Parcelable {
         companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -232,6 +232,11 @@ data class Order(
 
     fun getProductIds() = items.map { it.productId }
 
+    fun isEmpty() = this.copy(
+            dateCreated = DEFAULT_EMPTY_ORDER.dateCreated,
+            dateModified = DEFAULT_EMPTY_ORDER.dateModified
+        ) == DEFAULT_EMPTY_ORDER
+
     sealed class Status(val value: String) : Parcelable {
         companion object {
             fun fromValue(value: String): Status {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -233,6 +233,7 @@ data class Order(
     fun getProductIds() = items.map { it.productId }
 
     fun isEmpty() = this.copy(
+        currency = "",
         dateCreated = DEFAULT_EMPTY_ORDER.dateCreated,
         dateModified = DEFAULT_EMPTY_ORDER.dateModified
     ) == DEFAULT_EMPTY_ORDER

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -282,7 +282,7 @@ data class Order(
     }
 
     companion object {
-        val EMPTY by lazy {
+        private val DEFAULT_EMPTY_ORDER by lazy {
             Order(
                 id = 0,
                 number = "",
@@ -318,6 +318,9 @@ data class Order(
                 paymentUrl = ""
             )
         }
+
+        val EMPTY
+            get() = DEFAULT_EMPTY_ORDER.copy(dateCreated = Date(), dateModified = Date())
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -240,7 +240,7 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onBackButtonClicked() {
-        if (_orderDraft.value.copy(currency = "").isEmpty()) {
+        if (_orderDraft.value.isEmpty()) {
             triggerEvent(Exit)
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -240,7 +240,7 @@ class OrderCreationViewModel @Inject constructor(
     }
 
     fun onBackButtonClicked() {
-        if (_orderDraft.value.copy(currency = "") == Order.EMPTY) {
+        if (_orderDraft.value.copy(currency = "").isEmpty()) {
             triggerEvent(Exit)
             return
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
@@ -25,6 +25,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
@@ -719,10 +720,11 @@ class OrderCreationViewModelTest : BaseUnitTest() {
 
     private fun initMocks() {
         val defaultOrderItem = createOrderItem()
+        val emptyOrder = Order.EMPTY
         viewState = ViewState()
         savedState = mock {
             on { getLiveData(viewState.javaClass.name, viewState) } doReturn MutableLiveData(viewState)
-            on { getLiveData(Order.EMPTY.javaClass.name, Order.EMPTY) } doReturn MutableLiveData(Order.EMPTY)
+            on { getLiveData(eq(Order.EMPTY.javaClass.name), any<Order>()) } doReturn MutableLiveData(emptyOrder)
         }
         createOrUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(Order.EMPTY))


### PR DESCRIPTION
Summary
==========
Fix the Order Creation timestamp issue by making the default `EMPTY` Order property we have inside the `Order` model to be a computed companion object property with a just created Date instead of a constant lazily initialized one, but keeping a default private one just to avoid creating the entire object every time we access the `EMPTY` field. This way, we avoid creating all Orders in a given moment using an incorrect timestamp.

How to reproduce the issue
==========
1. Fresh start the app
2. Go to the Order Creation view
3. Check if the time displayed there matches the current time
4. Go back and wait 5 minutes
5. Go to the Order Creation view again, check that the time is incorrect and displaying a past time, probably the very same time it was displayed in step 3


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.