### PR TITLE
[Coupons] "Individual Use" and "Exclude Sale Items" toggles

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -26,12 +26,20 @@ import java.math.BigDecimal
 @Composable
 fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        CouponRestrictionsScreen(it)
+        CouponRestrictionsScreen(
+            viewState = it,
+            onIndividualUseChanged = viewModel::onIndividualUseChanged,
+            onExcludeSaleItemsChanged = viewModel::onExcludeSaleItemsChanged
+        )
     }
 }
 
 @Composable
-fun CouponRestrictionsScreen(viewState: CouponRestrictionsViewModel.ViewState) {
+fun CouponRestrictionsScreen(
+    viewState: CouponRestrictionsViewModel.ViewState,
+    onIndividualUseChanged: (Boolean) -> Unit,
+    onExcludeSaleItemsChanged: (Boolean) -> Unit
+) {
     val scrollState = rememberScrollState()
     Column(
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
@@ -57,18 +65,24 @@ fun CouponRestrictionsScreen(viewState: CouponRestrictionsViewModel.ViewState) {
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
         )
 
-        IndividualUseSwitch(viewState.restrictions.isForIndividualUse ?: false)
-        SaleItemsSwitch(viewState.restrictions.areSaleItemsExcluded ?: false)
+        IndividualUseSwitch(
+            isForIndividualUse = viewState.restrictions.isForIndividualUse ?: false,
+            onIndividualUseChanged = onIndividualUseChanged
+        )
+        SaleItemsSwitch(
+            areSaleItemsExcluded = viewState.restrictions.areSaleItemsExcluded ?: false,
+            onExcludeSaleItemsChanged = onExcludeSaleItemsChanged
+        )
     }
 }
 
 @Composable
-private fun IndividualUseSwitch(isForIndividualUse: Boolean) {
+private fun IndividualUseSwitch(isForIndividualUse: Boolean, onIndividualUseChanged: (Boolean) -> Unit) {
     Column(Modifier.fillMaxWidth()) {
         WCSwitch(
             text = stringResource(id = R.string.coupon_restrictions_individual_use),
             checked = isForIndividualUse,
-            onCheckedChange = {},
+            onCheckedChange = onIndividualUseChanged,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = dimensionResource(id = R.dimen.major_100))
@@ -89,12 +103,12 @@ private fun IndividualUseSwitch(isForIndividualUse: Boolean) {
 }
 
 @Composable
-private fun SaleItemsSwitch(areSaleItemsExcluded: Boolean) {
+private fun SaleItemsSwitch(areSaleItemsExcluded: Boolean, onExcludeSaleItemsChanged: (Boolean) -> Unit) {
     Column(Modifier.fillMaxWidth()) {
         WCSwitch(
             text = stringResource(id = R.string.coupon_restrictions_exclude_sale_items),
             checked = areSaleItemsExcluded,
-            onCheckedChange = {},
+            onCheckedChange = onExcludeSaleItemsChanged,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -4,18 +4,23 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
+import com.woocommerce.android.ui.compose.component.WCSwitch
 import java.math.BigDecimal
 
 @Composable
@@ -33,11 +38,7 @@ fun CouponRestrictionsScreen(viewState: CouponRestrictionsViewModel.ViewState) {
         modifier = Modifier
             .background(color = MaterialTheme.colors.surface)
             .verticalScroll(scrollState)
-            .padding(
-                start = dimensionResource(id = R.dimen.major_100),
-                top = dimensionResource(id = R.dimen.major_100),
-                bottom = dimensionResource(id = R.dimen.major_100)
-            )
+            .padding(vertical = dimensionResource(id = R.dimen.major_100))
             .fillMaxSize()
     ) {
         WCOutlinedTypedTextField(
@@ -45,7 +46,7 @@ fun CouponRestrictionsScreen(viewState: CouponRestrictionsViewModel.ViewState) {
             onValueChange = { },
             label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
             valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100))
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
         )
 
         WCOutlinedTypedTextField(
@@ -53,7 +54,63 @@ fun CouponRestrictionsScreen(viewState: CouponRestrictionsViewModel.ViewState) {
             onValueChange = { },
             label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
             valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100))
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        )
+
+        IndividualUseSwitch(viewState.restrictions.isForIndividualUse ?: false)
+        SaleItemsSwitch(viewState.restrictions.areSaleItemsExcluded ?: false)
+    }
+}
+
+@Composable
+private fun IndividualUseSwitch(isForIndividualUse: Boolean) {
+    Column(Modifier.fillMaxWidth()) {
+        WCSwitch(
+            text = stringResource(id = R.string.coupon_restrictions_individual_use),
+            checked = isForIndividualUse,
+            onCheckedChange = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        )
+        Divider(
+            modifier = Modifier.padding(
+                bottom = dimensionResource(id = R.dimen.major_100),
+                start = dimensionResource(id = R.dimen.major_100)
+            )
+        )
+        Text(
+            text = stringResource(id = R.string.coupon_restrictions_individual_use_hint),
+            style = MaterialTheme.typography.caption,
+            color = colorResource(id = R.color.color_on_surface_medium),
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
         )
     }
 }
+
+@Composable
+private fun SaleItemsSwitch(areSaleItemsExcluded: Boolean) {
+    Column(Modifier.fillMaxWidth()) {
+        WCSwitch(
+            text = stringResource(id = R.string.coupon_restrictions_exclude_sale_items),
+            checked = areSaleItemsExcluded,
+            onCheckedChange = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        )
+        Divider(
+            modifier = Modifier.padding(
+                bottom = dimensionResource(id = R.dimen.major_100),
+                start = dimensionResource(id = R.dimen.major_100)
+            )
+        )
+        Text(
+            text = stringResource(id = R.string.coupon_restrictions_exclude_sale_items_hint),
+            style = MaterialTheme.typography.caption,
+            color = colorResource(id = R.color.color_on_surface_medium),
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        )
+    }
+}
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -127,4 +127,3 @@ private fun SaleItemsSwitch(areSaleItemsExcluded: Boolean, onExcludeSaleItemsCha
         )
     }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,6 +41,18 @@ class CouponRestrictionsViewModel @Inject constructor(
         } ?: Exit
 
         triggerEvent(event)
+    }
+
+    fun onIndividualUseChanged(isForIndividualUse: Boolean) {
+        restrictionsDraft.update {
+            it.copy(isForIndividualUse = isForIndividualUse)
+        }
+    }
+
+    fun onExcludeSaleItemsChanged(areSaleItemsExcluded: Boolean) {
+        restrictionsDraft.update {
+            it.copy(areSaleItemsExcluded = areSaleItemsExcluded)
+        }
     }
 
     data class ViewState(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1979,6 +1979,10 @@
     <string name="coupon_restrictions_maximum_spend_hint">Maximum Spend (%1$s)</string>
     <string name="coupon_restrictions_limit_per_coupon_hint">Usage Limit Per Coupon</string>
     <string name="coupon_restrictions_amount_limit_hint">Limit Usage To X Items</string>
+    <string name="coupon_restrictions_individual_use">Individual Use Only</string>
+    <string name="coupon_restrictions_individual_use_hint">Turn this on if the coupon cannot be used in conjunction with other coupons.</string>
+    <string name="coupon_restrictions_exclude_sale_items">Exclude Sale Items</string>
+    <string name="coupon_restrictions_exclude_sale_items_hint">Turn this on if the coupon should not apply to items on sale. Per-item coupons will only work if the item is not on sale. Per-cart coupons will only work if there are items in the cart that are not on sale.</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponTestUtils.kt
@@ -26,6 +26,14 @@ object CouponTestUtils {
         )
     }
 
+    fun generateCouponRestrictions() = CouponRestrictions(
+        minimumAmount = BigDecimal.TEN,
+        maximumAmount = BigDecimal("100"),
+        excludedProductIds = emptyList(),
+        excludedCategoryIds = emptyList(),
+        restrictedEmails = emptyList(),
+    )
+
     fun generateTestCouponPerformance(couponId: Long): CouponPerformanceReport {
         return CouponPerformanceReport(
             couponId = couponId,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModelTest.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.coupons.edit
+
+import com.woocommerce.android.initSavedStateHandle
+import com.woocommerce.android.ui.coupons.CouponTestUtils
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CouponRestrictionsViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: CouponRestrictionsViewModel
+    private var storedRestrictions = CouponTestUtils.generateCouponRestrictions()
+
+    suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+
+        viewModel = CouponRestrictionsViewModel(
+            savedStateHandle = CouponRestrictionsFragmentArgs(storedRestrictions, "USD").initSavedStateHandle(),
+        )
+    }
+
+    @Test
+    fun `when individual use toggle changes, then update restrictions draft`() = testBlocking {
+        storedRestrictions = storedRestrictions.copy(isForIndividualUse = false)
+        setup()
+
+        viewModel.onIndividualUseChanged(true)
+
+        val state = viewModel.viewState.captureValues().last()
+        assertThat(state.restrictions.isForIndividualUse).isTrue()
+    }
+
+    @Test
+    fun `when exclude sale items toggle changes, then update restrictions draft`() = testBlocking {
+        storedRestrictions = storedRestrictions.copy(areSaleItemsExcluded = false)
+        setup()
+
+        viewModel.onExcludeSaleItemsChanged(true)
+
+        val state = viewModel.viewState.captureValues().last()
+        assertThat(state.restrictions.areSaleItemsExcluded).isTrue()
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #5543, closes #6555
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds both the "Individual Use" and "Exclude Sale Items" toggles to the restrictions page.

### Testing instructions
1.  Make sure Coupons beta toggle is enabled
2. Open the app, and open the coupons details.
3. Click on the Menu, then click on "Edit coupon"
4. Tap Usage Restrictions,
5. Change value of both the "Individual Use" and "Exclude Sale Items" toggles.
6. Tap (X) to leave the screen, this will return to the Edit Coupon screen,
7. Confirm the Save button is enabled.
8. Click again on "Usage restrictions".
9. Make sure the values chosen in step 5 are still displayed.

### Images/gif
<img width="397" alt="Screen Shot 2022-05-20 at 5 49 14 PM" src="https://user-images.githubusercontent.com/1657201/169574994-dac59777-ea17-44fb-b4d9-1eada09c9e48.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
