### PR TITLE
[Shipping Labels Onboarding] Small improvements to the CTA scree

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWcShippingOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWcShippingOnboardingScreen.kt
@@ -130,7 +130,7 @@ private fun LinkText(
 }
 
 @Composable
-fun InstallWcsOnboardingBullets(onboardingBullets: List<InstallWcShippingOnboardingBulletUi>) {
+private fun InstallWcsOnboardingBullets(onboardingBullets: List<InstallWcShippingOnboardingBulletUi>) {
     onboardingBullets.forEach {
         InstallWcsOnboardingBullet(bullet = it, modifier = Modifier.fillMaxWidth())
         Spacer(Modifier.size(dimensionResource(id = R.dimen.major_100)))
@@ -138,7 +138,7 @@ fun InstallWcsOnboardingBullets(onboardingBullets: List<InstallWcShippingOnboard
 }
 
 @Composable
-fun InstallWcsOnboardingBullet(
+private fun InstallWcsOnboardingBullet(
     bullet: InstallWcShippingOnboardingBulletUi,
     modifier: Modifier = Modifier
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWcShippingOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWcShippingOnboardingScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -53,10 +52,12 @@ fun InstallWcShippingOnboardingScreen(onboardingFlowUiState: InstallWcShippingOn
                 start = dimensionResource(id = R.dimen.major_200),
                 end = dimensionResource(id = R.dimen.major_200)
             )
-            .verticalScroll(rememberScrollState())
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
         ) {
             Text(
                 modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_350)),
@@ -88,8 +89,6 @@ fun InstallWcShippingOnboardingScreen(onboardingFlowUiState: InstallWcShippingOn
                     top = dimensionResource(id = R.dimen.major_200),
                     bottom = dimensionResource(id = R.dimen.major_200),
                 )
-                .fillMaxHeight(),
-            verticalArrangement = Arrangement.Bottom
         ) {
             WCColoredButton(
                 modifier = Modifier.fillMaxWidth(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWcShippingOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWcShippingOnboardingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
@@ -131,24 +132,25 @@ private fun LinkText(
 @Composable
 fun InstallWcsOnboardingBullets(onboardingBullets: List<InstallWcShippingOnboardingBulletUi>) {
     onboardingBullets.forEach {
-        InstallWcsOnboardingBullet(bullet = it)
+        InstallWcsOnboardingBullet(bullet = it, modifier = Modifier.fillMaxWidth())
         Spacer(Modifier.size(dimensionResource(id = R.dimen.major_100)))
     }
 }
 
 @Composable
 fun InstallWcsOnboardingBullet(
-    modifier: Modifier = Modifier,
-    bullet: InstallWcShippingOnboardingBulletUi
+    bullet: InstallWcShippingOnboardingBulletUi,
+    modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+        horizontalArrangement = Arrangement.Start
     ) {
         Image(
             painter = painterResource(id = bullet.icon),
             contentDescription = null,
         )
+        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
         Column {
             Text(
                 style = MaterialTheme.typography.subtitle1,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6586 

### Description
This PR just adds two small improvements to the WCShip installation onboarding screen:
1. Make the CTA buttons sticky to the bottom of the screen, while the rest is scrollable.
2. Fix alignments of the bullet points in landscape.

### Testing instructions
To access this new screen a site eligible for shipping labels is required for the https://github.com/woocommerce/woocommerce-android/pull/6620 to be displayed inside OrderDetail screen. Conditions for the banner to be shown:

- The store is located in US.
- The order currency is USD.
- The products are eligible for SL (not virtual/downloadable).
- The order is not eligible for IPP.
- WC Shipping plugin must be uninstalled or unactive

Once the banner is shown, click on "Get WooCommerce Shipping" button and the new screen should be displayed, please confirm that the above two changes are working as expected.

### Images/gif
![image](https://user-images.githubusercontent.com/1657201/173104824-6efc8927-251e-474c-9664-559be721ef27.png)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
