### PR TITLE
[Coupons] implement saving

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 
 /**
  * Centralized snackbar creation and management. An implementing class could then be injected at the
@@ -170,6 +171,20 @@ interface UIMessageResolver {
      * @param [msgId] The resource ID of the message to display in the snackbar
      */
     fun showSnack(@StringRes msgId: Int) = Snackbar.make(snackbarRoot, msgId, BaseTransientBottomBar.LENGTH_LONG).show()
+
+    /**
+     * Display a snackbar with the provided [UiString].
+     *
+     * @param [message] The message to display in the snackbar
+     */
+    fun showSnack(message: UiString) {
+        val snackbar = when (message) {
+            is UiString.UiStringRes ->
+                Snackbar.make(snackbarRoot, message.stringRes, BaseTransientBottomBar.LENGTH_LONG)
+            is UiString.UiStringText -> Snackbar.make(snackbarRoot, message.text, BaseTransientBottomBar.LENGTH_LONG)
+        }
+        snackbar.show()
+    }
 
     private fun getIndefiniteSnackbarWithAction(
         view: View,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ProgressDialog.kt
@@ -1,0 +1,57 @@
+package com.woocommerce.android.ui.compose.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun ProgressDialog(
+    title: String,
+    subtitle: String,
+    onDismissRequest: () -> Unit = {},
+    properties: DialogProperties = DialogProperties(dismissOnClickOutside = false)
+) {
+    Dialog(onDismissRequest = onDismissRequest, properties = properties) {
+        Surface(shape = MaterialTheme.shapes.medium) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_75)),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = dimensionResource(id = R.dimen.major_100),
+                        vertical = dimensionResource(id = R.dimen.major_150)
+                    )
+            ) {
+                Text(text = title, style = MaterialTheme.typography.h6)
+                Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_150))) {
+                    CircularProgressIndicator()
+                    Text(text = subtitle, style = MaterialTheme.typography.body2)
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ProgressDialogPreview() {
+    WooThemeWithBackground {
+        ProgressDialog(title = "Title", subtitle = "Subtitle")
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponRepository.kt
@@ -7,16 +7,19 @@ import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.CouponPerformanceReport
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
+import org.wordpress.android.fluxc.model.coupon.UpdateCouponRequest
 import org.wordpress.android.fluxc.store.CouponStore
 import javax.inject.Inject
 
 class CouponRepository @Inject constructor(
     private val store: CouponStore,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val dateUtils: DateUtils
 ) {
     suspend fun fetchCoupons(
         page: Int,
@@ -108,6 +111,40 @@ class CouponRepository @Inject constructor(
             site = selectedSite.get(),
             couponId = couponId,
             trash = false
+        )
+
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            else -> Result.success(Unit)
+        }
+    }
+
+    suspend fun updateCoupon(coupon: Coupon): Result<Unit> {
+        val request = UpdateCouponRequest(
+            code = coupon.code,
+            description = coupon.description,
+            amount = coupon.amount?.toPlainString(),
+            discountType = coupon.type?.value,
+            isShippingFree = coupon.isShippingFree,
+            expiryDate = coupon.dateExpires?.time?.let { dateUtils.toIso8601Format(it) } ?: "",
+            productIds = coupon.productIds,
+            productCategoryIds = coupon.categoryIds,
+            usageLimit = coupon.restrictions.usageLimit,
+            usageLimitPerUser = coupon.restrictions.usageLimitPerUser,
+            restrictedEmails = coupon.restrictions.restrictedEmails,
+            areSaleItemsExcluded = coupon.restrictions.areSaleItemsExcluded,
+            isForIndividualUse = coupon.restrictions.isForIndividualUse,
+            maximumAmount = coupon.restrictions.maximumAmount?.toPlainString(),
+            minimumAmount = coupon.restrictions.minimumAmount?.toPlainString(),
+            limitUsageToXItems = coupon.restrictions.limitUsageToXItems,
+            excludedProductIds = coupon.restrictions.excludedProductIds,
+            excludedProductCategoryIds = coupon.restrictions.excludedCategoryIds
+        )
+
+        val result = store.updateCoupon(
+            site = selectedSite.get(),
+            couponId = coupon.id,
+            updateCouponRequest = request
         )
 
         return when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.properties.Delegates.observable
@@ -66,7 +66,7 @@ class EditCouponFragment : BaseFragment() {
             when (event) {
                 is EditCouponNavigationTarget -> EditCouponNavigator.navigate(this, event)
                 is Exit -> findNavController().navigateUp()
-                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is ShowUiStringSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -7,19 +7,26 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlin.properties.Delegates.observable
 
 @AndroidEntryPoint
 class EditCouponFragment : BaseFragment() {
     private val viewModel: EditCouponViewModel by viewModels()
+
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(
@@ -58,6 +65,8 @@ class EditCouponFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is EditCouponNavigationTarget -> EditCouponNavigator.navigate(this, event)
+                is Exit -> findNavController().navigateUp()
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.model.Coupon.Type
 import com.woocommerce.android.model.Coupon.Type.Percent
 import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.DatePickerDialog
+import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
@@ -70,7 +71,8 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
             onDescriptionButtonClick = viewModel::onDescriptionButtonClick,
             onExpiryDateChanged = viewModel::onExpiryDateChanged,
             onFreeShippingChanged = viewModel::onFreeShippingChanged,
-            onUsageRestrictionsClick = viewModel::onUsageRestrictionsClick
+            onUsageRestrictionsClick = viewModel::onUsageRestrictionsClick,
+            onSaveClick = viewModel::onSaveClick
         )
     }
 }
@@ -84,7 +86,8 @@ fun EditCouponScreen(
     onDescriptionButtonClick: () -> Unit = {},
     onExpiryDateChanged: (Date?) -> Unit = {},
     onFreeShippingChanged: (Boolean) -> Unit = {},
-    onUsageRestrictionsClick: () -> Unit = {}
+    onUsageRestrictionsClick: () -> Unit = {},
+    onSaveClick: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -107,12 +110,19 @@ fun EditCouponScreen(
         ConditionsSection(viewState)
         UsageRestrictionsSection(viewState, onUsageRestrictionsClick)
         WCColoredButton(
-            onClick = { /*TODO*/ },
+            onClick = onSaveClick,
             text = stringResource(id = R.string.coupon_edit_save_button),
             modifier = Modifier
                 .padding(horizontal = dimensionResource(id = R.dimen.major_100))
                 .fillMaxWidth(),
             enabled = viewState.hasChanges
+        )
+    }
+
+    if (viewState.isSaving) {
+        ProgressDialog(
+            title = "Saving coupon",
+            subtitle = "Please wait..."
         )
     }
 }
@@ -317,7 +327,8 @@ private fun EditCouponPreview() {
                 ),
                 localizedType = "Fixed Rate Discount",
                 amountUnit = "%",
-                hasChanges = true
+                hasChanges = true,
+                isSaving = true
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -121,8 +121,8 @@ fun EditCouponScreen(
 
     if (viewState.isSaving) {
         ProgressDialog(
-            title = "Saving coupon",
-            subtitle = "Please wait..."
+            title = stringResource(id = R.string.coupon_edit_saving_dialog_title),
+            subtitle = stringResource(id = R.string.coupon_edit_saving_dialog_subtitle)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.coupons.edit
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R.string
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.Coupon.CouponRestrictions
 import com.woocommerce.android.ui.coupons.CouponRepository
@@ -10,13 +11,14 @@ import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenCo
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.util.CouponUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
@@ -133,7 +135,16 @@ class EditCouponViewModel @Inject constructor(
 
     fun onSaveClick() = launch {
         isSaving.value = true
-        delay(5000)
+        couponRepository.updateCoupon(couponDraft.value!!)
+            .fold(
+                onSuccess = {
+                    triggerEvent(ShowSnackbar(string.coupon_edit_coupon_updated))
+                    triggerEvent(Exit)
+                },
+                onFailure = {
+                    TODO()
+                }
+            )
         isSaving.value = false
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.coupons.edit
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.R.string
+import com.woocommerce.android.R
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.Coupon.CouponRestrictions
 import com.woocommerce.android.ui.coupons.CouponRepository
@@ -138,11 +138,11 @@ class EditCouponViewModel @Inject constructor(
         couponRepository.updateCoupon(couponDraft.value!!)
             .fold(
                 onSuccess = {
-                    triggerEvent(ShowSnackbar(string.coupon_edit_coupon_updated))
+                    triggerEvent(ShowSnackbar(R.string.coupon_edit_coupon_updated))
                     triggerEvent(Exit)
                 },
                 onFailure = {
-                    TODO()
+                    triggerEvent(ShowSnackbar(R.string.coupon_edit_coupon_update_failed))
                 }
             )
         isSaving.value = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R.string
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -115,6 +116,8 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
             val message: String,
             val action: View.OnClickListener
         ) : Event()
+
+        data class ShowUiStringSnackbar(val message: UiString) : MultiLiveEvent.Event()
 
         object Logout : Event()
         object Exit : Event()

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1974,6 +1974,9 @@
     <string name="coupon_edit_free_shipping">Include Free Shipping?</string>
     <string name="coupon_edit_usage_section">Usage Details</string>
     <string name="coupon_edit_usage_restrictions">Usage Restrictions</string>
+    <string name="coupon_edit_coupon_updated">Coupon updated</string>
+    <string name="coupon_edit_saving_dialog_title">Saving coupon</string>
+    <string name="coupon_edit_saving_dialog_subtitle">Please wait…</string>
     <string name="coupon_restrictions_minimum_spend_hint">Minimum Spend (%1$s)</string>
     <string name="coupon_restrictions_maximum_spend_hint">Maximum Spend (%1$s)</string>
     <string name="coupon_restrictions_limit_per_coupon_hint">Usage Limit Per Coupon</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1975,6 +1975,7 @@
     <string name="coupon_edit_usage_section">Usage Details</string>
     <string name="coupon_edit_usage_restrictions">Usage Restrictions</string>
     <string name="coupon_edit_coupon_updated">Coupon updated</string>
+    <string name="coupon_edit_coupon_update_failed">Updating coupon failed</string>
     <string name="coupon_edit_saving_dialog_title">Saving coupon</string>
     <string name="coupon_edit_saving_dialog_subtitle">Please wait…</string>
     <string name="coupon_restrictions_minimum_spend_hint">Minimum Spend (%1$s)</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModelTests.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.coupons.edit
 
+import com.woocommerce.android.R
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.coupons.CouponRepository
@@ -11,15 +12,19 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito.spy
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.util.Date
@@ -206,5 +211,41 @@ class EditCouponViewModelTests : BaseUnitTest() {
 
         val state = viewModel.viewState.captureValues().last()
         assertThat(state.couponDraft.isShippingFree).isTrue()
+    }
+
+    @Test
+    fun `when save button is clicked, then update coupon`() = testBlocking {
+        setup()
+
+        viewModel.onCouponCodeChanged("New code")
+        viewModel.onSaveClick()
+
+        verify(couponRepository).updateCoupon(argThat { code == "New code" })
+    }
+
+    @Test
+    fun `when coupon is updated, then show a snackbar and navigate up`() = testBlocking {
+        setup {
+            whenever(couponRepository.updateCoupon(any())).thenReturn(Result.success(Unit))
+        }
+
+        val events = viewModel.event.runAndCaptureValues {
+            viewModel.onSaveClick()
+        }.takeLast(2)
+
+        assertThat(events[0]).isEqualTo(ShowSnackbar(R.string.coupon_edit_coupon_updated))
+        assertThat(events[1]).isEqualTo(Exit)
+    }
+
+    @Test
+    fun `when coupon is fails, then show an error snackbar`() = testBlocking {
+        setup {
+            whenever(couponRepository.updateCoupon(any())).thenReturn(Result.failure(Exception()))
+        }
+
+        viewModel.onSaveClick()
+
+        val event = viewModel.event.captureValues().last()
+        assertThat(event).isEqualTo(ShowSnackbar(R.string.coupon_edit_coupon_update_failed))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModelTests.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.coupons.edit
 import com.woocommerce.android.R
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.ui.coupons.CouponRepository
 import com.woocommerce.android.ui.coupons.CouponTestUtils
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
@@ -14,6 +15,7 @@ import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
@@ -28,7 +30,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.util.Date
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.DAYS
 
 private const val COUPON_ID = 1L
 
@@ -180,7 +182,7 @@ class EditCouponViewModelTests : BaseUnitTest() {
 
     @Test
     fun `when expiry date is changed, then update the coupon draft`() = testBlocking {
-        val newDate = Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1))
+        val newDate = Date(System.currentTimeMillis() + DAYS.toMillis(1))
         setup()
 
         val state = viewModel.viewState.runAndCaptureValues {
@@ -246,6 +248,6 @@ class EditCouponViewModelTests : BaseUnitTest() {
         viewModel.onSaveClick()
 
         val event = viewModel.event.captureValues().last()
-        assertThat(event).isEqualTo(ShowSnackbar(R.string.coupon_edit_coupon_update_failed))
+        assertThat(event).isEqualTo(ShowUiStringSnackbar(UiStringRes(R.string.coupon_edit_coupon_update_failed)))
     }
 }


### PR DESCRIPTION
Closes: #6580 

### Description
This PR adds the saving logic to the edit coupon screen:
1. It shows a progress dialog when the saving is in progress.
2. Shows a success snackbar and navigates up when saving finishes successfully.
3. Shows an error snackbar if saving fails.

### Testing instructions
#### Happy path
1. Make sure coupons beta toggle is enabled.
2. Open coupon details.
3. Click on menu, then edit coupon.
4. Make some changes to the coupon.
5. Click on Save.
6. Confirm a progress dialog is shown.
7. Confirm a snackbar is shown when the API request finishes, and you are navigated back to the coupon details.
8. Confirm the coupon details have been updated as well.

#### Unhappy path
1. Make sure coupons beta toggle is enabled.
2. Open coupon details.
3. Click on menu, then edit coupon.
4. Make some changes to the coupon.
5. Enable airplane mode.
6. Click on Save.
7. Confirm an error snackbar is shown.

### Images/gif
https://user-images.githubusercontent.com/1657201/170095244-e4f1f419-0b56-4a02-a509-8ac88dcbc293.mov


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
