### PR TITLE
Partial `Fastfile` refactoring in preparation for L10n upgrade work

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -522,7 +522,7 @@ platform :android do
       locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] }
     )
     add_us_release_notes(
-      relese_notes_path: download_path + "/release_notes.xml",
+      release_notes_path: download_path + "/release_notes.xml",
       version_name: options[:version]
     )
     # TODO: use Fastlane API to add, commit, and ask caller whether they want to push
@@ -699,7 +699,7 @@ platform :android do
 
   private_lane :add_us_release_notes do | options |
     en_release_notes_path = RELEASE_NOTES_PATH
-    File.open(options[:relese_notes_path], "a") { |f|
+    File.open(options[:release_notes_path], "a") { |f|
       f.puts("<en-US>")
       f.puts("#{options[:version_name]}:")
       f.puts(File.open(en_release_notes_path).read)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -496,10 +496,10 @@ platform :android do
   lane :download_metadata_strings do |options|
     values = options[:version].split('.')
     files = {
-      "release_note_#{values[0].to_s.rjust(2, "0")}#{values[1]}" => {desc: "changelogs/#{options[:build_number]}.txt", max_size: 0},
-      play_store_promo: {desc:"short_description.txt", max_size: 80},
-      play_store_desc: {desc:"full_description.txt", max_size: 0},
-      play_store_app_title: {desc:"title.txt", max_size: 50}
+      "release_note_#{values[0].to_s.rjust(2, "0")}#{values[1]}" => { desc: "changelogs/#{options[:build_number]}.txt", max_size: 0 },
+      play_store_promo: { desc: "short_description.txt", max_size: 80 },
+      play_store_desc: { desc: "full_description.txt", max_size: 0 },
+      play_store_app_title: { desc: "title.txt", max_size: 50 }
     }
 
     delete_old_changelogs(build: options[:build_number])
@@ -510,7 +510,7 @@ platform :android do
                         source_locale: "en-US",
                         download_path: download_path)
 
-    android_create_xml_release_notes(download_path: download_path, build_number: "#{options[:build_number]}", locales: SUPPORTED_LOCALES.map {| hsh | [ hsh[:glotpress], hsh[:google_play] ]})
+    android_create_xml_release_notes(download_path: download_path, build_number: "#{options[:build_number]}", locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] })
     add_us_release_notes(relese_notes_path: download_path + "/release_notes.xml", version_name: options[:version])
     sh("git add #{download_path} && (git diff-index --quiet HEAD || git commit -m \"Update metadata translations for #{options[:version]}\") && git push")
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -522,7 +522,7 @@ platform :android do
       locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] }
     )
     add_us_release_notes(
-      release_notes_path: download_path + "/release_notes.xml",
+      release_notes_path: File.join(download_path, release_notes.xml),
       version_name: options[:version]
     )
     # TODO: use Fastlane API to add, commit, and ask caller whether they want to push

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -87,7 +87,7 @@ platform :android do
 
     extract_release_notes_for_version(
       version: new_version,
-      release_notes_file_path:"#{PROJECT_ROOT_FOLDER}/RELEASE-NOTES.txt",
+      release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt'),
       extracted_notes_file_path: RELEASE_NOTES_PATH
     )
     android_update_release_notes(new_version: new_version)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -521,6 +521,7 @@ platform :android do
       relese_notes_path: download_path + "/release_notes.xml",
       version_name: options[:version]
     )
+    # TODO: use Fastlane API to add, commit, and ask caller whether they want to push
     sh("git add #{download_path} && (git diff-index --quiet HEAD || git commit -m \"Update metadata translations for #{options[:version]}\") && git push")
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,8 @@ end
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
 INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
-RELEASE_NOTES_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata', 'release_notes.txt')
+METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
+RELEASE_NOTES_PATH = File.join(METADATA_DIR_PATH, 'release_notes.txt')
 
 ########################################################################
 # Environment
@@ -128,25 +129,23 @@ platform :android do
   lane :update_appstore_strings do |options|
     ensure_git_status_clean
 
