### PR TITLE
[Coupons] Inline clearing expiry date in the date picker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AlertDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AlertDialog.kt
@@ -1,0 +1,89 @@
+package com.woocommerce.android.ui.compose.component
+
+import android.R.string
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.DialogProperties
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+/**
+ * An [androidx.compose.material.AlertDialog] that supports a third neutral button.
+ */
+@Composable
+fun AlertDialog(
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissButton: @Composable () -> Unit,
+    neutralButton: (@Composable () -> Unit),
+    title: @Composable (() -> Unit)? = null,
+    text: @Composable (() -> Unit)? = null,
+    shape: Shape = MaterialTheme.shapes.medium,
+    backgroundColor: Color = MaterialTheme.colors.surface,
+    contentColor: Color = contentColorFor(backgroundColor),
+    properties: DialogProperties = DialogProperties()
+) {
+    androidx.compose.material.AlertDialog(
+        onDismissRequest = onDismissRequest,
+        buttons = {
+            DialogButtonsRowLayout(
+                confirmButton = confirmButton,
+                dismissButton = dismissButton,
+                neutralButton = neutralButton,
+                modifier = Modifier.padding(
+                    horizontal = dimensionResource(id = R.dimen.minor_100),
+                    vertical = dimensionResource(id = R.dimen.minor_25)
+                )
+            )
+        },
+        modifier = modifier,
+        title = title,
+        text = text,
+        shape = shape,
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+        properties = properties
+    )
+}
+
+@Preview
+@Composable
+private fun AlertDialogPreview() {
+    WooThemeWithBackground {
+        AlertDialog(
+            onDismissRequest = {},
+            title = {
+                Text(text = "Title")
+            },
+            text = {
+                Text(text = "This is a long text to preview the dialog dasd asdas ddsad")
+            },
+            confirmButton = {
+                TextButton(onClick = { }) {
+                    Text(stringResource(id = string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { }) {
+                    Text(stringResource(id = string.cancel))
+                }
+            },
+            neutralButton = {
+                TextButton(onClick = { }) {
+                    Text("Neutral")
+                }
+            }
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -5,13 +5,11 @@ package com.woocommerce.android.ui.compose.component
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,6 +20,8 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -43,12 +43,12 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -99,7 +99,6 @@ fun DatePickerDialog(
         var selectedDate: Calendar by rememberSaveable { mutableStateOf(currentDate ?: Calendar.getInstance()) }
 
         val orientation = LocalConfiguration.current.orientation
-
         if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
             Row(
                 modifier = Modifier
@@ -187,7 +186,11 @@ private fun Any.DatePickerContent(
         )
     }
 
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .verticalScroll(state = rememberScrollState())
+    ) {
         if (isShowingYearSelector) {
             YearSelector(
                 currentDate = selectedDate,
@@ -210,29 +213,31 @@ private fun Any.DatePickerContent(
                 }
             )
         }
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(
-                space = dimensionResource(id = R.dimen.minor_100),
-                alignment = Alignment.Start
-            ),
+        DialogButtonsRowLayout(
+            confirmButton = {
+                TextButton(onClick = onSubmitRequest) {
+                    Text(
+                        text = stringResource(id = android.R.string.ok),
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = onDismissRequest
+                ) {
+                    Text(
+                        text = stringResource(id = android.R.string.cancel),
+                    )
+                }
+            },
+            neutralButton = neutralButton,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(dimensionResource(id = R.dimen.major_100))
-        ) {
-            neutralButton?.invoke()
-            Spacer(modifier = Modifier.weight(1f))
-            TextButton(onClick = onDismissRequest) {
-                Text(
-                    text = stringResource(id = android.R.string.cancel),
+                .padding(
+                    horizontal = dimensionResource(id = R.dimen.minor_100),
+                    vertical = dimensionResource(id = R.dimen.minor_25)
                 )
-            }
-
-            TextButton(onClick = onSubmitRequest) {
-                Text(
-                    text = stringResource(id = android.R.string.ok),
-                )
-            }
-        }
+        )
     }
 }
 
@@ -293,7 +298,7 @@ private fun YearSelector(
                 modifier = Modifier
                     .clickable { onYearSelected(it) }
                     .fillMaxWidth()
-                    .padding(dimensionResource(id = R.dimen.major_75))
+                    .padding(10.dp)
             ) {
                 Text(
                     text = it.toString(),
@@ -311,8 +316,8 @@ private var Calendar.year
 
 @Preview
 @Composable
-private fun DatePickerPreview() {
-    WooThemeWithBackground {
+private fun InteractiveDatePickerPreview() {
+    MaterialTheme {
         var date by remember { mutableStateOf<Date?>(null) }
         var showPicker by remember { mutableStateOf(false) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -63,6 +64,7 @@ fun DatePickerDialog(
     currentDate: Date?,
     onDateSelected: (Date) -> Unit,
     onDismissRequest: () -> Unit,
+    neutralButton: (@Composable () -> Unit)? = null,
     minDate: Date = GregorianCalendar(DEFAULT_MIN_YEAR, 0, 1).time,
     maxDate: Date = GregorianCalendar(DEFAULT_MAX_YEAR, 0, 1).time,
     dateFormat: DateFormat = SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM),
@@ -73,6 +75,7 @@ fun DatePickerDialog(
         currentDate = currentDate?.toCalendar(),
         onDateSelected = { onDateSelected(it.time) },
         onDismissRequest = onDismissRequest,
+        neutralButton = neutralButton,
         minDate = minDate.toCalendar(),
         maxDate = maxDate.toCalendar(),
         dateFormat = dateFormat,
@@ -86,6 +89,7 @@ fun DatePickerDialog(
     currentDate: Calendar?,
     onDateSelected: (Calendar) -> Unit,
     onDismissRequest: () -> Unit,
+    neutralButton: (@Composable () -> Unit)? = null,
     minDate: Calendar = GregorianCalendar(DEFAULT_MIN_YEAR, 0, 1),
     maxDate: Calendar = GregorianCalendar(DEFAULT_MAX_YEAR, 0, 1),
     dateFormat: DateFormat = SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM),
@@ -113,6 +117,7 @@ fun DatePickerDialog(
                     onDateChanged = { selectedDate = it },
                     onSubmitRequest = { onDateSelected(selectedDate) },
                     onDismissRequest = onDismissRequest,
+                    neutralButton = neutralButton,
                     minDate = minDate,
                     maxDate = maxDate,
                     dateFormat = dateFormat
@@ -132,6 +137,7 @@ fun DatePickerDialog(
                     onDateChanged = { selectedDate = it },
                     onSubmitRequest = { onDateSelected(selectedDate) },
                     onDismissRequest = onDismissRequest,
+                    neutralButton = neutralButton,
                     minDate = minDate,
                     maxDate = maxDate,
                     dateFormat = dateFormat
@@ -148,6 +154,7 @@ private fun Any.DatePickerContent(
     onDateChanged: (Calendar) -> Unit,
     onSubmitRequest: () -> Unit,
     onDismissRequest: () -> Unit,
+    neutralButton: (@Composable () -> Unit)?,
     minDate: Calendar,
     maxDate: Calendar,
     dateFormat: DateFormat,
@@ -206,10 +213,14 @@ private fun Any.DatePickerContent(
         Row(
             horizontalArrangement = Arrangement.spacedBy(
                 space = dimensionResource(id = R.dimen.minor_100),
-                alignment = Alignment.End
+                alignment = Alignment.Start
             ),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(dimensionResource(id = R.dimen.major_100))
         ) {
+            neutralButton?.invoke()
+            Spacer(modifier = Modifier.weight(1f))
             TextButton(onClick = onDismissRequest) {
                 Text(
                     text = stringResource(id = android.R.string.cancel),
@@ -300,7 +311,7 @@ private var Calendar.year
 
 @Preview
 @Composable
-fun DatePickerPreview() {
+private fun DatePickerPreview() {
     WooThemeWithBackground {
         var date by remember { mutableStateOf<Date?>(null) }
         var showPicker by remember { mutableStateOf(false) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -316,7 +317,7 @@ private var Calendar.year
 @Preview
 @Composable
 private fun InteractiveDatePickerPreview() {
-    MaterialTheme {
+    WooThemeWithBackground {
         var date by remember { mutableStateOf<Date?>(null) }
         var showPicker by remember { mutableStateOf(false) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -298,7 +298,7 @@ private fun YearSelector(
                 modifier = Modifier
                     .clickable { onYearSelected(it) }
                     .fillMaxWidth()
-                    .padding(10.dp)
+                    .padding(dimensionResource(id = R.dimen.major_75))
             ) {
                 Text(
                     text = it.toString(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -260,7 +260,7 @@ private fun CalendarView(
             if (maxDate != null)
                 view.maxDate = maxDate.timeInMillis
 
-            view.date = currentDate.timeInMillis
+            view.setDate(currentDate.timeInMillis, false, true)
 
             view.setOnDateChangeListener { _, year, month, dayOfMonth ->
                 onDateSelected(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
@@ -37,13 +37,13 @@ fun DialogButtonsRowLayout(
             measurables: List<Measurable>,
             constraints: Constraints
         ): MeasureResult {
-            val loosConstraints = constraints.copy(minWidth = 0)
+            val childConstraints = constraints.copy(minWidth = 0)
             val confirmPlaceable =
-                measurables.first { it.layoutId == "confirm" }.measure(loosConstraints)
+                measurables.first { it.layoutId == "confirm" }.measure(childConstraints)
             val dismissPlaceable =
-                measurables.first { it.layoutId == "dismiss" }.measure(loosConstraints)
+                measurables.first { it.layoutId == "dismiss" }.measure(childConstraints)
             val neutralPlaceable =
-                measurables.firstOrNull { it.layoutId == "neutral" }?.measure(loosConstraints)
+                measurables.firstOrNull { it.layoutId == "neutral" }?.measure(childConstraints)
 
             val placeables = listOfNotNull(neutralPlaceable, dismissPlaceable, confirmPlaceable)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.compose.component
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
@@ -20,6 +19,7 @@ import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 /**
  * This is a layout that supports laying out Dialog's buttons according to the material guidelines, meaning:
@@ -131,7 +131,7 @@ fun DialogButtonsRowLayout(
 @Preview(widthDp = 300)
 @Composable
 private fun DialogButtonsRowLayoutPreview() {
-    MaterialTheme {
+    WooThemeWithBackground {
         Column {
             listOf(null, "Neutral", "A very long neutral button").forEach { neutralButton ->
                 DialogButtonsRowLayout(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import androidx.compose.ui.layout.IntrinsicMeasureScope
@@ -32,77 +33,79 @@ fun DialogButtonsRowLayout(
     neutralButton: (@Composable () -> Unit)?,
     modifier: Modifier = Modifier
 ) {
-    val measurePolicy = object : MeasurePolicy {
-        override fun MeasureScope.measure(
-            measurables: List<Measurable>,
-            constraints: Constraints
-        ): MeasureResult {
-            val childConstraints = constraints.copy(minWidth = 0)
-            val confirmPlaceable =
-                measurables.first { it.layoutId == "confirm" }.measure(childConstraints)
-            val dismissPlaceable =
-                measurables.first { it.layoutId == "dismiss" }.measure(childConstraints)
-            val neutralPlaceable =
-                measurables.firstOrNull { it.layoutId == "neutral" }?.measure(childConstraints)
+    val measurePolicy = remember {
+        object : MeasurePolicy {
+            override fun MeasureScope.measure(
+                measurables: List<Measurable>,
+                constraints: Constraints
+            ): MeasureResult {
+                val childConstraints = constraints.copy(minWidth = 0)
+                val confirmPlaceable =
+                    measurables.first { it.layoutId == "confirm" }.measure(childConstraints)
+                val dismissPlaceable =
+                    measurables.first { it.layoutId == "dismiss" }.measure(childConstraints)
+                val neutralPlaceable =
+                    measurables.firstOrNull { it.layoutId == "neutral" }?.measure(childConstraints)
 
-            val placeables = listOfNotNull(neutralPlaceable, dismissPlaceable, confirmPlaceable)
+                val placeables = listOfNotNull(neutralPlaceable, dismissPlaceable, confirmPlaceable)
 
-            val placeablesWidth = placeables.sumOf { it.width }
+                val placeablesWidth = placeables.sumOf { it.width }
 
-            val shouldStackItems = placeablesWidth > constraints.maxWidth
-            val height = if (shouldStackItems) {
-                placeables.sumOf { it.height }
-            } else {
-                placeables.maxOf { it.height }
-            }
-
-            return layout(constraints.maxWidth, height) {
-                if (!shouldStackItems) {
-                    neutralPlaceable?.placeRelative(
-                        x = 0,
-                        y = (height - neutralPlaceable.height) / 2
-                    )
-                    confirmPlaceable.placeRelative(
-                        x = constraints.maxWidth - confirmPlaceable.width,
-                        y = (height - confirmPlaceable.height) / 2
-                    )
-                    dismissPlaceable.placeRelative(
-                        x = constraints.maxWidth - confirmPlaceable.width - dismissPlaceable.width,
-                        y = (height - dismissPlaceable.height) / 2
-                    )
+                val shouldStackItems = placeablesWidth > constraints.maxWidth
+                val height = if (shouldStackItems) {
+                    placeables.sumOf { it.height }
                 } else {
-                    var yPosition = 0
+                    placeables.maxOf { it.height }
+                }
 
-                    placeables.forEach { placeable ->
-                        placeable.placeRelative(
-                            x = constraints.maxWidth - placeable.width,
-                            y = yPosition
+                return layout(constraints.maxWidth, height) {
+                    if (!shouldStackItems) {
+                        neutralPlaceable?.placeRelative(
+                            x = 0,
+                            y = (height - neutralPlaceable.height) / 2
                         )
-                        yPosition += placeable.height
+                        confirmPlaceable.placeRelative(
+                            x = constraints.maxWidth - confirmPlaceable.width,
+                            y = (height - confirmPlaceable.height) / 2
+                        )
+                        dismissPlaceable.placeRelative(
+                            x = constraints.maxWidth - confirmPlaceable.width - dismissPlaceable.width,
+                            y = (height - dismissPlaceable.height) / 2
+                        )
+                    } else {
+                        var yPosition = 0
+
+                        placeables.forEach { placeable ->
+                            placeable.placeRelative(
+                                x = constraints.maxWidth - placeable.width,
+                                y = yPosition
+                            )
+                            yPosition += placeable.height
+                        }
                     }
                 }
             }
-        }
 
-        override fun IntrinsicMeasureScope.minIntrinsicHeight(
-            measurables: List<IntrinsicMeasurable>,
-            width: Int
-        ): Int {
-            return if (measurables.sumOf { it.maxIntrinsicWidth(Constraints.Infinity) } > width) {
-                measurables.sumOf { it.minIntrinsicHeight(width) }
-            } else {
-                measurables.maxOf { it.minIntrinsicHeight(width) }
+            override fun IntrinsicMeasureScope.minIntrinsicHeight(
+                measurables: List<IntrinsicMeasurable>,
+                width: Int
+            ): Int {
+                return if (measurables.sumOf { it.maxIntrinsicWidth(Constraints.Infinity) } > width) {
+                    measurables.sumOf { it.minIntrinsicHeight(width) }
+                } else {
+                    measurables.maxOf { it.minIntrinsicHeight(width) }
+                }
             }
-        }
 
-        override fun IntrinsicMeasureScope.maxIntrinsicHeight(
-            measurables: List<IntrinsicMeasurable>,
-            width: Int
-        ): Int {
-            return if (measurables.sumOf { it.maxIntrinsicWidth(Constraints.Infinity) } > width) {
-                measurables.sumOf { it.maxIntrinsicHeight(width) }
-            } else {
-                measurables.maxOf { it.maxIntrinsicHeight(width) }
+            override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+                measurables: List<IntrinsicMeasurable>,
+                width: Int
+            ): Int {
+                return if (measurables.sumOf { it.maxIntrinsicWidth(Constraints.Infinity) } > width) {
+                    measurables.sumOf { it.maxIntrinsicHeight(width) }
+                } else {
+                    measurables.maxOf { it.maxIntrinsicHeight(width) }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
@@ -1,0 +1,158 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+
+/**
+ * This is a layout that supports laying out Dialog's buttons according to the material guidelines, meaning:
+ * - {Neutral}-----{Negative}-{Positive} when the Dialog's width fits the three buttons
+ * - A stacked layout when the dialog's width doesn't fit them.
+ */
+@Composable
+fun DialogButtonsRowLayout(
+    confirmButton: @Composable () -> Unit,
+    dismissButton: @Composable () -> Unit,
+    neutralButton: (@Composable () -> Unit)?,
+    modifier: Modifier = Modifier
+) {
+    val measurePolicy = object : MeasurePolicy {
+        override fun MeasureScope.measure(
+            measurables: List<Measurable>,
+            constraints: Constraints
+        ): MeasureResult {
+            val loosConstraints = constraints.copy(minWidth = 0)
+            val confirmPlaceable =
+                measurables.first { it.layoutId == "confirm" }.measure(loosConstraints)
+            val dismissPlaceable =
+                measurables.first { it.layoutId == "dismiss" }.measure(loosConstraints)
+            val neutralPlaceable =
+                measurables.firstOrNull { it.layoutId == "neutral" }?.measure(loosConstraints)
+
+            val placeables = listOfNotNull(neutralPlaceable, dismissPlaceable, confirmPlaceable)
+
+            val placeablesWidth = placeables.sumOf { it.width }
+
+            val shouldStackItems = placeablesWidth > constraints.maxWidth
+            val height = if (shouldStackItems) {
+                placeables.sumOf { it.height }
+            } else {
+                placeables.maxOf { it.height }
+            }
+
+            return layout(constraints.maxWidth, height) {
+                if (!shouldStackItems) {
+                    neutralPlaceable?.placeRelative(
+                        x = 0,
+                        y = (height - neutralPlaceable.height) / 2
+                    )
+                    confirmPlaceable.placeRelative(
+                        x = constraints.maxWidth - confirmPlaceable.width,
+                        y = (height - confirmPlaceable.height) / 2
+                    )
+                    dismissPlaceable.placeRelative(
+                        x = constraints.maxWidth - confirmPlaceable.width - dismissPlaceable.width,
+                        y = (height - dismissPlaceable.height) / 2
+                    )
+                } else {
+                    var yPosition = 0
+
+                    placeables.forEach { placeable ->
+                        placeable.placeRelative(
+                            x = constraints.maxWidth - placeable.width,
+                            y = yPosition
+                        )
+                        yPosition += placeable.height
+                    }
+                }
+            }
+        }
+
+        override fun IntrinsicMeasureScope.minIntrinsicHeight(
+            measurables: List<IntrinsicMeasurable>,
+            width: Int
+        ): Int {
+            return if (measurables.sumOf { it.maxIntrinsicWidth(Constraints.Infinity) } > width) {
+                measurables.sumOf { it.minIntrinsicHeight(width) }
+            } else {
+                measurables.maxOf { it.minIntrinsicHeight(width) }
+            }
+        }
+
+        override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+            measurables: List<IntrinsicMeasurable>,
+            width: Int
+        ): Int {
+            return if (measurables.sumOf { it.maxIntrinsicWidth(Constraints.Infinity) } > width) {
+                measurables.sumOf { it.maxIntrinsicHeight(width) }
+            } else {
+                measurables.maxOf { it.maxIntrinsicHeight(width) }
+            }
+        }
+    }
+    Layout(
+        content = {
+            Box(Modifier.layoutId("confirm")) {
+                confirmButton()
+            }
+            Box(Modifier.layoutId("dismiss")) {
+                dismissButton()
+            }
+            neutralButton?.let {
+                Box(Modifier.layoutId("neutral")) {
+                    neutralButton()
+                }
+            }
+        },
+        measurePolicy = measurePolicy,
+        modifier = modifier
+    )
+}
+
+@Preview(widthDp = 300)
+@Composable
+private fun DialogButtonsRowLayoutPreview() {
+    MaterialTheme {
+        Column {
+            listOf(null, "Neutral", "A very long neutral button").forEach { neutralButton ->
+                DialogButtonsRowLayout(
+                    confirmButton = {
+                        TextButton(onClick = { }) {
+                            Text(stringResource(id = android.R.string.ok))
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { }) {
+                            Text(stringResource(id = android.R.string.cancel))
+                        }
+                    },
+                    neutralButton = {
+                        neutralButton?.let {
+                            TextButton(onClick = { }) {
+                                Text(neutralButton)
+                            }
+                        }
+                    }
+                )
+
+                Divider()
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -10,11 +10,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.AlertDialog
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
@@ -25,7 +25,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.colorResource
@@ -37,7 +36,6 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.toLowerCase
 import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.window.DialogProperties
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.Coupon.Type
@@ -74,7 +72,7 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
 
 @Composable
 fun EditCouponScreen(
-    viewState: EditCouponViewModel.ViewState,
+    viewState: ViewState,
     onAmountChanged: (BigDecimal?) -> Unit = {},
     onCouponCodeChanged: (String) -> Unit = {},
     onRegenerateCodeClick: () -> Unit = {},
@@ -166,13 +164,13 @@ private fun DetailsSection(
 
 @Composable
 @Suppress("UnusedPrivateMember")
-private fun ConditionsSection(viewState: EditCouponViewModel.ViewState) {
+private fun ConditionsSection(viewState: ViewState) {
     /*TODO*/
 }
 
 @Composable
 @Suppress("UnusedPrivateMember")
-private fun UsageRestrictionsSection(viewState: EditCouponViewModel.ViewState) {
+private fun UsageRestrictionsSection(viewState: ViewState) {
     /*TODO*/
 }
 
@@ -218,59 +216,15 @@ private fun DescriptionButton(description: String?, onButtonClicked: () -> Unit)
 @Composable
 private fun ExpiryField(dateExpires: Date?, onExpiryDateChanged: (Date?) -> Unit) {
     val dateFormat = remember { SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM) }
-    var showEditDateDialog by rememberSaveable { mutableStateOf(false) }
     var showDatePicker by rememberSaveable { mutableStateOf(false) }
 
     WCOutlinedSpinner(
-        onClick = {
-            if (dateExpires != null) {
-                showEditDateDialog = true
-            } else {
-                showDatePicker = true
-            }
-        },
+        onClick = { showDatePicker = true },
         value = dateExpires?.let { dateFormat.format(it) }
             ?: stringResource(id = R.string.coupon_edit_expiry_date_none),
         label = stringResource(id = R.string.coupon_edit_expiry_date),
         modifier = Modifier.fillMaxWidth()
     )
-
-    if (showEditDateDialog) {
-        AlertDialog(
-            onDismissRequest = { showEditDateDialog = false },
-            properties = DialogProperties(),
-            buttons = {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(dimensionResource(id = R.dimen.major_100))
-                        .background(MaterialTheme.colors.surface)
-                ) {
-                    WCOutlinedButton(
-                        text = stringResource(id = R.string.coupon_edit_expiry_date_dialog_edit),
-                        onClick = {
-                            showEditDateDialog = false
-                            showDatePicker = true
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                    )
-
-                    WCOutlinedButton(
-                        text = stringResource(id = R.string.coupon_edit_expiry_date_dialog_delete),
-                        onClick = {
-                            showEditDateDialog = false
-                            onExpiryDateChanged(null)
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                    )
-                }
-            }
-        )
-    }
 
     if (showDatePicker) {
         DatePickerDialog(
@@ -280,6 +234,14 @@ private fun ExpiryField(dateExpires: Date?, onExpiryDateChanged: (Date?) -> Unit
                 onExpiryDateChanged(it)
             },
             onDismissRequest = { showDatePicker = false },
+            neutralButton = {
+                TextButton(onClick = {
+                    showDatePicker = false
+                    onExpiryDateChanged(null)
+                }) {
+                    Text(stringResource(id = R.string.coupon_edit_expiry_clear_expiry_date))
+                }
+            },
             dateFormat = dateFormat
         )
     }
@@ -290,7 +252,7 @@ private fun ExpiryField(dateExpires: Date?, onExpiryDateChanged: (Date?) -> Unit
 private fun EditCouponPreview() {
     WooTheme {
         EditCouponScreen(
-            viewState = EditCouponViewModel.ViewState(
+            viewState = ViewState(
                 couponDraft = Coupon(
                     id = 0L,
                     code = "code",

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1970,8 +1970,7 @@
     <string name="coupon_edit_add_description_hint">Add the description of the coupon.</string>
     <string name="coupon_edit_expiry_date">Coupon Expiry Date</string>
     <string name="coupon_edit_expiry_date_none">None</string>
-    <string name="coupon_edit_expiry_date_dialog_edit">Edit Expiry Date</string>
-    <string name="coupon_edit_expiry_date_dialog_delete">Delete Expiry Date</string>
+    <string name="coupon_edit_expiry_clear_expiry_date">Clear</string>
     <string name="coupon_edit_free_shipping">Include Free Shipping?</string>
 
     <!-- Other -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6540 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the logic of editing/clearing the expiry date by adding a "clear" button to the date picker, and removing the requirement of using an intermediate dialog.

This was supposed to be a small task for adding a neutral button to the dialog, but I found out that Compose doesn't support this by default, and simply adding the button in the buttons `Row` layout won't work for all cases, as if the text is long, the buttons would overlap, so I decided to experiment with writing a custom layout that achieves the same behavior that non-Compose `AlertDialog` had, and which follows the Material guidelines:
1. Displays the buttons horizontally when their content fit the available width, with the neutral button to the end.
2. Displays the buttons stacked when their content doesn't fit in the available width.

And with this layout, I was also able to add an overload of `AlertDialog` that accepts a neutral button, as the available options in Compose don't have it.

### Testing instructions
##### Test the component
Play around with the different `@Preview` functions, or add new ones to confirm the component behaves correctly.
A tip: I generally run the preview in my device for full experience.

##### Test usage in Coupons
1. Make sure Coupons beta toggle is enabled
2. Open the app, and open the coupons details.
3. Click on the Menu, then click on "Edit coupon"
4. Click on the expiry date spinner.
5. Select a date.
6. Click a second time on the expiry date spinner.
7. Click on Clear.
8. Confirm the date has been cleared.

### Images/gif
This is how the layout lays out the buttons on the Date picker, you can also check the different previews in the code:
<img width="300" alt="Screen Shot 2022-05-19 at 10 42 40" src="https://user-images.githubusercontent.com/1657201/169264190-474e84dc-df23-402c-be25-cc600a6578dc.png">  <img width="300" alt="Screen Shot 2022-05-19 at 10 42 57" src="https://user-images.githubusercontent.com/1657201/169264185-cd4164d4-6bcf-4aeb-b59f-583cc002e2b5.png"> 



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
