### PR TITLE
Adjust the Attributes management card to appear when there's at least a single one configured

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -565,7 +565,7 @@ class ProductDetailCardBuilder(
         )
 
     private fun Product.variationAttributes() =
-        takeIf { this.numVariations > 0 && this.variationEnabledAttributes.isNotEmpty() }?.let {
+        takeIf { this.variationEnabledAttributes.isNotEmpty() }?.let {
             val properties = mutableMapOf<String, String>()
             for (attribute in this.variationEnabledAttributes) {
                 properties[attribute.name] = attribute.terms.size.toString()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -80,6 +81,8 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
                 attributes = emptyList()
             )
 
+
+        var foundAttributesCard = false
         val cards = sut.buildPropertyCards(productStub, "")
         assertThat(cards).isNotEmpty
 
@@ -89,7 +92,9 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
                 propertyGroup.properties.toList()
                     .find { it.first == "Color" } != null
             }?.properties?.toList()?.let {
-                fail("Expected no Product card with Attributes configured")
+                foundAttributesCard = true
             }
+
+        assertFalse("Expected no Product card with Attributes configured", foundAttributesCard)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -17,7 +17,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ProductDetailCardBuilderTest: BaseUnitTest() {
+class ProductDetailCardBuilderTest : BaseUnitTest() {
     private lateinit var sut: ProductDetailCardBuilder
     private lateinit var productStub: Product
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -81,7 +81,6 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
                 attributes = emptyList()
             )
 
-
         var foundAttributesCard = false
         val cards = sut.buildPropertyCards(productStub, "")
         assertThat(cards).isNotEmpty

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -2,10 +2,14 @@ package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.addons.AddonRepository
+import com.woocommerce.android.ui.products.models.ProductProperty
+import com.woocommerce.android.ui.products.models.ProductProperty.Type.PROPERTY_GROUP
+import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -37,5 +41,30 @@ class ProductDetailCardBuilderTest: BaseUnitTest() {
             addonRepository = addonRepo,
             variationRepository = mock()
         )
+    }
+
+    @Test
+    fun `given a product with at least one attribute, then create Attributes card`() = testBlocking {
+        productStub = ProductTestUtils.generateProduct()
+            .copy(
+                reviewsAllowed = false,
+                type = ProductType.VARIABLE.value,
+                weight = 0F,
+                length = 0F,
+                width = 0F,
+                height = 0F
+            )
+
+        val cards = sut.buildPropertyCards(productStub, "")
+        assertThat(cards).isNotEmpty
+
+        cards.filter { it.type == SECONDARY }
+            .takeIf { it.isNotEmpty() and (it.size == 1) }
+            ?.first()?.properties?.filter { it.type == PROPERTY_GROUP }
+            ?.takeIf { it.isNotEmpty() and (it.size == 1) }
+            ?.first()?.run { this as? ProductProperty.PropertyGroup }
+            ?.properties?.toList()
+            ?.let { assertThat(it.first()).isEqualTo(Pair("Color", "3")) }
+            ?: fail("Expected a Product with a single Attribute named Color with value 3 selected")
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.model.Product
+import org.junit.Before
+import org.mockito.kotlin.mock
+
+class ProductDetailCardBuilderTest {
+    private lateinit var sut: ProductDetailCardBuilder
+    private lateinit var productStub: Product
+
+    @Before
+    fun setUp() {
+        productStub = ProductTestUtils.generateProduct(
+            productType = ProductType.VARIABLE.value
+        )
+
+        sut = ProductDetailCardBuilder(
+            viewModel = mock(),
+            resources = mock(),
+            currencyFormatter = mock(),
+            parameters = mock(),
+            addonRepository = mock(),
+            variationRepository = mock()
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.products
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.ui.products.models.ProductProperty
-import com.woocommerce.android.ui.products.models.ProductProperty.Type.PROPERTY_GROUP
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -58,13 +57,39 @@ class ProductDetailCardBuilderTest: BaseUnitTest() {
         val cards = sut.buildPropertyCards(productStub, "")
         assertThat(cards).isNotEmpty
 
-        cards.filter { it.type == SECONDARY }
-            .takeIf { it.isNotEmpty() and (it.size == 1) }
-            ?.first()?.properties?.filter { it.type == PROPERTY_GROUP }
-            ?.takeIf { it.isNotEmpty() and (it.size == 1) }
-            ?.first()?.run { this as? ProductProperty.PropertyGroup }
-            ?.properties?.toList()
-            ?.let { assertThat(it.first()).isEqualTo(Pair("Color", "3")) }
-            ?: fail("Expected a Product with a single Attribute named Color with value 3 selected")
+        cards.find { it.type == SECONDARY }
+            ?.properties?.mapNotNull { it as? ProductProperty.PropertyGroup }
+            ?.find { propertyGroup ->
+                propertyGroup.properties.toList()
+                    .find { it.first == "Color" } != null
+            }?.properties?.toList()?.let {
+                assertThat(it.first()).isEqualTo(Pair("Color", "3"))
+            } ?: fail("Expected a Product card with a single Attribute named Color with value 3 selected")
+    }
+
+    @Test
+    fun `given a product with no attribute, then ignore Attributes card`() = testBlocking {
+        productStub = ProductTestUtils.generateProduct()
+            .copy(
+                reviewsAllowed = false,
+                type = ProductType.VARIABLE.value,
+                weight = 0F,
+                length = 0F,
+                width = 0F,
+                height = 0F,
+                attributes = emptyList()
+            )
+
+        val cards = sut.buildPropertyCards(productStub, "")
+        assertThat(cards).isNotEmpty
+
+        cards.find { it.type == SECONDARY }
+            ?.properties?.mapNotNull { it as? ProductProperty.PropertyGroup }
+            ?.find { propertyGroup ->
+                propertyGroup.properties.toList()
+                    .find { it.first == "Color" } != null
+            }?.properties?.toList()?.let {
+                fail("Expected no Product card with Attributes configured")
+            }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -1,25 +1,40 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.addons.AddonRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
-class ProductDetailCardBuilderTest {
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProductDetailCardBuilderTest: BaseUnitTest() {
     private lateinit var sut: ProductDetailCardBuilder
     private lateinit var productStub: Product
 
     @Before
     fun setUp() {
-        productStub = ProductTestUtils.generateProduct(
-            productType = ProductType.VARIABLE.value
-        )
+        val resources: ResourceProvider = mock {
+            on { getString(any()) } doReturn ""
+            on { getString(any(), anyVararg()) } doReturn ""
+        }
+
+        val addonRepo: AddonRepository = mock {
+            onBlocking { hasAnyProductSpecificAddons(any()) } doReturn false
+        }
 
         sut = ProductDetailCardBuilder(
             viewModel = mock(),
-            resources = mock(),
+            resources = resources,
             currencyFormatter = mock(),
             parameters = mock(),
-            addonRepository = mock(),
+            addonRepository = addonRepo,
             variationRepository = mock()
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -44,7 +44,16 @@ object ProductTestUtils {
             width = "2"
             height = "3"
             variations = if (isVariable) "[123]" else "[]"
-            attributes = """[{"id":1,"name":"Color","position":0,"visible":true,"variation":true,"options":["Blue","Green","Red"]}]"""
+            attributes = """[
+                                {
+                                    "id": 1,
+                                    "name":"Color",
+                                    "position":0",
+                                    "visible":"true",
+                                    "variation":"true",
+                                    "options": ["Blue","Green","Red"]
+                                }
+                            ]"""
             categories = ""
             ratingCount = 4
             groupedProductIds = "[10,11]"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -15,7 +15,8 @@ object ProductTestUtils {
         isVirtual: Boolean = false,
         isVariable: Boolean = false,
         isPurchasable: Boolean = true,
-        customStatus: String? = null
+        customStatus: String? = null,
+        productType: String = "simple"
     ): Product {
         return WCProductModel(2).apply {
             dateCreated = "2018-01-05T05:14:30Z"
@@ -44,7 +45,7 @@ object ProductTestUtils {
             width = "2"
             height = "3"
             variations = if (isVariable) "[123]" else "[]"
-            attributes = "[]"
+            attributes = """[{"id":1,"name":"Color","position":0,"visible":true,"variation":true,"options":["Blue","Green","Red"]}]"""
             categories = ""
             ratingCount = 4
             groupedProductIds = "[10,11]"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -23,7 +23,7 @@ object ProductTestUtils {
             localSiteId = 1
             remoteProductId = productId
             status = customStatus ?: "publish"
-            type = "simple"
+            type = productType
             stockStatus = "instock"
             price = "20.00"
             salePrice = "10.00"
@@ -54,6 +54,7 @@ object ProductTestUtils {
             virtual = isVirtual
             stockQuantity = 4.2
             purchasable = isPurchasable
+            reviewsAllowed = false
         }.toAppModel()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -15,15 +15,14 @@ object ProductTestUtils {
         isVirtual: Boolean = false,
         isVariable: Boolean = false,
         isPurchasable: Boolean = true,
-        customStatus: String? = null,
-        productType: String = "simple"
+        customStatus: String? = null
     ): Product {
         return WCProductModel(2).apply {
             dateCreated = "2018-01-05T05:14:30Z"
             localSiteId = 1
             remoteProductId = productId
             status = customStatus ?: "publish"
-            type = productType
+            type = "simple"
             stockStatus = "instock"
             price = "20.00"
             salePrice = "10.00"
@@ -54,7 +53,6 @@ object ProductTestUtils {
             virtual = isVirtual
             stockQuantity = 4.2
             purchasable = isPurchasable
-            reviewsAllowed = false
         }.toAppModel()
     }
 


### PR DESCRIPTION
Summary
==========
Fix issue #4155 by allowing the Attributes management card to be enabled once the first attribute flow is done, achieving platform parity with the iOS, and sticking to the original strategy of triggering the `Add attribute` flow when the merchant starts configuring the first Variation of the given product.

@malinajirka let me know what you think of this solution, I went back and forth on what would be the best fix here, and I decided to keep modifications to a minimum just fixing the main experience issue, which was the main difference you pointed out between the Android and iOS flows. Let me know what you think.

How to Test
==========
1. When you create a product only "Add variations" row is visible
<img src="https://user-images.githubusercontent.com/2261188/166936832-27e9ef17-3182-4747-9708-8d48c32be044.png" width="150px" />

2. When you tap on it, you are prompted to add an attribute
<img src="https://user-images.githubusercontent.com/2261188/166937026-d8f81543-576b-4e34-b5ce-f2742c7bffda.png" width="150px" />

3. Add an attribute and go back to Product detail
4. Notice only "Add variations" row is visible
5. Tap on "Add variations" and verify that now you can add new attributes


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.