### PR TITLE
Orders: improve logic to avoid unnecessary orders list fetches on changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -31,9 +31,6 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.EventBus
@@ -139,12 +136,6 @@ class OrderListViewModel @Inject constructor(
                 )
             }
         }
-
-        // Observe any order list changes
-        orderStore.observeOrdersForSite(selectedSite.get())
-            .distinctUntilChanged()
-            .onEach { loadOrders() }
-            .launchIn(viewModelScope)
     }
 
     fun loadOrders() {

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2436-832c3301dd0609230be0faacf456e348ad8d24e4'
+    fluxCVersion = 'trunk-009d8865ba5dcab36e101586a0a14e72e9659ea0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-9ec9755830b57f10e6899a166641b7e72d848a68'
+    fluxCVersion = '2436-832c3301dd0609230be0faacf456e348ad8d24e4'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6693 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2436

This PR removes the DB observer we had in OrderListViewModel, I added this when working on Order Creation to make sure the created order is displayed on the list automatically, but as Nick noticed, this was causing another issue, as the `loadOrders` function was making an API call to re-fetch orders, which is not what we need.
Now with the change done on FluxC, this is not needed anymore, as FluxC will make sure the `WCOrderSummaryModel` table is refreshed after creating a new order.

### Testing instructions
1. Open the app.
2. Open Flipper and open the network tab.
3. Open Order Creation Form.
4. Make changes to the order, and confirm no API requests to fetch orders are done.
5. Create the order.
6. Navigate back to the order list.
7. Confirm the created order is displayed on the list.

Optionally repeat the above for a simple payment.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
