### PR TITLE
Order details show refunded shipping lines in refund summary

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.details.adapter
 
-import android.content.Context
 import android.text.format.DateFormat
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -11,12 +10,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderDetailRefundPaymentItemBinding
 import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.model.Refund
-import com.woocommerce.android.util.StringUtils
 import java.math.BigDecimal
 
 class OrderDetailRefundsAdapter(
     private val isCashPayment: Boolean,
     private val paymentMethodTitle: String,
+    private val orderDetailRefundsLineBuilder: OrderDetailRefundsLineBuilder,
     private val formatCurrency: (BigDecimal) -> String
 ) : RecyclerView.Adapter<OrderDetailRefundsAdapter.ViewHolder>() {
     var refundList: List<Refund> = ArrayList()
@@ -40,6 +39,7 @@ class OrderDetailRefundsAdapter(
             ),
             isCashPayment,
             paymentMethodTitle,
+            orderDetailRefundsLineBuilder,
             formatCurrency
         )
     }
@@ -54,6 +54,7 @@ class OrderDetailRefundsAdapter(
         private val viewBinding: OrderDetailRefundPaymentItemBinding,
         private val isCashPayment: Boolean,
         private val paymentMethodTitle: String,
+        private val orderDetailRefundsLineBuilder: OrderDetailRefundsLineBuilder,
         private val formatCurrency: (BigDecimal) -> String
     ) : RecyclerView.ViewHolder(
         viewBinding.root
@@ -61,10 +62,8 @@ class OrderDetailRefundsAdapter(
         fun bind(refund: Refund) {
             val context = viewBinding.root.context
 
-            viewBinding.refundsListLblRefund.text = context.getString(
-                R.string.orderdetail_refunded,
-                buildRefundLine(context, refund)
-            )
+            val refundLine = orderDetailRefundsLineBuilder.buildRefundLine(refund)
+            viewBinding.refundsListLblRefund.text = context.getString(R.string.orderdetail_refunded, refundLine)
             viewBinding.refundsListRefundAmount.text = context.getString(
                 R.string.orderdetail_refund_amount,
                 formatCurrency(refund.amount)
@@ -82,27 +81,6 @@ class OrderDetailRefundsAdapter(
             viewBinding.refundsListItemRoot.setOnClickListener {
                 // TODO: open refund detail screen
             }
-        }
-
-        private fun buildRefundLine(context: Context, refund: Refund): String {
-            val tokens = mutableListOf<String>()
-            if (refund.items.isNotEmpty()) {
-                val quantity = refund.items.sumOf { it.quantity }
-                val productString = StringUtils.getQuantityString(
-                    context = context,
-                    quantity = quantity,
-                    default = R.string.orderdetail_product_multiple,
-                    one = R.string.orderdetail_product
-                )
-                tokens.add("$quantity $productString")
-            }
-            if (refund.shippingLines.isNotEmpty()) {
-                tokens.add(context.getString(R.string.product_shipping))
-            }
-            if (refund.feeLines.isNotEmpty()) {
-                tokens.add(context.getString(R.string.orderdetail_payment_fees))
-            }
-            return tokens.joinToString(separator = ", ") { it.lowercase() }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.details.adapter
 
+import android.content.Context
 import android.text.format.DateFormat
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -10,6 +11,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderDetailRefundPaymentItemBinding
 import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.util.StringUtils
 import java.math.BigDecimal
 
 class OrderDetailRefundsAdapter(
@@ -58,6 +60,11 @@ class OrderDetailRefundsAdapter(
     ) {
         fun bind(refund: Refund) {
             val context = viewBinding.root.context
+
+            viewBinding.refundsListLblRefund.text = context.getString(
+                R.string.orderdetail_refunded,
+                buildRefundLine(context, refund)
+            )
             viewBinding.refundsListRefundAmount.text = context.getString(
                 R.string.orderdetail_refund_amount,
                 formatCurrency(refund.amount)
@@ -75,6 +82,27 @@ class OrderDetailRefundsAdapter(
             viewBinding.refundsListItemRoot.setOnClickListener {
                 // TODO: open refund detail screen
             }
+        }
+
+        private fun buildRefundLine(context: Context, refund: Refund): String {
+            val tokens = mutableListOf<String>()
+            if (refund.items.isNotEmpty()) {
+                val quantity = refund.items.sumOf { it.quantity }
+                val productString = StringUtils.getQuantityString(
+                    context = context,
+                    quantity = quantity,
+                    default = R.string.orderdetail_product_multiple,
+                    one = R.string.orderdetail_product
+                )
+                tokens.add("$quantity $productString")
+            }
+            if (refund.shippingLines.isNotEmpty()) {
+                tokens.add(context.getString(R.string.product_shipping))
+            }
+            if (refund.feeLines.isNotEmpty()) {
+                tokens.add(context.getString(R.string.orderdetail_payment_fees))
+            }
+            return tokens.joinToString(separator = ", ") { it.lowercase() }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
@@ -63,7 +63,10 @@ class OrderDetailRefundsAdapter(
             val context = viewBinding.root.context
 
             val refundLine = orderDetailRefundsLineBuilder.buildRefundLine(refund)
-            viewBinding.refundsListLblRefund.text = context.getString(R.string.orderdetail_refunded, refundLine)
+            viewBinding.refundsListLblRefund.text = context.getString(
+                R.string.orderdetail_refunded_line_with_info,
+                refundLine
+            )
             viewBinding.refundsListRefundAmount.text = context.getString(
                 R.string.orderdetail_refund_amount,
                 formatCurrency(refund.amount)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsLineBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsLineBuilder.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.orders.details.adapter
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Refund
+import com.woocommerce.android.viewmodel.ResourceProvider
+import javax.inject.Inject
+
+class OrderDetailRefundsLineBuilder @Inject constructor(
+    private val resourceProvider: ResourceProvider,
+) {
+    fun buildRefundLine(refund: Refund): String {
+        val tokens = mutableListOf<String>()
+        if (refund.items.isNotEmpty()) {
+            val quantity = refund.items.sumOf { it.quantity }
+            val productString = resourceProvider.getQuantityString(
+                quantity = quantity,
+                default = R.string.orderdetail_product_multiple,
+                one = R.string.orderdetail_product
+            )
+            tokens.add("$quantity $productString")
+        }
+        if (refund.shippingLines.isNotEmpty()) {
+            tokens.add(resourceProvider.getString(R.string.product_shipping))
+        }
+        if (refund.feeLines.isNotEmpty()) {
+            tokens.add(resourceProvider.getString(R.string.orderdetail_payment_fees))
+        }
+        return tokens.joinToString(separator = ", ") { it.lowercase() }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -16,13 +16,19 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailRefundsAdapter
+import com.woocommerce.android.ui.orders.details.adapter.OrderDetailRefundsLineBuilder
+import dagger.hilt.android.AndroidEntryPoint
 import java.math.BigDecimal
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class OrderDetailPaymentInfoView @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    @Inject lateinit var orderDetailRefundsLineBuilder: OrderDetailRefundsLineBuilder
+
     private val binding = OrderDetailPaymentInfoBinding.inflate(LayoutInflater.from(ctx), this)
 
     @Suppress("LongParameterList")
@@ -174,7 +180,12 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         formatCurrencyForDisplay: (BigDecimal) -> String
     ) {
         val adapter = binding.paymentInfoRefunds.adapter as? OrderDetailRefundsAdapter
-            ?: OrderDetailRefundsAdapter(order.isCashPayment, order.paymentMethodTitle, formatCurrencyForDisplay)
+            ?: OrderDetailRefundsAdapter(
+                order.isCashPayment,
+                order.paymentMethodTitle,
+                orderDetailRefundsLineBuilder,
+                formatCurrencyForDisplay,
+            )
         binding.paymentInfoRefunds.adapter = adapter
         adapter.refundList = refunds
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ResourceProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ResourceProvider.kt
@@ -1,8 +1,13 @@
 package com.woocommerce.android.viewmodel
 
 import android.content.Context
-import androidx.annotation.*
+import androidx.annotation.ArrayRes
+import androidx.annotation.ColorRes
+import androidx.annotation.DimenRes
+import androidx.annotation.RawRes
+import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
+import com.woocommerce.android.util.StringUtils
 import java.io.InputStream
 import javax.inject.Inject
 
@@ -32,4 +37,17 @@ class ResourceProvider @Inject constructor(private val context: Context) {
         val resources = context.resources
         return resources.openRawResource(rawId)
     }
+
+    fun getQuantityString(
+        quantity: Int,
+        @StringRes default: Int,
+        @StringRes zero: Int? = null,
+        @StringRes one: Int? = null
+    ) = StringUtils.getQuantityString(
+        context,
+        quantity,
+        default,
+        zero,
+        one,
+    )
 }

--- a/WooCommerce/src/main/res/layout/order_detail_refund_payment_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_refund_payment_item.xml
@@ -26,7 +26,7 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:layout_marginTop="@dimen/major_75"
-        android:text="@string/orderdetail_refunded"
+        android:text="@string/orderdetail_refunded_line_with_info"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/refundsList_refundDivider" />
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -438,7 +438,7 @@
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
     <string name="orderdetail_payment_summary_onhold">Awaiting payment via %s</string>
     <string name="orderdetail_payment_paid_by_customer">Paid</string>
-    <string name="orderdetail_refunded">Refunded</string>
+    <string name="orderdetail_refunded">Refunded: %s</string>
     <string name="orderdetail_refunded_products">Refunded products</string>
     <string name="orderdetail_refund_detail">%1$s via %2$s</string>
     <string name="orderdetail_net">Net Payment</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -438,7 +438,7 @@
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
     <string name="orderdetail_payment_summary_onhold">Awaiting payment via %s</string>
     <string name="orderdetail_payment_paid_by_customer">Paid</string>
-    <string name="orderdetail_refunded">Refunded: %s</string>
+    <string name="orderdetail_refunded">Refunded: %1$s</string>
     <string name="orderdetail_refunded_products">Refunded products</string>
     <string name="orderdetail_refund_detail">%1$s via %2$s</string>
     <string name="orderdetail_net">Net Payment</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -438,7 +438,8 @@
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
     <string name="orderdetail_payment_summary_onhold">Awaiting payment via %s</string>
     <string name="orderdetail_payment_paid_by_customer">Paid</string>
-    <string name="orderdetail_refunded">Refunded: %1$s</string>
+    <string name="orderdetail_refunded">Refunded</string>
+    <string name="orderdetail_refunded_line_with_info">Refunded: %1$s</string>
     <string name="orderdetail_refunded_products">Refunded products</string>
     <string name="orderdetail_refund_detail">%1$s via %2$s</string>
     <string name="orderdetail_net">Net Payment</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsLineBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsLineBuilderTest.kt
@@ -172,4 +172,24 @@ class OrderDetailRefundsLineBuilderTest : BaseUnitTest() {
         // THEN
         assertThat(result).isEqualTo("1 product, shipping, fees")
     }
+
+    @Test
+    fun `given refund with product and fees, when building line, then product and fees returned`() {
+        // GIVEN
+        val item = mock<Item> {
+            on { quantity }.thenReturn(1)
+        }
+        whenever(refund.items).thenReturn(
+            listOf(item)
+        )
+        whenever(refund.feeLines).thenReturn(
+            listOf(mock())
+        )
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("1 product, fees")
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsLineBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsLineBuilderTest.kt
@@ -1,0 +1,175 @@
+package com.woocommerce.android.ui.orders.details.adapter
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.Refund.Item
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class OrderDetailRefundsLineBuilderTest : BaseUnitTest() {
+    private val resourceProvider: ResourceProvider = mock {
+        on {
+            getQuantityString(
+                quantity = 1,
+                default = R.string.orderdetail_product_multiple,
+                one = R.string.orderdetail_product
+            )
+        }.thenReturn("Product")
+        on {
+            getQuantityString(
+                quantity = 2,
+                default = R.string.orderdetail_product_multiple,
+                one = R.string.orderdetail_product
+            )
+        }.thenReturn("Products")
+        on { getString(R.string.product_shipping) }.thenReturn("Shipping")
+        on { getString(R.string.orderdetail_payment_fees) }.thenReturn("Fees")
+    }
+
+    private val refund = mock<Refund> {
+        on { items }.thenReturn(emptyList())
+        on { shippingLines }.thenReturn(emptyList())
+        on { feeLines }.thenReturn(emptyList())
+    }
+
+    private val builder = OrderDetailRefundsLineBuilder(resourceProvider)
+
+    @Test
+    fun `given refund with product, when building line, then product returned`() {
+        // GIVEN
+        val item = mock<Item> {
+            on { quantity }.thenReturn(1)
+        }
+        whenever(refund.items).thenReturn(
+            listOf(item)
+        )
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("1 product")
+    }
+
+    @Test
+    fun `given refund with products, when building line, then products returned`() {
+        // GIVEN
+        val itemOne = mock<Item> {
+            on { quantity }.thenReturn(3)
+        }
+        val itemTwo = mock<Item> {
+            on { quantity }.thenReturn(4)
+        }
+        val itemThree = mock<Item> {
+            on { quantity }.thenReturn(5)
+        }
+        whenever(refund.items).thenReturn(
+            listOf(itemOne, itemTwo, itemThree)
+        )
+        whenever(
+            resourceProvider.getQuantityString(
+                quantity = 12,
+                default = R.string.orderdetail_product_multiple,
+                one = R.string.orderdetail_product
+            )
+        ).thenReturn("Products")
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("12 products")
+    }
+
+    @Test
+    fun `given refund with fee, when building line, then fees returned`() {
+        // GIVEN
+        whenever(refund.feeLines).thenReturn(
+            listOf(mock())
+        )
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("fees")
+    }
+
+    @Test
+    fun `given refund with shipping, when building line, then shipping returned`() {
+        // GIVEN
+        whenever(refund.shippingLines).thenReturn(
+            listOf(mock())
+        )
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("shipping")
+    }
+
+    @Test
+    fun `given refund with product and shipping, when building line, then product and shipping returned`() {
+        // GIVEN
+        val item = mock<Item> {
+            on { quantity }.thenReturn(1)
+        }
+        whenever(refund.items).thenReturn(
+            listOf(item)
+        )
+        whenever(refund.shippingLines).thenReturn(
+            listOf(mock())
+        )
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("1 product, shipping")
+    }
+
+    @Test
+    fun `given refund with shipping and fee, when building line, then shipping and fee returned`() {
+        // GIVEN
+        whenever(refund.shippingLines).thenReturn(
+            listOf(mock())
+        )
+        whenever(refund.feeLines).thenReturn(
+            listOf(mock())
+        )
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("shipping, fees")
+    }
+
+    @Test
+    fun `given refund with product, shipping and fee, when building line, then product shipping and fee returned`() {
+        // GIVEN
+        val item = mock<Item> {
+            on { quantity }.thenReturn(1)
+        }
+        whenever(refund.items).thenReturn(
+            listOf(item)
+        )
+        whenever(refund.shippingLines).thenReturn(
+            listOf(mock())
+        )
+        whenever(refund.feeLines).thenReturn(
+            listOf(mock())
+        )
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("1 product, shipping, fees")
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsLineBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsLineBuilderTest.kt
@@ -192,4 +192,81 @@ class OrderDetailRefundsLineBuilderTest : BaseUnitTest() {
         // THEN
         assertThat(result).isEqualTo("1 product, fees")
     }
+
+    @Test
+    fun `given refund with 2 products and fees, when building line, then 2 products and fees returned`() {
+        // GIVEN
+        val item = mock<Item> {
+            on { quantity }.thenReturn(2)
+        }
+        whenever(refund.items).thenReturn(
+            listOf(item)
+        )
+        whenever(refund.feeLines).thenReturn(
+            listOf(mock())
+        )
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("2 products, fees")
+    }
+
+    @Test
+    fun `given refund with 5 products and shipping, when building line, then 5 products and shipping returned`() {
+        // GIVEN
+        val item = mock<Item> {
+            on { quantity }.thenReturn(5)
+        }
+        whenever(refund.items).thenReturn(
+            listOf(item)
+        )
+        whenever(refund.shippingLines).thenReturn(
+            listOf(mock())
+        )
+        whenever(
+            resourceProvider.getQuantityString(
+                quantity = 5,
+                default = R.string.orderdetail_product_multiple,
+                one = R.string.orderdetail_product
+            )
+        ).thenReturn("Products")
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("5 products, shipping")
+    }
+
+    @Test
+    fun `given refund with 10 products ship fees, when building line, then 10 products, ship and fees returned`() {
+        // GIVEN
+        val item = mock<Item> {
+            on { quantity }.thenReturn(10)
+        }
+        whenever(refund.items).thenReturn(
+            listOf(item)
+        )
+        whenever(refund.shippingLines).thenReturn(
+            listOf(mock())
+        )
+        whenever(refund.feeLines).thenReturn(
+            listOf(mock())
+        )
+        whenever(
+            resourceProvider.getQuantityString(
+                quantity = 10,
+                default = R.string.orderdetail_product_multiple,
+                one = R.string.orderdetail_product
+            )
+        ).thenReturn("Products")
+
+        // WHEN
+        val result = builder.buildRefundLine(refund)
+
+        // THEN
+        assertThat(result).isEqualTo("10 products, shipping, fees")
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6714
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds more info in the refund lines. 

Possible cases:
* Refunded: 1 product
* Refunded: 2 products
* Refunded: 1 product, shipping
* Refunded: 1 product, fees
* Refunded: 1 product, shipping, fees
* Refunded: shipping, fees
* Refunded: fees
* Refunded: shipping

@joe-keenan @joshheald wdyt about this approach?

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="451" alt="image" src="https://user-images.githubusercontent.com/4923871/172809199-5bb94ff6-38a1-4715-bfbf-2b22c893cf13.png">
<img width="454" alt="image" src="https://user-images.githubusercontent.com/4923871/172809635-123fb8f3-caa9-4189-8de6-09fe2da90081.png">
