### PR TITLE
Add fluxc crash logger

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -249,7 +249,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
             override fun sendReport(exception: Throwable?, tags: Map<String, String>, message: String?) {
                 crashLogging.sendReport(exception, tags, message)
             }
-
         })
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -45,6 +45,8 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.logging.FluxCCrashLogger
+import org.wordpress.android.fluxc.logging.FluxCCrashLoggerProvider
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
@@ -115,6 +117,8 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         AppThemeUtils.setAppTheme()
 
         dispatcher.register(this)
+
+        initFluxCCrashLogger()
 
         AppRatingDialog.init(application)
 
@@ -230,6 +234,23 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         } else {
             AnalyticsTracker.refreshMetadata(accountStore.account?.userName)
         }
+    }
+
+    private fun initFluxCCrashLogger() {
+        FluxCCrashLoggerProvider.initLogger(object : FluxCCrashLogger {
+            override fun recordEvent(message: String, category: String?) {
+                crashLogging.recordEvent(message, category)
+            }
+
+            override fun recordException(exception: Throwable, category: String?) {
+                crashLogging.recordException(exception, category)
+            }
+
+            override fun sendReport(exception: Throwable?, tags: Map<String, String>, message: String?) {
+                crashLogging.sendReport(exception, tags, message)
+            }
+
+        })
     }
 
     private fun trackStartupAnalytics() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -63,6 +63,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     }
 
     @Inject lateinit var crashLogging: CrashLogging
+    @Inject lateinit var fluxCCrashLogger: FluxCCrashLogger
     @Inject lateinit var androidInjector: DispatchingAndroidInjector<Any>
 
     @Inject lateinit var dispatcher: Dispatcher
@@ -118,7 +119,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
 
         dispatcher.register(this)
 
-        initFluxCCrashLogger()
+        FluxCCrashLoggerProvider.initLogger(fluxCCrashLogger)
 
         AppRatingDialog.init(application)
 
@@ -234,22 +235,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         } else {
             AnalyticsTracker.refreshMetadata(accountStore.account?.userName)
         }
-    }
-
-    private fun initFluxCCrashLogger() {
-        FluxCCrashLoggerProvider.initLogger(object : FluxCCrashLogger {
-            override fun recordEvent(message: String, category: String?) {
-                crashLogging.recordEvent(message, category)
-            }
-
-            override fun recordException(exception: Throwable, category: String?) {
-                crashLogging.recordException(exception, category)
-            }
-
-            override fun sendReport(exception: Throwable?, tags: Map<String, String>, message: String?) {
-                crashLogging.sendReport(exception, tags, message)
-            }
-        })
     }
 
     private fun trackStartupAnalytics() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/CrashLoggingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/CrashLoggingModule.kt
@@ -14,6 +14,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import org.wordpress.android.fluxc.logging.FluxCCrashLogger
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLoggingKey
 import javax.inject.Singleton
 
@@ -30,6 +31,11 @@ abstract class CrashLoggingModule {
         @Provides
         fun provideEncryptedLoggingKey(): EncryptedLoggingKey {
             return EncryptedLoggingKey(Key.fromBytes(Base64.decode(BuildConfig.ENCRYPTED_LOGGING_KEY, Base64.DEFAULT)))
+        }
+
+        @Provides
+        fun provideFluxCCrashLogger(crashLogging: CrashLogging): FluxCCrashLogger {
+            return FluxCCrashLoggerImpl(crashLogging)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/FluxCCrashLoggerImpl.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/FluxCCrashLoggerImpl.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.util.crashlogging
+
+import com.automattic.android.tracks.crashlogging.CrashLogging
+import org.wordpress.android.fluxc.logging.FluxCCrashLogger
+
+class FluxCCrashLoggerImpl constructor(private val crashLogging: CrashLogging) : FluxCCrashLogger {
+    override fun recordEvent(message: String, category: String?) {
+        crashLogging.recordEvent(message, category)
+    }
+
+    override fun recordException(exception: Throwable, category: String?) {
+        crashLogging.recordException(exception, category)
+    }
+
+    override fun sendReport(exception: Throwable?, tags: Map<String, String>, message: String?) {
+        crashLogging.sendReport(exception, tags, message)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-2d7a475229e73e20102dd2f04266cad2a71edf26'
+    fluxCVersion = '2421-f132e83b5d8d9fb6872ecfec65179b3141ed6f89'
     glideVersion = '4.12.0'
     constraintLayoutVersion = '1.2.0'
     libaddressinputVersion = '0.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2421-f132e83b5d8d9fb6872ecfec65179b3141ed6f89'
+    fluxCVersion = 'trunk-21cbff3a77afe5890b95beb6de72fd23875ace88'
     glideVersion = '4.13.2'
     constraintLayoutVersion = '1.2.0'
     libaddressinputVersion = '0.0.2'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR initializes FluxC Crash logger. The logger currently records only `request path` as a breadcrumb when an error occurs while parsing a server response.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Use a tool which can intercept server response and replace the body (eg. I used charles proxy)
2. Intercept any of the responses (eg. fetch orders) and replace the body with an invalid json
3. Open sentry and find the failure - verify the event contains `Request path` breadcrumb` - eg. such as this one https://sentry.io/share/issue/cdb25a8994934bbea4ccd5b9f9a252d0/

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
