### PR TITLE
Remove product variations banner from Products tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -404,7 +404,8 @@ class ProductListFragment :
 
     private fun showProductList(products: List<Product>) {
         productAdapter.submitList(products)
-        //set to false to remove the new feature banner temporarily
+
+        // set to false to remove the new feature banner temporarily
         showProductWIPNoticeCard(false)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -18,27 +18,17 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialFadeThrough
-import com.woocommerce.android.FeedbackPrefs
-import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsEvent.FEATURE_FEEDBACK_BANNER
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentProductListBinding
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.pinFabAboveBottomNavigationBar
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.PRODUCT_VARIATIONS
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
@@ -65,8 +55,11 @@ class ProductListFragment :
         val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
     }
 
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
-    @Inject lateinit var currencyFormatter: CurrencyFormatter
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
+    @Inject
+    lateinit var currencyFormatter: CurrencyFormatter
 
     private var _productAdapter: ProductListAdapter? = null
     private val productAdapter: ProductListAdapter
@@ -85,10 +78,15 @@ class ProductListFragment :
     private var _binding: FragmentProductListBinding? = null
     private val binding get() = _binding!!
 
-    private val feedbackState: FeedbackState
-        get() =
-            FeedbackPrefs.getFeatureFeedbackSettings(PRODUCT_VARIATIONS)?.feedbackState
-                ?: UNANSWERED
+    /**
+     * Commenting showProductWIPNoticeCard function and code related to it to remove the
+     * banner but leaving the code here since we will be using it in the future to display other features
+     */
+
+//    private val feedbackState: FeedbackState
+//        get() =
+//            FeedbackPrefs.getFeatureFeedbackSettings(PRODUCT_VARIATIONS)?.feedbackState
+//                ?: UNANSWERED
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -396,7 +394,7 @@ class ProductListFragment :
 
     private fun showSkeleton(show: Boolean) {
         if (show) {
-            showProductWIPNoticeCard(false)
+//            showProductWIPNoticeCard(false)
             skeletonView.show(binding.productsRecycler, R.layout.skeleton_product_list, delayed = true)
         } else {
             skeletonView.hide()
@@ -410,25 +408,30 @@ class ProductListFragment :
     private fun showProductList(products: List<Product>) {
         productAdapter.submitList(products)
 
-        showProductWIPNoticeCard(true)
+//        showProductWIPNoticeCard(true)
     }
 
-    private fun showProductWIPNoticeCard(show: Boolean) {
-        if (show && feedbackState != DISMISSED) {
-            val wipCardTitleId = R.string.product_wip_title_m5
-            val wipCardMessageId = R.string.product_wip_message_variations
+    /**
+     * Commenting showProductWIPNoticeCard function and code related to it to remove the
+     * banner but leaving the code here since we will be using it in the future to display other features
+     */
 
-            binding.productsWipCard.visibility = View.VISIBLE
-            binding.productsWipCard.initView(
-                title = getString(wipCardTitleId),
-                message = getString(wipCardMessageId),
-                onGiveFeedbackClick = ::onGiveFeedbackClicked,
-                onDismissClick = ::onDismissProductWIPNoticeCardClicked
-            )
-        } else {
-            binding.productsWipCard.visibility = View.GONE
-        }
-    }
+//    private fun showProductWIPNoticeCard(show: Boolean) {
+//        if (show && feedbackState != DISMISSED) {
+//            val wipCardTitleId = R.string.product_wip_title_m5
+//            val wipCardMessageId = R.string.product_wip_message_variations
+//
+//            binding.productsWipCard.visibility = View.VISIBLE
+//            binding.productsWipCard.initView(
+//                title = getString(wipCardTitleId),
+//                message = getString(wipCardMessageId),
+//                onGiveFeedbackClick = ::onGiveFeedbackClicked,
+//                onDismissClick = ::onDismissProductWIPNoticeCardClicked
+//            )
+//        } else {
+//            binding.productsWipCard.visibility = View.GONE
+//        }
+//    }
 
     private fun showProductSortAndFiltersCard(show: Boolean) {
         if (show) {
@@ -508,38 +511,43 @@ class ProductListFragment :
         viewModel.onSortButtonTapped()
     }
 
-    private fun onGiveFeedbackClicked() {
-        AnalyticsTracker.track(
-            FEATURE_FEEDBACK_BANNER,
-            mapOf(
-                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_PRODUCTS_VARIATIONS_FEEDBACK,
-                AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
-            )
-        )
-        registerFeedbackSetting(GIVEN)
-        NavGraphMainDirections
-            .actionGlobalFeedbackSurveyFragment(SurveyType.PRODUCT)
-            .apply { findNavController().navigateSafely(this) }
-    }
+    /**
+     * Commenting showProductWIPNoticeCard function and code related to it to remove the
+     * banner but leaving the code here since we will be using it in the future to display other features
+     */
 
-    private fun onDismissProductWIPNoticeCardClicked() {
-        AnalyticsTracker.track(
-            FEATURE_FEEDBACK_BANNER,
-            mapOf(
-                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_PRODUCTS_VARIATIONS_FEEDBACK,
-                AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
-            )
-        )
-        registerFeedbackSetting(DISMISSED)
-        showProductWIPNoticeCard(false)
-    }
+//    private fun onGiveFeedbackClicked() {
+//        AnalyticsTracker.track(
+//            FEATURE_FEEDBACK_BANNER,
+//            mapOf(
+//                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_PRODUCTS_VARIATIONS_FEEDBACK,
+//                AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
+//            )
+//        )
+//        registerFeedbackSetting(GIVEN)
+//        NavGraphMainDirections
+//            .actionGlobalFeedbackSurveyFragment(SurveyType.PRODUCT)
+//            .apply { findNavController().navigateSafely(this) }
+//    }
 
-    private fun registerFeedbackSetting(state: FeedbackState) {
-        FeatureFeedbackSettings(
-            PRODUCT_VARIATIONS,
-            state
-        ).registerItself()
-    }
+//    private fun onDismissProductWIPNoticeCardClicked() {
+//        AnalyticsTracker.track(
+//            FEATURE_FEEDBACK_BANNER,
+//            mapOf(
+//                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_PRODUCTS_VARIATIONS_FEEDBACK,
+//                AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
+//            )
+//        )
+//        registerFeedbackSetting(DISMISSED)
+//        showProductWIPNoticeCard(false)
+//    }
+//
+//    private fun registerFeedbackSetting(state: FeedbackState) {
+//        FeatureFeedbackSettings(
+//            PRODUCT_VARIATIONS,
+//            state
+//        ).registerItself()
+//    }
 
     override fun shouldExpandToolbar(): Boolean {
         return binding.productsRecycler.computeVerticalScrollOffset() == 0 && !viewModel.isSearching()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -55,11 +55,9 @@ class ProductListFragment :
         val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
     }
 
-    @Inject
-    lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    @Inject
-    lateinit var currencyFormatter: CurrencyFormatter
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     private var _productAdapter: ProductListAdapter? = null
     private val productAdapter: ProductListAdapter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -13,13 +13,13 @@ import androidx.core.view.doOnPreDraw
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import com.woocommerce.android.NavGraphMainDirections
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialFadeThrough
 import com.woocommerce.android.FeedbackPrefs
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -404,7 +404,7 @@ class ProductListFragment :
 
     private fun showProductList(products: List<Product>) {
         productAdapter.submitList(products)
-
+        //set to false to remove the new feature banner temporarily
         showProductWIPNoticeCard(false)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6319 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We currently display a feature announcement & feedback surveys banner on the Product list screen about adding variations to the products from the app for about one year now (Context: p1650475217179219-slack-CGPNUU63E)

This PR removes the banner by commenting out the code (Context: p1652980622932019-slack-CGPNUU63E) related to the `showProductWIPNoticeCard ` function.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Open the app
- go to the Products tab
- Confirm the new feature banner is no longer being displayed
- as an extra step, confirm the banner in the Orders tab is still being displayed 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/169400727-4cc7134d-5afe-447a-8cc4-7794bfdfcedd.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/169400779-87b8d1cb-7162-48bd-bba0-f36cb3a4b2d5.png" width="350"/> |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->