### PR TITLE
Issue/6511 order detail datetime

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -62,11 +62,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
                 date.getMediumDate(context)
             }
             Mode.OrderEdit -> {
-                when (date.isToday()) {
-                    true -> date.getTimeString(context)
-                    false -> date.getMediumDate(context)
-                    null -> ""
-                }
+                "${date.getMediumDate(context)}, ${date.getTimeString(context)}"
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -34,16 +34,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     }
 
     fun updateOrder(order: Order) {
-        val dateStr = getFormattedDate(order.dateCreated)
-        binding.orderStatusSubtitle.text =
-            when (mode) {
-                Mode.OrderEdit -> context.getString(
-                    R.string.orderdetail_orderstatus_date_and_ordernum,
-                    dateStr,
-                    order.number
-                )
-                Mode.OrderCreation -> dateStr
-            }
+        binding.orderStatusSubtitle.text = getFormattedDate(order.dateCreated)
 
         when (mode) {
             Mode.OrderEdit -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderDetailOrderStatusBinding
 import com.woocommerce.android.extensions.getMediumDate
 import com.woocommerce.android.extensions.getTimeString
-import com.woocommerce.android.extensions.isToday
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.ui.orders.OrderStatusTag

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -417,7 +417,6 @@
     <string name="orderdetail_customer_note">\u0022%1$s\u0022</string>
     <string name="orderdetail_customer_name_default">Guest</string>
     <string name="orderdetail_orderstatus_ordernum">Order #%s</string>
-    <string name="orderdetail_orderstatus_date_and_ordernum">%1$s \u2022 #%2$s</string>
     <string name="orderdetail_orderstatus_name">%1$s %2$s</string>
     <string name="orderdetail_shipping_method">Shipping method</string>
     <string name="orderdetail_shipping_details">Shipping details</string>


### PR DESCRIPTION
Closes #6511 - this PR changes the order detail status line to show both the date and the time the order was created, regardless of whether the order was created today. It also removes the redundant order id from the status line, since that already appears in the toolbar.

![datetime](https://user-images.githubusercontent.com/3903757/171490158-c3f04888-e7fc-4e1a-9a08-4bfa05e9940e.png)

