### PR TITLE
Fix missing customer name in order details screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -47,8 +47,8 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
         when (mode) {
             Mode.OrderEdit -> {
-                binding.orderStatusHeader.text
-                order.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
+                binding.orderStatusHeader.text =
+                    order.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
             }
             Mode.OrderCreation -> {
                 binding.orderStatusHeader.isVisible = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This fixes an error introduced by #6501 where the name of the customer was not being displayed in the order details screen

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- go to the orders tab
- open any order
- make sure the customer's name is displayed

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/169592063-4a4c0cf0-78eb-4b57-8bfc-36f9641477ab.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/169592103-36c76110-5590-43c1-9179-723d81ed3076.png" width="350"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
