### PR TITLE
[Coupons] list improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
@@ -1,8 +1,13 @@
 package com.woocommerce.android.ui.coupons
 
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
+import android.view.View
+import android.view.ViewGroup
 import android.widget.SearchView.OnQueryTextListener
 import androidx.appcompat.widget.SearchView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -107,22 +112,7 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
                 searchMenuItem.collapseActionView()
             }
         }
-        searchMenuItem.setOnActionExpandListener(object : OnActionExpandListener {
-            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
-                if (isAdded) {
-                    viewModel.onSearchStateChanged(open = true)
-                }
-                return true
-            }
-
-            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
-                if (isAdded) {
-                    viewModel.onSearchStateChanged(open = false)
-                }
-                return true
-            }
-        })
-        searchView.setOnQueryTextListener(object : OnQueryTextListener, SearchView.OnQueryTextListener {
+        val textQueryListener = object : OnQueryTextListener, SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
                 if (isAdded) {
                     viewModel.onSearchQueryChanged(query.orEmpty())
@@ -133,6 +123,23 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
             override fun onQueryTextChange(newText: String?): Boolean {
                 if (isAdded) {
                     viewModel.onSearchQueryChanged(newText.orEmpty())
+                }
+                return true
+            }
+        }
+        searchMenuItem.setOnActionExpandListener(object : OnActionExpandListener {
+            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+                if (isAdded) {
+                    viewModel.onSearchStateChanged(open = true)
+                    searchView.setOnQueryTextListener(textQueryListener)
+                }
+                return true
+            }
+
+            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+                if (isAdded) {
+                    searchView.setOnQueryTextListener(null)
+                    viewModel.onSearchStateChanged(open = false)
                 }
                 return true
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
@@ -24,10 +24,13 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.COUPONS
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.coupons.CouponListViewModel.NavigateToCouponDetailsEvent
 import com.woocommerce.android.ui.feedback.SurveyType
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
@@ -44,6 +47,7 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
             ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
     private val viewModel: CouponListViewModel by viewModels()
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -83,6 +87,7 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is NavigateToCouponDetailsEvent -> navigateToCouponDetails(event.couponId)
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListHandler.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.coupons
 
 import com.woocommerce.android.model.Coupon
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.update
@@ -8,6 +9,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class CouponListHandler @Inject constructor(private val repository: CouponRepository) {
     companion object {
         private const val PAGE_SIZE = 10

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -31,6 +31,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
@@ -46,6 +49,7 @@ fun CouponListScreen(viewModel: CouponListViewModel) {
     CouponListScreen(
         state = couponListState,
         onCouponClick = viewModel::onCouponClick,
+        onRefresh = viewModel::onRefresh,
         onLoadMore = viewModel::onLoadMore
     )
 }
@@ -54,6 +58,7 @@ fun CouponListScreen(viewModel: CouponListViewModel) {
 fun CouponListScreen(
     state: CouponListState,
     onCouponClick: (Long) -> Unit,
+    onRefresh: () -> Unit,
     onLoadMore: () -> Unit
 ) {
     when {
@@ -61,6 +66,7 @@ fun CouponListScreen(
             coupons = state.coupons,
             loadingState = state.loadingState,
             onCouponClick = onCouponClick,
+            onRefresh = onRefresh,
             onLoadMore = onLoadMore
         )
         state.loadingState == LoadingState.Loading -> CouponListSkeleton()
@@ -100,39 +106,52 @@ private fun CouponList(
     coupons: List<CouponListItem>,
     loadingState: LoadingState,
     onCouponClick: (Long) -> Unit,
+    onRefresh: () -> Unit,
     onLoadMore: () -> Unit
 ) {
-    val listState = rememberLazyListState()
-    LazyColumn(
-        state = listState,
-        modifier = Modifier
-            .background(color = MaterialTheme.colors.surface)
-    ) {
-        itemsIndexed(coupons) { _, coupon ->
-            CouponListItem(
-                coupon = coupon,
-                onCouponClick = onCouponClick
-            )
-            Divider(
-                modifier = Modifier.offset(x = dimensionResource(id = R.dimen.major_100)),
-                color = colorResource(id = R.color.divider_color),
-                thickness = dimensionResource(id = R.dimen.minor_10)
+    SwipeRefresh(
+        state = rememberSwipeRefreshState(isRefreshing = loadingState == LoadingState.Refreshing),
+        onRefresh = onRefresh,
+        indicator = { state, refreshTrigger ->
+            SwipeRefreshIndicator(
+                state = state,
+                refreshTriggerDistance = refreshTrigger,
+                contentColor = MaterialTheme.colors.primary,
             )
         }
-        if (loadingState == LoadingState.Appending) {
-            item {
-                CircularProgressIndicator(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .wrapContentWidth()
-                        .padding(vertical = dimensionResource(id = R.dimen.minor_100))
+    ) {
+        val listState = rememberLazyListState()
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .background(color = MaterialTheme.colors.surface)
+        ) {
+            itemsIndexed(coupons) { _, coupon ->
+                CouponListItem(
+                    coupon = coupon,
+                    onCouponClick = onCouponClick
+                )
+                Divider(
+                    modifier = Modifier.offset(x = dimensionResource(id = R.dimen.major_100)),
+                    color = colorResource(id = R.color.divider_color),
+                    thickness = dimensionResource(id = R.dimen.minor_10)
                 )
             }
+            if (loadingState == LoadingState.Appending) {
+                item {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentWidth()
+                            .padding(vertical = dimensionResource(id = R.dimen.minor_100))
+                    )
+                }
+            }
         }
-    }
 
-    InfiniteListHandler(listState = listState) {
-        onLoadMore()
+        InfiniteListHandler(listState = listState) {
+            onLoadMore()
+        }
     }
 }
 
@@ -272,7 +291,7 @@ private fun CouponListPreview() {
         ),
     )
 
-    CouponList(coupons = coupons, loadingState = LoadingState.Idle, {}, {})
+    CouponList(coupons = coupons, loadingState = LoadingState.Idle, {}, {}, {})
 }
 
 @Preview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -125,6 +125,7 @@ private fun CouponList(
                     modifier = Modifier
                         .fillMaxWidth()
                         .wrapContentWidth()
+                        .padding(vertical = dimensionResource(id = R.dimen.minor_100))
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -3,10 +3,19 @@ package com.woocommerce.android.ui.coupons
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -27,6 +36,7 @@ import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListItem
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListState
+import com.woocommerce.android.ui.coupons.CouponListViewModel.LoadingState
 import com.woocommerce.android.ui.coupons.components.CouponExpirationLabel
 
 @Composable
@@ -49,10 +59,11 @@ fun CouponListScreen(
     when {
         state.coupons.isNotEmpty() -> CouponList(
             coupons = state.coupons,
+            loadingState = state.loadingState,
             onCouponClick = onCouponClick,
             onLoadMore = onLoadMore
         )
-        state.coupons.isEmpty() && state.isLoading -> CouponListSkeleton()
+        state.loadingState == LoadingState.Loading -> CouponListSkeleton()
         state.isSearchOpen -> SearchEmptyList(searchQuery = state.searchQuery.orEmpty())
         else -> EmptyCouponList()
     }
@@ -87,6 +98,7 @@ private fun EmptyCouponList() {
 @Composable
 private fun CouponList(
     coupons: List<CouponListItem>,
+    loadingState: LoadingState,
     onCouponClick: (Long) -> Unit,
     onLoadMore: () -> Unit
 ) {
@@ -106,6 +118,15 @@ private fun CouponList(
                 color = colorResource(id = R.color.divider_color),
                 thickness = dimensionResource(id = R.dimen.minor_10)
             )
+        }
+        if (loadingState == LoadingState.Appending) {
+            item {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .wrapContentWidth()
+                )
+            }
         }
     }
 
@@ -250,7 +271,7 @@ private fun CouponListPreview() {
         ),
     )
 
-    CouponList(coupons = coupons, {}, {})
+    CouponList(coupons = coupons, loadingState = LoadingState.Idle, {}, {})
 }
 
 @Preview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectIndexed
@@ -29,7 +30,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.util.Date
 import javax.inject.Inject
 
-@FlowPreview
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class CouponListViewModel @Inject constructor(
     savedState: SavedStateHandle,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -103,6 +103,12 @@ class CouponListViewModel @Inject constructor(
         }
     }
 
+    fun onRefresh() = launch {
+        loadingState.value = LoadingState.Refreshing
+        couponListHandler.fetchCoupons(forceRefresh = true)
+        loadingState.value = LoadingState.Idle
+    }
+
     private fun monitorSearchQuery() {
         viewModelScope.launch {
             searchQuery

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -89,7 +89,9 @@ class CouponListViewModel @Inject constructor(
     fun onLoadMore() {
         viewModelScope.launch {
             loadingState.value = LoadingState.Appending
-            couponListHandler.loadMore()
+            couponListHandler.loadMore().onFailure {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.coupon_list_loading_failed))
+            }
             loadingState.value = LoadingState.Idle
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppConstants
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.Coupon
@@ -106,6 +107,9 @@ class CouponListViewModel @Inject constructor(
     fun onRefresh() = launch {
         loadingState.value = LoadingState.Refreshing
         couponListHandler.fetchCoupons(forceRefresh = true)
+            .onFailure {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.coupon_list_loading_failed))
+            }
         loadingState.value = LoadingState.Idle
     }
 
@@ -124,7 +128,14 @@ class CouponListViewModel @Inject constructor(
                         couponListHandler.fetchCoupons(
                             searchQuery = query,
                             forceRefresh = index == 0 && query == null // Force refresh on initial loading
-                        )
+                        ).onFailure {
+                            triggerEvent(
+                                MultiLiveEvent.Event.ShowSnackbar(
+                                    if (query.isNullOrEmpty()) R.string.coupon_list_loading_failed
+                                    else R.string.coupon_list_search_failed
+                                )
+                            )
+                        }
                     } finally {
                         loadingState.value = LoadingState.Idle
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -136,7 +136,7 @@ class CouponListViewModel @Inject constructor(
                         ).onFailure {
                             triggerEvent(
                                 MultiLiveEvent.Event.ShowSnackbar(
-                                    if (query.isNullOrEmpty()) R.string.coupon_list_loading_failed
+                                    if (query == null) R.string.coupon_list_loading_failed
                                     else R.string.coupon_list_search_failed
                                 )
                             )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1914,6 +1914,8 @@
     <string name="coupon_list_wip_title">View and edit coupons</string>
     <string name="coupon_list_wip_message_enabled">We’ve been working on making it possible to view and edit coupons from your device!</string>
     <string name="coupon_list_view_coupon">View coupon summary</string>
+    <string name="coupon_list_loading_failed">Fetching coupons failed</string>
+    <string name="coupon_list_search_failed">Searching coupons failed</string>
     <string name="coupon_details_heading">Coupon Summary</string>
     <string name="coupon_details_minimum_spend">Minimum spend of %s</string>
     <string name="coupon_details_maximum_spend">Maximum spend of %s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
@@ -24,7 +24,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.math.BigDecimal
 
 class CouponsListViewModelTests : BaseUnitTest() {
     private lateinit var viewModel: CouponListViewModel
@@ -38,9 +37,7 @@ class CouponsListViewModelTests : BaseUnitTest() {
         on { couponsFlow } doReturn couponsStateFlow
     }
     private val wooCommerceStore: WooCommerceStore = mock()
-    private val currencyFormatter: CurrencyFormatter = mock {
-        on { formatCurrency(any<BigDecimal>(), any(), any()) } doAnswer { it.arguments[0].toString() }
-    }
+    private val currencyFormatter: CurrencyFormatter = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
         on { getString(any(), anyVararg()) } doAnswer { it.arguments[0].toString() }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
@@ -1,0 +1,139 @@
+package com.woocommerce.android.ui.coupons
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.util.CouponUtils
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.math.BigDecimal
+
+class CouponsListViewModelTests : BaseUnitTest() {
+    private lateinit var viewModel: CouponListViewModel
+
+    private val defaultCouponsList = (1L..10L).map {
+        CouponTestUtils.generateTestCoupon(it)
+    }
+    private val couponsStateFlow = MutableStateFlow(emptyList<Coupon>())
+
+    private val couponListHandler: CouponListHandler = mock {
+        on { couponsFlow } doReturn couponsStateFlow
+    }
+    private val wooCommerceStore: WooCommerceStore = mock()
+    private val currencyFormatter: CurrencyFormatter = mock {
+        on { formatCurrency(any<BigDecimal>(), any(), any()) } doAnswer { it.arguments[0].toString() }
+    }
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doAnswer { it.arguments[0].toString() }
+        on { getString(any(), anyVararg()) } doAnswer { it.arguments[0].toString() }
+    }
+    private val couponUtils = CouponUtils(
+        currencyFormatter = currencyFormatter,
+        resourceProvider = resourceProvider
+    )
+
+    suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+        viewModel = CouponListViewModel(
+            savedState = SavedStateHandle(),
+            wooCommerceStore = wooCommerceStore,
+            couponListHandler = couponListHandler,
+            couponUtils = couponUtils,
+            selectedSite = mock {
+                on { get() } doReturn SiteModel()
+            }
+        )
+    }
+
+    @Test
+    fun `when screen is loaded, then fetch coupons`() = testBlocking {
+        setup {
+            whenever(couponListHandler.fetchCoupons(null, true)).doSuspendableAnswer {
+                delay(1L)
+                return@doSuspendableAnswer Result.success(Unit)
+            }
+        }
+
+        val fetchingState = viewModel.couponsState.captureValues().last()
+
+        verify(couponListHandler).fetchCoupons(searchQuery = null, forceRefresh = true)
+        assertThat(fetchingState.loadingState).isEqualTo(CouponListViewModel.LoadingState.Loading)
+
+        advanceUntilIdle()
+        val idleState = viewModel.couponsState.captureValues().last()
+        assertThat(idleState.loadingState).isEqualTo(CouponListViewModel.LoadingState.Idle)
+    }
+
+    @Test
+    fun `when screen is loaded, then load saved coupons`() = testBlocking {
+        setup()
+
+        val state = viewModel.couponsState.runAndCaptureValues {
+            couponsStateFlow.value = defaultCouponsList
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(state.coupons.map { it.id }).isEqualTo(defaultCouponsList.map { it.id })
+        assertThat(state.loadingState).isEqualTo(CouponListViewModel.LoadingState.Idle)
+    }
+
+    @Test
+    fun `when search is opened, then update state`() = testBlocking {
+        setup()
+
+        viewModel.onSearchStateChanged(true)
+
+        val state = viewModel.couponsState.captureValues().last()
+        assertThat(state.isSearchOpen).isTrue()
+    }
+
+    @Test
+    fun `when search query is entered, then search for coupons`() = testBlocking {
+        setup()
+
+        val state = viewModel.couponsState.runAndCaptureValues {
+            viewModel.onSearchQueryChanged("Search")
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(state.searchQuery).isEqualTo("Search")
+        verify(couponListHandler).fetchCoupons("Search", forceRefresh = false)
+    }
+
+    @Test
+    fun `when load more is requested, then load next page`() = testBlocking {
+        setup()
+
+        viewModel.onLoadMore()
+
+        verify(couponListHandler).loadMore()
+    }
+
+    @Test
+    fun `when list is swiped, then force refresh the coupons`() = testBlocking {
+        setup()
+        clearInvocations(couponListHandler)
+
+        viewModel.onRefresh()
+
+        verify(couponListHandler).fetchCoupons(forceRefresh = true)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
@@ -180,7 +180,7 @@ class CouponsListViewModelTests : BaseUnitTest() {
             whenever(couponListHandler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(Exception()))
         }
 
-        viewModel.onLoadMore()
+        viewModel.onRefresh()
         advanceUntilIdle()
         val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
 

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -191,9 +191,6 @@
     <ID>NoWildcardImports:com.woocommerce.android.ui.compose.animations.SkeletonAnimation.kt:3</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.compose.component.InfiniteListHandler.kt:4</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.compose.theme.Theme.kt:4</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.ui.coupons.CouponListFragment.kt:4</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.ui.coupons.CouponListScreen.kt:6</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.ui.coupons.CouponListViewModel.kt:17</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.coupons.details.CouponDetailsScreen.kt:10</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.coupons.details.CouponDetailsScreen.kt:19</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.coupons.details.CouponDetailsScreen.kt:3</ID>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6468 Closes: #6470 Closes #6338

### Description
This PR adds the following functionalities to the coupons list:
- Swipe-to-refresh.
- A loading indicator when loading the next page.
- An error Snackbar if the loading of the next page fails.
- Fixes a bug that resulted in #6338 

It adds also some unit tests for the CouponsListViewModel.

### Testing instructions
For all tests, make sure the coupons beta feature flag is enabled
#### Pagination loading indicator
1. Open coupons list.
2. Scroll down to trigger loading of next page.
3. Confirm a circular progress indicator is shown at the end of the list during loading.
4. Confirm the loading indicator is hidden when loading is completed.

#### Swipe to refresh
1. Open coupons list.
2. Swipe down to trigger refresh.
3. Confirm the list is refreshed, and the indicator is hidden when it's completed.

#### Error snackbar
1. Enable airplane mode.
2. Make some actions: swipe to refresh or search.
3. Confirm a snackbar is shown with an error message.

### Images/gif

https://user-images.githubusercontent.com/1657201/169901979-af3f3f99-533f-49e1-83b0-62f30571181c.mov

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
