### PR TITLE
Add Receipt viewed event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -296,6 +296,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     RECEIPT_PRINT_FAILED,
     RECEIPT_PRINT_CANCELED,
     RECEIPT_PRINT_SUCCESS,
+    RECEIPT_VIEW_TAPPED,
 
     // -- Top-level navigation
     MAIN_MENU_SETTINGS_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -258,7 +258,7 @@ final class OrderDetailViewModel @Inject constructor(
         trackerWrapper.track(
             RECEIPT_VIEW_TAPPED,
             mapOf(
-                AnalyticsTracker.KEY_ID to order.id,
+                AnalyticsTracker.KEY_ORDER_ID to order.id,
                 AnalyticsTracker.KEY_STATUS to order.status
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -19,9 +19,11 @@ import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_ADD
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_DELETE_FAILED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_DELETE_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED
+import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_VIEW_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.SHIPPING_LABEL_ORDER_IS_ELIGIBLE
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_EDITING
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.semverCompareTo
@@ -94,6 +96,7 @@ final class OrderDetailViewModel @Inject constructor(
     private val productImageMap: ProductImageMap,
     private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker,
     private val cardReaderTracker: CardReaderTracker,
+    private val trackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState), OnProductFetchedListener {
     companion object {
         // The required version to support shipping label creation
@@ -252,6 +255,7 @@ final class OrderDetailViewModel @Inject constructor(
     }
 
     fun onSeeReceiptClicked() {
+        trackerWrapper.track(RECEIPT_VIEW_TAPPED)
         loadReceiptUrl()?.let {
             triggerEvent(PreviewReceipt(order.billingAddress.email, it, order.id))
         } ?: WooLog.e(T.ORDERS, "ReceiptUrl is null, but SeeReceipt button is visible")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -255,7 +255,13 @@ final class OrderDetailViewModel @Inject constructor(
     }
 
     fun onSeeReceiptClicked() {
-        trackerWrapper.track(RECEIPT_VIEW_TAPPED)
+        trackerWrapper.track(
+            RECEIPT_VIEW_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_ID to order.id,
+                AnalyticsTracker.KEY_STATUS to order.status
+            )
+        )
         loadReceiptUrl()?.let {
             triggerEvent(PreviewReceipt(order.billingAddress.email, it, order.id))
         } ?: WooLog.e(T.ORDERS, "ReceiptUrl is null, but SeeReceipt button is visible")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -441,10 +441,10 @@ final class OrderDetailViewModel @Inject constructor(
                 navArgs.orderId, shipmentTracking.toDataModel()
             )
             if (!onOrderChanged.isError) {
-                AnalyticsTracker.track(ORDER_TRACKING_DELETE_SUCCESS)
+                trackerWrapper.track(ORDER_TRACKING_DELETE_SUCCESS)
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_delete_success))
             } else {
-                AnalyticsTracker.track(
+                trackerWrapper.track(
                     ORDER_TRACKING_DELETE_FAILED,
                     prepareTracksEventsDetails(onOrderChanged)
                 )
@@ -465,12 +465,12 @@ final class OrderDetailViewModel @Inject constructor(
                                 if (result.event.isError) {
                                     reloadOrderDetails()
                                     triggerEvent(ShowSnackbar(string.order_error_update_general))
-                                    AnalyticsTracker.track(
+                                    trackerWrapper.track(
                                         ORDER_STATUS_CHANGE_FAILED,
                                         prepareTracksEventsDetails(result.event)
                                     )
                                 } else {
-                                    AnalyticsTracker.track(ORDER_STATUS_CHANGE_SUCCESS)
+                                    trackerWrapper.track(ORDER_STATUS_CHANGE_SUCCESS)
                                 }
                             }
                         }
@@ -651,7 +651,7 @@ final class OrderDetailViewModel @Inject constructor(
         ) {
             // we check against the viewstate to avoid sending the event multiple times
             // if the eligibility was cached, and we had the same value after re-fetching it
-            AnalyticsTracker.track(
+            trackerWrapper.track(
                 stat = SHIPPING_LABEL_ORDER_IS_ELIGIBLE,
                 properties = mapOf(
                     "order_status" to order.status.value

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -319,7 +319,7 @@ final class OrderDetailViewModel @Inject constructor(
     }
 
     fun onNewShipmentTrackingAdded(shipmentTracking: OrderShipmentTracking) {
-        AnalyticsTracker.track(
+        trackerWrapper.track(
             ORDER_TRACKING_ADD,
             mapOf(
                 AnalyticsTracker.KEY_ID to order.id,
@@ -357,7 +357,7 @@ final class OrderDetailViewModel @Inject constructor(
     }
 
     fun onOrderStatusChanged(updateSource: OrderStatusUpdateSource) {
-        AnalyticsTracker.track(
+        trackerWrapper.track(
             ORDER_STATUS_CHANGE,
             mapOf(
                 AnalyticsTracker.KEY_ID to order.id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -245,7 +245,7 @@ final class OrderDetailViewModel @Inject constructor(
     }
 
     fun onSharePaymentUrlClicked() {
-        AnalyticsTracker.track(AnalyticsEvent.ORDER_DETAIL_PAYMENT_LINK_SHARED)
+        trackerWrapper.track(AnalyticsEvent.ORDER_DETAIL_PAYMENT_LINK_SHARED)
         triggerEvent(TakePaymentViewModel.SharePaymentUrl(selectedSite.get().name, order.paymentUrl))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -217,7 +217,7 @@ final class OrderDetailViewModel @Inject constructor(
     }
 
     fun onRefreshRequested() {
-        AnalyticsTracker.track(ORDER_DETAIL_PULLED_TO_REFRESH)
+        trackerWrapper.track(ORDER_DETAIL_PULLED_TO_REFRESH)
         viewState = viewState.copy(isRefreshing = true)
         launch { fetchOrder(false) }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -480,17 +480,17 @@ final class OrderDetailViewModel @Inject constructor(
     }
 
     fun onCreateShippingLabelButtonTapped() {
-        AnalyticsTracker.track(ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED)
+        trackerWrapper.track(ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED)
         triggerEvent(StartShippingLabelCreationFlow(order.id))
     }
 
     fun onMarkOrderCompleteButtonTapped() {
-        AnalyticsTracker.track(ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
+        trackerWrapper.track(ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
         triggerEvent(ViewOrderFulfillInfo(order.id))
     }
 
     fun onViewOrderedAddonButtonTapped(orderItem: Order.Item) {
-        AnalyticsTracker.track(PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED)
+        trackerWrapper.track(PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED)
         triggerEvent(
             ViewOrderedAddons(
                 navArgs.orderId,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1117,7 +1117,13 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             viewModel.onSeeReceiptClicked()
 
-            verify(analyticsTraWrapper).track(AnalyticsEvent.RECEIPT_VIEW_TAPPED)
+            verify(analyticsTraWrapper).track(
+                AnalyticsEvent.RECEIPT_VIEW_TAPPED,
+                mapOf(
+                    AnalyticsTracker.KEY_ID to order.id,
+                    AnalyticsTracker.KEY_STATUS to order.status
+                )
+            )
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1236,4 +1236,55 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 )
             )
         }
+
+    @Test
+    fun `when user taps a create shipping label button, then event tracked`() =
+        testBlocking {
+            // Given
+            doReturn(order).whenever(repository).getOrderById(any())
+            doReturn(order).whenever(repository).fetchOrderById(any())
+            doReturn(false).whenever(repository).fetchOrderNotes(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
+            viewModel.start()
+
+            // When
+            viewModel.onCreateShippingLabelButtonTapped()
+
+            // Then
+            verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED)
+        }
+
+    @Test
+    fun `when user taps a mark order complete button, then event tracked`() =
+        testBlocking {
+            // Given
+            doReturn(order).whenever(repository).getOrderById(any())
+            doReturn(order).whenever(repository).fetchOrderById(any())
+            doReturn(false).whenever(repository).fetchOrderNotes(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
+            viewModel.start()
+
+            // When
+            viewModel.onMarkOrderCompleteButtonTapped()
+
+            // Then
+            verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
+        }
+
+    @Test
+    fun `when user taps a view order addon button, then event tracked`() =
+        testBlocking {
+            // Given
+            doReturn(order).whenever(repository).getOrderById(any())
+            doReturn(order).whenever(repository).fetchOrderById(any())
+            doReturn(false).whenever(repository).fetchOrderNotes(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
+            viewModel.start()
+
+            // When
+            viewModel.onViewOrderedAddonButtonTapped(order.items[0])
+
+            // Then
+            verify(analyticsTraWrapper).track(AnalyticsEvent.PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED)
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1148,4 +1148,19 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             // Then
             verify(cardReaderTracker).trackCollectPaymentTapped()
         }
+
+    @Test
+    fun `when user refreshes order, then event tracked`() =
+        testBlocking {
+            // Given
+            doReturn(order).whenever(repository).getOrderById(any())
+            doReturn(order).whenever(repository).fetchOrderById(any())
+            viewModel.start()
+
+            // When
+            viewModel.onRefreshRequested()
+
+            // Then
+            verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_PULLED_TO_REFRESH)
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -132,9 +132,11 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             it.id = 1
             it.siteId = 1
             it.selfHostedSiteId = 1
+            it.name = "https://www.testname.com"
             it
         }
         doReturn(site).whenever(selectedSite).getIfExists()
+        doReturn(site).whenever(selectedSite).get()
         testBlocking {
             doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
         }
@@ -1162,5 +1164,22 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             // Then
             verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_PULLED_TO_REFRESH)
+        }
+
+    @Test
+    fun `when user clicks on share payment url, then event tracked`() =
+        testBlocking {
+            // Given
+            doReturn(order).whenever(repository).getOrderById(any())
+            doReturn(order).whenever(repository).fetchOrderById(any())
+            doReturn(false).whenever(repository).fetchOrderNotes(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
+            viewModel.start()
+
+            // When
+            viewModel.onSharePaymentUrlClicked()
+
+            // Then
+            verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_PAYMENT_LINK_SHARED)
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1120,7 +1120,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             verify(analyticsTraWrapper).track(
                 AnalyticsEvent.RECEIPT_VIEW_TAPPED,
                 mapOf(
-                    AnalyticsTracker.KEY_ID to order.id,
+                    AnalyticsTracker.KEY_ORDER_ID to order.id,
                     AnalyticsTracker.KEY_STATUS to order.status
                 )
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6434 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR 
1. Adds `*_receipt_view_tapped` event which was missing in Android. This event gets triggered when a merchant taps on the `See receipt` button in the Order details screen.
2. Refactor the Order detail screen to use `AnalyticsTrackerWrapper` instead of directly using `AnalyticsTracker`. This refactoring is done so that we can write unit tests to verify that the event is being tracked as expected.
3. Contains a few unit tests which verify that the events are being tracked in the Order detail screen.

### Note to reviewer: 
Please follow the commits to understand my train of thought.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to any order detail screen which is eligible for IPP.
5. Collect IPP for that order.
6. After successful payment collection, Tap on the `See receipt` button in the Order detail screen
7. Ensure the event is tracked by checking in the logs.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
