### PR TITLE
[Coupons] Search for categories

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -1,20 +1,32 @@
 package com.woocommerce.android.ui.compose.component
 
 import android.content.res.Configuration
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldColors
 import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -160,6 +172,54 @@ private fun WCOutlinedTextFieldLayout(
     }
 }
 
+@Composable
+fun WCSearchView(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    hint: String = ""
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .defaultMinSize(minHeight = dimensionResource(id = R.dimen.major_250))
+            .background(
+                TextFieldDefaults
+                    .textFieldColors()
+                    .backgroundColor(enabled = true).value,
+                RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+            ),
+        decorationBox = { innerTextField ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .padding(horizontal = dimensionResource(id = R.dimen.minor_100))
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    tint = colorResource(id = R.color.color_on_surface_medium)
+                )
+
+                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+
+                Box {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = hint,
+                            style = MaterialTheme.typography.subtitle1,
+                            color = colorResource(id = R.color.color_on_surface_medium)
+                        )
+                    }
+
+                    innerTextField()
+                }
+            }
+        }
+    )
+}
+
 @Preview(name = "Light mode")
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
@@ -176,6 +236,17 @@ private fun WCOutlinedTextFieldPreview() {
                 onValueChange = {},
                 helperText = "Helper Text",
                 isError = true
+            )
+            WCSearchView(
+                value = "",
+                onValueChange = {},
+                hint = "Search",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = dimensionResource(id = R.dimen.major_100),
+                        vertical = dimensionResource(id = R.dimen.minor_100)
+                    )
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -11,18 +11,21 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldColors
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -30,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -204,7 +208,7 @@ fun WCSearchView(
 
                 Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
 
-                Box {
+                Box(Modifier.weight(1f)) {
                     if (value.isEmpty()) {
                         Text(
                             text = hint,
@@ -214,6 +218,18 @@ fun WCSearchView(
                     }
 
                     innerTextField()
+                }
+                if (value.isNotEmpty()) {
+                    IconButton(
+                        onClick = { onValueChange("") },
+                        modifier = Modifier.size(dimensionResource(id = R.dimen.major_250))
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = stringResource(id = R.string.clear),
+                            tint = colorResource(id = R.color.color_on_surface_medium)
+                        )
+                    }
                 }
             }
         }
@@ -238,7 +254,7 @@ private fun WCOutlinedTextFieldPreview() {
                 isError = true
             )
             WCSearchView(
-                value = "",
+                value = "test",
                 onValueChange = {},
                 hint = "Search",
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandler.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.products.categories.selector
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -17,31 +20,65 @@ class ProductCategoryListHandler @Inject constructor(
     private var offset = 0
     private var canLoadMore = true
 
-    val categories: Flow<List<ProductCategoryTreeItem>> = repository.observeCategories()
-        .map { it.convertToTree() }
+    private val searchQuery = MutableStateFlow("")
+    private val searchResults = MutableStateFlow(emptyList<ProductCategoryTreeItem>())
+
+    val categories: Flow<List<ProductCategoryTreeItem>> = searchQuery.flatMapLatest {
+        if (it.isEmpty()) {
+            repository.observeCategories()
+                .map { it.convertToTree() }
+        } else {
+            searchResults
+        }
+    }
 
     suspend fun fetchCategories(
-        forceRefresh: Boolean = false
+        forceRefresh: Boolean = false,
+        searchQuery: String = ""
     ): Result<Unit> = mutex.withLock {
         // Reset pagination attributes
         offset = 0
         canLoadMore = true
 
-        return if (forceRefresh) {
-            loadCategories()
+        this.searchQuery.value = searchQuery
+        return@withLock if (searchQuery.isEmpty()) {
+            if (forceRefresh) {
+                loadCategories()
+            } else {
+                Result.success(Unit)
+            }
         } else {
-            Result.success(Unit)
+            searchResults.value = emptyList()
+            searchCategories()
         }
     }
 
     suspend fun loadMore(): Result<Unit> = mutex.withLock {
         if (!canLoadMore) return@withLock Result.success(Unit)
-        return loadCategories()
+        return if (searchQuery.value.isEmpty()) {
+            loadCategories()
+        } else {
+            searchCategories()
+        }
     }
 
     private suspend fun loadCategories(): Result<Unit> {
         return repository.fetchCategories(offset, PAGE_SIZE).onSuccess {
             canLoadMore = it
+            offset += PAGE_SIZE
+        }.map { }
+    }
+
+    private suspend fun searchCategories(): Result<Unit> {
+        return repository.searchCategories(
+            searchQuery = searchQuery.value,
+            offset = offset,
+            pageSize = PAGE_SIZE
+        ).onSuccess { result ->
+            // Return results as flat tree
+            val mappedResults = result.productCategories.map { ProductCategoryTreeItem(it, emptyList()) }
+            searchResults.update { it + mappedResults }
+            canLoadMore = result.canLoadMore
             offset += PAGE_SIZE
         }.map { }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandler.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.categories.selector
 
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
@@ -13,7 +14,8 @@ class ProductCategoryListHandler @Inject constructor(
     private val repository: ProductCategorySelectorRepository
 ) {
     companion object {
-        private const val PAGE_SIZE = 25
+        @VisibleForTesting
+        const val PAGE_SIZE = 25
     }
 
     private val mutex = Mutex()
@@ -23,8 +25,8 @@ class ProductCategoryListHandler @Inject constructor(
     private val searchQuery = MutableStateFlow("")
     private val searchResults = MutableStateFlow(emptyList<ProductCategoryTreeItem>())
 
-    val categories: Flow<List<ProductCategoryTreeItem>> = searchQuery.flatMapLatest {
-        if (it.isEmpty()) {
+    val categories: Flow<List<ProductCategoryTreeItem>> = searchQuery.flatMapLatest { query ->
+        if (query.isEmpty()) {
             repository.observeCategories()
                 .map { it.convertToTree() }
         } else {
@@ -76,7 +78,7 @@ class ProductCategoryListHandler @Inject constructor(
             pageSize = PAGE_SIZE
         ).onSuccess { result ->
             // Return results as flat tree
-            val mappedResults = result.productCategories.map { ProductCategoryTreeItem(it, emptyList()) }
+            val mappedResults = result.productCategories.convertToFlatTree()
             searchResults.update { it + mappedResults }
             canLoadMore = result.canLoadMore
             offset += PAGE_SIZE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
@@ -10,10 +10,13 @@ import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ProductCategorySelectorFragment : BaseFragment() {
@@ -22,6 +25,8 @@ class ProductCategorySelectorFragment : BaseFragment() {
     }
 
     private val viewModel: ProductCategorySelectorViewModel by viewModels()
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(
@@ -49,6 +54,7 @@ class ProductCategorySelectorFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(PRODUCT_CATEGORY_SELECTOR_RESULT, event.data)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
@@ -25,8 +25,7 @@ class ProductCategorySelectorFragment : BaseFragment() {
     }
 
     private val viewModel: ProductCategorySelectorViewModel by viewModels()
-    @Inject
-    lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorRepository.kt
@@ -37,7 +37,7 @@ class ProductCategorySelectorRepository @Inject constructor(
             .let { result ->
                 if (result.isError) {
                     WooLog.w(
-                        WooLog.T.COUPONS,
+                        WooLog.T.PRODUCTS,
                         "Fetching categories failed, error: ${result.error.type}: ${result.error.message}"
                     )
                     Result.failure(WooException(result.error))
@@ -46,4 +46,39 @@ class ProductCategorySelectorRepository @Inject constructor(
                 }
             }
     }
+
+    suspend fun searchCategories(
+        searchQuery: String,
+        offset: Int,
+        pageSize: Int
+    ): Result<SearchResult> {
+        return store.searchProductCategories(
+            selectedSite.get(),
+            searchString = searchQuery,
+            offset = offset,
+            pageSize = pageSize
+        ).let { result ->
+            if (result.isError) {
+                WooLog.w(
+                    WooLog.T.PRODUCTS,
+                    "Searching product categories failed, error: ${result.error.type}: ${result.error.message}"
+                )
+                Result.failure(WooException(result.error))
+            } else {
+                val searchResult = result.model!!
+                Result.success(
+                    SearchResult(
+                        productCategories = searchResult.categories
+                            .map { categoryDataModel -> categoryDataModel.toProductCategory() },
+                        canLoadMore = searchResult.canLoadMore
+                    )
+                )
+            }
+        }
+    }
+
+    data class SearchResult(
+        val productCategories: List<ProductCategory>,
+        val canLoadMore: Boolean
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -111,11 +111,13 @@ private fun CategoriesList(
         modifier = Modifier
             .fillMaxHeight()
     ) {
-        WCTextButton(
-            onClick = onClearSelectionClick,
-            modifier = Modifier.padding(dimensionResource(id = R.dimen.minor_100))
-        ) {
-            Text(text = stringResource(id = R.string.product_category_selector_clear_selection))
+        if (viewState.selectedCategoriesCount > 0) {
+            WCTextButton(
+                onClick = onClearSelectionClick,
+                modifier = Modifier.padding(dimensionResource(id = R.dimen.minor_100))
+            ) {
+                Text(text = stringResource(id = R.string.product_category_selector_clear_selection))
+            }
         }
         val lazyListState = rememberLazyListState()
         LazyColumn(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCSearchView
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorViewModel.CategoryUiModel
@@ -56,6 +57,7 @@ fun ProductCategorySelectorScreen(viewModel: ProductCategorySelectorViewModel) {
             viewState = it,
             onLoadMore = viewModel::onLoadMore,
             onClearSelectionClick = viewModel::onClearSelectionClick,
+            onSearchQueryChanged = viewModel::onSearchQueryChanged,
             onDoneClick = viewModel::onDoneClick
         )
     }
@@ -66,17 +68,35 @@ fun ProductCategorySelectorScreen(
     viewState: ProductCategorySelectorViewModel.ViewState,
     onLoadMore: () -> Unit = {},
     onClearSelectionClick: () -> Unit = {},
+    onSearchQueryChanged: (String) -> Unit = {},
     onDoneClick: () -> Unit = {},
 ) {
-    when {
-        viewState.categories.isNotEmpty() -> CategoriesList(
-            viewState = viewState,
-            onLoadMore = onLoadMore,
-            onClearSelectionClick = onClearSelectionClick,
-            onDoneClick = onDoneClick
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.surface)
+    ) {
+        WCSearchView(
+            value = viewState.searchQuery,
+            onValueChange = onSearchQueryChanged,
+            hint = stringResource(id = R.string.product_category_selector_search_hint),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = dimensionResource(id = R.dimen.major_100),
+                    vertical = dimensionResource(id = R.dimen.minor_100)
+                )
         )
-        viewState.loadingState == LoadingState.Loading -> CategoriesSkeleton()
-        else -> EmptyCategoriesList()
+        when {
+            viewState.categories.isNotEmpty() -> CategoriesList(
+                viewState = viewState,
+                onLoadMore = onLoadMore,
+                onClearSelectionClick = onClearSelectionClick,
+                onDoneClick = onDoneClick
+            )
+            viewState.loadingState == LoadingState.Loading -> CategoriesSkeleton()
+            else -> EmptyCategoriesList()
+        }
     }
 }
 
@@ -90,7 +110,6 @@ private fun CategoriesList(
     Column(
         modifier = Modifier
             .fillMaxHeight()
-            .background(MaterialTheme.colors.surface)
     ) {
         WCTextButton(
             onClick = onClearSelectionClick,
@@ -212,7 +231,7 @@ private fun EmptyCategoriesList() {
 @Composable
 private fun CategoriesSkeleton() {
     val numberOfInboxSkeletonRows = 20
-    LazyColumn(Modifier.background(color = MaterialTheme.colors.surface)) {
+    LazyColumn {
         repeat(numberOfInboxSkeletonRows) {
             item {
                 Column(
@@ -264,7 +283,8 @@ private fun PreviewProductCategorySelector() {
             viewState = ProductCategorySelectorViewModel.ViewState(
                 categories = categories,
                 selectedCategoriesCount = 1,
-                loadingState = LoadingState.Idle
+                loadingState = LoadingState.Idle,
+                searchQuery = ""
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -95,7 +95,7 @@ fun ProductCategorySelectorScreen(
                 onDoneClick = onDoneClick
             )
             viewState.loadingState == LoadingState.Loading -> CategoriesSkeleton()
-            else -> EmptyCategoriesList()
+            else -> EmptyCategoriesList(viewState.searchQuery)
         }
     }
 }
@@ -203,7 +203,7 @@ private fun LazyListScope.categoryItem(item: CategoryUiModel, depth: Int = 0) {
 }
 
 @Composable
-private fun EmptyCategoriesList() {
+private fun EmptyCategoriesList(searchQuery: String) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -211,8 +211,13 @@ private fun EmptyCategoriesList() {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        val message = if (searchQuery.isEmpty()) {
+            stringResource(id = R.string.product_category_selector_empty_state)
+        } else {
+            stringResource(id = R.string.empty_message_with_search, searchQuery)
+        }
         Text(
-            text = stringResource(id = R.string.product_category_selector_empty_state),
+            text = message,
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.h6,
             modifier = Modifier.padding(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -232,6 +232,16 @@ private fun EmptyCategoriesList() {
 private fun CategoriesSkeleton() {
     val numberOfInboxSkeletonRows = 20
     LazyColumn {
+        item {
+            SkeletonView(
+                modifier = Modifier
+                    .padding(dimensionResource(id = R.dimen.major_100))
+                    .size(
+                        width = dimensionResource(id = R.dimen.skeleton_text_medium_width),
+                        height = dimensionResource(R.dimen.major_125)
+                    )
+            )
+        }
         repeat(numberOfInboxSkeletonRows) {
             item {
                 Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.products.categories.selector
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppConstants
+import com.woocommerce.android.ui.coupons.CouponListViewModel.LoadingState
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -9,9 +12,12 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
@@ -29,6 +35,7 @@ class ProductCategorySelectorViewModel @Inject constructor(
 
     private val navArgs: ProductCategorySelectorFragmentArgs by savedState.navArgs()
 
+    private val searchQuery = savedState.getStateFlow(this, "")
     private val selectedCategories = savedState.getStateFlow(this, navArgs.categoryIds.toSet())
     private val loadingState = MutableStateFlow(LoadingState.Idle)
     private val categories = listHandler.categories
@@ -36,7 +43,8 @@ class ProductCategorySelectorViewModel @Inject constructor(
     val viewState = combine(
         flow = categories,
         flow2 = selectedCategories,
-        flow3 = loadingState.withIndex()
+        flow3 = searchQuery,
+        flow4 = loadingState.withIndex()
             .debounce { (index, loadingState) ->
                 if (index != 0 && loadingState == LoadingState.Idle) {
                     // When resetting to Idle, wait a bit to make sure the data has been fetched from DB
@@ -44,15 +52,17 @@ class ProductCategorySelectorViewModel @Inject constructor(
                 } else 0L
             }
             .map { it.value }
-    ) { categories, selectedCategories, loadingState ->
+    ) { categories, selectedCategories, searchQuery, loadingState ->
         ViewState(
             categories = categories.map { it.toUiModel(selectedCategories = selectedCategories) },
             selectedCategoriesCount = selectedCategories.size,
+            searchQuery = searchQuery,
             loadingState = loadingState
         )
     }.asLiveData()
 
     init {
+        monitorSearchQuery()
         launch {
             loadingState.value = LoadingState.Loading
             listHandler.fetchCategories(forceRefresh = true)
@@ -70,8 +80,40 @@ class ProductCategorySelectorViewModel @Inject constructor(
         selectedCategories.value = emptySet()
     }
 
+    fun onSearchQueryChanged(query: String) {
+        searchQuery.value = query
+    }
+
     fun onDoneClick() {
         triggerEvent(ExitWithResult(selectedCategories.value.toList()))
+    }
+
+    private fun monitorSearchQuery() {
+        viewModelScope.launch {
+            searchQuery
+                .withIndex()
+                .filterNot {
+                    // Skip initial value to avoid double fetching product categories
+                    it.index == 0 && it.value.isEmpty()
+                }
+                .map { it.value }
+                .onEach {
+                    loadingState.value = LoadingState.Loading
+                }
+                .debounce {
+                    if (it.isNullOrEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
+                }
+                .collectLatest { query ->
+                    try {
+                        listHandler.fetchCategories(searchQuery = query)
+                            .onFailure {
+                                TODO()
+                            }
+                    } finally {
+                        loadingState.value = LoadingState.Idle
+                    }
+                }
+        }
     }
 
     private fun ProductCategoryTreeItem.toUiModel(selectedCategories: Set<Long>): CategoryUiModel = CategoryUiModel(
@@ -101,6 +143,7 @@ class ProductCategorySelectorViewModel @Inject constructor(
     data class ViewState(
         val categories: List<CategoryUiModel>,
         val selectedCategoriesCount: Int,
+        val searchQuery: String,
         val loadingState: LoadingState
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppConstants
-import com.woocommerce.android.ui.coupons.CouponListViewModel.LoadingState
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryTreeItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryTreeItem.kt
@@ -16,3 +16,12 @@ fun List<ProductCategory>.convertToTree(parentId: Long = 0): List<ProductCategor
             )
         }
 }
+
+fun List<ProductCategory>.convertToFlatTree(): List<ProductCategoryTreeItem> {
+    return map {
+        ProductCategoryTreeItem(
+            productCategory = it,
+            children = emptyList()
+        )
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1441,6 +1441,9 @@
     <string name="product_category_selector_select_button_title_one">Select 1 category</string>
     <string name="product_category_selector_check_content_description">Click to uncheck</string>
     <string name="product_category_selector_clear_selection">Clear selection</string>
+    <string name="product_category_selector_search_hint">Search Categories</string>
+    <string name="product_category_selector_loading_failed">Loading product categories failed</string>
+    <string name="product_category_selector_search_failed">Searching product categories failed</string>
     <!--
         Product Add more details Bottom sheet
     -->
@@ -2019,7 +2022,6 @@
     <string name="product_selector_select_button_title_one">Select %d Product</string>
     <string name="product_selector_clear_button_title">Clear Selection</string>
     <string name="product_selector_filter_button_title">Filter</string>
-    <string name="product_category_selector_search_hint">Search Categories</string>
 
     <!-- WC Shipping installation flow -->
     <string name="install_wc_shipping_flow_onboarding_screen_title">Fulfill your orders with WooCommerce Shipping</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2019,6 +2019,7 @@
     <string name="product_selector_select_button_title_one">Select %d Product</string>
     <string name="product_selector_clear_button_title">Clear Selection</string>
     <string name="product_selector_filter_button_title">Filter</string>
+    <string name="product_category_selector_search_hint">Search Categories</string>
 
     <!-- WC Shipping installation flow -->
     <string name="install_wc_shipping_flow_onboarding_screen_title">Fulfill your orders with WooCommerce Shipping</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandlerTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandlerTests.kt
@@ -91,7 +91,7 @@ class ProductCategoryListHandlerTests : BaseUnitTest() {
     fun `given search is active, when we load more, then search for next page`() = testBlocking {
         val searchQuery = "query"
         setup {
-            whenever(repository.searchCategories(searchQuery, 0, ProductCategoryListHandler.PAGE_SIZE))
+            whenever(repository.searchCategories(eq(searchQuery), any(), eq(ProductCategoryListHandler.PAGE_SIZE)))
                 .thenReturn(
                     Result.success(
                         ProductCategorySelectorRepository.SearchResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandlerTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandlerTests.kt
@@ -1,0 +1,117 @@
+package com.woocommerce.android.ui.products.categories.selector
+
+import com.woocommerce.android.model.ProductCategory
+import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ProductCategoryListHandlerTests : BaseUnitTest() {
+    private lateinit var listHandler: ProductCategoryListHandler
+
+    private val repository: ProductCategorySelectorRepository = mock {
+        on { observeCategories() } doReturn flowOf(emptyList())
+        onBlocking { fetchCategories(any(), any()) } doReturn Result.success(false)
+    }
+
+    suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+        listHandler = ProductCategoryListHandler(
+            repository = repository
+        )
+    }
+
+    @Test
+    fun `when fetching results, then return repository results as a tree`() = testBlocking {
+        val productCategories = ProductTestUtils.generateProductCategories()
+        setup {
+            whenever(repository.observeCategories()).thenReturn(flowOf(productCategories))
+        }
+
+        val results = listHandler.categories.runAndCaptureValues {
+            listHandler.fetchCategories()
+        }.last()
+
+        assertThat(results).isEqualTo(productCategories.convertToTree())
+    }
+
+    @Test
+    fun `when searching for results results, then return search results as a flat tree`() = testBlocking {
+        val productCategories = ProductTestUtils.generateProductCategories()
+
+        setup {
+            whenever(repository.searchCategories(any(), any(), any()))
+                .thenReturn(Result.success(ProductCategorySelectorRepository.SearchResult(productCategories, false)))
+        }
+
+        val results = listHandler.categories.runAndCaptureValues {
+            listHandler.fetchCategories(searchQuery = "query")
+        }.last()
+
+        assertThat(results).isEqualTo(productCategories.convertToFlatTree())
+    }
+
+    @Test
+    fun `when force fetching, then refresh results`() = testBlocking {
+        setup()
+
+        listHandler.fetchCategories(forceRefresh = true)
+
+        verify(repository).fetchCategories(eq(0), any())
+    }
+
+    @Test
+    fun `given search is not active, when we load more, then load next page`() = testBlocking {
+        setup {
+            whenever(
+                repository.fetchCategories(
+                    0,
+                    ProductCategoryListHandler.PAGE_SIZE
+                )
+            ).thenReturn(Result.success(true))
+        }
+
+        listHandler.fetchCategories(forceRefresh = true)
+        listHandler.loadMore()
+
+        verify(repository).fetchCategories(0, ProductCategoryListHandler.PAGE_SIZE)
+        verify(repository).fetchCategories(ProductCategoryListHandler.PAGE_SIZE, ProductCategoryListHandler.PAGE_SIZE)
+    }
+
+    @Test
+    fun `given search is active, when we load more, then search for next page`() = testBlocking {
+        val searchQuery = "query"
+        setup {
+            whenever(repository.searchCategories(searchQuery, 0, ProductCategoryListHandler.PAGE_SIZE))
+                .thenReturn(
+                    Result.success(
+                        ProductCategorySelectorRepository.SearchResult(
+                            List(ProductCategoryListHandler.PAGE_SIZE) {
+                                ProductCategory(name = "Category")
+                            },
+                            canLoadMore = true
+                        )
+                    )
+                )
+        }
+
+        listHandler.fetchCategories(searchQuery = "query")
+        listHandler.loadMore()
+
+        verify(repository).searchCategories("query", 0, ProductCategoryListHandler.PAGE_SIZE)
+        verify(repository).searchCategories(
+            "query",
+            ProductCategoryListHandler.PAGE_SIZE,
+            ProductCategoryListHandler.PAGE_SIZE
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModelTests.kt
@@ -1,0 +1,149 @@
+package com.woocommerce.android.ui.products.categories.selector
+
+import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorViewModel.LoadingState
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ProductCategorySelectorViewModelTests : BaseUnitTest() {
+    private lateinit var viewModel: ProductCategorySelectorViewModel
+
+    private val categoriesStateFlow = MutableStateFlow(emptyList<ProductCategoryTreeItem>())
+
+    private val productCategoryListHandler: ProductCategoryListHandler = mock {
+        on { categories } doReturn categoriesStateFlow
+    }
+
+    private val defaultProductCategoriesList = ProductTestUtils.generateProductCategories().convertToTree()
+
+    suspend fun setup(
+        selectedCategories: LongArray = longArrayOf(),
+        prepareMocks: suspend () -> Unit = {}
+    ) {
+        prepareMocks()
+        viewModel = ProductCategorySelectorViewModel(
+            savedState = ProductCategorySelectorFragmentArgs(selectedCategories).toSavedStateHandle(),
+            listHandler = productCategoryListHandler
+        )
+    }
+
+    @Test
+    fun `when screen is loaded, then fetch product categories`() = testBlocking {
+        setup {
+            whenever(productCategoryListHandler.fetchCategories(true)).doSuspendableAnswer {
+                delay(1L)
+                return@doSuspendableAnswer Result.success(Unit)
+            }
+        }
+
+        val fetchingState = viewModel.viewState.captureValues().last()
+
+        verify(productCategoryListHandler).fetchCategories(forceRefresh = true)
+        assertThat(fetchingState.loadingState).isEqualTo(LoadingState.Loading)
+
+        advanceUntilIdle()
+        val idleState = viewModel.viewState.captureValues().last()
+        assertThat(idleState.loadingState).isEqualTo(LoadingState.Idle)
+    }
+
+    @Test
+    fun `when screen is loaded, then load saved categories`() = testBlocking {
+        setup()
+
+        val state = viewModel.viewState.runAndCaptureValues {
+            categoriesStateFlow.value = defaultProductCategoriesList
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(state.categories.map { it.id }).isEqualTo(defaultProductCategoriesList.map { it.productCategory.remoteCategoryId })
+        assertThat(state.loadingState).isEqualTo(LoadingState.Idle)
+    }
+
+    @Test
+    fun `when search query is entered, then search for categories`() = testBlocking {
+        setup()
+
+        val state = viewModel.viewState.runAndCaptureValues {
+            viewModel.onSearchQueryChanged("Search")
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(state.searchQuery).isEqualTo("Search")
+        verify(productCategoryListHandler).fetchCategories(searchQuery = "Search")
+    }
+
+    @Test
+    fun `when load more is requested, then load next page`() = testBlocking {
+        setup()
+
+        viewModel.onLoadMore()
+
+        verify(productCategoryListHandler).loadMore()
+    }
+
+//    @Test
+//    fun `when fetching coupons fails, then show an error`() = testBlocking {
+//        setup {
+//            whenever(productCategoryListHandler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(Exception()))
+//        }
+//
+//        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+//
+//        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
+//    }
+
+//    @Test
+//    fun `when searching coupons fails, then show an error`() = testBlocking {
+//        setup {
+//            whenever(
+//                productCategoryListHandler.fetchCoupons(
+//                    any(),
+//                    anyBoolean()
+//                )
+//            ).thenReturn(Result.failure(Exception()))
+//        }
+//
+//        viewModel.onSearchQueryChanged("Search")
+//        advanceUntilIdle()
+//        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+//
+//        assertThat(event.message).isEqualTo(R.string.coupon_list_search_failed)
+//    }
+//
+//    @Test
+//    fun `when loading next page, then show an error`() = testBlocking {
+//        setup {
+//            whenever(productCategoryListHandler.loadMore()).thenReturn(Result.failure(Exception()))
+//        }
+//
+//        viewModel.onLoadMore()
+//        advanceUntilIdle()
+//        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+//
+//        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
+//    }
+//
+//    @Test
+//    fun `when refreshing fails, then show an error`() = testBlocking {
+//        setup {
+//            whenever(productCategoryListHandler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(Exception()))
+//        }
+//
+//        viewModel.onRefresh()
+//        advanceUntilIdle()
+//        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+//
+//        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
+//    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModelTests.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.products.categories.selector
 
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorViewModel.LoadingState
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -66,7 +68,8 @@ class ProductCategorySelectorViewModelTests : BaseUnitTest() {
             advanceUntilIdle()
         }.last()
 
-        assertThat(state.categories.map { it.id }).isEqualTo(defaultProductCategoriesList.map { it.productCategory.remoteCategoryId })
+        assertThat(state.categories.map { it.id })
+            .isEqualTo(defaultProductCategoriesList.map { it.productCategory.remoteCategoryId })
         assertThat(state.loadingState).isEqualTo(LoadingState.Idle)
     }
 
@@ -92,58 +95,46 @@ class ProductCategorySelectorViewModelTests : BaseUnitTest() {
         verify(productCategoryListHandler).loadMore()
     }
 
-//    @Test
-//    fun `when fetching coupons fails, then show an error`() = testBlocking {
-//        setup {
-//            whenever(productCategoryListHandler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(Exception()))
-//        }
-//
-//        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
-//
-//        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
-//    }
+    @Test
+    fun `when fetching coupons fails, then show an error`() = testBlocking {
+        setup {
+            whenever(productCategoryListHandler.fetchCategories(forceRefresh = true)).thenReturn(
+                Result.failure(
+                    Exception()
+                )
+            )
+        }
 
-//    @Test
-//    fun `when searching coupons fails, then show an error`() = testBlocking {
-//        setup {
-//            whenever(
-//                productCategoryListHandler.fetchCoupons(
-//                    any(),
-//                    anyBoolean()
-//                )
-//            ).thenReturn(Result.failure(Exception()))
-//        }
-//
-//        viewModel.onSearchQueryChanged("Search")
-//        advanceUntilIdle()
-//        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
-//
-//        assertThat(event.message).isEqualTo(R.string.coupon_list_search_failed)
-//    }
-//
-//    @Test
-//    fun `when loading next page, then show an error`() = testBlocking {
-//        setup {
-//            whenever(productCategoryListHandler.loadMore()).thenReturn(Result.failure(Exception()))
-//        }
-//
-//        viewModel.onLoadMore()
-//        advanceUntilIdle()
-//        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
-//
-//        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
-//    }
-//
-//    @Test
-//    fun `when refreshing fails, then show an error`() = testBlocking {
-//        setup {
-//            whenever(productCategoryListHandler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(Exception()))
-//        }
-//
-//        viewModel.onRefresh()
-//        advanceUntilIdle()
-//        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
-//
-//        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
-//    }
+        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+
+        assertThat(event.message).isEqualTo(R.string.product_category_selector_loading_failed)
+    }
+
+    @Test
+    fun `when searching coupons fails, then show an error`() = testBlocking {
+        setup {
+            whenever(
+                productCategoryListHandler.fetchCategories(searchQuery = "Search")
+            ).thenReturn(Result.failure(Exception()))
+        }
+
+        viewModel.onSearchQueryChanged("Search")
+        advanceUntilIdle()
+        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+
+        assertThat(event.message).isEqualTo(R.string.product_category_selector_search_failed)
+    }
+
+    @Test
+    fun `when loading next page, then show an error`() = testBlocking {
+        setup {
+            whenever(productCategoryListHandler.loadMore()).thenReturn(Result.failure(Exception()))
+        }
+
+        viewModel.onLoadMore()
+        advanceUntilIdle()
+        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+
+        assertThat(event.message).isEqualTo(R.string.product_category_selector_loading_failed)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FlowUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FlowUtils.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.util
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+
+suspend fun <T> Flow<T>.runAndCaptureValues(block: suspend () -> Unit): List<T> = coroutineScope {
+    val list = mutableListOf<T>()
+    val job = launch {
+        toList(list)
+    }
+    block()
+    job.cancel()
+    return@coroutineScope list
+}

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-ae5410d016884c3b2b4faed8600b44ee4e6ad8ad'
+    fluxCVersion = '2437-979d2f5501d12fc2a41b16dbcd4582de4b874c21'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2437-979d2f5501d12fc2a41b16dbcd4582de4b874c21'
+    fluxCVersion = 'trunk-53349731a8c7ef646cdebdfdaa2d679438b97560'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6362
<!-- Id number of the GitHub issue this PR addresses. -->

Please make sure https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2437 is merged before merging this one.

### Description
This PR adds support for searching for product categories, and it adds unit tests for the main components of the screen.

### Testing instructions
1. Make sure coupons are enabled.
2. Open a coupon in the app.
3. Click on the menu button.
4. Click on edit coupon.
5. Click on "Add categories" or "Select categories".
6. Search for categories in the search view.
7. Confirm the results are retrieved from the API.
8. Confirm child categories are shown too when they are part of the results.

### Images/gif
<img width=400 src="https://user-images.githubusercontent.com/1657201/172811985-421f175f-eb3a-44bd-bb1b-acaaa76f3511.png"/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
