### PR TITLE
[Coupons] Restrictions: Various Usage Limitations

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
@@ -169,6 +170,24 @@ class NullableBigDecimalTextFieldValueMapper(
         return when {
             clearedText.isEmpty() || clearedText == "-" || clearedText == "." -> clearedText
             clearedText.toBigDecimalOrNull() != null -> clearedText
+            else -> oldText
+        }
+    }
+}
+
+class IntTextFieldValueMapper(
+    private val supportsNegativeValue: Boolean = true
+) : TextFieldValueMapper<Int> {
+    override fun parseText(text: String): Int = text.toInt()
+    override fun printValue(value: Int): String = value.toString()
+    override fun transformText(oldText: String, newText: String): String {
+        val clearedText = if (!supportsNegativeValue) newText.filter { it != '-' } else newText
+        return when {
+            clearedText.isEmpty() || clearedText == "-" -> "0"
+            clearedText.matches("^-?0+\\d".toRegex()) ->
+                // Delete any leading 0s, since this field can't be cleared
+                clearedText.replace("^(-?)0+".toRegex(), "$1")
+            clearedText.toIntOrNull() != null -> clearedText
             else -> oldText
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -30,8 +30,10 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
     viewModel.viewState.observeAsState().value?.let {
         CouponRestrictionsScreen(
             viewState = it,
-            viewModel::onMinimumAmountChanged,
-            viewModel::onMaximumAmountChanged,
+            onMinimumAmountChanged = viewModel::onMinimumAmountChanged,
+            onMaximumAmountChanged = viewModel::onMaximumAmountChanged,
+            onUsageLimitPerCouponChanged = viewModel::onUsageLimitPerCouponChanged,
+            onLimitUsageToXItemsChanged = viewModel::onLimitUsageToXItemsChanged,
             onIndividualUseChanged = viewModel::onIndividualUseChanged,
             onExcludeSaleItemsChanged = viewModel::onExcludeSaleItemsChanged
         )
@@ -41,8 +43,10 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
 @Composable
 fun CouponRestrictionsScreen(
     viewState: CouponRestrictionsViewModel.ViewState,
-    onMinimumAmountChanged: (BigDecimal) -> Unit = {},
-    onMaximumAmountChanged: (BigDecimal) -> Unit = {},
+    onMinimumAmountChanged: (BigDecimal) -> Unit,
+    onMaximumAmountChanged: (BigDecimal) -> Unit,
+    onUsageLimitPerCouponChanged: (Int) -> Unit,
+    onLimitUsageToXItemsChanged: (Int) -> Unit,
     onIndividualUseChanged: (Boolean) -> Unit,
     onExcludeSaleItemsChanged: (Boolean) -> Unit
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -96,16 +96,18 @@ fun CouponRestrictionsScreen(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
 
-        WCOutlinedTypedTextField(
-            value = viewState.restrictions.limitUsageToXItems ?: 0,
-            onValueChange = onLimitUsageToXItemsChanged,
-            label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
-            valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
-            //  (https://issuetracker.google.com/issues/209835363)
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-        )
+        if (viewState.showLimitUsageToXItems) {
+            WCOutlinedTypedTextField(
+                value = viewState.restrictions.limitUsageToXItems ?: 0,
+                onValueChange = onLimitUsageToXItemsChanged,
+                label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
+                valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
+                modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+                // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+                //  (https://issuetracker.google.com/issues/209835363)
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            )
+        }
 
         WCOutlinedTypedTextField(
             value = viewState.restrictions.usageLimitPerUser ?: 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -91,8 +91,6 @@ fun CouponRestrictionsScreen(
             label = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_hint),
             valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
-            //  (https://issuetracker.google.com/issues/209835363)
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
 
@@ -103,8 +101,6 @@ fun CouponRestrictionsScreen(
                 label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
                 valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
                 modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-                // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
-                //  (https://issuetracker.google.com/issues/209835363)
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
         }
@@ -115,8 +111,6 @@ fun CouponRestrictionsScreen(
             label = stringResource(id = R.string.coupon_restrictions_limit_per_user_hint),
             valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
-            //  (https://issuetracker.google.com/issues/209835363)
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -35,6 +35,7 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
             onMaximumAmountChanged = viewModel::onMaximumAmountChanged,
             onUsageLimitPerCouponChanged = viewModel::onUsageLimitPerCouponChanged,
             onLimitUsageToXItemsChanged = viewModel::onLimitUsageToXItemsChanged,
+            onUsageLimitPerUserChanged = viewModel::onUsageLimitPerUserChanged,
             onIndividualUseChanged = viewModel::onIndividualUseChanged,
             onExcludeSaleItemsChanged = viewModel::onExcludeSaleItemsChanged
         )
@@ -48,6 +49,7 @@ fun CouponRestrictionsScreen(
     onMaximumAmountChanged: (BigDecimal) -> Unit,
     onUsageLimitPerCouponChanged: (Int) -> Unit,
     onLimitUsageToXItemsChanged: (Int) -> Unit,
+    onUsageLimitPerUserChanged: (Int) -> Unit,
     onIndividualUseChanged: (Boolean) -> Unit,
     onExcludeSaleItemsChanged: (Boolean) -> Unit
 ) {
@@ -98,6 +100,17 @@ fun CouponRestrictionsScreen(
             value = viewState.restrictions.limitUsageToXItems ?: 0,
             onValueChange = onLimitUsageToXItemsChanged,
             label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
+            valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+            //  (https://issuetracker.google.com/issues/209835363)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+        )
+
+        WCOutlinedTypedTextField(
+            value = viewState.restrictions.usageLimitPerUser ?: 0,
+            onValueChange = onUsageLimitPerUserChanged,
+            label = stringResource(id = R.string.coupon_restrictions_limit_per_user_hint),
             valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
             // TODO use KeyboardType.Decimal after updating to Compose 1.2.0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -94,6 +94,17 @@ fun CouponRestrictionsScreen(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
 
+        WCOutlinedTypedTextField(
+            value = viewState.restrictions.limitUsageToXItems ?: 0,
+            onValueChange = onLimitUsageToXItemsChanged,
+            label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
+            valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+            //  (https://issuetracker.google.com/issues/209835363)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+        )
+
         IndividualUseSwitch(
             isForIndividualUse = viewState.restrictions.isForIndividualUse ?: false,
             onIndividualUseChanged = onIndividualUseChanged

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
+import com.woocommerce.android.ui.compose.component.IntTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import com.woocommerce.android.ui.compose.component.WCSwitch
 import java.math.BigDecimal
@@ -76,6 +77,17 @@ fun CouponRestrictionsScreen(
             onValueChange = onMaximumAmountChanged,
             label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
             valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+            //  (https://issuetracker.google.com/issues/209835363)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+        )
+
+        WCOutlinedTypedTextField(
+            value = viewState.restrictions.usageLimit ?: 0,
+            onValueChange = onUsageLimitPerCouponChanged,
+            label = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_hint),
+            valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
             // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
             //  (https://issuetracker.google.com/issues/209835363)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -56,6 +56,18 @@ class CouponRestrictionsViewModel @Inject constructor(
         }
     }
 
+    fun onUsageLimitPerCouponChanged(value: Int) {
+        restrictionsDraft.update {
+            it.copy(usageLimit = value)
+        }
+    }
+
+    fun onLimitUsageToXItemsChanged(value: Int) {
+        restrictionsDraft.update {
+            it.copy(limitUsageToXItems = value)
+        }
+    }
+
     fun onIndividualUseChanged(isForIndividualUse: Boolean) {
         restrictionsDraft.update {
             it.copy(isForIndividualUse = isForIndividualUse)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -68,6 +68,13 @@ class CouponRestrictionsViewModel @Inject constructor(
         }
     }
 
+    fun onUsageLimitPerUserChanged(value: Int) {
+        restrictionsDraft.update {
+            it.copy(usageLimitPerUser = value)
+        }
+    }
+
+
     fun onIndividualUseChanged(isForIndividualUse: Boolean) {
         restrictionsDraft.update {
             it.copy(isForIndividualUse = isForIndividualUse)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -74,7 +74,6 @@ class CouponRestrictionsViewModel @Inject constructor(
         }
     }
 
-
     fun onIndividualUseChanged(isForIndividualUse: Boolean) {
         restrictionsDraft.update {
             it.copy(isForIndividualUse = isForIndividualUse)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -32,7 +32,8 @@ class CouponRestrictionsViewModel @Inject constructor(
             ViewState(
                 restrictions = restrictions,
                 currencyCode = navArgs.currencyCode,
-                hasChanges = !restrictions.isSameRestrictions(navArgs.restrictions)
+                hasChanges = !restrictions.isSameRestrictions(navArgs.restrictions),
+                showLimitUsageToXItems = navArgs.showLimitUsageToXItems
             )
         }.asLiveData()
 
@@ -89,6 +90,7 @@ class CouponRestrictionsViewModel @Inject constructor(
     data class ViewState(
         val restrictions: CouponRestrictions,
         val currencyCode: String,
-        val hasChanges: Boolean
+        val hasChanges: Boolean,
+        val showLimitUsageToXItems: Boolean
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
@@ -8,6 +8,6 @@ sealed class EditCouponNavigationTarget : Event() {
     data class OpenCouponRestrictions(
         val restrictions: CouponRestrictions,
         val currencyCode: String,
-        val showLimitUsageToXItems: Boolean = false
+        val showLimitUsageToXItems: Boolean
     ) : EditCouponNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
@@ -7,6 +7,7 @@ sealed class EditCouponNavigationTarget : Event() {
     data class OpenDescriptionEditor(val currentDescription: String?) : EditCouponNavigationTarget()
     data class OpenCouponRestrictions(
         val restrictions: CouponRestrictions,
-        val currencyCode: String
+        val currencyCode: String,
+        val showLimitUsageToXItems: Boolean = false
     ) : EditCouponNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
@@ -23,7 +23,8 @@ object EditCouponNavigator {
                 navController.navigate(
                     EditCouponFragmentDirections.actionEditCouponFragmentToCouponRestrictionsFragment(
                         target.restrictions,
-                        target.currencyCode
+                        target.currencyCode,
+                        target.showLimitUsageToXItems
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -112,7 +112,7 @@ class EditCouponViewModel @Inject constructor(
                 OpenCouponRestrictions(
                     restrictions = it.restrictions,
                     currencyCode = currencyCode,
-                    showLimitUsageToXItems = it.type == Coupon.Type.FixedCart
+                    showLimitUsageToXItems = it.type != Coupon.Type.FixedCart
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -108,7 +108,13 @@ class EditCouponViewModel @Inject constructor(
 
     fun onUsageRestrictionsClick() {
         couponDraft.value?.let {
-            triggerEvent(OpenCouponRestrictions(it.restrictions, currencyCode))
+            triggerEvent(
+                OpenCouponRestrictions(
+                    restrictions = it.restrictions,
+                    currencyCode = currencyCode,
+                    showLimitUsageToXItems = it.type == Coupon.Type.FixedCart
+                )
+            )
         }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -45,7 +45,6 @@
             app:argType="string" />
         <argument
             android:name="showLimitUsageToXItems"
-            app:argType="boolean"
-            android:defaultValue="false" />
+            app:argType="boolean" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -43,5 +43,9 @@
         <argument
             android:name="currencyCode"
             app:argType="string" />
+        <argument
+            android:name="showLimitUsageToXItems"
+            app:argType="boolean"
+            android:defaultValue="false" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1979,6 +1979,7 @@
     <string name="coupon_restrictions_maximum_spend_hint">Maximum Spend (%1$s)</string>
     <string name="coupon_restrictions_limit_per_coupon_hint">Usage Limit Per Coupon</string>
     <string name="coupon_restrictions_amount_limit_hint">Limit Usage To X Items</string>
+    <string name="coupon_restrictions_limit_per_user_hint">Usage Limit Per User</string>
     <string name="coupon_restrictions_individual_use">Individual Use Only</string>
     <string name="coupon_restrictions_individual_use_hint">Turn this on if the coupon cannot be used in conjunction with other coupons.</string>
     <string name="coupon_restrictions_exclude_sale_items">Exclude Sale Items</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModelTest.kt
@@ -15,7 +15,11 @@ class CouponRestrictionsViewModelTest : BaseUnitTest() {
         prepareMocks()
 
         viewModel = CouponRestrictionsViewModel(
-            savedStateHandle = CouponRestrictionsFragmentArgs(storedRestrictions, "USD").initSavedStateHandle(),
+            savedStateHandle = CouponRestrictionsFragmentArgs(
+                restrictions = storedRestrictions,
+                currencyCode = "USD",
+                showLimitUsageToXItems = true
+            ).initSavedStateHandle(),
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5539
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the following fields on the Usage Restrictions screen:
- Usage limit per coupon
- Limit usage to X items (only shown if Coupon type not `FixedCart`)
- Usage imit per user


**Not included in this PR:**
In the design, the restrictions text fields have various placeholder texts if there's no set value. This will be implemented in a future PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Make sure Coupons beta toggle is enabled
2. Open the app, pick a Coupon with  a non-"Fixed Cart" type, and open the coupons details.
3. Click on the Menu, then click on "Edit coupon", then click "Usage Restrictions",
4. Make sure the fields "Usage limit per coupon",  "Limit usage to X items", "Usage imit per user" are shown,
5. Edit the values, then tap (X) to leave the screen,
6. Tap Usage Restrictions again,
7. Make sure the shown numbers in the three fields remain the same,
8. Start over and pick a Coupon with the "Fixed Cart" type,
9. Click on the Menu, then click on "Edit coupon", then click "Usage Restrictions", 
10. Make sure only "Usage limit per coupon"  and "Usage imit per user" are shown.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/266376/169963244-c3803a37-e1cf-4bfc-827e-a6eab405dc75.mov



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
