### PR TITLE
Fix build after products room removal

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -10,7 +10,6 @@ import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.WCProductFileModel
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.persistence.entity.ProductEntity
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.*
@@ -454,66 +453,6 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
         it.purchasable = isPurchasable
     }
 }
-
-@Suppress("ComplexMethod")
-fun ProductEntity.toAppModel() = Product(
-    remoteId = this.id,
-    name = this.name ?: "",
-    description = this.description ?: "",
-    shortDescription = this.shortDescription ?: "",
-    type = this.type ?: "",
-    status = this.status?.let { ProductStatus.fromString(it) },
-    catalogVisibility = this.catalogVisibility?.let { ProductCatalogVisibility.fromString(it) },
-    isFeatured = this.isFeatured ?: false,
-    stockStatus = ProductStockStatus.fromString(stockStatus),
-    backorderStatus = ProductBackorderStatus.fromString(this.backorders),
-    dateCreated = DateTimeUtils.dateFromIso8601(this.dateCreated) ?: Date(),
-    totalSales = this.totalSales ?: 0L,
-    reviewsAllowed = areReviewsAllowed ?: false,
-    isVirtual = isVirtual ?: false,
-    ratingCount = ratingCount ?: 0,
-    averageRating = this.averageRating?.toFloatOrNull() ?: 0f,
-    permalink = this.permalink ?: "",
-    externalUrl = this.externalUrl ?: "",
-    buttonText = this.buttonText ?: "",
-    price = this.price?.toBigDecimalOrNull(),
-    salePrice = this.salePrice?.toBigDecimalOrNull(),
-    regularPrice = this.regularPrice?.toBigDecimalOrNull(),
-    taxClass = if (this.taxClass.isNullOrEmpty()) Product.TAX_CLASS_DEFAULT else this.taxClass ?: "",
-    isStockManaged = this.isStockManaged ?: false,
-    stockQuantity = this.stockQuantity ?: 0.0,
-    sku = this.sku ?: "",
-    slug = this.slug ?: "",
-    shippingClass = this.shippingClass ?: "",
-    shippingClassId = this.shippingClassId?.toLong() ?: 0,
-    isDownloadable = this.isDownloadable ?: false,
-    downloadLimit = this.downloadLimit ?: 0,
-    downloadExpiry = this.downloadExpiry ?: 0,
-    purchaseNote = this.purchaseNote ?: "",
-    saleEndDateGmt = this.dateOnSaleToGmt.parseFromIso8601DateFormat(),
-    saleStartDateGmt = this.dateOnSaleFromGmt.parseFromIso8601DateFormat(),
-    isSoldIndividually = this.isSoldIndividually ?: false,
-    taxStatus = ProductTaxStatus.fromString(this.taxStatus),
-    isSaleScheduled = !this.dateOnSaleFromGmt.isNullOrEmpty() || !this.dateOnSaleToGmt.isNullOrEmpty(),
-    menuOrder = this.menuOrder ?: 0,
-    isPurchasable = this.isPurchasable ?: false,
-
-    // NOTE: These properties will be added to ProductEntity later
-    firstImageUrl = null,
-    downloads = emptyList(),
-    numVariations = 0,
-    images = emptyList(),
-    attributes = emptyList(),
-    categories = emptyList(),
-    tags = emptyList(),
-    groupedProductIds = emptyList(),
-    crossSellProductIds = emptyList(),
-    upsellProductIds = emptyList(),
-    length = 0f,
-    width = 0f,
-    height = 0f,
-    weight = 0f
-)
 
 fun WCProductModel.toAppModel(): Product {
     return Product(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -3,8 +3,18 @@ package com.woocommerce.android.model
 import android.os.Parcelable
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.woocommerce.android.extensions.*
-import com.woocommerce.android.ui.products.*
+import com.woocommerce.android.extensions.areSameImagesAs
+import com.woocommerce.android.extensions.fastStripHtml
+import com.woocommerce.android.extensions.formatToString
+import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
+import com.woocommerce.android.extensions.isEquivalentTo
+import com.woocommerce.android.extensions.isNotSet
+import com.woocommerce.android.extensions.parseFromIso8601DateFormat
+import com.woocommerce.android.ui.products.ProductBackorderStatus
+import com.woocommerce.android.ui.products.ProductStatus
+import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.products.ProductTaxStatus
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.MediaModel
@@ -12,7 +22,7 @@ import org.wordpress.android.fluxc.model.WCProductFileModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
-import java.util.*
+import java.util.Date
 
 @Parcelize
 data class Product(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductCategory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductCategory.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.ui.products.categories.ProductCategoryItemUiModel
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
-import org.wordpress.android.fluxc.persistence.entity.ProductCategoryEntity
 import java.util.Locale
 import java.util.Stack
 
@@ -140,10 +139,3 @@ fun WCProductCategoryModel.toProductCategory(): ProductCategory {
         parentId = this.parent
     )
 }
-
-fun ProductCategoryEntity.toAppModel() = ProductCategory(
-    remoteCategoryId = id,
-    name = name ?: "",
-    parentId = parentId ?: 0L,
-    slug = slug ?: ""
-)

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.43.0'
+    fluxCVersion = 'trunk-2d7a475229e73e20102dd2f04266cad2a71edf26'
     glideVersion = '4.12.0'
     constraintLayoutVersion = '1.2.0'
     libaddressinputVersion = '0.0.2'


### PR DESCRIPTION
This PR fixed the build after the removal of `Products` and `ProductCategories` Room tables from FluxC.

**To test:**
Just checking the app can be run should be enough.