### PR TITLE
[Coupons] exclude products and categories

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
@@ -56,6 +56,7 @@ class CouponRestrictionsFragment : BaseFragment(), BackPressListener {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is EditCouponNavigationTarget -> EditCouponNavigator.navigate(this, event)
                 is OpenAllowedEmailsEditor -> {
                     findNavController().navigateSafely(
                         CouponRestrictionsFragmentDirections.actionCouponRestrictionsFragmentToEmailRestrictionFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
@@ -18,6 +18,8 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.coupons.edit.CouponRestrictionsViewModel.OpenAllowedEmailsEditor
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorFragment
+import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
@@ -75,6 +77,12 @@ class CouponRestrictionsFragment : BaseFragment(), BackPressListener {
     private fun handleResults() {
         handleResult<List<String>>(EmailRestrictionFragment.ALLOWED_EMAILS) {
             viewModel.onAllowedEmailsUpdated(it)
+        }
+        handleResult<Set<Long>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
+            viewModel.onExcludedProductChanged(it)
+        }
+        handleResult<Set<Long>>(ProductCategorySelectorFragment.PRODUCT_CATEGORY_SELECTOR_RESULT) {
+            viewModel.onExcludedProductCategoriesChanged(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -4,16 +4,23 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -22,12 +29,16 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toUpperCase
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.NullableBigDecimalTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.NullableIntTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.WCListItemWithInlineSubtitle
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import com.woocommerce.android.ui.compose.component.WCSwitch
+import com.woocommerce.android.ui.coupons.edit.CouponRestrictionsViewModel.ViewState
 import java.math.BigDecimal
 
 @Composable
@@ -42,7 +53,9 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
             onUsageLimitPerUserChanged = viewModel::onUsageLimitPerUserChanged,
             onIndividualUseChanged = viewModel::onIndividualUseChanged,
             onExcludeSaleItemsChanged = viewModel::onExcludeSaleItemsChanged,
-            onAllowedEmailsButtonClicked = viewModel::onAllowedEmailsButtonClicked
+            onAllowedEmailsButtonClicked = viewModel::onAllowedEmailsButtonClicked,
+            onExcludeProductsButtonClick = {},
+            onExcludeCategoriesButtonClick = {}
         )
     }
 }
@@ -57,7 +70,9 @@ fun CouponRestrictionsScreen(
     onUsageLimitPerUserChanged: (Int?) -> Unit,
     onIndividualUseChanged: (Boolean) -> Unit,
     onExcludeSaleItemsChanged: (Boolean) -> Unit,
-    onAllowedEmailsButtonClicked: () -> Unit
+    onAllowedEmailsButtonClicked: () -> Unit,
+    onExcludeProductsButtonClick: () -> Unit,
+    onExcludeCategoriesButtonClick: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -127,6 +142,8 @@ fun CouponRestrictionsScreen(
             areSaleItemsExcluded = viewState.restrictions.areSaleItemsExcluded ?: false,
             onExcludeSaleItemsChanged = onExcludeSaleItemsChanged
         )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+        ExclusionsSection(viewState, onExcludeProductsButtonClick, onExcludeCategoriesButtonClick)
     }
 }
 
@@ -231,6 +248,58 @@ private fun SaleItemsSwitch(areSaleItemsExcluded: Boolean, onExcludeSaleItemsCha
             style = MaterialTheme.typography.caption,
             color = colorResource(id = R.color.color_on_surface_medium),
             modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        )
+    }
+}
+
+@Composable
+private fun ExclusionsSection(
+    viewState: ViewState,
+    onExcludeProductsButtonClick: () -> Unit,
+    onExcludeCategoriesButtonClick: () -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+        modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+    ) {
+        Text(
+            text = stringResource(id = R.string.coupon_restrictions_exclusions_section_title).toUpperCase(Locale.current),
+            style = MaterialTheme.typography.body2,
+            color = colorResource(id = R.color.color_on_surface_medium)
+        )
+
+        val productsButtonSuffix = if (viewState.restrictions.excludedProductIds.isEmpty()) ""
+        else "(${viewState.restrictions.excludedProductIds.size})"
+        WCOutlinedButton(
+            onClick = onExcludeProductsButtonClick,
+            text = "${stringResource(R.string.coupon_restrictions_exclude_products)}$productsButtonSuffix",
+            leadingIcon = {
+                Icon(
+                    imageVector = if (viewState.restrictions.excludedProductIds.isEmpty()) Icons.Filled.Add
+                    else Icons.Filled.Edit,
+                    contentDescription = null,
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.major_100))
+                )
+            },
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colors.onSurface),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        val categoriesButtonSuffix = if (viewState.restrictions.excludedCategoryIds.isEmpty()) ""
+        else "(${viewState.restrictions.excludedCategoryIds.size})"
+        WCOutlinedButton(
+            onClick = onExcludeCategoriesButtonClick,
+            text = "${stringResource(R.string.coupon_restrictions_exclude_categories)}$categoriesButtonSuffix",
+            leadingIcon = {
+                Icon(
+                    imageVector = if (viewState.restrictions.excludedCategoryIds.isEmpty()) Icons.Filled.Add
+                    else Icons.Filled.Edit,
+                    contentDescription = null,
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.major_100))
+                )
+            },
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colors.onSurface),
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -54,8 +54,8 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
             onIndividualUseChanged = viewModel::onIndividualUseChanged,
             onExcludeSaleItemsChanged = viewModel::onExcludeSaleItemsChanged,
             onAllowedEmailsButtonClicked = viewModel::onAllowedEmailsButtonClicked,
