### PR TITLE
Add Edit button to Order Details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -82,7 +82,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
 
     private val skeletonView = SkeletonView()
     private var undoSnackbar: Snackbar? = null
-    private var mnuSharePaymentLink: MenuItem? = null
+    private var menuSharePaymentLink: MenuItem? = null
 
     private var screenTitle = ""
         set(value) {
@@ -151,7 +151,9 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_order_detail, menu)
-        mnuSharePaymentLink = menu.findItem(R.id.menu_share_payment_link)
+        menuSharePaymentLink = menu.findItem(R.id.menu_share_payment_link)
+        val menuEditOrder = menu.findItem(R.id.menu_edit_order)
+        menuEditOrder.isVisible = FeatureFlag.UNIFIED_ORDER_EDITING.isEnabled()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -195,7 +197,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
                 binding.orderDetailProductList.isVisible = it
             }
             new.isSharePaymentLinkVisible?.takeIfNotEqualTo(old?.isSharePaymentLinkVisible) {
-                mnuSharePaymentLink?.isVisible = new.isSharePaymentLinkVisible
+                menuSharePaymentLink?.isVisible = new.isSharePaymentLinkVisible
             }
             new.toolbarTitle?.takeIfNotEqualTo(old?.toolbarTitle) { screenTitle = it }
             new.isOrderDetailSkeletonShown?.takeIfNotEqualTo(old?.isOrderDetailSkeletonShown) { showSkeleton(it) }

--- a/WooCommerce/src/main/res/menu/menu_order_detail.xml
+++ b/WooCommerce/src/main/res/menu/menu_order_detail.xml
@@ -11,5 +11,5 @@
         android:id="@+id/menu_edit_order"
         android:title="@string/edit"
         android:visible="false"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
 </menu>

--- a/WooCommerce/src/main/res/menu/menu_order_detail.xml
+++ b/WooCommerce/src/main/res/menu/menu_order_detail.xml
@@ -6,4 +6,10 @@
         android:title="@string/simple_payments_share_payment_link"
         android:visible="false"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/menu_edit_order"
+        android:title="@string/edit"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
 </menu>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6607 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds an `Edit` button for Order Details (in debuggable builds only).


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

None.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

If the Order has Simple Payments link available to share, we'll show Edit next to the button now. I'm not sure if it looks good - I wanted users to always see the "Edit" possibility. cc: @joe-keenan 

Maybe we should organize it differently? But I don't think it should be a blocker for this PR, I just want to provide a way to show a unified screen ASAP so we can all start to work on different parts there.

<img width="429" alt="image" src="https://user-images.githubusercontent.com/5845095/170560759-16ad9f43-7bb8-44ae-ab74-db8497ca7d92.png">





- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
