### PR TITLE
Bump Stripe terminal SDK from v2.9.0 to v2.10.0

### DIFF
--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 
-    implementation "com.stripe:stripeterminal:2.9.0"
+    implementation "com.stripe:stripeterminal:2.10.0"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Closes: #6591 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Bump Stripe terminal SDK from v2.9.0 to v2.10.0

**ChangeLog:
2.10.0 - 2022-05-23**
New: Added currency characters to WisePad 3 display. See stripe/stripe-terminal-android#147 for details.

New: Refunds can now be collected when using a simulated reader. See stripe/stripe-terminal-android#226 for details.

Update: When connecting to Internet Readers, the SDK uses an embedded DNS to resolve reader IP addresses. This 
resolves an error experienced by users of some DNS providers.

Fix: Resolved USB_PERMISSION_DENIED error after granting permission. See stripe/stripe-terminal-android#231 for details

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Refunds can now be collected when using a simulated reader - Ensure we can collect Interac refunds using a simulated reader.
2. Ensure IPP works end to end on a high level.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
