### PR TITLE
Increases no_output_timeout for CircleCI UI Tests to 20m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ workflows:
       - Connected Tests:
           name: UI Tests (Pixel 2 | API 28)
           post-to-slack: true
+          no_output_timeout: 20m
           # Always run connected tests on develop and release branches
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,11 @@ jobs:
       - run:
           name: Build
           command: ./gradlew WooCommerce:assembleVanillaDebug --stacktrace
+          no_output_timeout: 20m
       - run:
           name: Build Tests
           command: ./gradlew WooCommerce:assembleVanillaDebugAndroidTest --stacktrace
+          no_output_timeout: 20m
       - run:
           name: Decrypt credentials
           command: openssl aes-256-cbc -md sha256 -d -in .circleci/.firebase.secrets.json.enc -out .circleci/.firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"
@@ -76,7 +78,6 @@ workflows:
       - Connected Tests:
           name: UI Tests (Pixel 2 | API 28)
           post-to-slack: true
-          no_output_timeout: 20m
           # Always run connected tests on develop and release branches
           filters:
             branches:


### PR DESCRIPTION
### Description

Increases `no_output_timeout` for CircleCI UI Tests to `20m` so CircleCI doesn't fail with `Too long with no output (exceeded 10m0s): context deadline exceeded` such as [in this run](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/21158/workflows/bc22e1d2-eb25-4ba1-9d9c-67014cd2a31d/jobs/76852).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* Successful CI run is enough

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