-    metadata_folder = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
-
     files = {
       release_note: RELEASE_NOTES_PATH,
-      play_store_promo: prj_folder + "/WooCommerce/metadata/short_description.txt",
-      play_store_desc: prj_folder + "/WooCommerce/metadata/full_description.txt",
-      play_store_app_title: prj_folder + "/WooCommerce/metadata/title.txt",
-      play_store_screenshot_1: prj_folder + "/WooCommerce/metadata/promo_screenshot_1.txt",
-      play_store_screenshot_1_b: prj_folder + "/WooCommerce/metadata/promo_screenshot_1_b.txt",
-      play_store_screenshot_2: prj_folder + "/WooCommerce/metadata/promo_screenshot_2.txt",
-      play_store_screenshot_3: prj_folder + "/WooCommerce/metadata/promo_screenshot_3.txt",
-      play_store_screenshot_4: prj_folder + "/WooCommerce/metadata/promo_screenshot_4.txt",
-      play_store_screenshot_5: prj_folder + "/WooCommerce/metadata/promo_screenshot_5.txt",
-      play_store_screenshot_6: prj_folder + "/WooCommerce/metadata/promo_screenshot_6.txt",
-      play_store_screenshot_7: prj_folder + "/WooCommerce/metadata/promo_screenshot_7.txt",
-      play_store_screenshot_8: prj_folder + "/WooCommerce/metadata/promo_screenshot_8.txt"
+      play_store_promo: File.join(METADATA_DIR_PATH, 'short_description.txt'),
+      play_store_desc: File.join(METADATA_DIR_PATH, 'full_description.txt'),
+      play_store_app_title: File.join(METADATA_DIR_PATH, 'title.txt'),
+      play_store_screenshot_1: File.join(METADATA_DIR_PATH, 'promo_screenshot_1.txt'),
+      play_store_screenshot_1_b: File.join(METADATA_DIR_PATH, 'promo_screenshot_1_b.txt'),
+      play_store_screenshot_2: File.join(METADATA_DIR_PATH, 'promo_screenshot_2.txt'),
+      play_store_screenshot_3: File.join(METADATA_DIR_PATH, 'promo_screenshot_3.txt'),
+      play_store_screenshot_4: File.join(METADATA_DIR_PATH, 'promo_screenshot_4.txt'),
+      play_store_screenshot_5: File.join(METADATA_DIR_PATH, 'promo_screenshot_5.txt'),
+      play_store_screenshot_6: File.join(METADATA_DIR_PATH, 'promo_screenshot_6.txt'),
+      play_store_screenshot_7: File.join(METADATA_DIR_PATH, 'promo_screenshot_7.txt'),
+      play_store_screenshot_8: File.join(METADATA_DIR_PATH, 'promo_screenshot_8.txt')
     }
 
-    po_path = File.join(metadata_folder, 'PlayStoreStrings.pot')
+    po_path = File.join(METADATA_DIR_PATH, 'PlayStoreStrings.pot')
 
     an_update_metadata_source(
       po_file_path: po_path,
@@ -503,7 +502,7 @@ platform :android do
     }
 
     delete_old_changelogs(build: options[:build_number])
