### PR TITLE
[Coupons] Restrictions: Allow empty values and add input field placeholders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -46,7 +46,8 @@ fun WCOutlinedTextField(
     singleLine: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors(),
+    placeholderText: String? = null
 ) {
     WCOutlinedTextFieldLayout(
         modifier = modifier,
@@ -71,7 +72,12 @@ fun WCOutlinedTextField(
             keyboardActions = keyboardActions,
             singleLine = singleLine,
             maxLines = maxLines,
-            interactionSource = interactionSource
+            interactionSource = interactionSource,
+            placeholder = {
+                placeholderText?.let {
+                    Text(text = it)
+                }
+            }
         )
     }
 }
@@ -97,7 +103,8 @@ fun WCOutlinedTextField(
     singleLine: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors(),
+    placeholderText: String? = null
 ) {
     WCOutlinedTextFieldLayout(
         modifier = modifier,
@@ -122,7 +129,12 @@ fun WCOutlinedTextField(
             keyboardActions = keyboardActions,
             singleLine = singleLine,
             maxLines = maxLines,
-            interactionSource = interactionSource
+            interactionSource = interactionSource,
+            placeholder = {
+                placeholderText?.let {
+                    Text(text = it)
+                }
+            }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -182,7 +182,7 @@ class NullableIntTextFieldValueMapper(
     override fun transformText(oldText: String, newText: String): String {
         val clearedText = if (!supportsNegativeValue) newText.filter { it != '-' } else newText
         return when {
-            clearedText.isEmpty() || clearedText == "-" -> "0"
+            clearedText.isEmpty() || clearedText == "-" -> ""
             clearedText.matches("^-?0+\\d".toRegex()) ->
                 // Delete any leading 0s, since this field can't be cleared
                 clearedText.replace("^(-?)0+".toRegex(), "$1")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -49,7 +49,8 @@ fun <T> WCOutlinedTypedTextField(
     singleLine: Boolean = true,
     maxLines: Int = Int.MAX_VALUE,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors(),
+    placeholderText: String? = null
 ) {
     var currentValue by remember {
         mutableStateOf(value)
@@ -99,7 +100,8 @@ fun <T> WCOutlinedTypedTextField(
         singleLine = singleLine,
         maxLines = maxLines,
         interactionSource = interactionSource,
-        colors = colors
+        colors = colors,
+        placeholderText = placeholderText
     )
 }
 
@@ -167,7 +169,8 @@ class NullableBigDecimalTextFieldValueMapper(
     override fun transformText(oldText: String, newText: String): String {
         val clearedText = if (!supportsNegativeValue) newText.filter { it != '-' } else newText
         return when {
-            clearedText.isEmpty() || clearedText == "-" || clearedText == "." -> clearedText
+            clearedText.isEmpty() -> ""
+            clearedText == "0" || clearedText == "-" || clearedText == "." -> clearedText
             clearedText.toBigDecimalOrNull() != null -> clearedText
             else -> oldText
         }
@@ -182,7 +185,8 @@ class NullableIntTextFieldValueMapper(
     override fun transformText(oldText: String, newText: String): String {
         val clearedText = if (!supportsNegativeValue) newText.filter { it != '-' } else newText
         return when {
-            clearedText.isEmpty() || clearedText == "-" -> ""
+            clearedText.isEmpty() -> ""
+            clearedText == "-" -> clearedText
             clearedText.matches("^-?0+\\d".toRegex()) ->
                 // Delete any leading 0s, since this field can't be cleared
                 clearedText.replace("^(-?)0+".toRegex(), "$1")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -174,11 +174,11 @@ class NullableBigDecimalTextFieldValueMapper(
     }
 }
 
-class IntTextFieldValueMapper(
+class NullableIntTextFieldValueMapper(
     private val supportsNegativeValue: Boolean = true
-) : TextFieldValueMapper<Int> {
-    override fun parseText(text: String): Int = text.toInt()
-    override fun printValue(value: Int): String = value.toString()
+) : TextFieldValueMapper<Int?> {
+    override fun parseText(text: String): Int? = text.toIntOrNull()
+    override fun printValue(value: Int?): String = value?.toString().orEmpty()
     override fun transformText(oldText: String, newText: String): String {
         val clearedText = if (!supportsNegativeValue) newText.filter { it != '-' } else newText
         return when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
-import com.woocommerce.android.ui.compose.component.IntTextFieldValueMapper
+import com.woocommerce.android.ui.compose.component.NullableBigDecimalTextFieldValueMapper
+import com.woocommerce.android.ui.compose.component.NullableIntTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import com.woocommerce.android.ui.compose.component.WCSwitch
 import java.math.BigDecimal
@@ -45,11 +45,11 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
 @Composable
 fun CouponRestrictionsScreen(
     viewState: CouponRestrictionsViewModel.ViewState,
-    onMinimumAmountChanged: (BigDecimal) -> Unit,
-    onMaximumAmountChanged: (BigDecimal) -> Unit,
-    onUsageLimitPerCouponChanged: (Int) -> Unit,
-    onLimitUsageToXItemsChanged: (Int) -> Unit,
-    onUsageLimitPerUserChanged: (Int) -> Unit,
+    onMinimumAmountChanged: (BigDecimal?) -> Unit,
+    onMaximumAmountChanged: (BigDecimal?) -> Unit,
+    onUsageLimitPerCouponChanged: (Int?) -> Unit,
+    onLimitUsageToXItemsChanged: (Int?) -> Unit,
+    onUsageLimitPerUserChanged: (Int?) -> Unit,
     onIndividualUseChanged: (Boolean) -> Unit,
     onExcludeSaleItemsChanged: (Boolean) -> Unit
 ) {
@@ -66,7 +66,7 @@ fun CouponRestrictionsScreen(
             value = viewState.restrictions.minimumAmount ?: BigDecimal.ZERO,
             onValueChange = onMinimumAmountChanged,
             label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
-            valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
+            valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
             // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
             //  (https://issuetracker.google.com/issues/209835363)
@@ -75,10 +75,10 @@ fun CouponRestrictionsScreen(
         )
 
         WCOutlinedTypedTextField(
-            value = viewState.restrictions.maximumAmount ?: BigDecimal.ZERO,
+            value = viewState.restrictions.maximumAmount,
             onValueChange = onMaximumAmountChanged,
             label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
-            valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
+            valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
             // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
             //  (https://issuetracker.google.com/issues/209835363)
@@ -86,20 +86,20 @@ fun CouponRestrictionsScreen(
         )
 
         WCOutlinedTypedTextField(
-            value = viewState.restrictions.usageLimit ?: 0,
+            value = viewState.restrictions.usageLimit,
             onValueChange = onUsageLimitPerCouponChanged,
             label = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_hint),
-            valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
+            valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
 
         if (viewState.showLimitUsageToXItems) {
             WCOutlinedTypedTextField(
-                value = viewState.restrictions.limitUsageToXItems ?: 0,
+                value = viewState.restrictions.limitUsageToXItems,
                 onValueChange = onLimitUsageToXItemsChanged,
                 label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
-                valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
+                valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
                 modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
@@ -109,7 +109,7 @@ fun CouponRestrictionsScreen(
             value = viewState.restrictions.usageLimitPerUser ?: 0,
             onValueChange = onUsageLimitPerUserChanged,
             label = stringResource(id = R.string.coupon_restrictions_limit_per_user_hint),
-            valueMapper = IntTextFieldValueMapper(supportsNegativeValue = false),
+            valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -62,27 +62,16 @@ fun CouponRestrictionsScreen(
             .padding(vertical = dimensionResource(id = R.dimen.major_100))
             .fillMaxSize()
     ) {
-        WCOutlinedTypedTextField(
+        SpendingRestrictionField(
             value = viewState.restrictions.minimumAmount,
             onValueChange = onMinimumAmountChanged,
-            label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
-            valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
-            //  (https://issuetracker.google.com/issues/209835363)
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-
+            label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode)
         )
 
-        WCOutlinedTypedTextField(
+        SpendingRestrictionField(
             value = viewState.restrictions.maximumAmount,
             onValueChange = onMaximumAmountChanged,
-            label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
-            valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
-            //  (https://issuetracker.google.com/issues/209835363)
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode)
         )
 
         WCOutlinedTypedTextField(
@@ -91,7 +80,8 @@ fun CouponRestrictionsScreen(
             label = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_hint),
             valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            placeholderText = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_placeholder)
         )
 
         if (viewState.showLimitUsageToXItems) {
@@ -101,7 +91,8 @@ fun CouponRestrictionsScreen(
                 label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
                 valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
                 modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                placeholderText = stringResource(id = R.string.coupon_restrictions_amount_limit_placeholder)
             )
         }
 
@@ -111,7 +102,8 @@ fun CouponRestrictionsScreen(
             label = stringResource(id = R.string.coupon_restrictions_limit_per_user_hint),
             valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            placeholderText = stringResource(id = R.string.coupon_restrictions_limit_per_user_placeholder)
         )
 
         IndividualUseSwitch(
@@ -123,6 +115,25 @@ fun CouponRestrictionsScreen(
             onExcludeSaleItemsChanged = onExcludeSaleItemsChanged
         )
     }
+}
+
+@Composable
+private fun SpendingRestrictionField(
+    value: BigDecimal?,
+    onValueChange: (BigDecimal?) -> Unit,
+    label: String
+) {
+    WCOutlinedTypedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = label,
+        valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = false),
+        modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+        // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
+        //  (https://issuetracker.google.com/issues/209835363)
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        placeholderText = stringResource(id = R.string.coupon_restrictions_minimum_maximum_spend_placeholder)
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -63,7 +63,7 @@ fun CouponRestrictionsScreen(
             .fillMaxSize()
     ) {
         WCOutlinedTypedTextField(
-            value = viewState.restrictions.minimumAmount ?: BigDecimal.ZERO,
+            value = viewState.restrictions.minimumAmount,
             onValueChange = onMinimumAmountChanged,
             label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
             valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = false),
@@ -106,7 +106,7 @@ fun CouponRestrictionsScreen(
         }
 
         WCOutlinedTypedTextField(
-            value = viewState.restrictions.usageLimitPerUser ?: 0,
+            value = viewState.restrictions.usageLimitPerUser,
             onValueChange = onUsageLimitPerUserChanged,
             label = stringResource(id = R.string.coupon_restrictions_limit_per_user_hint),
             valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -65,13 +65,15 @@ fun CouponRestrictionsScreen(
         SpendingRestrictionField(
             value = viewState.restrictions.minimumAmount,
             onValueChange = onMinimumAmountChanged,
-            label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode)
+            label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
         )
 
         SpendingRestrictionField(
             value = viewState.restrictions.maximumAmount,
             onValueChange = onMaximumAmountChanged,
-            label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode)
+            label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
         )
 
         WCOutlinedTypedTextField(
@@ -121,14 +123,15 @@ fun CouponRestrictionsScreen(
 private fun SpendingRestrictionField(
     value: BigDecimal?,
     onValueChange: (BigDecimal?) -> Unit,
-    label: String
+    label: String,
+    modifier: Modifier = Modifier
 ) {
     WCOutlinedTypedTextField(
         value = value,
         onValueChange = onValueChange,
         label = label,
         valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = false),
-        modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+        modifier = modifier,
         // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
         //  (https://issuetracker.google.com/issues/209835363)
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -45,31 +45,31 @@ class CouponRestrictionsViewModel @Inject constructor(
         triggerEvent(event)
     }
 
-    fun onMinimumAmountChanged(value: BigDecimal) {
+    fun onMinimumAmountChanged(value: BigDecimal?) {
         restrictionsDraft.update {
             it.copy(minimumAmount = value)
         }
     }
 
-    fun onMaximumAmountChanged(value: BigDecimal) {
+    fun onMaximumAmountChanged(value: BigDecimal?) {
         restrictionsDraft.update {
             it.copy(maximumAmount = value)
         }
     }
 
-    fun onUsageLimitPerCouponChanged(value: Int) {
+    fun onUsageLimitPerCouponChanged(value: Int?) {
         restrictionsDraft.update {
             it.copy(usageLimit = value)
         }
     }
 
-    fun onLimitUsageToXItemsChanged(value: Int) {
+    fun onLimitUsageToXItemsChanged(value: Int?) {
         restrictionsDraft.update {
             it.copy(limitUsageToXItems = value)
         }
     }
 
-    fun onUsageLimitPerUserChanged(value: Int) {
+    fun onUsageLimitPerUserChanged(value: Int?) {
         restrictionsDraft.update {
             it.copy(usageLimitPerUser = value)
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1984,9 +1984,13 @@
     <string name="coupon_edit_saving_dialog_subtitle">Please wait…</string>
     <string name="coupon_restrictions_minimum_spend_hint">Minimum Spend (%1$s)</string>
     <string name="coupon_restrictions_maximum_spend_hint">Maximum Spend (%1$s)</string>
+    <string name="coupon_restrictions_minimum_maximum_spend_placeholder">None</string>
     <string name="coupon_restrictions_limit_per_coupon_hint">Usage Limit Per Coupon</string>
+    <string name="coupon_restrictions_limit_per_coupon_placeholder">Unlimited</string>
     <string name="coupon_restrictions_amount_limit_hint">Limit Usage To X Items</string>
+    <string name="coupon_restrictions_amount_limit_placeholder">All Qualifying</string>
     <string name="coupon_restrictions_limit_per_user_hint">Usage Limit Per User</string>
+    <string name="coupon_restrictions_limit_per_user_placeholder">Unlimited</string>
     <string name="coupon_restrictions_individual_use">Individual Use Only</string>
     <string name="coupon_restrictions_individual_use_hint">Turn this on if the coupon cannot be used in conjunction with other coupons.</string>
     <string name="coupon_restrictions_exclude_sale_items">Exclude Sale Items</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the following input field placeholders on the Usage Restriction screen:
- Minimum Spend: "None"
- Maximum Spend: "None"
- Usage Liimit Per Coupon: "Unlimited"
- Limit Usage To X Items: "All Qualifying"
- Usage Limit Per Coupon: "Unlimited"

Additionally, to allow for those placeholders to appear, the fields now accept empty values (both when the data is passed from the Edit Coupon screen, or when customers empty the fields themselves).

### ⚠️  Difference from Design ⚠️ 

The original app design has the placeholder displayed inside the field if there's no current value, even if the field is not currently in focus state.

![Screen Shot 2022-05-30 at 15 21 12](https://user-images.githubusercontent.com/266376/170949733-c6c48e09-cc69-435b-a349-00c713d7de6a.png)

Meanwhile, [with the behavior of `OutlinedTextField` in Material design](https://material.io/components/text-fields#outlined-text-field), when there is no existing value in the text field, by default the **input label** is shown inside the text. The placeholder text only shows up **if the field is in focus state**. Video below:

https://user-images.githubusercontent.com/266376/170950526-59f82db2-595f-49e4-bb2e-dca6988aa102.mov


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

0. In wp-admin, create a test Coupon: "Discount type" is Percentage discount, and make sure everything in "Usage restriction" and "Usage limits" are empty.
1. Start the app, make sure Coupons beta toggle is enabled,
2. Open the details for the test Coupon created on step 1,
3. Click on the Menu, then click on "Edit coupon", then click "Usage Restrictions",
4. Make sure the five outlined text fields show and behave similarly to the video above: input label shown inside the field, and placeholder shown when input is focused.
5. Try entering something on each field, then delete them all. Make sure placeholder text is shown when the value is deleted.