### PR TITLE
Change for the condition when refund button is available

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -51,12 +51,15 @@ data class Order(
     @IgnoredOnParcel
     val isOrderPaid = datePaid != null
 
+    @IgnoredOnParcel
+    val isOrderFullyRefunded = refundTotal >= total
+
     // Allow refunding only integer quantities
     @IgnoredOnParcel
-    val availableRefundQuantity = items.sumByFloat { it.quantity }.toInt() + feesLines.count()
+    val quantityOfItemsWhichPossibleToRefund = items.sumByFloat { it.quantity }.toInt() + feesLines.count()
 
     @IgnoredOnParcel
-    val isRefundAvailable = refundTotal < total && availableRefundQuantity > 0
+    val isRefundAvailable = !isOrderFullyRefunded && quantityOfItemsWhichPossibleToRefund > 0 && isOrderPaid
 
     @Parcelize
     data class ShippingMethod(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -468,6 +468,7 @@ final class OrderDetailViewModel @Inject constructor(
                                         prepareTracksEventsDetails(result.event)
                                     )
                                 } else {
+                                    reloadOrderDetails()
                                     trackerWrapper.track(ORDER_STATUS_CHANGE_SUCCESS)
                                 }
                             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -457,18 +457,19 @@ final class OrderDetailViewModel @Inject constructor(
             launch {
                 orderDetailRepository.updateOrderStatus(order.id, newStatus)
                     .collect { result ->
+                        reloadOrderDetails()
                         when (result) {
-                            is OptimisticUpdateResult -> reloadOrderDetails()
+                            is OptimisticUpdateResult -> {
+                                // no-op. We reload order details in any case
+                            }
                             is RemoteUpdateResult -> {
                                 if (result.event.isError) {
-                                    reloadOrderDetails()
                                     triggerEvent(ShowSnackbar(string.order_error_update_general))
                                     trackerWrapper.track(
                                         ORDER_STATUS_CHANGE_FAILED,
                                         prepareTracksEventsDetails(result.event)
                                     )
                                 } else {
-                                    reloadOrderDetails()
                                     trackerWrapper.track(ORDER_STATUS_CHANGE_SUCCESS)
                                 }
                             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -61,7 +61,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
             } else {
                 binding.paymentInfoPaid.text = formatCurrencyForDisplay(order.total)
 
-                val dateStr = order.datePaid?.getMediumDate(context)
+                val dateStr = order.datePaid.getMediumDate(context)
                 binding.paymentInfoPaymentMsg.text = if (order.paymentMethodTitle.isNotEmpty()) {
                     context.getString(
                         R.string.orderdetail_payment_summary_completed,
@@ -181,7 +181,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         binding.paymentInfoRefunds.show()
         binding.paymentInfoRefundTotalSection.hide()
 
-        var availableRefundQuantity = order.availableRefundQuantity
+        var availableRefundQuantity = order.quantityOfItemsWhichPossibleToRefund
         refunds.flatMap { it.items }.groupBy { it.orderItemId }.forEach { productRefunds ->
             val refundedCount = productRefunds.value.sumOf { it.quantity }
             availableRefundQuantity -= refundedCount

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderTest.kt
@@ -1,0 +1,202 @@
+package com.woocommerce.android.model
+
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import java.math.BigDecimal
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OrderTest {
+
+    @Test
+    fun `given order has date paid, when check is order paid, then returns true`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(datePaid = mock())
+
+        // WHEN
+        val result = order.isOrderPaid
+
+        // THEN
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given order does not have date paid, when check is order paid, then returns false`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(datePaid = null)
+
+        // WHEN
+        val result = order.isOrderPaid
+
+        // THEN
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given refunded total equal to total, when check is order fully refunded, then returns true`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            total = BigDecimal(100),
+            refundTotal = BigDecimal(100)
+        )
+
+        // WHEN
+        val result = order.isOrderFullyRefunded
+
+        // THEN
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given refunded total less than total, when check is order fully refunded, then returns false`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            total = BigDecimal(100),
+            refundTotal = BigDecimal(50)
+        )
+
+        // WHEN
+        val result = order.isOrderFullyRefunded
+
+        // THEN
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given items quantity is 0, when check is quantity items possible to refund, then returns 0`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            items = listOf(
+                mock {
+                    on { quantity }.thenReturn(0F)
+                }
+            )
+        )
+
+        // WHEN
+        val result = order.quantityOfItemsWhichPossibleToRefund
+
+        // THEN
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `given items quantity is 5 and 3, when check is quantity items possible to refund, then returns 8`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            items = listOf(
+                mock { on { quantity }.thenReturn(3F) },
+                mock { on { quantity }.thenReturn(5F) },
+            )
+        )
+
+        // WHEN
+        val result = order.quantityOfItemsWhichPossibleToRefund
+
+        // THEN
+        assertThat(result).isEqualTo(8)
+    }
+
+    @Test
+    fun `given items quantity is 1 fees 1, when check is quantity items possible to refund, then returns 2`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            items = listOf(
+                mock { on { quantity }.thenReturn(1F) },
+            ),
+            feesLines = listOf(mock())
+        )
+
+        // WHEN
+        val result = order.quantityOfItemsWhichPossibleToRefund
+
+        // THEN
+        assertThat(result).isEqualTo(2)
+    }
+
+    @Test
+    fun `given order fully refunded, when check is refund available, then returns false`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            total = BigDecimal(100),
+            refundTotal = BigDecimal(100)
+        )
+
+        // WHEN
+        val result = order.isRefundAvailable
+
+        // THEN
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given items quantity is 0, when check is refund available, then returns false`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            items = listOf(mock { on { quantity }.thenReturn(0F) })
+        )
+
+        // WHEN
+        val result = order.isRefundAvailable
+
+        // THEN
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given date paid is null, when check is refund available, then returns false`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(datePaid = null)
+
+        // WHEN
+        val result = order.isRefundAvailable
+
+        // THEN
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given order not fully refunded, when check is refund available, then returns true`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            total = BigDecimal(100),
+            refundTotal = BigDecimal(50),
+            datePaid = mock()
+        )
+
+        // WHEN
+        val result = order.isRefundAvailable
+
+        // THEN
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given items quantity is 1, when check is refund available, then returns true`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(
+            items = listOf(mock { on { quantity }.thenReturn(1F) }),
+            datePaid = mock()
+        )
+
+        // WHEN
+        val result = order.isRefundAvailable
+
+        // THEN
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given date paid is null, when check is refund available, then returns true`() {
+        // GIVEN
+        val order = OrderTestUtils.generateTestOrder().copy(datePaid = mock())
+
+        // WHEN
+        val result = order.isRefundAvailable
+
+        // THEN
+        assertTrue(result)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class OrderTest {
-
     @Test
     fun `given order has date paid, when check is order paid, then returns true`() {
         // GIVEN


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6641
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds a condition that the refund button is visible only when an order is partially or fully paid

@anitaa1990 @hichamboushaba asking you to review this too, because this changes the logic which you were working with, so we might be missing something here

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Try the following:
* Order is not paid -> NOT visible
* Order is fully paid -> Visible 
* Order is partially refunded -> Visible
* Order is fully refunded -> NOT Visible

~~Still in consultations with @joshheald about the state when the order is partially paid. I don't know how to end up in this state, therefore do not merge label~~

Apparently we don't support this at the moment in the app anyway, so we ignore this case for now


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### Partial Refund
<img src="https://user-images.githubusercontent.com/4923871/172364021-3a8fb06f-3ccc-4b86-a0e2-2a2fcd64a326.jpg" width="200px" />

#### Fully Paid
<img src="https://user-images.githubusercontent.com/4923871/172364028-aa26f228-5218-4f2b-ab2d-29656fccec49.jpg" width="200px" />


#### Not paid
<img src="https://user-images.githubusercontent.com/4923871/172364033-4616502c-d8c7-4ea8-84a8-6805a8b7ef6a.jpg" width="200px" />

#### Fully Refund
<img src="https://user-images.githubusercontent.com/4923871/172364039-8045fb94-b3b5-43f2-a5b6-22bf257ebd7e.jpg" width="200px" />
### Ensure that the Issue Refund button shows for orders with only Shipping lines (left) to refund
<img width="200px" alt="image" src="https://user-images.githubusercontent.com/4923871/172366096-ea41e107-6b93-4f3b-a58c-e56835728623.png">
