### PR TITLE
Use Fastlane APIs to interact with Git when committing metadata

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -535,14 +535,7 @@ platform :android do
       allow_nothing_to_commit: true
     )
 
-    if prompt_for_confirmation(
-      message: 'Push changes to remote?',
-      bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false)
-    )
-      push_to_git_remote(tags: false)
-    else
-      UI.message('Lane completed without pushing')
-    end
+    push_to_git_remote_with_confirmation
   end
 
   ########################################################################
@@ -786,14 +779,16 @@ platform :android do
     end
   end
 
-  # Wrapper around Fastlane `UI.confirm` that adds the option to bypass the
-  # prompt if a given flag is true
+  # Asks the user whether they want to push to the Git remote using `UI.confirm`.
   #
-  # @param [String] message The text to pass to `UI.confirm` to show the user
-  # @param [Boolean] bypass A flag that allows bypassing the `UI.confirm` prompt, i.e. acting as if the prompt returned `true`
-  def prompt_for_confirmation(message:, bypass:)
-    return true if bypass
-
-    UI.confirm(message)
+  # @note It supports an override environment variable flag, `RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM`.
+  # If set to `false` the user won't be asked for confirmation.
+  #
+  def push_to_git_remote_with_confirmation
+    if ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false) || UI.confirm('Push changes to remote?')
+      push_to_git_remote(tags: false)
+    else
+      UI.message('Continuing without pushing')
+    end
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -533,7 +533,14 @@ platform :android do
       allow_nothing_to_commit: true
     )
 
-    push_to_git_remote(tags: false)
+    if prompt_for_confirmation(
+      message: 'Push changes to remote?',
+      bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false)
+    )
+      push_to_git_remote(tags: false)
+    else
+      UI.message('Lane completed without pushing')
+    end
   end
 
   ########################################################################
@@ -775,5 +782,16 @@ platform :android do
 
       return "#{branch}-#{commit}"
     end
+  end
+
+  # Wrapper around Fastlane `UI.confirm` that adds the option to bypass the
+  # prompt if a given flag is true
+  #
+  # @param [String] message The text to pass to `UI.confirm` to show the user
+  # @param [Boolean] bypass A flag that allows bypassing the `UI.confirm` prompt, i.e. acting as if the prompt returned `true`
+  def prompt_for_confirmation(message:, bypass:)
+    return true if bypass
+
+    UI.confirm(message)
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -526,6 +526,8 @@ platform :android do
       version_name: options[:version]
     )
 
+    # We need to explicitly call `git_add`, despite the path being passed to `git_commit` as well.
+    # That's because we might have new file, that the commit command would otherwise miss.
     git_add(path: download_path)
     git_commit(
       path: download_path,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -525,8 +525,15 @@ platform :android do
       release_notes_path: File.join(download_path, release_notes.xml),
       version_name: options[:version]
     )
-    # TODO: use Fastlane API to add, commit, and ask caller whether they want to push
-    sh("git add #{download_path} && (git diff-index --quiet HEAD || git commit -m \"Update metadata translations for #{options[:version]}\") && git push")
+
+    git_add(path: download_path)
+    git_commit(
+      path: download_path,
+      message: "Update metadata translations for #{options[:version]}",
+      allow_nothing_to_commit: true
+    )
+
+    push_to_git_remote(tags: false)
   end
 
   ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -527,7 +527,7 @@ platform :android do
     )
 
     # We need to explicitly call `git_add`, despite the path being passed to `git_commit` as well.
-    # That's because we might have new file, that the commit command would otherwise miss.
+    # That's because we might have new files, that the commit command would otherwise miss.
     git_add(path: download_path)
     git_commit(
       path: download_path,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -522,7 +522,7 @@ platform :android do
       locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] }
     )
     add_us_release_notes(
-      release_notes_path: File.join(download_path, release_notes.xml),
+      release_notes_path: File.join(download_path, 'release_notes.xml'),
       version_name: options[:version]
     )
 


### PR DESCRIPTION
### Description

Part of #6663, used the Fastlane APIs to interface with Git in the `download_metadata_strings` lane. Given how much we rely on Fastlane already, it makes sense to delegate interfacing with Git to its built-in actions, and get better code and support for edge cases in return.

### Testing instructions

- Create a new branch from this one
- Run `bundle exec fastalne download_metadata_strings version:9.3 build_number:'1234'
- Verify that, aside from the files being downloaded as usual, the commit behavior remained intact
- Also notice the interactive prompt before pushing

I've done all that in #6681 if you want to compare (or skip)

![image](https://user-images.githubusercontent.com/1218433/171352645-a8dd0d28-06a9-454b-9041-a4b34800e51a.png)
![image](https://user-images.githubusercontent.com/1218433/171352661-f300ee38-8ae5-4b7d-9691-d447757e8152.png)

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
