### PR TITLE
Open order edit from order details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -56,4 +56,5 @@ sealed class OrderNavigationTarget : Event() {
         OrderNavigationTarget()
     data class ViewOrderedAddons(val remoteOrderID: Long, val orderItemID: Long, val addonsProductID: Long) :
         OrderNavigationTarget()
+    data class EditOrder(val orderId: Long) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.common.InfoScreenFragment.InfoScreenLinkAction.LearnMoreAboutShippingLabels
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.EditOrder
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.PreviewReceipt
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.PrintShippingLabel
@@ -26,6 +27,7 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProdu
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewShipmentTrackingProviders
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewShippingLabelFormatOptions
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewShippingLabelPaperSizes
+import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelFragmentDirections
 import com.woocommerce.android.ui.orders.tracking.AddOrderShipmentTrackingFragmentDirections
@@ -173,6 +175,12 @@ class OrderNavigator @Inject constructor() {
                         orderId = target.remoteOrderID,
                         orderItemId = target.orderItemID,
                         addonsProductId = target.addonsProductID
+                    ).let { fragment.findNavController().navigateSafely(it) }
+            }
+            is EditOrder -> {
+                OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToOrderCreationFragment(
+                        OrderCreationViewModel.Mode.Edit(target.orderId)
                     ).let { fragment.findNavController().navigateSafely(it) }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -157,11 +157,18 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return if (item.itemId == R.id.menu_share_payment_link) {
-            viewModel.onSharePaymentUrlClicked()
-            true
-        } else {
-            super.onOptionsItemSelected(item)
+        return when (item.itemId) {
+            R.id.menu_share_payment_link -> {
+                viewModel.onSharePaymentUrlClicked()
+                true
+            }
+            R.id.menu_edit_order -> {
+                viewModel.onEditClicked()
+                true
+            }
+            else -> {
+                super.onOptionsItemSelected(item)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.tools.ProductImageMap.OnProductFetchedListener
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.cardreader.payment.CardReaderPaymentCollectibilityChecker
+import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
@@ -244,6 +245,10 @@ final class OrderDetailViewModel @Inject constructor(
     fun onSharePaymentUrlClicked() {
         AnalyticsTracker.track(AnalyticsEvent.ORDER_DETAIL_PAYMENT_LINK_SHARED)
         triggerEvent(TakePaymentViewModel.SharePaymentUrl(selectedSite.get().name, order.paymentUrl))
+    }
+
+    fun onEditClicked() {
+        triggerEvent(OrderNavigationTarget.EditOrder(order.id))
     }
 
     fun onAcceptCardPresentPaymentClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
+import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.Companion.KEY_ORDER_CREATION_ACTION_RESULT
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.OrderCreationAction
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
@@ -329,7 +330,11 @@ class OrderListFragment :
 
     private fun openOrderCreationFragment() {
         AnalyticsTracker.track(AnalyticsEvent.ORDER_ADD_NEW)
-        findNavController().navigateSafely(R.id.action_orderListFragment_to_orderCreationFragment)
+        findNavController().navigateSafely(
+            OrderListFragmentDirections.actionOrderListFragmentToOrderCreationFragment(
+                OrderCreationViewModel.Mode.Creation
+            )
+        )
     }
 
     private fun hideEmptyView() {

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -65,7 +65,11 @@
             app:enterAnim="@anim/activity_fade_in"
             app:exitAnim="@null"
             app:popEnterAnim="@null"
-            app:popExitAnim="@anim/activity_fade_out" />
+            app:popExitAnim="@anim/activity_fade_out" >
+            <argument
+                android:name="mode"
+                app:argType="com.woocommerce.android.ui.orders.creation.OrderCreationViewModel$Mode" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/products"

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -69,6 +69,9 @@
                 app:nullable="true"
                 android:defaultValue="@null"/>
         </action>
+        <argument
+            android:name="mode"
+            app:argType="com.woocommerce.android.ui.orders.creation.OrderCreationViewModel$Mode" />
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -229,6 +229,18 @@
                 app:argType="com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam"
                 app:nullable="false" />
         </action>
+
+        <action
+            android:id="@+id/action_orderDetailFragment_to_orderCreationFragment"
+            app:destination="@id/nav_graph_order_creations"
+            app:enterAnim="@anim/activity_fade_in"
+            app:exitAnim="@null"
+            app:popEnterAnim="@null"
+            app:popExitAnim="@anim/activity_fade_out" >
+            <argument
+                android:name="mode"
+                app:argType="com.woocommerce.android.ui.orders.creation.OrderCreationViewModel$Mode" />
+        </action>
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelInitializationTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelInitializationTest.kt
@@ -1,0 +1,83 @@
+package com.woocommerce.android.ui.orders.creation
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.creation.CreateOrUpdateOrderDraft.OrderDraftUpdateStatus
+import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel.Mode
+import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel.ViewState
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OrderCreationViewModelInitializationTest : BaseUnitTest() {
+    val orderDetailRepository: OrderDetailRepository = mock()
+    val viewState = ViewState()
+    val createOrUpdateOrderDraft: CreateOrUpdateOrderDraft = mock {
+        onBlocking { invoke(any(), any()) } doReturn flowOf(OrderDraftUpdateStatus.Succeeded(Order.EMPTY))
+    }
+
+    lateinit var savedState: SavedStateHandle
+    lateinit var sut: OrderCreationViewModel
+
+    @Test
+    fun `should not load order from repository when is in creation mode`() {
+        withInitialState(Mode.Creation)
+
+        initializeSut()
+
+        verifyNoInteractions(orderDetailRepository)
+    }
+
+    @Test
+    fun `should load order from repository when is in edit mode`() = testBlocking {
+        val id = 123L
+        val orderToEdit = Order.EMPTY.copy(id = id)
+        whenever(orderDetailRepository.getOrderById(id)).doReturn(orderToEdit)
+        withInitialState(Mode.Edit(id))
+
+        initializeSut()
+
+        verify(orderDetailRepository).getOrderById(id)
+        assertThat(sut.orderDraft.value).isEqualTo(orderToEdit)
+    }
+
+    private fun withInitialState(mode: Mode) {
+        savedState = spy(OrderCreationFormFragmentArgs(mode).toSavedStateHandle()) {
+            on { getLiveData(viewState.javaClass.name, viewState) } doReturn MutableLiveData(viewState)
+            on { getLiveData(eq(Order.EMPTY.javaClass.name), any<Order>()) } doReturn MutableLiveData(Order.EMPTY)
+        }
+    }
+
+    private fun initializeSut() {
+        val parameterRepository: ParameterRepository = mock {
+            on { getParameters(any(), eq(savedState)) } doReturn
+                SiteParameters("", null, null, null, null, 0F)
+        }
+        sut = OrderCreationViewModel(
+            savedState,
+            mock(),
+            orderDetailRepository,
+            mock(),
+            mock(),
+            createOrUpdateOrderDraft,
+            mock(),
+            parameterRepository,
+        )
+        sut.orderDraft.observeForever { }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModelTest.kt
@@ -27,6 +27,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import java.math.BigDecimal
@@ -722,7 +723,7 @@ class OrderCreationViewModelTest : BaseUnitTest() {
         val defaultOrderItem = createOrderItem()
         val emptyOrder = Order.EMPTY
         viewState = ViewState()
-        savedState = mock {
+        savedState = spy(OrderCreationFormFragmentArgs(OrderCreationViewModel.Mode.Creation).toSavedStateHandle()) {
             on { getLiveData(viewState.javaClass.name, viewState) } doReturn MutableLiveData(viewState)
             on { getLiveData(eq(Order.EMPTY.javaClass.name), any<Order>()) } doReturn MutableLiveData(emptyOrder)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Relates to: #6614 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR opens an Order Creation screen with prefilled existing Order data when tapping `Edit` button.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

TC 1 Order Edit
1. Open some order
2. Click `Edit`
3. See that fields contain more-or-less correct data of the edited order

TC 2 Create Order
1. Go to list of orders
2. Click on Create Order
3. Assert that app didn't crash

**Warning!** Running TC 1 and navigating back will remove the edited order.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5845095/170705282-a5b339b0-a985-4e83-919a-a5d0d5570787.mov




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
