### PR TITLE
Enable IPP in canada to public

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [*] In-Person Payments: Individual Card Reader Manual tabs removed from IPP Screen and moved to the new screen `Card Reader Manuals` [https://github.com/woocommerce/woocommerce-android/pull/6518]
 - [*] Show "We don't support stripe in Canada" when both WCPay and Stripe are active [https://github.com/woocommerce/woocommerce-android/pull/6573]
-- [***] In-Person Payments: In-Person Payments in Canada is now available for public!
+- [***] In-Person Payments: In-Person Payments in Canada is now available for public! [https://github.com/woocommerce/woocommerce-android/pull/6579]
 
 9.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] In-Person Payments: Individual Card Reader Manual tabs removed from IPP Screen and moved to the new screen `Card Reader Manuals` [https://github.com/woocommerce/woocommerce-android/pull/6518]
 - [*] Show "We don't support stripe in Canada" when both WCPay and Stripe are active [https://github.com/woocommerce/woocommerce-android/pull/6573]
+- [***] In-Person Payments: In-Person Payments in Canada is now available for public!
 
 9.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -21,10 +21,10 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
             JETPACK_CP,
+            IN_PERSON_PAYMENTS_CANADA,
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
             ORDER_FILTERS,
             ANALYTICS_HUB,
-            IN_PERSON_PAYMENTS_CANADA,
             MORE_MENU_INBOX,
             COUPONS_M2 -> PackageUtils.isDebugBuild()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6578 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Disable the feature flag for IPP in Canada feature so that it's available for the public! We should do this within the May 30th code freeze (9.3) since we are planning to release the feature on June 13th.

### Note:
Make sure to merge this before the May 30th code freeze.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Green CI should be enough. Make sure the release notes wordings are proper :)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
