### PR TITLE
Re-enable Gradle dependency cache and update bash-cache-buildkite-plugin

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -5,4 +5,4 @@
 
 set -e
 
-#restore_gradle_dependency_cache || true
+restore_gradle_dependency_cache || true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.4.0
+    - automattic/bash-cache#2.5.0
 
 steps:
   - label: "checkstyle"


### PR DESCRIPTION
### Description
This PR re-enables the Gradle dependency cache we temporarily disabled in #6606. The new AMI configuration worked without issues and in https://github.com/Automattic/bash-cache-buildkite-plugin/pull/26 we made the necessary changes to the Buildkite plugin. https://github.com/Automattic/android-dependency-catalog/pull/2 updated where the Gradle dependency cache is generated from and this PR closes the loop by utilizing the Gradle dependency cache from its new location.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

No testing necessary. [This log from CI ](https://buildkite.com/automattic/woocommerce-android/builds/3437#018101e5-eb9f-49a1-8332-b82541e77988/159-164) verifies that the dependency cache was restored as expected and [this one](https://buildkite.com/automattic/woocommerce-android/builds/3437#018101e5-eb9f-49a1-8332-b82541e77988/175-178) verifies that there weren't any errors while utilizing the dependency cache.

Comparing the `Data downloaded` section for the installable build from [this PR](https://gradle.a8c.com/s/pr74jgbw5lwfw/performance/network-activity) and [from #6606](https://gradle.a8c.com/s/5xlgc6mj2g224/performance/network-activity) also verifies that dependency cache was utilized: `178.8 MiB` vs `407.5 MiB`

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
