### PR TITLE
[Coupons] Product category selector functionality: selecting and submitting

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
+import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -83,6 +84,10 @@ class EditCouponFragment : BaseFragment() {
 
         handleResult<Set<Long>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
             viewModel.onSelectedProductsUpdated(it)
+        }
+
+        handleResult<List<Long>>(ProductCategorySelectorFragment.PRODUCT_CATEGORY_SELECTOR_RESULT) {
+            viewModel.onIncludedCategoriesChanged(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -16,8 +16,8 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorFragment
+import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -139,6 +139,12 @@ class EditCouponViewModel @Inject constructor(
         }
     }
 
+    fun onSelectedProductsUpdated(productIds: Set<Long>) {
+        couponDraft.update {
+            it?.copy(productIds = productIds.toList())
+        }
+    }
+
     fun onSelectCategoriesButtonClick() {
         couponDraft.value?.let {
             triggerEvent(EditIncludedProductCategories(it.categoryIds))
@@ -154,12 +160,6 @@ class EditCouponViewModel @Inject constructor(
     fun onRestrictionsUpdated(restrictions: CouponRestrictions) {
         couponDraft.update {
             it?.copy(restrictions = restrictions)
-        }
-    }
-
-    fun onSelectedProductsUpdated(productIds: Set<Long>) {
-        couponDraft.update {
-            it?.copy(productIds = productIds.toList())
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -145,6 +145,12 @@ class EditCouponViewModel @Inject constructor(
         }
     }
 
+    fun onIncludedCategoriesChanged(includedCategoryIds: List<Long>) {
+        couponDraft.update {
+            it?.copy(categoryIds = includedCategoryIds)
+        }
+    }
+
     fun onRestrictionsUpdated(restrictions: CouponRestrictions) {
         couponDraft.update {
             it?.copy(restrictions = restrictions)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
@@ -25,7 +25,8 @@ class ProductCategorySelectorFragment : BaseFragment() {
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
+            navigationIcon = R.drawable.ic_gridicons_cross_24dp,
+            hasShadow = false
         )
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
@@ -8,13 +8,19 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ProductCategorySelectorFragment : BaseFragment() {
+    companion object {
+        const val PRODUCT_CATEGORY_SELECTOR_RESULT = "product-category-selector-result"
+    }
+
     private val viewModel: ProductCategorySelectorViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
@@ -30,6 +36,19 @@ class ProductCategorySelectorFragment : BaseFragment() {
                 WooThemeWithBackground {
                     ProductCategorySelectorScreen(viewModel = viewModel)
                 }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ExitWithResult<*> -> navigateBackWithResult(PRODUCT_CATEGORY_SELECTOR_RESULT, event.data)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorViewModel.CategoryUiModel
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorViewModel.LoadingState
@@ -85,6 +86,12 @@ private fun CategoriesList(
             .fillMaxHeight()
             .background(MaterialTheme.colors.surface)
     ) {
+        WCTextButton(
+            onClick = { /*TODO*/ },
+            modifier = Modifier.padding(dimensionResource(id = R.dimen.minor_100))
+        ) {
+            Text(text = stringResource(id = R.string.product_category_selector_clear_selection))
+        }
         val lazyListState = rememberLazyListState()
         LazyColumn(
             state = lazyListState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
@@ -159,7 +160,8 @@ private fun LazyListScope.categoryItem(item: CategoryUiModel, depth: Int = 0) {
                     modifier = Modifier.padding(
                         start = dimensionResource(id = R.dimen.major_100) * depth,
                     ),
-                    maxLines = 1
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
 
                 if (item.isSelected) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -51,7 +51,8 @@ fun ProductCategorySelectorScreen(viewModel: ProductCategorySelectorViewModel) {
     viewState?.let {
         ProductCategorySelectorScreen(
             viewState = it,
-            onLoadMore = viewModel::onLoadMore
+            onLoadMore = viewModel::onLoadMore,
+            onDoneClick = viewModel::onDoneClick
         )
     }
 }
@@ -59,12 +60,14 @@ fun ProductCategorySelectorScreen(viewModel: ProductCategorySelectorViewModel) {
 @Composable
 fun ProductCategorySelectorScreen(
     viewState: ProductCategorySelectorViewModel.ViewState,
-    onLoadMore: () -> Unit = {}
+    onLoadMore: () -> Unit = {},
+    onDoneClick: () -> Unit = {},
 ) {
     when {
         viewState.categories.isNotEmpty() -> CategoriesList(
             viewState = viewState,
-            onLoadMore = onLoadMore
+            onLoadMore = onLoadMore,
+            onDoneClick = onDoneClick
         )
         viewState.loadingState == LoadingState.Loading -> CategoriesSkeleton()
         else -> EmptyCategoriesList()
@@ -74,7 +77,8 @@ fun ProductCategorySelectorScreen(
 @Composable
 private fun CategoriesList(
     viewState: ProductCategorySelectorViewModel.ViewState,
-    onLoadMore: () -> Unit = {}
+    onLoadMore: () -> Unit,
+    onDoneClick: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -110,7 +114,7 @@ private fun CategoriesList(
         )
 
         WCColoredButton(
-            onClick = { /*TODO*/ },
+            onClick = onDoneClick,
             text = StringUtils.getQuantityString(
                 quantity = viewState.selectedCategoriesCount,
                 default = R.string.product_category_selector_select_button_title_default,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -2,10 +2,12 @@ package com.woocommerce.android.ui.products.categories.selector
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,8 +19,11 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -67,7 +72,10 @@ fun ProductCategorySelectorScreen(
 }
 
 @Composable
-private fun CategoriesList(viewState: ProductCategorySelectorViewModel.ViewState, onLoadMore: () -> Unit = {}) {
+private fun CategoriesList(
+    viewState: ProductCategorySelectorViewModel.ViewState,
+    onLoadMore: () -> Unit = {}
+) {
     Column(
         modifier = Modifier
             .fillMaxHeight()
@@ -122,14 +130,32 @@ private fun LazyListScope.categoryItem(item: CategoryUiModel, depth: Int = 0) {
             modifier = Modifier
                 .fillMaxWidth()
         ) {
-            Row(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))) {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = dimensionResource(id = R.dimen.line_height_major_100))
+                    .clickable(onClick = item.onItemClick)
+                    .padding(dimensionResource(id = R.dimen.major_100))
+            ) {
                 Text(
                     text = item.title,
                     style = MaterialTheme.typography.subtitle1,
                     modifier = Modifier.padding(
                         start = dimensionResource(id = R.dimen.major_100) * depth,
-                    )
+                    ),
+                    maxLines = 1
                 )
+
+                if (item.isSelected) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = stringResource(
+                            id = R.string.product_category_selector_check_content_description
+                        ),
+                        tint = MaterialTheme.colors.primary
+                    )
+                }
             }
 
             Divider(modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100) * (depth + 1)))
@@ -206,7 +232,8 @@ private fun PreviewProductCategorySelector() {
             children = if (childrenDepth > 0) {
                 listOf(generateCategory("$childrenDepth$id".toLong(), childrenDepth - 1))
             } else emptyList(),
-            isSelected = (id.mod(2)) == 0
+            isSelected = (id.mod(2)) == 0,
+            onItemClick = {}
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -146,9 +146,8 @@ private fun LazyListScope.categoryItem(item: CategoryUiModel, depth: Int = 0) {
             modifier = Modifier
                 .fillMaxWidth()
         ) {
-            Row(
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier
+            Box(
+                Modifier
                     .fillMaxWidth()
                     .defaultMinSize(minHeight = dimensionResource(id = R.dimen.line_height_major_100))
                     .clickable(onClick = item.onItemClick)
@@ -157,9 +156,12 @@ private fun LazyListScope.categoryItem(item: CategoryUiModel, depth: Int = 0) {
                 Text(
                     text = item.title,
                     style = MaterialTheme.typography.subtitle1,
-                    modifier = Modifier.padding(
-                        start = dimensionResource(id = R.dimen.major_100) * depth,
-                    ),
+                    modifier = Modifier
+                        .padding(
+                            start = dimensionResource(id = R.dimen.major_100) * depth,
+                            end = dimensionResource(id = R.dimen.major_150)
+                        )
+                        .align(Alignment.CenterStart),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -170,7 +172,8 @@ private fun LazyListScope.categoryItem(item: CategoryUiModel, depth: Int = 0) {
                         contentDescription = stringResource(
                             id = R.string.product_category_selector_check_content_description
                         ),
-                        tint = MaterialTheme.colors.primary
+                        tint = MaterialTheme.colors.primary,
+                        modifier = Modifier.align(Alignment.CenterEnd)
                     )
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -53,6 +53,7 @@ fun ProductCategorySelectorScreen(viewModel: ProductCategorySelectorViewModel) {
         ProductCategorySelectorScreen(
             viewState = it,
             onLoadMore = viewModel::onLoadMore,
+            onClearSelectionClick = viewModel::onClearSelectionClick,
             onDoneClick = viewModel::onDoneClick
         )
     }
@@ -62,12 +63,14 @@ fun ProductCategorySelectorScreen(viewModel: ProductCategorySelectorViewModel) {
 fun ProductCategorySelectorScreen(
     viewState: ProductCategorySelectorViewModel.ViewState,
     onLoadMore: () -> Unit = {},
+    onClearSelectionClick: () -> Unit = {},
     onDoneClick: () -> Unit = {},
 ) {
     when {
         viewState.categories.isNotEmpty() -> CategoriesList(
             viewState = viewState,
             onLoadMore = onLoadMore,
+            onClearSelectionClick = onClearSelectionClick,
             onDoneClick = onDoneClick
         )
         viewState.loadingState == LoadingState.Loading -> CategoriesSkeleton()
@@ -79,6 +82,7 @@ fun ProductCategorySelectorScreen(
 private fun CategoriesList(
     viewState: ProductCategorySelectorViewModel.ViewState,
     onLoadMore: () -> Unit,
+    onClearSelectionClick: () -> Unit,
     onDoneClick: () -> Unit
 ) {
     Column(
@@ -87,7 +91,7 @@ private fun CategoriesList(
             .background(MaterialTheme.colors.surface)
     ) {
         WCTextButton(
-            onClick = { /*TODO*/ },
+            onClick = onClearSelectionClick,
             modifier = Modifier.padding(dimensionResource(id = R.dimen.minor_100))
         ) {
             Text(text = stringResource(id = R.string.product_category_selector_clear_selection))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -30,6 +30,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -146,8 +147,9 @@ private fun LazyListScope.categoryItem(item: CategoryUiModel, depth: Int = 0) {
             modifier = Modifier
                 .fillMaxWidth()
         ) {
-            Box(
-                Modifier
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
                     .fillMaxWidth()
                     .defaultMinSize(minHeight = dimensionResource(id = R.dimen.line_height_major_100))
                     .clickable(onClick = item.onItemClick)
@@ -157,25 +159,20 @@ private fun LazyListScope.categoryItem(item: CategoryUiModel, depth: Int = 0) {
                     text = item.title,
                     style = MaterialTheme.typography.subtitle1,
                     modifier = Modifier
-                        .padding(
-                            start = dimensionResource(id = R.dimen.major_100) * depth,
-                            end = dimensionResource(id = R.dimen.major_150)
-                        )
-                        .align(Alignment.CenterStart),
+                        .padding(start = dimensionResource(id = R.dimen.major_100) * depth)
+                        .weight(1f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
 
-                if (item.isSelected) {
-                    Icon(
-                        imageVector = Icons.Default.Check,
-                        contentDescription = stringResource(
-                            id = R.string.product_category_selector_check_content_description
-                        ),
-                        tint = MaterialTheme.colors.primary,
-                        modifier = Modifier.align(Alignment.CenterEnd)
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = stringResource(
+                        id = R.string.product_category_selector_check_content_description
+                    ),
+                    tint = MaterialTheme.colors.primary,
+                    modifier = Modifier.alpha(if (item.isSelected) 1f else 0f)
+                )
             }
 
             Divider(modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100) * (depth + 1)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -27,7 +28,7 @@ class ProductCategorySelectorViewModel @Inject constructor(
 
     private val navArgs: ProductCategorySelectorFragmentArgs by savedState.navArgs()
 
-    private val selectedCategories = savedState.getStateFlow(this, navArgs.categoryIds.toList())
+    private val selectedCategories = savedState.getStateFlow(this, navArgs.categoryIds.toSet())
     private val loadingState = MutableStateFlow(LoadingState.Idle)
     private val categories = listHandler.categories
 
@@ -64,18 +65,28 @@ class ProductCategorySelectorViewModel @Inject constructor(
         loadingState.value = LoadingState.Idle
     }
 
-    private fun ProductCategoryTreeItem.toUiModel(selectedCategories: List<Long>): CategoryUiModel = CategoryUiModel(
+    private fun ProductCategoryTreeItem.toUiModel(selectedCategories: Set<Long>): CategoryUiModel = CategoryUiModel(
         id = productCategory.remoteCategoryId,
         title = productCategory.name,
         children = children.map { it.toUiModel(selectedCategories) },
-        isSelected = selectedCategories.contains(productCategory.remoteCategoryId)
+        isSelected = selectedCategories.contains(productCategory.remoteCategoryId),
+        onItemClick = {
+            this@ProductCategorySelectorViewModel.selectedCategories.update {
+                if (it.contains(productCategory.remoteCategoryId)) {
+                    it - productCategory.remoteCategoryId
+                } else {
+                    it + productCategory.remoteCategoryId
+                }
+            }
+        }
     )
 
     data class CategoryUiModel(
         val id: Long,
         val title: String,
         val children: List<CategoryUiModel>,
-        val isSelected: Boolean
+        val isSelected: Boolean,
+        val onItemClick: () -> Unit
     )
 
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products.categories.selector
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
@@ -63,6 +64,10 @@ class ProductCategorySelectorViewModel @Inject constructor(
         loadingState.value = LoadingState.Appending
         listHandler.loadMore()
         loadingState.value = LoadingState.Idle
+    }
+
+    fun onDoneClick() {
+        triggerEvent(ExitWithResult(selectedCategories.value.toList()))
     }
 
     private fun ProductCategoryTreeItem.toUiModel(selectedCategories: Set<Long>): CategoryUiModel = CategoryUiModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
@@ -66,6 +66,10 @@ class ProductCategorySelectorViewModel @Inject constructor(
         loadingState.value = LoadingState.Idle
     }
 
+    fun onClearSelectionClick() {
+        selectedCategories.value = emptySet()
+    }
+
     fun onDoneClick() {
         triggerEvent(ExitWithResult(selectedCategories.value.toList()))
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1437,6 +1437,7 @@
     <string name="product_category_selector_select_button_title_default">Select %1$d Categories</string>
     <string name="product_category_selector_select_button_title_one">Select 1 category</string>
     <string name="product_category_selector_check_content_description">Click to uncheck</string>
+    <string name="product_category_selector_clear_selection">Clear selection</string>
     <!--
         Product Add more details Bottom sheet
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1436,6 +1436,7 @@
     <string name="product_category_selector_empty_state">No product categories found</string>
     <string name="product_category_selector_select_button_title_default">Select %1$d Categories</string>
     <string name="product_category_selector_select_button_title_one">Select 1 category</string>
+    <string name="product_category_selector_check_content_description">Click to uncheck</string>
     <!--
         Product Add more details Bottom sheet
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of 6362

### Description
This PR builds upon the previous PR #6602, it adds the following functionality:
- Displays the selection status.
- Handles changing selection.
- Returns the updated selection to parent fragment.
- Adds a clear selection button.

### Testing instructions

1. Make sure coupons beta toggle is enabled.
2. Open coupon details.
3. Click on Menu, then edit coupons.
4. Click on "Select product categories".
5. Confirm the selected categories are shown as checked.
7. Test the clear selection button.
8. Change the selection of categories.
9. Click on "Done" (or "Select X categories") and confirm the included categories of the coupon are updated.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