-            onExcludeProductsButtonClick = {},
-            onExcludeCategoriesButtonClick = {}
+            onExcludeProductsButtonClick = viewModel::onExcludeProductsButtonClick,
+            onExcludeCategoriesButtonClick = viewModel::onExcludeCategoriesButtonClick
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -263,7 +263,8 @@ private fun ExclusionsSection(
         modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
     ) {
         Text(
-            text = stringResource(id = R.string.coupon_restrictions_exclusions_section_title).toUpperCase(Locale.current),
+            text = stringResource(id = R.string.coupon_restrictions_exclusions_section_title)
+                .toUpperCase(Locale.current),
             style = MaterialTheme.typography.body2,
             color = colorResource(id = R.color.color_on_surface_medium)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -269,7 +269,7 @@ private fun ExclusionsSection(
         )
 
         val productsButtonSuffix = if (viewState.restrictions.excludedProductIds.isEmpty()) ""
-        else "(${viewState.restrictions.excludedProductIds.size})"
+        else " (${viewState.restrictions.excludedProductIds.size})"
         WCOutlinedButton(
             onClick = onExcludeProductsButtonClick,
             text = "${stringResource(R.string.coupon_restrictions_exclude_products)}$productsButtonSuffix",
@@ -286,7 +286,7 @@ private fun ExclusionsSection(
         )
 
         val categoriesButtonSuffix = if (viewState.restrictions.excludedCategoryIds.isEmpty()) ""
-        else "(${viewState.restrictions.excludedCategoryIds.size})"
+        else " (${viewState.restrictions.excludedCategoryIds.size})"
         WCOutlinedButton(
             onClick = onExcludeCategoriesButtonClick,
             text = "${stringResource(R.string.coupon_restrictions_exclude_categories)}$categoriesButtonSuffix",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -108,6 +108,18 @@ class CouponRestrictionsViewModel @Inject constructor(
         triggerEvent(EditExcludedProductCategories(restrictionsDraft.value.excludedCategoryIds))
     }
 
+    fun onExcludedProductChanged(excludedProductIds: Set<Long>) {
+        restrictionsDraft.update {
+            it.copy(excludedProductIds = excludedProductIds.toList())
+        }
+    }
+
+    fun onExcludedProductCategoriesChanged(excludedCategoryIds: Set<Long>) {
+        restrictionsDraft.update {
+            it.copy(excludedCategoryIds = excludedCategoryIds.toList())
+        }
+    }
+
     data class ViewState(
         val restrictions: CouponRestrictions,
         val currencyCode: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Coupon.CouponRestrictions
+import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProductCategories
+import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProducts
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -96,6 +98,14 @@ class CouponRestrictionsViewModel @Inject constructor(
         restrictionsDraft.update {
             it.copy(restrictedEmails = allowedEmails)
         }
+    }
+
+    fun onExcludeProductsButtonClick() {
+        triggerEvent(EditExcludedProducts(restrictionsDraft.value.excludedProductIds))
+    }
+
+    fun onExcludeCategoriesButtonClick() {
+        triggerEvent(EditExcludedProductCategories(restrictionsDraft.value.excludedCategoryIds))
     }
 
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -86,7 +86,7 @@ class EditCouponFragment : BaseFragment() {
             viewModel.onSelectedProductsUpdated(it)
         }
 
-        handleResult<List<Long>>(ProductCategorySelectorFragment.PRODUCT_CATEGORY_SELECTOR_RESULT) {
+        handleResult<Set<Long>>(ProductCategorySelectorFragment.PRODUCT_CATEGORY_SELECTOR_RESULT) {
             viewModel.onIncludedCategoriesChanged(it)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
@@ -12,4 +12,6 @@ sealed class EditCouponNavigationTarget : Event() {
     ) : EditCouponNavigationTarget()
     data class EditIncludedProducts(val selectedProductIds: List<Long>) : EditCouponNavigationTarget()
     data class EditIncludedProductCategories(val categoryIds: List<Long>) : EditCouponNavigationTarget()
+    data class EditExcludedProducts(val excludedProductIds: List<Long>) : EditCouponNavigationTarget()
+    data class EditExcludedProductCategories(val excludedCategoryIds: List<Long>) : EditCouponNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
@@ -3,8 +3,10 @@ package com.woocommerce.android.ui.coupons.edit
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.NavGraphMainDirections
-import com.woocommerce.android.R
+import com.woocommerce.android.R.string
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProductCategories
+import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProducts
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditIncludedProductCategories
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditIncludedProducts
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenCouponRestrictions
@@ -18,8 +20,8 @@ object EditCouponNavigator {
                 navController.navigateSafely(
                     NavGraphMainDirections.actionGlobalSimpleTextEditorFragment(
                         currentText = target.currentDescription,
-                        screenTitle = fragment.getString(R.string.coupon_edit_description_editor_title),
-                        hint = fragment.getString(R.string.coupon_edit_add_description_hint)
+                        screenTitle = fragment.getString(string.coupon_edit_description_editor_title),
+                        hint = fragment.getString(string.coupon_edit_add_description_hint)
                     )
                 )
             }
@@ -43,6 +45,20 @@ object EditCouponNavigator {
                 navController.navigateSafely(
                     EditCouponFragmentDirections.actionEditCouponFragmentToProductCategorySelectorFragment(
                         categoryIds = target.categoryIds.toLongArray()
+                    )
+                )
+            }
+            is EditExcludedProducts -> {
+                navController.navigateSafely(
+                    CouponRestrictionsFragmentDirections.actionCouponRestrictionsFragmentToProductSelectorFragment(
+                        productIds = target.excludedProductIds.toLongArray()
+                    )
+                )
+            }
+            is EditExcludedProductCategories -> {
+                navController.navigateSafely(
+                    CouponRestrictionsFragmentDirections.actionCouponRestrictionsToProductCategorySelector(
+                        categoryIds = target.excludedCategoryIds.toLongArray()
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -163,9 +163,9 @@ class EditCouponViewModel @Inject constructor(
         }
     }
 
-    fun onIncludedCategoriesChanged(includedCategoryIds: List<Long>) {
+    fun onIncludedCategoriesChanged(includedCategoryIds: Set<Long>) {
         couponDraft.update {
-            it?.copy(categoryIds = includedCategoryIds)
+            it?.copy(categoryIds = includedCategoryIds.toList())
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
@@ -90,7 +90,7 @@ class ProductCategorySelectorViewModel @Inject constructor(
     }
 
     fun onDoneClick() {
-        triggerEvent(ExitWithResult(selectedCategories.value.toList()))
+        triggerEvent(ExitWithResult(selectedCategories.value))
     }
 
     private fun monitorSearchQuery() {

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -55,6 +55,12 @@
         <action
             android:id="@+id/action_couponRestrictionsFragment_to_emailRestrictionFragment"
             app:destination="@id/emailRestrictionFragment" />
+        <action
+            android:id="@+id/action_couponRestrictions_to_productCategorySelector"
+            app:destination="@id/productCategorySelectorFragment" />
+        <action
+            android:id="@+id/action_couponRestrictionsFragment_to_productSelectorFragment"
+            app:destination="@id/productSelectorFragment" />
     </fragment>
     <fragment
         android:id="@+id/productSelectorFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2011,6 +2011,9 @@
     <string name="coupon_restrictions_exclude_sale_items_hint">Turn this on if the coupon should not apply to items on sale. Per-item coupons will only work if the item is not on sale. Per-cart coupons will only work if there are items in the cart that are not on sale.</string>
     <string name="coupon_restrictions_allowed_emails">Allowed emails</string>
     <string name="coupon_restrictions_allowed_emails_placeholder">No restrictions</string>
+    <string name="coupon_restrictions_exclusions_section_title">Apply this coupon to</string>
+    <string name="coupon_restrictions_exclude_products">Exclude Products</string>
+    <string name="coupon_restrictions_exclude_categories">Exclude Product Categories</string>
     <string name="coupon_conditions_products_select_products_title">Select Products</string>
     <string name="coupon_conditions_products_all_products_title">All Products</string>
     <string name="coupon_conditions_products_edit_products_title">Edit Products (%d)</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5542 Closes: #6542
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ please don't merge before the parent PR #6722 

### Description
This PR adds the exclusions section to the restrictions screen, and handles navigation and result from the product and category selectors.

### Testing instructions
1. Make sure coupon management is enabled.
2. Open a coupon.
3. Click on the menu.
4. Click on Edit coupon.
5. Click on Usage restrictions.
6. Make some changes to the excluded products and categories.
7. Confirm changes are displayed correctly.
8. Go back and click on Save.
9. Confirm the coupon is updated correctly.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
