### PR TITLE
Fix Behavior of BackPressListener

### DIFF
--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -62,7 +62,8 @@
                 android:id="@+id/nav_host_fragment_main"
                 android:name="androidx.navigation.fragment.NavHostFragment"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                app:defaultNavHost="true" />
         </FrameLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 


### PR DESCRIPTION
### Description
When dispatching back navigation event to child fragments we try to retrieve the current fragment from the `NavHostFragment`, but since the `defaultNavHost` tag was removed in the PR #6488, the `NavHostFragment` is not being set as the `primaryNavigationFragment`, which means we can't retrieve the child fragments.

This PR simply reintroduces the missing tag.

### Testing instructions
1. Open Product details.
2. Make some changes.
3. Press on back button.
4. Confirm the discard changes dialog is displayed.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
