### PR TITLE
Currency edit text shows multiple zeroes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -267,6 +267,10 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
                 // Prevent entering more decimals than what allowed
                 ""
             }
+            (newValue.startsWith("-0") || newValue.startsWith("00")) && source.startsWith("0") -> {
+                // do not allow to have several zeros at the beginning
+                ""
+            }
             else -> source.toString().replace(".", decimalSeparator)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6538 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes too issues:
* Multiple leading zero
* It was not possible to change once set negative number to a positive

Please text attentively, any fix in this code can cause another bug =)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Start order creation
* Start entering the fee
* Try to enter multiple leading zero (negative too)
* Try to start entering a negative number, remove them and try to enter a positve number

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/169522628-0212ac01-6ee9-4f38-a402-6f4c9f40d342.mp4


