### PR TITLE
Add feature flag files for payment plugin selection screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/IppSelectPaymentGateway.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/IppSelectPaymentGateway.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.cardreader
+
+import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+
+class IppSelectPaymentGateway @Inject constructor() {
+    fun isEnabled() = FeatureFlag.IPP_SELECT_PAYMENT_GATEWAY.isEnabled(context = null)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -13,6 +13,7 @@ enum class FeatureFlag {
     IN_PERSON_PAYMENTS_CANADA,
     MORE_MENU_INBOX,
     COUPONS_M2,
+    IPP_SELECT_PAYMENT_GATEWAY,
     UNIFIED_ORDER_EDITING;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -26,6 +27,7 @@ enum class FeatureFlag {
             ANALYTICS_HUB,
             MORE_MENU_INBOX,
             COUPONS_M2,
+            IPP_SELECT_PAYMENT_GATEWAY,
             UNIFIED_ORDER_EDITING -> PackageUtils.isDebugBuild()
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6603
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add feature flag files to introduce the Payment Plugin selection screen if the user has both WCpay and Stripe plugins installed for IPP

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
