### PR TITLE
Fix crash by removing non parcelable lambda fields from ui state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -228,7 +228,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
                 binding.orderRefreshLayout.isRefreshing = it
             }
             new.refreshedProductId?.takeIfNotEqualTo(old?.refreshedProductId) { refreshProduct(it) }
-            new.wcShippingBannerStatus?.takeIfNotEqualTo(old?.wcShippingBannerStatus) {
+            new.wcShippingBannerVisible?.takeIfNotEqualTo(old?.wcShippingBannerVisible) {
                 showInstallWcShippingBanner(it)
             }
         }
@@ -278,12 +278,12 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         )
     }
 
-    private fun showInstallWcShippingBanner(wcShippingBannerStatus: OrderDetailViewModel.WcShippingBannerStatus) {
+    private fun showInstallWcShippingBanner(isVisible: Boolean) {
         val banner = binding.orderDetailInstallWcShippingBanner
-        banner.isVisible = wcShippingBannerStatus.isVisible && FeatureFlag.WC_SHIPPING_BANNER.isEnabled()
+        banner.isVisible = isVisible && FeatureFlag.WC_SHIPPING_BANNER.isEnabled()
         banner.setClickListeners(
-            onInstallWcShipping = wcShippingBannerStatus.onGetWcShippingClicked,
-            onDismiss = wcShippingBannerStatus.onDismiss
+            onInstallWcShipping = { viewModel.onGetWcShippingClicked() },
+            onDismiss = { viewModel.onWcShippingBannerDismissed() }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -265,6 +265,10 @@ final class OrderDetailViewModel @Inject constructor(
         triggerEvent(ViewPrintingInstructions)
     }
 
+    fun onGetWcShippingClicked() {
+        triggerEvent(InstallWcShippingFlowViewModel.InstallWcShipping)
+    }
+
     /**
      * This is triggered when the user taps "Done" on any of the order editing fragments
      */
@@ -657,19 +661,12 @@ final class OrderDetailViewModel @Inject constructor(
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,
             areShippingLabelsVisible = shippingLabels.isVisible,
-            wcShippingBannerStatus = getWcShippingBannerStatus(order, orderEligibleForInPersonPayments)
-        )
-    }
-
-    private fun getWcShippingBannerStatus(order: Order, orderEligibleForInPersonPayments: Boolean) =
-        WcShippingBannerStatus(
-            isVisible = shippingLabelOnboardingRepository.shouldShowWcShippingBanner(
+            wcShippingBannerVisible = shippingLabelOnboardingRepository.shouldShowWcShippingBanner(
                 order,
                 orderEligibleForInPersonPayments
-            ),
-            onDismiss = ::onWcShippingBannerDismissed,
-            onGetWcShippingClicked = { triggerEvent(InstallWcShippingFlowViewModel.InstallWcShipping) }
+            )
         )
+    }
 
     override fun onProductFetched(remoteProductId: Long) {
         viewState = viewState.copy(refreshedProductId = remoteProductId)
@@ -712,7 +709,7 @@ final class OrderDetailViewModel @Inject constructor(
         val areShippingLabelsVisible: Boolean? = null,
         val isProductListMenuVisible: Boolean? = null,
         val isSharePaymentLinkVisible: Boolean? = null,
-        val wcShippingBannerStatus: WcShippingBannerStatus? = null
+        val wcShippingBannerVisible: Boolean? = null
     ) : Parcelable {
         val isMarkOrderCompleteButtonVisible: Boolean?
             get() = if (orderStatus != null) orderStatus.statusKey == CoreOrderStatus.PROCESSING.value else null
@@ -726,13 +723,6 @@ final class OrderDetailViewModel @Inject constructor(
         val order: Order? = null,
         val isPaymentCollectableWithCardReader: Boolean = false,
         val isReceiptButtonsVisible: Boolean = false
-    ) : Parcelable
-
-    @Parcelize
-    data class WcShippingBannerStatus(
-        val isVisible: Boolean,
-        val onDismiss: () -> Unit,
-        val onGetWcShippingClicked: () -> Unit
     ) : Parcelable
 
     sealed class OrderStatusUpdateSource(open val oldStatus: String, open val newStatus: String) : Parcelable {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderInfo
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.ViewState
-import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.WcShippingBannerStatus
 import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.util.ContinuationWrapper
@@ -107,10 +106,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         orderId = ORDER_ID,
         localSiteId = ORDER_SITE_ID,
     )
-    private val testWcShippingBannerStatus = WcShippingBannerStatus(
-        isVisible = false,
-        onDismiss = {}
-    )
     private val orderShippingLabels = OrderTestUtils.generateShippingLabels(totalCount = 5)
     private val testOrderRefunds = OrderTestUtils.generateRefunds(1)
     private lateinit var viewModel: OrderDetailViewModel
@@ -127,7 +122,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         areShippingLabelsVisible = false,
         isProductListMenuVisible = false,
         isSharePaymentLinkVisible = false,
-        wcShippingBannerStatus = testWcShippingBannerStatus
+        wcShippingBannerVisible = false
     )
 
     @Before
@@ -185,10 +180,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         val nonRefundedOrder = order.copy(refundTotal = BigDecimal.ZERO)
 
         val expectedViewState = orderWithParameters.copy(
-            orderInfo = orderInfo.copy(order = nonRefundedOrder),
-            wcShippingBannerStatus = testWcShippingBannerStatus.copy(
-                onDismiss = viewModel::onWcShippingBannerDismissed
-            )
+            orderInfo = orderInfo.copy(order = nonRefundedOrder)
         )
 
         doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())


### PR DESCRIPTION
…rderDetailViewModel

This fix is realted to the completed task: #6585

### Description
When adding the new UI banner [#6585](https://github.com/woocommerce/woocommerce-android/issues/6585) I used a lambda approach to handle onClick events over the banner instead of calling the `viewModel` directly from the Fragment. Did not realize that `OrderDetailViewModel` is saving all of its UiState using `@Parcelable`. Lambdas are not `@Parcelable` so this led to a crash whenever the system attempted to save the current state of `OrderDetailViewModel`. 


### Testing instructions
The crash is easily reproducible when we click on the Install WC shipping banner and then from the new Onboarding screen we open the link to see more info about WC shipping:

https://user-images.githubusercontent.com/2663464/171836333-8b20e3b6-9d04-4ab1-9fab-7de600537535.mp4

Test the same flow from this branch and check the app does not crash when pressing back after opening the url from the new Onboarding screen. When the url is loaded pressing back should return to the Onboarding screen:

https://user-images.githubusercontent.com/2663464/171835931-b8354992-c852-43d1-80b2-358739a46340.mp4


