### PR TITLE
Show don't support stripe in Canada when both WCPay and Stripe are active

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 9.3
 -----
 - [*] In-Person Payments: Individual Card Reader Manual tabs removed from IPP Screen and moved to the new screen `Card Reader Manuals` [https://github.com/woocommerce/woocommerce-android/pull/6518]
-
+- [*] Show "We don't support stripe in Canada" when both WCPay and Stripe are active [https://github.com/woocommerce/woocommerce-android/pull/6573]
 
 9.2
 -----

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1091,8 +1091,8 @@
     <string name="card_reader_onboarding_country_not_supported_contact_support">Need some help? &lt;a href=\'\'&gt;Contact support&lt;/a&gt;</string>
     <string name="card_reader_onboarding_country_not_supported_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting payments with your mobile device and ordering card readers</string>
 
-    <string name="card_reader_onboarding_stripe_unsupported_in_country_header">We don\'t support Stripe in %1$s</string>
-    <string name="card_reader_onboarding_wcpay_unsupported_in_country_header">We don\'t support WooCommerce Payments in %1$s</string>
+    <string name="card_reader_onboarding_stripe_unsupported_in_country_header">We don\'t support WooCommerce Stripe extension in %1$s</string>
+    <string name="card_reader_onboarding_wcpay_unsupported_in_country_header">We don\'t support WooCommerce Payments extension in %1$s</string>
     <string name="card_reader_onboarding_stripe_account_in_unsupported_country">We don\'t support Stripe accounts registered in %1$s</string>
 
     <string name="card_reader_onboarding_wcpay_not_installed_header">Install WooCommerce Payments</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -5,8 +5,11 @@ import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_O
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_PENDING
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForCanada
+import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUnsupportedCountry
+import com.woocommerce.android.cardreader.internal.config.SupportedExtension
+import com.woocommerce.android.cardreader.internal.config.SupportedExtensionType
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.CardReaderCountryConfigProvider
@@ -230,7 +233,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             assertThat(result).isEqualTo(
                 CardReaderOnboardingState.OnboardingCompleted(
-                    PluginType.STRIPE_EXTENSION_GATEWAY,
+                    STRIPE_EXTENSION_GATEWAY,
                     stripePluginVersion,
                     countryCode
                 )
@@ -248,7 +251,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             val result = checker.getOnboardingState()
 
             assertThat(result).isEqualTo(
-                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.STRIPE_EXTENSION_GATEWAY)
+                CardReaderOnboardingState.PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
             )
         }
 
@@ -284,7 +287,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             assertThat(result).isEqualTo(
                 CardReaderOnboardingState.SetupNotCompleted(
-                    PluginType.STRIPE_EXTENSION_GATEWAY
+                    STRIPE_EXTENSION_GATEWAY
                 )
             )
         }
@@ -364,7 +367,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             assertThat(result).isEqualTo(
                 CardReaderOnboardingState.OnboardingCompleted(
-                    PluginType.STRIPE_EXTENSION_GATEWAY,
+                    STRIPE_EXTENSION_GATEWAY,
                     stripePluginVersion,
                     countryCode
                 )
@@ -398,8 +401,85 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             val result = checker.getOnboardingState()
 
             assertThat(result).isInstanceOf(PluginIsNotSupportedInTheCountry::class.java)
-            assertThat((result as PluginIsNotSupportedInTheCountry).countryCode).isEqualTo("CA")
-            assertThat((result).preferredPlugin).isEqualTo(STRIPE_EXTENSION_GATEWAY)
+        }
+
+    @Test
+    fun `given wcpay and stripe are installed in RU, when get state, then country code RU returned`() =
+        testBlocking {
+            val countryCode = "RU"
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn(countryCode)
+            val cardReaderConfigForSupportedCountry = mock<CardReaderConfigForSupportedCountry>()
+            whenever(cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode))
+                .thenReturn(cardReaderConfigForSupportedCountry)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(isActive = true))
+
+            val result = checker.getOnboardingState()
+
+            assertThat((result as PluginIsNotSupportedInTheCountry).countryCode).isEqualTo(countryCode)
+        }
+
+    @Test
+    fun `given wcpay and stripe are installed in RU with Stripe support, when get state, then WCPay returned`() =
+        testBlocking {
+            val countryCode = "RU"
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn(countryCode)
+            val cardReaderConfigForSupportedCountry = mock<CardReaderConfigForSupportedCountry> {
+                on { this.supportedExtensions }.thenReturn(
+                    listOf(
+                        SupportedExtension(
+                            type = SupportedExtensionType.STRIPE,
+                            supportedSince = "4.0.0"
+                        ),
+                    ),
+                )
+            }
+            whenever(cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode))
+                .thenReturn(cardReaderConfigForSupportedCountry)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(isActive = true))
+
+            val result = checker.getOnboardingState()
+
+            assertThat((result as PluginIsNotSupportedInTheCountry).preferredPlugin).isEqualTo(
+                PluginType.WOOCOMMERCE_PAYMENTS
+            )
+        }
+
+    @Test
+    fun `given wcpay and stripe are installed in RU with Wcpay support, when get state, then Stripe returned`() =
+        testBlocking {
+            val countryCode = "RU"
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn(countryCode)
+            val cardReaderConfigForSupportedCountry = mock<CardReaderConfigForSupportedCountry> {
+                on { this.supportedExtensions }.thenReturn(
+                    listOf(
+                        SupportedExtension(
+                            type = SupportedExtensionType.WC_PAY,
+                            supportedSince = "4.0.0"
+                        ),
+                    ),
+                )
+            }
+            whenever(cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode))
+                .thenReturn(cardReaderConfigForSupportedCountry)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(isActive = true))
+
+            val result = checker.getOnboardingState()
+
+            assertThat((result as PluginIsNotSupportedInTheCountry).preferredPlugin).isEqualTo(
+                PluginType.STRIPE_EXTENSION_GATEWAY
+            )
         }
 
     @Test
@@ -911,7 +991,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             anyLong(),
             captor.capture(),
         )
-        assertThat(captor.firstValue.preferredPlugin).isEqualTo(PluginType.STRIPE_EXTENSION_GATEWAY)
+        assertThat(captor.firstValue.preferredPlugin).isEqualTo(STRIPE_EXTENSION_GATEWAY)
     }
 
     @Test
@@ -961,7 +1041,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isInstanceOf(CardReaderOnboardingState.PluginIsNotSupportedInTheCountry::class.java)
+            assertThat(result).isInstanceOf(PluginIsNotSupportedInTheCountry::class.java)
         }
 
     @Test
@@ -1018,7 +1098,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         val result = checker.fetchPreferredPlugin()
 
         assertThat(result).isInstanceOf(PreferredPluginResult.Success::class.java)
-        assertThat((result as PreferredPluginResult.Success).type).isEqualTo(PluginType.STRIPE_EXTENSION_GATEWAY)
+        assertThat((result as PreferredPluginResult.Success).type).isEqualTo(STRIPE_EXTENSION_GATEWAY)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6572
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR is a compromise between making proper UI states for the case when both plugins are installed in a country that does not support one of them. Before this PR we were showing conflicting plugins screen

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Activate both string and WcPay pluging on you Canada store
* Go to the Settings -> IPP 
* Notice `We don't support Stripe in Canada` screen

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="328" alt="image" src="https://user-images.githubusercontent.com/4923871/169822443-f36552b3-5d64-4340-ab29-f7a942a8e4fb.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
