### PR TITLE
Non-editable order warning message

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/ExpandableMessageView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/ExpandableMessageView.kt
@@ -18,7 +18,6 @@ class ExpandableMessageView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : MaterialCardView(ctx, attrs, defStyleAttr) {
-
     private val binding = ViewExpandableMessageBinding.inflate(LayoutInflater.from(ctx), this)
 
     var title: String = ""

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/ExpandableMessageView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/ExpandableMessageView.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.ui.common
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.ContextCompat
+import androidx.core.content.res.use
+import androidx.core.widget.ImageViewCompat
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.ViewExpandableMessageBinding
+
+class ExpandableMessageView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+
+    private val binding = ViewExpandableMessageBinding.inflate(LayoutInflater.from(ctx), this)
+
+    var title: String = ""
+        set(value) {
+            field = value
+            binding.title.text = value
+        }
+
+    var message: String = ""
+        set(value) {
+            field = value
+            binding.message.text = value
+        }
+
+    @DrawableRes
+    var icon: Int = 0
+        set(value) {
+            field = value
+            if (value != 0) {
+                val drawable = ContextCompat.getDrawable(context, value)
+                binding.icon.setImageDrawable(drawable)
+            }
+        }
+
+    @ColorRes
+    var iconTint: Int = 0
+        set(value) {
+            field = value
+            if (value != 0) {
+                ImageViewCompat.setImageTintList(
+                    binding.icon,
+                    AppCompatResources.getColorStateList(context, value)
+                )
+            }
+        }
+
+    var isExpanded: Boolean = false
+        set(value) {
+            field = value
+            if (isExpanded) {
+                binding.expandableMessageRoot.transitionToEnd()
+            } else {
+                binding.expandableMessageRoot.transitionToStart()
+            }
+        }
+
+    init {
+        binding.root.setOnClickListener { isExpanded = !isExpanded }
+        context.obtainStyledAttributes(attrs, R.styleable.ExpandableMessageView, 0, 0).use { typedArray ->
+            title = typedArray.getString(R.styleable.ExpandableMessageView_title).orEmpty()
+            message = typedArray.getString(R.styleable.ExpandableMessageView_message).orEmpty()
+            icon = typedArray.getResourceId(R.styleable.ExpandableMessageView_icon, 0)
+            iconTint = typedArray.getResourceId(R.styleable.ExpandableMessageView_iconTint, 0)
+            isExpanded = typedArray.getBoolean(R.styleable.ExpandableMessageView_isExpanded, false)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -36,7 +36,9 @@ import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog.Compa
 import com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.WCReadMoreTextView
 import dagger.hilt.android.AndroidEntryPoint
@@ -417,6 +419,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
     }
 
     private fun showEditableControls(binding: FragmentOrderCreationFormBinding) {
+        binding.messageNoEditableFields.visibility = View.GONE
         binding.productsSection.apply {
             isEachAddButtonEnabled = true
             content.productsAdapter?.areProductsEditable = true
@@ -428,6 +431,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
     }
 
     private fun hideEditableControls(binding: FragmentOrderCreationFormBinding) {
+        binding.messageNoEditableFields.visibility = View.VISIBLE
         binding.productsSection.apply {
             isEachAddButtonEnabled = false
             content.productsAdapter?.areProductsEditable = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -421,24 +421,28 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
     private fun showEditableControls(binding: FragmentOrderCreationFormBinding) {
         binding.messageNoEditableFields.visibility = View.GONE
         binding.productsSection.apply {
+            isLocked = false
             isEachAddButtonEnabled = true
             content.productsAdapter?.areProductsEditable = true
         }
         binding.paymentSection.apply {
             feeButton.isEnabled = true
             shippingButton.isEnabled = true
+            lockIcon.isVisible = false
         }
     }
 
     private fun hideEditableControls(binding: FragmentOrderCreationFormBinding) {
         binding.messageNoEditableFields.visibility = View.VISIBLE
         binding.productsSection.apply {
+            isLocked = true
             isEachAddButtonEnabled = false
             content.productsAdapter?.areProductsEditable = false
         }
         binding.paymentSection.apply {
             feeButton.isEnabled = false
             shippingButton.isEnabled = false
+            lockIcon.isVisible = true
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreationSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreationSectionView.kt
@@ -46,6 +46,12 @@ class OrderCreationSectionView @JvmOverloads constructor(
     var keepAddButtons: Boolean = false
     var hasEditButton: Boolean = true
 
+    var isLocked: Boolean = false
+        set(value) {
+            field = value
+            binding.lockIcon.isVisible = value
+        }
+
     init {
         attrs?.let {
             context.obtainStyledAttributes(attrs, R.styleable.OrderCreationSectionView, defStyleAttr, 0)

--- a/WooCommerce/src/main/res/drawable/ic_lock.xml
+++ b/WooCommerce/src/main/res/drawable/ic_lock.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/color_primary"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
@@ -16,7 +16,6 @@
             android:layout_height="wrap_content"
             app:icon="@drawable/ic_gridicons_notice"
             app:iconTint="@color/color_primary"
-            app:isExpanded="true"
             app:message="@string/order_editing_non_editable_message"
             app:title="@string/order_editing_non_editable_title" />
 

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
@@ -10,6 +10,16 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+        <com.woocommerce.android.ui.common.ExpandableMessageView
+            android:id="@+id/message_no_editable_fields"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_gridicons_notice"
+            app:iconTint="@color/color_primary"
+            app:isExpanded="true"
+            app:message="@string/order_editing_non_editable_message"
+            app:title="@string/order_editing_non_editable_title" />
+
         <com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
             android:id="@+id/order_status_view"
             style="@style/Woo.Card"
@@ -21,9 +31,9 @@
             style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:hasEditButton="false"
             app:header="@string/products"
-            app:keepAddButtons="true"
-            app:hasEditButton="false"/>
+            app:keepAddButtons="true" />
 
         <include
             android:id="@+id/payment_section"

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
@@ -14,8 +14,7 @@
             android:id="@+id/message_no_editable_fields"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:icon="@drawable/ic_gridicons_notice"
-            app:iconTint="@color/color_primary"
+            app:icon="@drawable/ic_lock"
             app:message="@string/order_editing_non_editable_message"
             app:title="@string/order_editing_non_editable_title" />
 

--- a/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
@@ -28,12 +28,22 @@
                 android:text="@string/order_creation_payment"
                 android:textAppearance="?attr/textAppearanceHeadline6" />
 
+            <ImageView
+                android:id="@+id/lock_icon"
+                android:layout_width="@dimen/image_minor_40"
+                android:layout_height="@dimen/image_minor_40"
+                android:src="@drawable/ic_lock"
+                android:visibility="gone"
+                android:contentDescription="@string/order_editing_locked_content_description"
+                android:layout_gravity="center_vertical"/>
+
             <ProgressBar
                 android:id="@+id/loading_progress"
                 android:layout_width="@dimen/major_200"
                 android:layout_height="@dimen/major_200"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
+
         </androidx.appcompat.widget.LinearLayoutCompat>
 
         <androidx.appcompat.widget.LinearLayoutCompat

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -28,6 +28,18 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
+    <ImageView
+        android:id="@+id/lock_icon"
+        android:layout_width="@dimen/image_minor_40"
+        android:layout_height="@dimen/image_minor_40"
+        android:layout_marginEnd="@dimen/major_100"
+        android:src="@drawable/ic_lock"
+        android:contentDescription="@string/order_editing_locked_content_description"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/header_label"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/header_label" />
+
     <FrameLayout
         android:id="@+id/content_layout"
         android:layout_width="0dp"

--- a/WooCommerce/src/main/res/layout/view_expandable_message.xml
+++ b/WooCommerce/src/main/res/layout/view_expandable_message.xml
@@ -11,8 +11,8 @@
 
         <ImageView
             android:id="@+id/icon"
-            android:layout_width="wrap_content"
-            android:layout_height="@dimen/image_minor_50"
+            android:layout_width="@dimen/image_minor_40"
+            android:layout_height="@dimen/image_minor_40"
             android:layout_marginStart="@dimen/major_100"
             app:layout_constraintBottom_toBottomOf="@+id/title"
             app:layout_constraintEnd_toStartOf="@+id/title"

--- a/WooCommerce/src/main/res/layout/view_expandable_message.xml
+++ b/WooCommerce/src/main/res/layout/view_expandable_message.xml
@@ -7,6 +7,8 @@
         android:id="@+id/expandable_message_root"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/major_75"
+        android:layout_marginTop="@dimen/major_75"
         app:layoutDescription="@xml/view_expandable_message_scene">
 
         <ImageView
@@ -14,20 +16,20 @@
             android:layout_width="@dimen/image_minor_40"
             android:layout_height="@dimen/image_minor_40"
             android:layout_marginStart="@dimen/major_100"
-            app:layout_constraintBottom_toBottomOf="@+id/title"
+            android:importantForAccessibility="no"
+            android:baselineAlignBottom="true"
+            app:layout_constraintBaseline_toBaselineOf="@+id/title"
+            android:translationY="@dimen/minor_25"
             app:layout_constraintEnd_toStartOf="@+id/title"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintStart_toStartOf="parent" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/title"
             style="@style/TextAppearance.Woo.Subtitle1"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/minor_100"
-            android:paddingTop="@dimen/major_85"
-            android:paddingBottom="@dimen/major_85"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginStart="@dimen/major_75"
+            app:layout_constraintEnd_toStartOf="@+id/expand_icon"
             app:layout_constraintStart_toEndOf="@+id/icon"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -35,9 +37,10 @@
             android:id="@+id/message"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/expand_icon"
             app:layout_constraintStart_toStartOf="@+id/title"
             app:layout_constraintTop_toBottomOf="@+id/title"
+            android:layout_marginTop="@dimen/minor_100"
             android:layout_marginEnd="@dimen/major_100" />
 
         <ImageView
@@ -47,10 +50,12 @@
             android:layout_marginEnd="@dimen/major_100"
             android:src="@drawable/ic_arrow_down"
             android:rotation="0"
-            app:layout_constraintBottom_toBottomOf="@id/title"
+            android:baselineAlignBottom="true"
+            app:layout_constraintBaseline_toBaselineOf="@+id/title"
             app:layout_constraintEnd_toEndOf="parent"
+            android:importantForAccessibility="no"
             android:layout_marginBottom="@dimen/major_85"
-            app:tint="@color/color_on_surface" />
+            app:tint="@color/color_on_surface"/>
 
     </androidx.constraintlayout.motion.widget.MotionLayout>
 </merge>

--- a/WooCommerce/src/main/res/layout/view_expandable_message.xml
+++ b/WooCommerce/src/main/res/layout/view_expandable_message.xml
@@ -1,0 +1,56 @@
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.motion.widget.MotionLayout
+        android:id="@+id/expandable_message_root"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layoutDescription="@xml/view_expandable_message_scene">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/image_minor_50"
+            android:layout_marginStart="@dimen/major_100"
+            app:layout_constraintBottom_toBottomOf="@+id/title"
+            app:layout_constraintEnd_toStartOf="@+id/title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            style="@style/TextAppearance.Woo.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_100"
+            android:paddingTop="@dimen/major_85"
+            android:paddingBottom="@dimen/major_85"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/icon"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/title"
+            app:layout_constraintTop_toBottomOf="@+id/title"
+            android:layout_marginEnd="@dimen/major_100" />
+
+        <ImageView
+            android:id="@+id/expand_icon"
+            android:layout_width="@dimen/image_minor_50"
+            android:layout_height="@dimen/image_minor_50"
+            android:layout_marginEnd="@dimen/major_100"
+            android:src="@drawable/ic_arrow_down"
+            android:rotation="0"
+            app:layout_constraintBottom_toBottomOf="@id/title"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginBottom="@dimen/major_85"
+            app:tint="@color/color_on_surface" />
+
+    </androidx.constraintlayout.motion.widget.MotionLayout>
+</merge>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -176,7 +176,7 @@
     <declare-styleable name="ShippingLabelCreationStepView">
         <attr name="caption" format="string" />
         <attr name="details" format="string" />
-        <attr name="icon" format="reference" />
+        <attr name="icon" />
         <attr name="continue_button_visible" format="boolean" />
         <attr name="edit_button_visible" format="boolean" />
         <attr name="divider_visible" format="boolean" />
@@ -184,9 +184,13 @@
         <attr name="android:enabled" />
     </declare-styleable>
 
+    <attr name="title" format="reference|string" />
+    <attr name="message" format="reference|string" />
+    <attr name="icon" format="reference" />
+
     <declare-styleable name="WCWarningBanner">
-        <attr name="title" format="string" />
-        <attr name="message" format="string" />
+        <attr name="title" />
+        <attr name="message" />
     </declare-styleable>
 
     <declare-styleable name="CircleProgressOverlayView">
@@ -216,6 +220,14 @@
             <enum name="fitBottom" value="8" />
             <enum name="matrix" value="9" />
         </attr>
+    </declare-styleable>
+
+    <declare-styleable name="ExpandableMessageView">
+        <attr name="title" />
+        <attr name="message" />
+        <attr name="icon" />
+        <attr name="iconTint" />
+        <attr name="isExpanded" format="boolean" />
     </declare-styleable>
 
 </resources>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -66,6 +66,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="button_height_major_100">36sp</dimen>
 
     <!-- Smaller image sizes (ex. icons) -->
+    <dimen name="image_minor_40">18dp</dimen>
     <dimen name="image_minor_50">24dp</dimen>
     <dimen name="image_minor_60">26dp</dimen>
     <dimen name="image_minor_100">40dp</dimen>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -386,6 +386,11 @@
     <string name="order_creation_fee_percentage_calculated_amount">Calculated amount: %s</string>
     <string name="order_creation_change_product_quantity">Change the product quantity from %d to %d</string>
     <!--
+        Order Editing
+    -->
+    <string name="order_editing_non_editable_title">Parts of this order are no longer editable</string>
+    <string name="order_editing_non_editable_message">To edit the rest of this order, change the status to <b>Pending Payment</b>.</string>
+    <!--
         Order Filters
     -->
     <string name="orderfilters_show_orders_button">Show Orders</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -389,7 +389,7 @@
         Order Editing
     -->
     <string name="order_editing_non_editable_title">Parts of this order are not currently editable</string>
-    <string name="order_editing_non_editable_message">To edit Products or Payment Details, please change the status to Pending Payment.</string>
+    <string name="order_editing_non_editable_message">To edit Products or Payment Details, change the status to Pending Payment.</string>
     <string name="order_editing_locked_content_description">locked</string>
     <!--
         Order Filters

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -388,8 +388,8 @@
     <!--
         Order Editing
     -->
-    <string name="order_editing_non_editable_title">Parts of this order are no longer editable</string>
-    <string name="order_editing_non_editable_message">To edit the rest of this order, change the status to <b>Pending Payment</b>.</string>
+    <string name="order_editing_non_editable_title">Parts of this order are not currently editable</string>
+    <string name="order_editing_non_editable_message">To edit Products or Payment Details, please change the status to Pending Payment.</string>
     <!--
         Order Filters
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -390,6 +390,7 @@
     -->
     <string name="order_editing_non_editable_title">Parts of this order are not currently editable</string>
     <string name="order_editing_non_editable_message">To edit Products or Payment Details, please change the status to Pending Payment.</string>
+    <string name="order_editing_locked_content_description">locked</string>
     <!--
         Order Filters
     -->

--- a/WooCommerce/src/main/res/xml/view_expandable_message_scene.xml
+++ b/WooCommerce/src/main/res/xml/view_expandable_message_scene.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ConstraintSet android:id="@+id/start">
+        <Constraint
+            android:id="@+id/message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_85"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/title"
+            app:layout_constraintTop_toTopOf="parent" />
+        <Constraint
+            android:id="@+id/expand_icon"
+            android:layout_width="@dimen/image_minor_50"
+            android:layout_height="@dimen/image_minor_50"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/minor_00"
+            android:rotation="0"
+            app:layout_constraintBottom_toBottomOf="@id/title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/title" />
+    </ConstraintSet>
+
+    <ConstraintSet android:id="@+id/end">
+        <Constraint
+            android:id="@+id/message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/major_100"
+            android:visibility="visible"
+            app:layout_constraintBottom_toTopOf="@+id/expand_icon"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/title"
+            app:layout_constraintTop_toBottomOf="@+id/title" />
+        <Constraint
+            android:id="@+id/expand_icon"
+            android:layout_width="@dimen/image_minor_50"
+            android:layout_height="@dimen/image_minor_50"
+            android:layout_marginTop="@dimen/minor_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/minor_100"
+            android:rotation="180"
+            app:layout_constraintBottom_toBottomOf="@+id/message"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/message" />
+    </ConstraintSet>
+
+    <Transition
+        app:constraintSetEnd="@id/end"
+        app:constraintSetStart="@+id/start">
+        <KeyFrameSet>
+            <KeyPosition
+                app:framePosition="70"
+                app:motionTarget="@+id/message"
+                app:percentY="1" />
+            <KeyAttribute
+                android:alpha="0.0"
+                app:framePosition="50"
+                app:motionTarget="@+id/message" />
+        </KeyFrameSet>
+    </Transition>
+</MotionScene>

--- a/WooCommerce/src/main/res/xml/view_expandable_message_scene.xml
+++ b/WooCommerce/src/main/res/xml/view_expandable_message_scene.xml
@@ -6,24 +6,22 @@
         <Constraint
             android:id="@+id/message"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_85"
             android:visibility="invisible"
-            app:layout_constraintBottom_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/title"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/expand_icon"
+            app:layout_constraintStart_toStartOf="@+id/title" />
         <Constraint
             android:id="@+id/expand_icon"
             android:layout_width="@dimen/image_minor_50"
             android:layout_height="@dimen/image_minor_50"
             android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/minor_00"
+            android:baselineAlignBottom="true"
             android:rotation="0"
-            app:layout_constraintBottom_toBottomOf="@id/title"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/title" />
+            android:translationY="@dimen/minor_100"
+            app:layout_constraintBaseline_toBaselineOf="@+id/title"
+            app:layout_constraintEnd_toEndOf="parent" />
     </ConstraintSet>
 
     <ConstraintSet android:id="@+id/end">
@@ -31,23 +29,24 @@
             android:id="@+id/message"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_100"
             android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/minor_50"
             android:visibility="visible"
-            app:layout_constraintBottom_toTopOf="@+id/expand_icon"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/expand_icon"
             app:layout_constraintStart_toStartOf="@+id/title"
             app:layout_constraintTop_toBottomOf="@+id/title" />
         <Constraint
             android:id="@+id/expand_icon"
             android:layout_width="@dimen/image_minor_50"
             android:layout_height="@dimen/image_minor_50"
-            android:layout_marginTop="@dimen/minor_100"
             android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/minor_100"
+            android:baselineAlignBottom="true"
             android:rotation="180"
-            app:layout_constraintBottom_toBottomOf="@+id/message"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/message" />
+            android:translationY="@dimen/minor_100"
+            app:layout_constraintBaseline_toBaselineOf="@+id/title"
+            app:layout_constraintEnd_toEndOf="parent" />
     </ConstraintSet>
 
     <Transition
@@ -55,12 +54,18 @@
         app:constraintSetStart="@+id/start">
         <KeyFrameSet>
             <KeyPosition
-                app:framePosition="70"
+                app:framePosition="40"
                 app:motionTarget="@+id/message"
                 app:percentY="1" />
+            <KeyPosition
+                app:framePosition="25"
+                app:keyPositionType="deltaRelative"
+                app:motionTarget="@id/message"
+                app:percentY="1"
+                app:sizePercent="100" />
             <KeyAttribute
                 android:alpha="0.0"
-                app:framePosition="50"
+                app:framePosition="90"
                 app:motionTarget="@+id/message" />
         </KeyFrameSet>
     </Transition>


### PR DESCRIPTION
‼️ Don't merge until is approved by design

Closes: #6652
Closes: #6768

### Description
This PR adds the non-editable warning message when the Order is in a status where not all fields are editable. 
It does that by using the new ExpandableMessageView which collapses/expands the message details in a similar fashion to what we do with the billing info.

### Testing instructions

1. Open the Orders section -> Select an Order -> Menu (3 dots) -> Select Edit
2. Change the Order status to an editable status such as `Pending payment`
3. Check that the non-editable warning message is hidden
4. Change the Order status to a non-editable status such as `Processing`
5. Check that the non-editable warning message is shown with the message `Parts of this order are no longer editable`
6. Press the message
7. Check that the message expands and shows the details `To edit the rest of this order, change the status to "Pending Payment".`
8. Press the message again
9. Check that the message collapses


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/175183054-a2cf14f8-31d7-4f8c-94ab-3dba8c6ae275.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
