### PR TITLE
Temporarily disable Gradle dependency cache

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -5,4 +5,4 @@
 
 set -e
 
-restore_gradle_dependency_cache || true
+#restore_gradle_dependency_cache || true


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR disables the Gradle dependency cache as we are updating our AMI configuration and [bash-cache-buildkite-plugin](https://github.com/Automattic/bash-cache-buildkite-plugin/). It's unlikely these changes would break this project, but temporarily disabling the dependency cache guarantees that we won't block developers in case something goes wrong.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

No testing necessary

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
