### PR TITLE
Workaround for the case when illustration is not visible after hiding the recycler view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -170,7 +170,9 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
         updateMultipleReadersFoundRecyclerView(binding, viewState)
 
         // the scanning for readers and connecting to reader images are AnimatedVectorDrawables
-        (binding.illustration.drawable as? AnimatedVectorDrawable)?.start()
+        binding.illustration.post {
+            (binding.illustration.drawable as? AnimatedVectorDrawable)?.start()
+        }
     }
 
     @Suppress("ComplexMethod", "LongMethod")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -169,9 +169,11 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
 
         updateMultipleReadersFoundRecyclerView(binding, viewState)
 
-        // the scanning for readers and connecting to reader images are AnimatedVectorDrawables
-        binding.illustration.post {
-            (binding.illustration.drawable as? AnimatedVectorDrawable)?.start()
+        with(binding.illustration) {
+            // the scanning for readers and connecting to reader images are AnimatedVectorDrawables
+            (drawable as? AnimatedVectorDrawable)?.start()
+            // workaround https://github.com/woocommerce/woocommerce-android/pull/6598#issuecomment-1139520598
+            alpha = 1f
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5080
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I could not figure out what exactly this happens, most probably that in some cases UI events queue ends up with incorrect order, e.g. starting animation comes ahead of remove recycler view from the screen

The workaround is not make sure that animation starts at the end

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Go to App Settings
* Tap on "In Person payments"
* Tap on "Manage Card Reader"
* Tap on "Connect to Reader"
* Make sure at least two readers are turned on
* Wait until "Multiple readers found" state is shown
* Select a reader
* Notice the illustration is in place

Try to do so several times
