### PR TITLE
Remove unnecessary snackbar when interac refund is initiated

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] In-Person Payments: Individual Card Reader Manual tabs removed from IPP Screen and moved to the new screen `Card Reader Manuals` [https://github.com/woocommerce/woocommerce-android/pull/6518]
 - [*] Show "We don't support stripe in Canada" when both WCPay and Stripe are active [https://github.com/woocommerce/woocommerce-android/pull/6573]
 - [***] In-Person Payments: In-Person Payments in Canada is now available for public! [https://github.com/woocommerce/woocommerce-android/pull/6579]
+- [*] In-Person Payments: Removed unnecessary notification when interac refund is initiated [https://github.com/woocommerce/woocommerce-android/pull/6601]
 
 9.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -366,14 +366,14 @@ class IssueRefundViewModel @Inject constructor(
                     if (isInteracRefund() && inPersonPaymentsCanadaFeatureFlag.isEnabled()) {
                         triggerEvent(IssueRefundEvent.NavigateToCardReaderScreen(order.id, commonState.refundTotal))
                     } else {
+                        triggerEvent(
+                            ShowSnackbar(
+                                R.string.order_refunds_amount_refund_progress_message,
+                                arrayOf(formatCurrency(commonState.refundTotal))
+                            )
+                        )
                         refund()
                     }
-                    triggerEvent(
-                        ShowSnackbar(
-                            R.string.order_refunds_amount_refund_progress_message,
-                            arrayOf(formatCurrency(commonState.refundTotal))
-                        )
-                    )
 
                     AnalyticsTracker.track(
                         REFUND_CREATE,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6567 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removes snack bar about refund is initiated during interac refund

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Perform normal refund
* Notice there is a snack bar
* Perform Interac refund
* Notice there is no snackbar

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/170485738-e0faae33-cee5-4efa-a858-000ee246cb68.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
