### PR TITLE
Bug with last known reader and different countries

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Show "We don't support stripe in Canada" when both WCPay and Stripe are active [https://github.com/woocommerce/woocommerce-android/pull/6573]
 - [***] In-Person Payments: In-Person Payments in Canada is now available for public! [https://github.com/woocommerce/woocommerce-android/pull/6579]
 - [*] In-Person Payments: Removed unnecessary notification when interac refund is initiated [https://github.com/woocommerce/woocommerce-android/pull/6601]
+- [*] In-Person Payments: Do not connect to the last know reader automatically after logout and site change [https://github.com/woocommerce/woocommerce-android/pull/6616]
 
 9.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/ClearCardReaderDataAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/ClearCardReaderDataAction.kt
@@ -1,15 +1,18 @@
 package com.woocommerce.android.ui.cardreader
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import javax.inject.Inject
 
 class ClearCardReaderDataAction @Inject constructor(
-    private val cardReaderManager: CardReaderManager
+    private val cardReaderManager: CardReaderManager,
+    private val appPrefsWrapper: AppPrefsWrapper,
 ) {
     suspend operator fun invoke() {
         if (cardReaderManager.initialized) {
             cardReaderManager.disconnectReader()
             cardReaderManager.clearCachedCredentials()
         }
+        appPrefsWrapper.removeLastConnectedCardReaderId()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/ClearCardReaderDataActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/ClearCardReaderDataActionTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.cardreader
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -12,11 +13,12 @@ import org.mockito.kotlin.whenever
 @ExperimentalCoroutinesApi
 class ClearCardReaderDataActionTest : BaseUnitTest() {
     private val cardReaderManager: CardReaderManager = mock()
+    private val appPrefsWrapper: AppPrefsWrapper  = mock()
 
-    private val sut = ClearCardReaderDataAction(cardReaderManager)
+    private val sut = ClearCardReaderDataAction(cardReaderManager, appPrefsWrapper)
 
     @Test
-    fun `Given card reader is initialised, when clearing card reader data, cache is cleared`() =
+    fun `given card reader is initialised, when clearing card reader data, cache is cleared`() =
         testBlocking {
             whenever(cardReaderManager.initialized).thenReturn(true)
 
@@ -27,7 +29,7 @@ class ClearCardReaderDataActionTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Given card reader is initialised, when clearing card reader data, card reader is disconnected`() =
+    fun `given card reader is initialised, when clearing card reader data, card reader is disconnected`() =
         testBlocking {
             whenever(cardReaderManager.initialized).thenReturn(true)
 
@@ -37,12 +39,23 @@ class ClearCardReaderDataActionTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Given card reader not initialised, when clearing card reader data, nothing happens`() = testBlocking {
+    fun `given card reader not initialised, when clearing card reader data, only remove last know reader`() = testBlocking {
         whenever(cardReaderManager.initialized).thenReturn(false)
 
         sut.invoke()
 
         verify(cardReaderManager, never()).clearCachedCredentials()
         verify(cardReaderManager, never()).disconnectReader()
+        verify(appPrefsWrapper).removeLastConnectedCardReaderId()
     }
+
+    @Test
+    fun `given card reader initialized, when clearing card reader data, removes last know reader`() =
+        testBlocking {
+            whenever(cardReaderManager.initialized).thenReturn(true)
+
+            sut.invoke()
+
+            verify(appPrefsWrapper).removeLastConnectedCardReaderId()
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/ClearCardReaderDataActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/ClearCardReaderDataActionTest.kt
@@ -13,7 +13,7 @@ import org.mockito.kotlin.whenever
 @ExperimentalCoroutinesApi
 class ClearCardReaderDataActionTest : BaseUnitTest() {
     private val cardReaderManager: CardReaderManager = mock()
-    private val appPrefsWrapper: AppPrefsWrapper  = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
 
     private val sut = ClearCardReaderDataAction(cardReaderManager, appPrefsWrapper)
 
@@ -39,15 +39,16 @@ class ClearCardReaderDataActionTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given card reader not initialised, when clearing card reader data, only remove last know reader`() = testBlocking {
-        whenever(cardReaderManager.initialized).thenReturn(false)
+    fun `given card reader not initialised, when clearing card reader data, only remove last know reader`() =
+        testBlocking {
+            whenever(cardReaderManager.initialized).thenReturn(false)
 
-        sut.invoke()
+            sut.invoke()
 
-        verify(cardReaderManager, never()).clearCachedCredentials()
-        verify(cardReaderManager, never()).disconnectReader()
-        verify(appPrefsWrapper).removeLastConnectedCardReaderId()
-    }
+            verify(cardReaderManager, never()).clearCachedCredentials()
+            verify(cardReaderManager, never()).disconnectReader()
+            verify(appPrefsWrapper).removeLastConnectedCardReaderId()
+        }
 
     @Test
     fun `given card reader initialized, when clearing card reader data, removes last know reader`() =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6615
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Clear last known reader on outside along with the moments we clear reader's data from the SDK

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Connect to the M2 reader in the US store
* Change the site on the Canadian site
* Try to connect to a reader again
* Notice that if the reader is still on it won't automatically connect to it but will ask. Also, if there are 2 readers ON you will see the list of the readers

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
