### PR TITLE
[Coupons] Initialize viewState usage on component, add currencyCode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -18,8 +19,14 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import java.math.BigDecimal
 
 @Composable
-@Suppress("UnusedPrivateMember")
 fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
+    viewModel.viewState.observeAsState().value?.let {
+        CouponRestrictionsScreen(it)
+    }
+}
+
+@Composable
+fun CouponRestrictionsScreen(viewState: CouponRestrictionsViewModel.ViewState) {
     val scrollState = rememberScrollState()
     Column(
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
@@ -34,17 +41,17 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
             .fillMaxSize()
     ) {
         WCOutlinedTypedTextField(
-            value = BigDecimal.ZERO,
+            value = viewState.restrictions.minimumAmount ?: BigDecimal.ZERO,
             onValueChange = { },
-            label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, "$"),
+            label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
             valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100))
         )
 
         WCOutlinedTypedTextField(
-            value = BigDecimal.ZERO,
+            value = viewState.restrictions.maximumAmount ?: BigDecimal.ZERO,
             onValueChange = { },
-            label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, "$"),
+            label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
             valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100))
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -29,6 +29,7 @@ class CouponRestrictionsViewModel @Inject constructor(
         .map { restrictions ->
             ViewState(
                 restrictions = restrictions,
+                currencyCode = navArgs.currencyCode,
                 hasChanges = !restrictions.isSameRestrictions(navArgs.restrictions)
             )
         }.asLiveData()
@@ -43,6 +44,7 @@ class CouponRestrictionsViewModel @Inject constructor(
 
     data class ViewState(
         val restrictions: CouponRestrictions,
+        val currencyCode: String,
         val hasChanges: Boolean
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
@@ -5,5 +5,8 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
 sealed class EditCouponNavigationTarget : Event() {
     data class OpenDescriptionEditor(val currentDescription: String?) : EditCouponNavigationTarget()
-    data class OpenCouponRestrictions(val restrictions: CouponRestrictions) : EditCouponNavigationTarget()
+    data class OpenCouponRestrictions(
+        val restrictions: CouponRestrictions,
+        val currencyCode: String
+    ) : EditCouponNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
@@ -22,7 +22,8 @@ object EditCouponNavigator {
             is OpenCouponRestrictions -> {
                 navController.navigate(
                     EditCouponFragmentDirections.actionEditCouponFragmentToCouponRestrictionsFragment(
-                        target.restrictions
+                        target.restrictions,
+                        target.currencyCode
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -108,7 +108,7 @@ class EditCouponViewModel @Inject constructor(
 
     fun onUsageRestrictionsClick() {
         couponDraft.value?.let {
-            triggerEvent(OpenCouponRestrictions(it.restrictions))
+            triggerEvent(OpenCouponRestrictions(it.restrictions, currencyCode))
         }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -40,5 +40,8 @@
         <argument
             android:name="restrictions"
             app:argType="com.woocommerce.android.model.Coupon$CouponRestrictions" />
+        <argument
+            android:name="currencyCode"
+            app:argType="string" />
     </fragment>
 </navigation>


### PR DESCRIPTION
Part of #5539

⚠️ Please don't merge until #6529 is merged.

### Description:

- This PR is mostly meant to start how `viewState` is used in the `CouponRestrictionsScreen` component, to allow different parts of the restrictions screen to be worked on in parallel later on.
- This PR also adds `currencyCode` as passed parameter when navigating to Coupon Restrictions screen.

### To test:
- Go to Edit Coupon and tap "Usage Restrictions", ensure the correct amount set on the coupon for minimum spent and maximum spent fields are shown.
- Make sure the shown currency code is correct as well.

(the fields themselves do not functionally work yet and do not need to be tested)