### PR TITLE
Clear handler's message queue on fragment's destroy to avoid potential memory leaks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -110,6 +110,8 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         override fun onTabReselected(tab: TabLayout.Tab) {}
     }
 
+    private val handler = Handler(Looper.getMainLooper())
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
@@ -169,9 +171,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
             if (tabLayout.getTabAt(tabLayout.selectedTabPosition)?.tag != activeGranularity) {
                 val index = StatsGranularity.values().indexOf(activeGranularity)
                 // Small delay needed to ensure tablayout scrolls to the selected tab if tab is not visible on screen.
-                Handler(Looper.getMainLooper()).postDelayed(
-                    { _tabLayout?.getTabAt(index)?.select() }, 300
-                )
+                handler.postDelayed({ tabLayout.getTabAt(index)?.select() }, 300)
             }
             binding.myStoreStats.loadDashboardStats(activeGranularity)
             binding.myStoreTopPerformers.onDateGranularityChanged(activeGranularity)
@@ -290,6 +290,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     }
 
     override fun onDestroyView() {
+        handler.removeCallbacksAndMessages(null)
         removeTabLayoutFromAppBar()
         tabLayout.removeOnTabSelectedListener(tabSelectedListener)
         _tabLayout = null


### PR DESCRIPTION
### Description
This is a minor improvement over an existing hotfix implementation. This aims to remove any potential memory leak issues that may occur from the hotfix changes. Full context here p91TBi-8SG-p2#comment-10186

### Testing instructions
To actually generate a memory leak is super hard. In theory following these steps a memory leak would occur: 
1. Open My Store tab.
2. Leave the app (while having Don’t keep activities enabled).
The whole fragment and activity will leak for +- 290ms => it won’t get garbage collected until the delay has passed.

In any case, the only thing to test here is that [this crash](https://github.com/woocommerce/woocommerce-android/pull/6532) doesn't happen either with the new implementation. So, please check tha following this steps the app does not crahs: 

1. Open the app, select “This Year” tab
2. Navigate to More Menu
3. Now as fast as you can click on My Store tab and then More Menu. If at any point the app crashes then we have a problem 😅