-    download_path = File.join(Dir.pwd, 'metadata', 'android')
+    download_path = METADATA_DIR_PATH
     gp_downloadmetadata(
       project_url: "https://translate.wordpress.com/projects/woocommerce/woocommerce-android/release-notes/",
       target_files: files,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -518,7 +518,7 @@ platform :android do
 
     android_create_xml_release_notes(
       download_path: download_path,
-      build_number: "#{options[:build_number]}",
+      build_number: options[:build_number],
       locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] }
     )
     add_us_release_notes(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,7 +82,7 @@ platform :android do
     extract_release_notes_for_version(
       version: new_version,
       release_notes_file_path:"#{PROJECT_ROOT_FOLDER}/RELEASE-NOTES.txt",
-      extracted_notes_file_path:RELEASE_NOTES_PATH
+      extracted_notes_file_path: RELEASE_NOTES_PATH
     )
     android_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
@@ -131,19 +131,19 @@ platform :android do
     metadata_folder = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
 
     files = {
-      release_note: File.join(metadata_folder, 'release_notes.txt'),
-      play_store_promo: File.join(metadata_folder, 'short_description.txt'),
-      play_store_desc: File.join(metadata_folder, 'full_description.txt'),
-      play_store_app_title: File.join(metadata_folder, 'title.txt'),
-      play_store_screenshot_1: File.join(metadata_folder, 'promo_screenshot_1.txt'),
-      play_store_screenshot_1_b: File.join(metadata_folder, 'promo_screenshot_1_b.txt'),
-      play_store_screenshot_2: File.join(metadata_folder, 'promo_screenshot_2.txt'),
-      play_store_screenshot_3: File.join(metadata_folder, 'promo_screenshot_3.txt'),
-      play_store_screenshot_4: File.join(metadata_folder, 'promo_screenshot_4.txt'),
-      play_store_screenshot_5: File.join(metadata_folder, 'promo_screenshot_5.txt'),
-      play_store_screenshot_6: File.join(metadata_folder, 'promo_screenshot_6.txt'),
-      play_store_screenshot_7: File.join(metadata_folder, 'promo_screenshot_7.txt'),
-      play_store_screenshot_8: File.join(metadata_folder, 'promo_screenshot_8.txt')
+      release_note: RELEASE_NOTES_PATH,
+      play_store_promo: prj_folder + "/WooCommerce/metadata/short_description.txt",
+      play_store_desc: prj_folder + "/WooCommerce/metadata/full_description.txt",
+      play_store_app_title: prj_folder + "/WooCommerce/metadata/title.txt",
+      play_store_screenshot_1: prj_folder + "/WooCommerce/metadata/promo_screenshot_1.txt",
+      play_store_screenshot_1_b: prj_folder + "/WooCommerce/metadata/promo_screenshot_1_b.txt",
+      play_store_screenshot_2: prj_folder + "/WooCommerce/metadata/promo_screenshot_2.txt",
+      play_store_screenshot_3: prj_folder + "/WooCommerce/metadata/promo_screenshot_3.txt",
+      play_store_screenshot_4: prj_folder + "/WooCommerce/metadata/promo_screenshot_4.txt",
+      play_store_screenshot_5: prj_folder + "/WooCommerce/metadata/promo_screenshot_5.txt",
+      play_store_screenshot_6: prj_folder + "/WooCommerce/metadata/promo_screenshot_6.txt",
+      play_store_screenshot_7: prj_folder + "/WooCommerce/metadata/promo_screenshot_7.txt",
+      play_store_screenshot_8: prj_folder + "/WooCommerce/metadata/promo_screenshot_8.txt"
     }
 
     po_path = File.join(metadata_folder, 'PlayStoreStrings.pot')
@@ -694,7 +694,7 @@ platform :android do
   end
 
   private_lane :add_us_release_notes do | options |
-    en_release_notes_path  = Dir.pwd + "/.." + "/WooCommerce/metadata/release_notes.txt"
+    en_release_notes_path = RELEASE_NOTES_PATH
     File.open(options[:relese_notes_path], "a") { |f|
       f.puts("<en-US>")
       f.puts("#{options[:version_name]}:")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -503,7 +503,7 @@ platform :android do
     }
 
     delete_old_changelogs(build: options[:build_number])
-    download_path=Dir.pwd + "/metadata/android"
+    download_path = File.join(Dir.pwd, 'metadata', 'android')
     gp_downloadmetadata(project_url: "https://translate.wordpress.com/projects/woocommerce/woocommerce-android/release-notes/",
                         target_files: files,
                         locales: SUPPORTED_LOCALES.map {| hsh | [ hsh[:glotpress], hsh[:google_play] ]},

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,6 +19,11 @@ INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
 METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
 RELEASE_NOTES_PATH = File.join(METADATA_DIR_PATH, 'release_notes.txt')
 
+# URL of the GlotPress project containing the app's strings
+GLOTPRESS_APP_STRINGS_URL = 'https://translate.wordpress.com/projects/woocommerce/woocommerce-android/'
+# URL of the GlotPress project containing the Play Store metadata (title, keywords, release notes, …)
+GLOTPRESS_METADATA_PROJECT_URL = 'https://translate.wordpress.com/projects/woocommerce/woocommerce-android/release-notes/'
+
 ########################################################################
 # Environment
 ########################################################################
@@ -231,7 +236,7 @@ platform :android do
   lane :download_translations do |options|
     android_download_translations(
       res_dir: File.join(ENV['PROJECT_NAME'], 'src', 'main', 'res'),
-      glotpress_url: 'https://translate.wordpress.com/projects/woocommerce/woocommerce-android/',
+      glotpress_url: GLOTPRESS_APP_STRINGS_URL,
       locales: SUPPORTED_LOCALES,
       lint_task: 'lintVanillaRelease'
     )
@@ -258,12 +263,12 @@ platform :android do
 
     UI.message('Checking app strings translation status...')
     check_translation_progress(
-      glotpress_url: 'https://translate.wordpress.com/projects/woocommerce/woocommerce-android/',
+      glotpress_url: GLOTPRESS_APP_STRINGS_URL,
       abort_on_violations: false
     )
     UI.message("Checking release notes strings translation status...")
     check_translation_progress(
-      glotpress_url: 'https://translate.wordpress.com/projects/woocommerce/woocommerce-android/release-notes/',
+      glotpress_url: GLOTPRESS_METADATA_PROJECT_URL,
       abort_on_violations: false
     )
 
@@ -504,7 +509,7 @@ platform :android do
     delete_old_changelogs(build: options[:build_number])
     download_path = METADATA_DIR_PATH
     gp_downloadmetadata(
-      project_url: "https://translate.wordpress.com/projects/woocommerce/woocommerce-android/release-notes/",
+      project_url: GLOTPRESS_METADATA_PROJECT_URL,
       target_files: files,
       locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] },
       source_locale: "en-US",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -504,14 +504,23 @@ platform :android do
 
     delete_old_changelogs(build: options[:build_number])
     download_path = File.join(Dir.pwd, 'metadata', 'android')
-    gp_downloadmetadata(project_url: "https://translate.wordpress.com/projects/woocommerce/woocommerce-android/release-notes/",
-                        target_files: files,
-                        locales: SUPPORTED_LOCALES.map {| hsh | [ hsh[:glotpress], hsh[:google_play] ]},
-                        source_locale: "en-US",
-                        download_path: download_path)
+    gp_downloadmetadata(
+      project_url: "https://translate.wordpress.com/projects/woocommerce/woocommerce-android/release-notes/",
+      target_files: files,
+      locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] },
+      source_locale: "en-US",
+      download_path: download_path
+    )
 
