### PR TITLE
Customer info is read only if UOE flag is enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -342,7 +342,8 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         binding.orderDetailCustomerInfo.updateCustomerInfo(
             order = order,
             isVirtualOrder = viewModel.hasVirtualProductsOnly(),
-            isReadOnly = false
+            // Customer Info is read-only in UOE
+            isReadOnly = FeatureFlag.UNIFIED_ORDER_EDITING.isEnabled()
         )
         binding.orderDetailPaymentInfo.updatePaymentInfo(
             order = order,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -34,6 +34,17 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         isVirtualOrder: Boolean, // don't display shipping section for virtual products
         isReadOnly: Boolean
     ) {
+        val noBillingInfo = order.billingAddress.hasInfo().not() && order.formatBillingInformationForDisplay().isEmpty()
+        val noShippingInfo = order.formatShippingInformationForDisplay().isEmpty()
+        val noCustomerNoteInfo = order.customerNote.isEmpty()
+
+        // hide this entire view if there is no info to display
+        val hideCustomerInfo = isReadOnly && noBillingInfo && noShippingInfo && noCustomerNoteInfo
+        if (hideCustomerInfo) {
+            hide()
+            return
+        }
+
         showCustomerNote(order, isReadOnly)
         showShippingAddress(order, isVirtualOrder, isReadOnly)
         showBillingInfo(order, isReadOnly)
@@ -48,12 +59,6 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             if (order.billingAddress.hasInfo()) {
                 binding.customerInfoBillingAddr.setText(resources.getString(R.string.orderdetail_empty_address), 0)
             } else {
-                // hide this entire view if there are no extra details and the shipping address is also empty
-                if (shippingAddress.isEmpty()) {
-                    hide()
-                    return
-                }
-
                 // hide the entire billing section since billing address is empty
                 binding.customerInfoMorePanel.hide()
                 binding.customerInfoViewMore.hide()


### PR DESCRIPTION
Closes: #6611, Closes #6612 , Closes #6702

### Description
This small PR makes the Order's customer information read-only in the Order Details Screen when the `UNIFIED_ORDER_EDITING` feature flag is enabled.

### Testing instructions

TC1
1. Create an order without customer information
2. Check that the app hides the whole customer section

TC2
1. Create an order with billing & shipping info
2. Check that the app shows only the billing & shipping info (without customer notes)

TC3
1. Create an order with a customer note
2. Check that the app shows only the customer notes (without billing & shipping info)

TC4
1. Create an order with a customer note, billing & shipping info
2. Check that the app shows customer notes, billing & shipping info

TC5
1. Change the build variant version to release (`UNIFIED_ORDER_EDITING` is available only in debug)
2. Install the app
3. Check that the customer information section is editable in the order detail screen

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| No info  | Only Billing & shipping | 
| ------------- | ------------- | 
|  <img src="https://user-images.githubusercontent.com/18119390/172875289-f28c80ab-c204-4359-a12f-af9fc444c900.png" width="300"> | <img src="https://user-images.githubusercontent.com/18119390/172875280-b5c5a8e4-adde-49ea-bc3a-182965422c16.png" width="300">  |

| Only customer note  | Billing & shipping &  customer note |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/18119390/172875297-121764c3-4e45-4176-96b4-353274765f4d.png" width="300">  | <img src="https://user-images.githubusercontent.com/18119390/172875292-b144a4db-7523-4fa9-b437-f0f9c26fbbb3.png" width="300">  |

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
