### PR TITLE
Issue/6212 product quantity accessibility hint

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProductsAdapter.kt
@@ -53,7 +53,8 @@ class OrderCreationProductsAdapter(
                 },
                 onMinusButtonClick = {
                     safePosition?.let { onDecreaseQuantity(getItem(it).item.itemId) }
-                }
+                },
+                plusMinusContentDescription = R.string.order_creation_change_product_quantity
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/StepperView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/StepperView.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.widgets
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import androidx.annotation.StringRes
 import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
@@ -14,6 +15,7 @@ class StepperView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : LinearLayoutCompat(context, attrs, defStyleAttr) {
     private val binding = ViewStepperBinding.inflate(LayoutInflater.from(context), this)
+    private var plusMinusContentDescription: Int? = null
 
     var value: Int
         get() = binding.valueText.text.toString().toIntOrNull() ?: 0
@@ -21,16 +23,18 @@ class StepperView @JvmOverloads constructor(
             val text = value.toString()
             if (text != binding.valueText.text) {
                 binding.valueText.text = text
-                binding.minusButton.contentDescription = context.getString(
-                    R.string.order_creation_change_product_quantity,
-                    value,
-                    value - 1
-                )
-                binding.plusButton.contentDescription = context.getString(
-                    R.string.order_creation_change_product_quantity,
-                    value,
-                    value + 1
-                )
+                plusMinusContentDescription?.let {
+                    binding.minusButton.contentDescription = context.getString(
+                        it,
+                        value,
+                        value - 1
+                    )
+                    binding.plusButton.contentDescription = context.getString(
+                        it,
+                        value,
+                        value + 1
+                    )
+                }
             }
         }
 
@@ -54,9 +58,11 @@ class StepperView @JvmOverloads constructor(
     fun init(
         currentValue: Int = 0,
         onPlusButtonClick: () -> Unit,
-        onMinusButtonClick: () -> Unit
+        onMinusButtonClick: () -> Unit,
+        @StringRes plusMinusContentDescription: Int? = null
     ) {
         value = currentValue
+        this.plusMinusContentDescription = plusMinusContentDescription
         binding.plusButton.setOnClickListener { onPlusButtonClick() }
         binding.minusButton.setOnClickListener { onMinusButtonClick() }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/StepperView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/StepperView.kt
@@ -21,6 +21,16 @@ class StepperView @JvmOverloads constructor(
             val text = value.toString()
             if (text != binding.valueText.text) {
                 binding.valueText.text = text
+                binding.minusButton.contentDescription = context.getString(
+                    R.string.order_creation_change_product_quantity,
+                    value,
+                    value - 1
+                )
+                binding.plusButton.contentDescription = context.getString(
+                    R.string.order_creation_change_product_quantity,
+                    value,
+                    value + 1
+                )
             }
         }
 

--- a/WooCommerce/src/main/res/layout/view_stepper.xml
+++ b/WooCommerce/src/main/res/layout/view_stepper.xml
@@ -14,7 +14,6 @@
         style="@style/Woo.Button.Icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/minus_one"
         app:icon="@drawable/ic_gridicons_minus" />
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -34,6 +33,5 @@
         style="@style/Woo.Button.Icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/plus_one"
         app:icon="@drawable/ic_add" />
 </merge>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -133,8 +133,6 @@
     <string name="generic_string" translatable="false">%s</string>
     <string name="error_required_field">Required field</string>
     <string name="analytics">Analytics</string>
-    <string name="minus_one">Minus one</string>
-    <string name="plus_one">Plus one</string>
     <string name="card">Card</string>
     <string name="cash">Cash</string>
     <string name="create">Create</string>
@@ -384,6 +382,7 @@
     <string name="order_creation_fee_percentage_hint">Percentage (%)</string>
     <string name="order_creation_fee_percentage_toggle_text">Calculate as percentage</string>
     <string name="order_creation_fee_percentage_calculated_amount">Calculated amount: %s</string>
+    <string name="order_creation_change_product_quantity">Change the product quantity from %d to %d</string>
     <!--
         Order Filters
     -->


### PR DESCRIPTION
Closes #6212 - previously the content description for the plus and minus buttons around the product quantity in order creation wasn't very helpful - it simply said "plus one button" and "minus one button."

I wasn't able to match the iOS wording, but I made the content description more helpful by including the current product quantity and what the button changes the quantity to (ex: "Change the product quantity from 2 to 3").

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.