### PR TITLE
Support "Done" button when in Edit mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -242,20 +242,25 @@ class OrderCreationViewModel @Inject constructor(
 
     fun onCreateOrderClicked(order: Order) {
         trackCreateOrderButtonClick()
-        viewModelScope.launch {
-            viewState = viewState.copy(isProgressDialogShown = true)
-            orderCreationRepository.placeOrder(order).fold(
-                onSuccess = {
-                    AnalyticsTracker.track(AnalyticsEvent.ORDER_CREATION_SUCCESS)
-                    triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
-                    triggerEvent(ShowCreatedOrder(it.id))
-                },
-                onFailure = {
-                    trackOrderCreationFailure(it)
-                    viewState = viewState.copy(isProgressDialogShown = false)
-                    triggerEvent(ShowSnackbar(string.order_creation_failure_snackbar))
-                }
-            )
+        when (mode) {
+            Mode.Creation -> viewModelScope.launch {
+                viewState = viewState.copy(isProgressDialogShown = true)
+                orderCreationRepository.placeOrder(order).fold(
+                    onSuccess = {
+                        AnalyticsTracker.track(AnalyticsEvent.ORDER_CREATION_SUCCESS)
+                        triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
+                        triggerEvent(ShowCreatedOrder(it.id))
+                    },
+                    onFailure = {
+                        trackOrderCreationFailure(it)
+                        viewState = viewState.copy(isProgressDialogShown = false)
+                        triggerEvent(ShowSnackbar(string.order_creation_failure_snackbar))
+                    }
+                )
+            }
+            is Mode.Edit -> {
+                triggerEvent(Exit)
+            }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreationViewModelTest.kt
@@ -74,4 +74,16 @@ class EditFocusedOrderCreationViewModelTest : UnifiedOrderEditViewModelTest() {
 
         assertThat(lastReceivedEvent).isInstanceOf(Event.ShowDialog::class.java)
     }
+
+    @Test
+    fun `when creating the order, then dismiss the screen`() {
+        var lastReceivedEvent: Event? = null
+        sut.event.observeForever {
+            lastReceivedEvent = it
+        }
+
+        sut.onCreateOrderClicked(defaultOrderValue)
+
+        assertThat(lastReceivedEvent).isEqualTo(Exit)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreationViewModelTest.kt
@@ -76,7 +76,7 @@ class EditFocusedOrderCreationViewModelTest : UnifiedOrderEditViewModelTest() {
     }
 
     @Test
-    fun `when creating the order, then dismiss the screen`() {
+    fun `when confirming order edit, then dismiss the screen`() {
         var lastReceivedEvent: Event? = null
         sut.event.observeForever {
             lastReceivedEvent = it


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6614
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PRs handles support for the "Done" button (top right corner) for the Unified Order Editing project.

The labels will be changed in a different issue (#6613).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to any order details
2. Click on `Edit` button
3. Change the order in any way
4. Click on `Create` (top right corner)
5. **Assert that the view is dismissed and the presented order is updated**

### Images/gif

https://user-images.githubusercontent.com/5845095/171406988-8c5c0543-ed7d-4f12-9c42-01261946a841.mov


<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
