### PR TITLE
An attempt on fixing different issues about WCCurrencyEditText

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -308,7 +308,7 @@ class RegularCurrencyInputHandler(
         }.toString().replace(decimalSeparator, ".")
 
         return when {
-            !supportsEmptyState && (newValue.isEmpty() || newValue == "-") -> {
+            !supportsEmptyState && newValue.isEmpty() -> {
                 // Prevent clearing the field if supportsEmptyState is false
                 "0"
             }
@@ -321,7 +321,7 @@ class RegularCurrencyInputHandler(
                 // Prevent negative values if they are not supported
                 ""
             }
-            supportsEmptyState && supportsNegativeValues && newValue == "-" -> {
+            supportsNegativeValues && newValue == "-" -> {
                 // Allow entering minus sign
                 source
             }
@@ -343,6 +343,7 @@ class RegularCurrencyInputHandler(
 
         val updatedText = when {
             text.toString() == "0-" -> "-0"
+            text.toString() == "-" && !supportsEmptyState -> "0"
             text.matches("^-?0+\\d+".toRegex()) -> text.replace("^(-?)0+(\\d+)".toRegex(), "$1$2")
             else -> text
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -12,6 +12,7 @@ import android.util.SparseArray
 import android.util.TypedValue
 import android.view.ViewGroup
 import androidx.annotation.AttrRes
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.res.use
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -190,7 +191,7 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
 }
 
 private abstract class CurrencyEditText(context: Context) : TextInputEditText(context, null, R.attr.editTextStyle) {
-    var supportsEmptyState: Boolean = true
+    open var supportsEmptyState: Boolean = true
     abstract var supportsNegativeValues: Boolean
     abstract val value: LiveData<BigDecimal?>
 
@@ -199,19 +200,35 @@ private abstract class CurrencyEditText(context: Context) : TextInputEditText(co
 }
 
 private class RegularCurrencyEditText(context: Context) : CurrencyEditText(context), InputFilter {
-    private var numberOfDecimals: Int = DEFAULT_DECIMALS_NUMBER
-    private lateinit var decimalSeparator: String
     private var isChangingText = false
     private var isInitialized = false
 
+    private lateinit var decimalSeparator: String
+
     override var supportsNegativeValues: Boolean = false
+        set(value) {
+            field = value
+            if (this::inputHandler.isInitialized) {
+                inputHandler.supportsNegativeValues = value
+            }
+        }
+
+    override var supportsEmptyState: Boolean = super.supportsEmptyState
+        set(value) {
+            field = value
+            if (this::inputHandler.isInitialized) {
+                inputHandler.supportsEmptyState = value
+            }
+        }
+
     private val _value = MutableLiveData<BigDecimal?>()
     override val value: LiveData<BigDecimal?> = _value
+
+    private lateinit var inputHandler: RegularCurrencyInputHandler
 
     override fun initView(formattingParameters: CurrencyFormattingParameters?) {
         decimalSeparator = formattingParameters?.currencyDecimalSeparator
             ?: DecimalFormatSymbols(Locale.getDefault()).decimalSeparator.toString()
-        numberOfDecimals = formattingParameters?.currencyDecimalNumber ?: 2
 
         inputType = InputType.TYPE_CLASS_NUMBER or
             InputType.TYPE_NUMBER_FLAG_DECIMAL or
@@ -219,6 +236,13 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
         val acceptedDigits = "0123456789.$decimalSeparator${if (supportsNegativeValues) "-" else ""}"
         keyListener = DigitsKeyListener.getInstance(acceptedDigits)
         filters = arrayOf(this)
+
+        inputHandler = RegularCurrencyInputHandler(
+            supportsEmptyState = supportsEmptyState,
+            supportsNegativeValues = supportsNegativeValues,
+            decimalSeparator = decimalSeparator,
+            numberOfDecimals = formattingParameters?.currencyDecimalNumber ?: DEFAULT_DECIMALS_NUMBER
+        )
 
         isInitialized = true
         if (!supportsEmptyState) {
@@ -241,6 +265,44 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
         dend: Int
     ): CharSequence {
         if (isChangingText) return source.toString().replace(".", decimalSeparator)
+        return inputHandler.filter(source, start, end, dest, dstart, dend)
+    }
+
+    @Suppress("TooGenericExceptionCaught", "NestedBlockDepth", "SwallowedException")
+    override fun onTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, lengthAfter: Int) {
+        if (isInitialized && !isChangingText) {
+            isChangingText = true
+
+            val adjustedText = inputHandler.adjustText(text)
+
+            _value.value = adjustedText.toString().replace(decimalSeparator, ".").toBigDecimalOrNull()
+            val currentSelectionPosition = selectionStart
+
+            setText(adjustedText)
+            val selection = (currentSelectionPosition + adjustedText.length - (text?.length ?: 0))
+                .coerceIn(0, adjustedText.length)
+            setSelection(selection)
+
+            isChangingText = false
+        }
+    }
+}
+
+@VisibleForTesting
+class RegularCurrencyInputHandler(
+    var supportsEmptyState: Boolean,
+    var supportsNegativeValues: Boolean,
+    val decimalSeparator: String,
+    val numberOfDecimals: Int
+) {
+    fun filter(
+        source: CharSequence,
+        start: Int,
+        end: Int,
+        dest: CharSequence,
+        dstart: Int,
+        dend: Int
+    ): CharSequence {
         val newValue = StringBuilder(dest).apply {
             replace(dstart, dend, source.subSequence(start, end).toString())
         }.toString().replace(decimalSeparator, ".")
@@ -248,7 +310,7 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
         return when {
             !supportsEmptyState && (newValue.isEmpty() || newValue == "-") -> {
                 // Prevent clearing the field if supportsEmptyState is false
-                if (source.isEmpty()) "0" else ""
+                "0"
             }
             !supportsEmptyState && supportsNegativeValues && newValue == "0-" -> {
                 // Allow entering minus sign at the end of the field if supportsEmptyState is false
@@ -276,31 +338,12 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
         }
     }
 
-    @Suppress("TooGenericExceptionCaught", "NestedBlockDepth", "SwallowedException")
-    override fun onTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, lengthAfter: Int) {
-        if (isInitialized && !isChangingText) {
-            isChangingText = true
-
-            val adjustedText = adjustText(text) ?: ""
-
-            _value.value = adjustedText.toString().replace(decimalSeparator, ".").toBigDecimalOrNull()
-            val currentSelectionPosition = selectionStart
-
-            setText(adjustedText)
-            val selection = (currentSelectionPosition + adjustedText.length - (text?.length ?: 0))
-                .coerceIn(0, adjustedText.length)
-            setSelection(selection)
-
-            isChangingText = false
-        }
-    }
-
-    private fun adjustText(text: CharSequence?): CharSequence? {
-        if (text == null) return null
+    fun adjustText(text: CharSequence?): CharSequence {
+        if (text == null) return ""
 
         val updatedText = when {
             text.toString() == "0-" -> "-0"
-            text.matches("^-?0+\\d".toRegex()) -> text.replace("^(-?)0+(\\d)".toRegex(), "$1$2")
+            text.matches("^-?0+\\d+".toRegex()) -> text.replace("^(-?)0+(\\d+)".toRegex(), "$1$2")
             else -> text
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -255,7 +255,6 @@ private class RegularCurrencyEditText(context: Context) : CurrencyEditText(conte
         setText(value.toPlainString())
     }
 
-    @Suppress("ComplexMethod")
     override fun filter(
         source: CharSequence,
         start: Int,
@@ -295,6 +294,7 @@ class RegularCurrencyInputHandler(
     val decimalSeparator: String,
     val numberOfDecimals: Int
 ) {
+    @Suppress("LongParameterList", "ComplexMethod")
     fun filter(
         source: CharSequence,
         start: Int,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/RegularCurrencyInputHandlerTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/RegularCurrencyInputHandlerTests.kt
@@ -39,7 +39,7 @@ class RegularCurrencyInputHandlerTests {
             supportsNegativeValues = true
         )
 
-        val filteredInput = inputHandler.filter("", 0, 0, "-1", 1, 2)
+        val filteredInput = inputHandler.filter("", 0, 0, "1", 0, 1)
 
         assertThat(filteredInput).isEqualTo("0")
     }
@@ -151,5 +151,19 @@ class RegularCurrencyInputHandlerTests {
         val adjustedText = inputHandler.adjustText("00999")
 
         assertThat(adjustedText).isEqualTo("999")
+    }
+
+    @Test
+    fun `given field doesn't support empty state, when deleting last digit before minus, then update content to 0`() {
+        setup(
+            supportsEmptyState = false,
+            supportsNegativeValues = true,
+        )
+
+        val initialText = "-9"
+        val filteredInput = inputHandler.filter("", 0, 0, initialText, 1, 2)
+        val adjustedText = inputHandler.adjustText(initialText.replaceRange(1, 2, filteredInput))
+
+        assertThat(adjustedText).isEqualTo("0")
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/RegularCurrencyInputHandlerTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/widgets/RegularCurrencyInputHandlerTests.kt
@@ -1,0 +1,155 @@
+package com.woocommerce.android.widgets
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class RegularCurrencyInputHandlerTests {
+    private lateinit var inputHandler: RegularCurrencyInputHandler
+
+    fun setup(
+        supportsEmptyState: Boolean,
+        supportsNegativeValues: Boolean,
+        decimalSeparator: String = ".",
+        numberOfDecimals: Int = 2
+    ) {
+        inputHandler = RegularCurrencyInputHandler(
+            supportsEmptyState = supportsEmptyState,
+            supportsNegativeValues = supportsNegativeValues,
+            decimalSeparator = decimalSeparator,
+            numberOfDecimals = numberOfDecimals
+        )
+    }
+
+    @Test
+    fun `given the field doesn't accept empty state, when deleting last character, then replace content with 0`() {
+        setup(
+            supportsEmptyState = false,
+            supportsNegativeValues = false
+        )
+
+        val filteredInput = inputHandler.filter("", 0, 0, "1", 0, 1)
+
+        assertThat(filteredInput).isEqualTo("0")
+    }
+
+    @Test
+    fun `given the field doesn't accept empty state, when deleting last digit, then replace content with 0`() {
+        setup(
+            supportsEmptyState = false,
+            supportsNegativeValues = true
+        )
+
+        val filteredInput = inputHandler.filter("", 0, 0, "-1", 1, 2)
+
+        assertThat(filteredInput).isEqualTo("0")
+    }
+
+    @Test
+    fun `given the field accepts empty state, when deleting last character, then empty content`() {
+        setup(
+            supportsEmptyState = true,
+            supportsNegativeValues = true
+        )
+
+        val filteredInput = inputHandler.filter("", 0, 0, "1", 0, 1)
+
+        assertThat(filteredInput).isEqualTo("")
+    }
+
+    @Test
+    fun `given the field doesn't accept empty state, when entering - after 0, then replace accept it`() {
+        setup(
+            supportsEmptyState = false,
+            supportsNegativeValues = true
+        )
+
+        val filteredInput = inputHandler.filter("-", 0, 1, "0", 1, 2)
+
+        assertThat(filteredInput).isEqualTo("-")
+    }
+
+    @Test
+    fun `given the field doesn't negative values, when entering -, then reject it`() {
+        setup(
+            supportsEmptyState = false,
+            supportsNegativeValues = false
+        )
+
+        val filteredInput = inputHandler.filter("-", 0, 1, "0", 1, 2)
+
+        assertThat(filteredInput).isEqualTo("")
+    }
+
+    @Test
+    fun `given the field accepts negative values and empty stats, when entering - at the beginning, then accept it`() {
+        setup(
+            supportsEmptyState = true,
+            supportsNegativeValues = true
+        )
+
+        val filteredInput = inputHandler.filter("-", 0, 1, "", 0, 0)
+
+        assertThat(filteredInput).isEqualTo("-")
+    }
+
+    @Test
+    fun `when entering a non valid BigDecimal value, then reject it`() {
+        setup(
+            supportsEmptyState = true,
+            supportsNegativeValues = true
+        )
+
+        val filteredInput = inputHandler.filter("a", 0, 1, "20", 2, 3)
+
+        assertThat(filteredInput).isEqualTo("")
+    }
+
+    @Test
+    fun `when entering fraction digits, then limit it to the allowed number of decimals`() {
+        setup(
+            supportsEmptyState = true,
+            supportsNegativeValues = true,
+            numberOfDecimals = 2
+        )
+
+        val filteredInput = inputHandler.filter("1", 0, 1, "20.10", 5, 6)
+
+        assertThat(filteredInput).isEqualTo("")
+    }
+
+    @Test
+    fun `when having 0- as content, then adjust it to -0`() {
+        setup(
+            supportsEmptyState = false,
+            supportsNegativeValues = true,
+        )
+
+        val adjustedText = inputHandler.adjustText("0-")
+
+        assertThat(adjustedText).isEqualTo("-0")
+    }
+
+    @Test
+    fun `when having multiple zeros, then adjust text to have a single one`() {
+        setup(
+            supportsEmptyState = false,
+            supportsNegativeValues = true,
+        )
+
+        val adjustedText = inputHandler.adjustText("00")
+
+        assertThat(adjustedText).isEqualTo("0")
+    }
+
+    @Test
+    fun `when having unwanted leading zeros, then remove them`() {
+        setup(
+            supportsEmptyState = false,
+            supportsNegativeValues = true,
+        )
+
+        val adjustedText = inputHandler.adjustText("00999")
+
+        assertThat(adjustedText).isEqualTo("999")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6536 Closes: #6538 

### Description
This PR fixes the two above issues, please review #6537 for more context.

I tried to add some unit tests, but I coulndn't spend more time on this, so there may be some missing cases from the tests, feel free to add more tests if needed @atorresveiga @kidinov.

### Testing instructions
1. Open Order Creation form.
2. Click on Add Shipping.
3. Play with the field, and confirm everything works as expected:
    - Confirm you can enter decimals starting with `0`.
    - Confirm the issue described in #6538 is fixed too.

Please also change the values of `supportsEmptyState` in the layout manually, and repeat the above tests.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
