### PR TITLE
Add is editable field

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -47,6 +47,7 @@ data class Order(
     val chargeId: String?,
     val shippingPhone: String,
     val paymentUrl: String,
+    val isEditable: Boolean
 ) : Parcelable {
     @IgnoredOnParcel
     val isOrderPaid = datePaid != null
@@ -323,7 +324,8 @@ data class Order(
                 feesLines = emptyList(),
                 taxLines = emptyList(),
                 shippingPhone = "",
-                paymentUrl = ""
+                paymentUrl = "",
+                isEditable = true
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -55,7 +55,8 @@ class OrderMapper @Inject constructor(private val getLocations: GetLocations) {
             taxLines = databaseEntity.getTaxLineList().mapTaxLines(),
             chargeId = metaDataList.getOrNull(CHARGE_ID_KEY),
             shippingPhone = metaDataList.getOrEmpty(SHIPPING_PHONE_KEY),
-            paymentUrl = databaseEntity.paymentUrl
+            paymentUrl = databaseEntity.paymentUrl,
+            isEditable = databaseEntity.isEditable
         )
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2435-b421af6ef45dd389ef52092cc834e09dfa351f89'
+    fluxCVersion = 'trunk-ae5410d016884c3b2b4faed8600b44ee4e6ad8ad'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2435-bd47520b089ede569e6a7a3b317a464b5aa96b4f'
+    fluxCVersion = '2435-b421af6ef45dd389ef52092cc834e09dfa351f89'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2435-c5d62ec65f71414f12308b62c5e577b206f6ac6a'
+    fluxCVersion = '2435-bd47520b089ede569e6a7a3b317a464b5aa96b4f'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-009d8865ba5dcab36e101586a0a14e72e9659ea0'
+    fluxCVersion = '2435-c5d62ec65f71414f12308b62c5e577b206f6ac6a'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
‼️ Don't merge until [FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2435) changes are merged 

Closes: #6649
Closes #6650

### Description
Add the `is_editable` field to the Order model. Now we can check if an order is editable based on this new field. 

### Testing instructions

TC1
1. Select a site using WooCommerce < 6.6
2. Open the Orders tab in the app
3. Open Flipper or the App inspection
4. Check `isEditable` column exists

TC2
1. Select a site using WooCommerce > 6.6
2. Open the Orders tab in the app
3. Open Flipper or the App inspection
4. Check `isEditable` column exists

TC3
1. Install the version from `trunk`
2. Open the Orders tab in the app
3. Install the version from this branch
4. Check the app don't crash because of any DB migration issues

### Images/gif
<img width="1363" alt="Screen Shot 2022-06-01 at 15 35 01" src="https://user-images.githubusercontent.com/18119390/171478394-621fa5be-dd2a-4253-908a-fe1265e74f21.png">



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
