### PR TITLE
Add auto draft as collectible status

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -240,6 +240,8 @@ data class Order(
 
     sealed class Status(val value: String) : Parcelable {
         companion object {
+            const val AUTO_DRAFT = "auto-draft"
+
             fun fromValue(value: String): Status {
                 return fromDataModel(CoreOrderStatus.fromValue(value)) ?: Custom(value)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
@@ -44,6 +44,6 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
         Pending,
         Processing,
         OnHold,
-        Custom("auto-draft")
+        Custom(Order.Status.AUTO_DRAFT)
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.extensions.STRIPE_PAYMENTS_PAYMENT_TYPE
 import com.woocommerce.android.extensions.WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
 import com.woocommerce.android.extensions.WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.Order.Status.Custom
 import com.woocommerce.android.model.Order.Status.OnHold
 import com.woocommerce.android.model.Order.Status.Pending
 import com.woocommerce.android.model.Order.Status.Processing
@@ -43,5 +44,6 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
         Pending,
         Processing,
         OnHold,
+        Custom("auto-draft")
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.ShippingLine
+import com.woocommerce.android.model.Order.Status.Companion.AUTO_DRAFT
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -188,6 +189,5 @@ class OrderCreationRepository @Inject constructor(
 
     companion object {
         const val AUTO_DRAFT_SUPPORTED_VERSION = "6.3.0"
-        const val AUTO_DRAFT = "auto-draft"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -217,6 +217,16 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when order has custom status with auto-draft, then is not collectable`() =
+        testBlocking {
+            val order = getOrder(paymentStatus = Order.Status.Custom("auto-draft"))
+
+            val isCollectable = checker.isCollectable(order)
+
+            assertThat(isCollectable).isTrue()
+        }
+
+    @Test
     fun `when order has refunded status, then is not collectable`() =
         testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Refunded)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -217,7 +217,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when order has custom status with auto-draft, then is not collectable`() =
+    fun `when order has custom status with auto-draft, then is collectable`() =
         testBlocking {
             val order = getOrder(paymentStatus = Order.Status.Custom(Order.Status.AUTO_DRAFT))
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -219,7 +219,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     @Test
     fun `when order has custom status with auto-draft, then is not collectable`() =
         testBlocking {
-            val order = getOrder(paymentStatus = Order.Status.Custom("auto-draft"))
+            val order = getOrder(paymentStatus = Order.Status.Custom(Order.Status.AUTO_DRAFT))
 
             val isCollectable = checker.isCollectable(order)
 


### PR DESCRIPTION
Summary
==========
This is a hotfix to the recent changes in trunk regarding the Simple Payments improvements to support the Order draft status introduced by the Order Creation feature, which introduced a bug where the Simple Payments couldn't be collected anymore since the Card Reader implementation does not track this Custom status.

@malinajirka, I currently don't have ways to test this fix in a real IPP scenario right now, so would you mind stressing this fix to see if it actually does fix the problem? Thanks!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.