### PR TITLE
Update Hilt to use the Plugin Marker Artifact

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.kapt'
     id 'org.jetbrains.kotlin.plugin.parcelize'
-    id 'dagger.hilt.android.plugin'
+    id 'com.google.dagger.hilt.android'
     id 'se.bjurr.violations.violation-comments-to-github-gradle-plugin'
     id 'io.sentry.android.gradle'
     id 'androidx.navigation.safeargs.kotlin'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'io.sentry.android.gradle'
     id 'com.android.application' apply false
     id 'org.jetbrains.kotlin.android' apply false
-    id 'dagger.hilt.android.plugin' apply false
+    id 'com.google.dagger.hilt.android' apply false
     id 'com.google.gms.google-services' apply false
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,10 +29,6 @@ pluginManagement {
 
     resolutionStrategy {
         eachPlugin {
-            if (requested.id.id == 'dagger.hilt.android.plugin') {
-                useModule("com.google.dagger:hilt-android-gradle-plugin:$gradle.ext.daggerVersion")
-            }
-
             // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
             if (requested.id.id == "com.automattic.android.fetchstyle") {
                 useModule("com.automattic.android:fetchstyle:1.1")

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ pluginManagement {
         id 'org.jetbrains.kotlin.kapt' version gradle.ext.kotlinVersion
         id 'org.jetbrains.kotlin.plugin.parcelize' version gradle.ext.kotlinVersion
         id 'se.bjurr.violations.violation-comments-to-github-gradle-plugin' version '1.69.0'
+        id 'com.google.dagger.hilt.android' version gradle.ext.daggerVersion
     }
 
     resolutionStrategy {


### PR DESCRIPTION
### Description
This PR updates Hilt to use the Plugin Marker Artifact.

### Testing instructions
Just make sure the app builds fine, and testing few screens won't hurt.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
