### PR TITLE
[Coupons] Restrictions: Minimum and Maximum Spend

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -13,6 +14,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
@@ -21,12 +23,20 @@ import java.math.BigDecimal
 @Composable
 fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        CouponRestrictionsScreen(it)
+        CouponRestrictionsScreen(
+            it,
+            viewModel::onMinimumAmountChanged,
+            viewModel::onMaximumAmountChanged
+        )
     }
 }
 
 @Composable
-fun CouponRestrictionsScreen(viewState: CouponRestrictionsViewModel.ViewState) {
+fun CouponRestrictionsScreen(
+    viewState: CouponRestrictionsViewModel.ViewState,
+    onMinimumAmountChanged: (BigDecimal?) -> Unit = {},
+    onMaximumAmountChanged: (BigDecimal?) -> Unit = {}
+) {
     val scrollState = rememberScrollState()
     Column(
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
@@ -42,18 +52,24 @@ fun CouponRestrictionsScreen(viewState: CouponRestrictionsViewModel.ViewState) {
     ) {
         WCOutlinedTypedTextField(
             value = viewState.restrictions.minimumAmount ?: BigDecimal.ZERO,
-            onValueChange = { },
+            onValueChange = onMinimumAmountChanged,
             label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
             valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100))
+            modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100)),
+            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+            //  (https://issuetracker.google.com/issues/209835363)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
 
         WCOutlinedTypedTextField(
             value = viewState.restrictions.maximumAmount ?: BigDecimal.ZERO,
-            onValueChange = { },
+            onValueChange = onMaximumAmountChanged,
             label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
             valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100))
+            modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100)),
+            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+            //  (https://issuetracker.google.com/issues/209835363)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -34,8 +34,8 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
 @Composable
 fun CouponRestrictionsScreen(
     viewState: CouponRestrictionsViewModel.ViewState,
-    onMinimumAmountChanged: (BigDecimal?) -> Unit = {},
-    onMaximumAmountChanged: (BigDecimal?) -> Unit = {}
+    onMinimumAmountChanged: (BigDecimal) -> Unit = {},
+    onMaximumAmountChanged: (BigDecimal) -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -44,13 +44,13 @@ class CouponRestrictionsViewModel @Inject constructor(
         triggerEvent(event)
     }
 
-    fun onMinimumAmountChanged(value: BigDecimal?) {
+    fun onMinimumAmountChanged(value: BigDecimal) {
         restrictionsDraft.update {
             it.copy(minimumAmount = value)
         }
     }
 
-    fun onMaximumAmountChanged(value: BigDecimal?) {
+    fun onMaximumAmountChanged(value: BigDecimal) {
         restrictionsDraft.update {
             it.copy(maximumAmount = value)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -11,6 +11,8 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,6 +42,18 @@ class CouponRestrictionsViewModel @Inject constructor(
         } ?: Exit
 
         triggerEvent(event)
+    }
+
+    fun onMinimumAmountChanged(value: BigDecimal?) {
+        restrictionsDraft.update {
+            it.copy(minimumAmount = value)
+        }
+    }
+
+    fun onMaximumAmountChanged(value: BigDecimal?) {
+        restrictionsDraft.update {
+            it.copy(maximumAmount = value)
+        }
     }
 
     data class ViewState(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #5539 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the first two fields in the Usage Restrictions screen:
- Minimum Spend
- Maximum Spend

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Make sure Coupons beta toggle is enabled
2. Open the app, and open the coupons details.
3. Click on the Menu, then click on "Edit coupon"
4. Tap Usage Restrictions,
5. Edit both fields: Minimum Spend and Maximum Spend (remember the entered numbers),
6. Tap (X) to leave the screen, this will return to the Edit Coupon screen,
7. Tap Usage Restrictions again,
8. Make sure the shown numbers are the entered numbers on step 3

### Video

https://user-images.githubusercontent.com/266376/169499296-ab8a4342-9a07-42a7-891f-710335037599.mov


