### PR TITLE
Issue/6536 decimal numbers starting with 0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 9.3
 -----
 - [*] In-Person Payments: Individual Card Reader Manual tabs removed from IPP Screen and moved to the new screen `Card Reader Manuals` [https://github.com/woocommerce/woocommerce-android/pull/6518]
-
+- [*] Fixed a bug that prevented entering decimal values starting with 0 [https://github.com/woocommerce/woocommerce-android/pull/6537]
 
 9.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -255,7 +255,7 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
                 // Prevent negative values if they are not supported
                 ""
             }
-            newValue.toBigDecimalOrNull() == null -> {
+            newValue.toBigDecimalOrNull() == null && newValue != decimalSeparator -> {
                 // Prevent entering non-valid numbers
                 ""
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -282,7 +282,9 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
                 updatedText
             } else text
 
-            _value.value = text?.toString()?.replace(decimalSeparator, ".")?.toBigDecimalOrNull() ?: BigDecimal.ZERO
+            val bigDecimalValue = text?.toString()?.replace(decimalSeparator, ".")?.toBigDecimalOrNull()
+            _value.value = if (supportsEmptyState) bigDecimalValue else bigDecimalValue ?: BigDecimal.ZERO
+
             if (text != null) {
                 // Trim any leading unwanted zeros
                 val cleanedText = text.trimStart('-').trimStart('0')

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -255,7 +255,7 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
                 // Prevent negative values if they are not supported
                 ""
             }
-            newValue.toBigDecimalOrNull() == null && newValue != decimalSeparator -> {
+            newValue.toBigDecimalOrNull() == null && newValue != "." && newValue != "-." -> {
                 // Prevent entering non-valid numbers
                 ""
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -282,7 +282,7 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
                 updatedText
             } else text
 
-            _value.value = text?.toString()?.replace(decimalSeparator, ".")?.toBigDecimalOrNull()
+            _value.value = text?.toString()?.replace(decimalSeparator, ".")?.toBigDecimalOrNull() ?: BigDecimal.ZERO
             if (text != null) {
                 // Trim any leading unwanted zeros
                 val cleanedText = text.trimStart('-').trimStart('0')


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6536

### Description
When adding a decimal value starting with 0, the EditText control removed the decimal separator and reset the text to 0, making it impossible to enter a decimal value like 0.93. To fix this behavior, I updated the `WCMaterialOutlinedCurrencyEditTextView` to perceive the decimal separator as a valid character. I also made a small change to reset the control value to 0 when the text is an invalid BigDecimal (as is the case of a string only containing the decimal separator).

### Testing instructions

1. In the app, go to the Order tab and create a new order.
2. Tap "Add shipping".
3. Enter an amount with a decimal value (e.g. $0.93)
4. The EditText control should allow you to type a decimal number starting with 0.

### Images/gif

https://user-images.githubusercontent.com/18119390/169092589-1aeb5c75-6c2a-43df-953b-51414e5a34e3.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
