### PR TITLE
Add nullcheck on tablayout when setting tab position after delay

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -48,7 +48,6 @@ import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
@@ -171,7 +170,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                 val index = StatsGranularity.values().indexOf(activeGranularity)
                 // Small delay needed to ensure tablayout scrolls to the selected tab if tab is not visible on screen.
                 Handler(Looper.getMainLooper()).postDelayed(
-                    { tabLayout.getTabAt(index)?.select() }, 300
+                    { _tabLayout?.getTabAt(index)?.select() }, 300
                 )
             }
             binding.myStoreStats.loadDashboardStats(activeGranularity)


### PR DESCRIPTION
HOTFIX 

Closes: #6487 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the same fix already applied to `release/9.2` [here](https://github.com/woocommerce/woocommerce-android/pull/6532). 

### Testing instructions

This was already tested and approved in this [PR](https://github.com/woocommerce/woocommerce-android/pull/6532), but in any case, the way to reproduce the crash is as follows:

- Open the app, select “This Year” tab
- Navigate to More Menu
- Now as fast as you can click on My Store tab and then More Menu. If you are fast enough or your device is slow enough you’ll see the `NullPointer` crash.

