### PR TITLE
Set Fragment Title to Card Reader Hub screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
@@ -16,7 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
-    override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
+//    override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
     val viewModel: CardReaderHubViewModel by viewModels()
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
@@ -16,8 +16,8 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
+    override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
     val viewModel: CardReaderHubViewModel by viewModels()
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
     override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
     val viewModel: CardReaderHubViewModel by viewModels()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
@@ -16,7 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
-//    override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
+    override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
     val viewModel: CardReaderHubViewModel by viewModels()
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubFragment.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
     override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
     val viewModel: CardReaderHubViewModel by viewModels()
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6713 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Sets the Fragment Title in the Card Reader Hub fragment to display `In-Person Payments`. The title is originally set in the Onboarding Fragment and when you navigate from the Hub screen to the Card Reader Manuals and back to the hub screen the Fragment title remains the one set in the Card Reader Manuals screen. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Menu - Settings - In-Person Payments
2. Note the Fragment Title reads In-Person Payments
3. Tap on Card Reader Manuals
4. Note the Fragment Title reads Card Reader Manuals
5. tap the back arrow
6. Make sure that when you are back to the In-Person Payments hub screen the Fragment title says `In-Person Payments` and not `Card Reader Manuals`

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/172623674-2251da5c-2254-4149-8ffd-f07bfbb63044.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/172623734-8a52d80d-874b-4fe5-b320-157abe4d3f5b.gif" width="350"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