-    android_create_xml_release_notes(download_path: download_path, build_number: "#{options[:build_number]}", locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] })
-    add_us_release_notes(relese_notes_path: download_path + "/release_notes.xml", version_name: options[:version])
+    android_create_xml_release_notes(
+      download_path: download_path,
+      build_number: "#{options[:build_number]}",
+      locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] }
+    )
+    add_us_release_notes(
+      relese_notes_path: download_path + "/release_notes.xml",
+      version_name: options[:version]
+    )
     sh("git add #{download_path} && (git diff-index --quiet HEAD || git commit -m \"Update metadata translations for #{options[:version]}\") && git push")
   end
 


### PR DESCRIPTION
### Description

Some minor [Tidy First](https://tidyfirst.substack.com/) before starting to work on the localization tooling for WooCommerce Android.

#### Why not Rubocop?

The thought occurred to me to just setup Rubocop once and for all, but that would have been a bigger job and could have resulted to a prep-PR that would have required various back and forth. So, I decided to do an ad hoc treatment, while walking to the code to familiarize myself with it and plan the true work (see https://github.com/woocommerce/woocommerce-android/issues/6663).

As such, I didn't explicitly tackle stuff like replacing `""` with `''` when the former wasn't needed, freezing constants, etc.

#### Why against `trunk`?

Note that I'm targeting 9.4 as the milestone for this. I considered targeting the release branch so that the work to update how we download metadata could happen on that branch (where it can be live tested soon). I decided not to do it because there's not much to change on that front from a functionality point of view, so I think it makes sense to avoid noise in the release branch and work on `trunk` only.

 But, I'm happy to change base branch and milestone if you think I missed something and it would indeed be valuable to land at least the metadata work on the release branch ASAP.

### Testing instructions

No behavior has been changed. But I would appreciate a careful double check that I didn't make any mistake in updating the code. 

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
