### PR TITLE
Change colour for "view add-ons" label on oder details screen

### DIFF
--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -79,7 +79,7 @@
         android:background="?attr/selectableItemBackground"
         android:drawableEnd="@drawable/ic_arrow_right"
         android:text="@string/orderdetail_product_lineitem_view_addons_action"
-        android:textColor="@color/woo_black"
+        android:textColor="@color/color_on_background"
         android:visibility="gone"
         app:drawableTint="@color/color_on_surface_medium"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6043
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR changes the color of the "View Add-ons" label on order details screen to be visible on dark mode. 
Please note this is not on Figma for Android, only iOS so I picked the option that is close to how it looks on iOS

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- enable Dark mode
- Make sure the View Add-ons beta feature is enabled
- Go to the Orders tab
- open an order that has a product with an add-on added directly to the product  (global add-ons won't work)
- Check if the label View Add-ons is white on dark mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

### Before

| Dark | Light |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/169615854-34c6f4e2-efc3-4c74-824e-00e31ab637a8.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/169615820-27561f63-054c-49cb-bb24-53aff768a672.png" width="350"/> |

### After

| Dark | Light |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/169615901-e05bb1d2-c2c9-46bb-a53d-2fdf1d6d6b49.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/169615931-fa274660-1c80-4e24-aac2-e3516a625daf.png" width="350"/> |





- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
