### PR TITLE
Fix `localize_libs` lane indentation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -448,37 +448,37 @@ platform :android do
   #####################################################################################
   desc "Merge libraries strings files into the main app one"
   lane :localize_libs do | options |
-  REMOTE_LIBRARIES_STRINGS_PATHS.each do  | lib |
-    download_path = android_download_file_by_version(
-      library_name: lib[:name],
-      import_key: lib[:import_key],
-      repository: lib[:repository],
-      file_path: lib[:strings_file_path]
-    )
+    REMOTE_LIBRARIES_STRINGS_PATHS.each do  | lib |
+      download_path = android_download_file_by_version(
+        library_name: lib[:name],
+        import_key: lib[:import_key],
+        repository: lib[:repository],
+        file_path: lib[:strings_file_path]
+      )
 
-  if download_path.nil?
-    error_message = <<~ERROR
-      Can't download strings file for #{lib[:name]}.
-      Strings for this library won't get translated.
-      Do you want to continue anyway?
-    ERROR
-    UI.user_error! "Abort." unless UI.confirm(error_message)
-  else
-    UI.message("Strings.xml file for #{lib[:name]} downloaded to #{download_path}.")
-    lib_to_merge = [{
-      library: lib[:name],
-      strings_path: download_path,
-      exclusions: lib[:exclusions]
-    }]
-    an_localize_libs(app_strings_path: MAIN_STRINGS_PATH, libs_strings_path: lib_to_merge)
-    File.delete(download_path) if File.exist?(download_path)
-  end
-  end
+      if download_path.nil?
+        error_message = <<~ERROR
+          Can't download strings file for #{lib[:name]}.
+          Strings for this library won't get translated.
+          Do you want to continue anyway?
+        ERROR
+        UI.user_error! "Abort." unless UI.confirm(error_message)
+      else
+        UI.message("Strings.xml file for #{lib[:name]} downloaded to #{download_path}.")
+        lib_to_merge = [{
+          library: lib[:name],
+          strings_path: download_path,
+          exclusions: lib[:exclusions]
+        }]
+        an_localize_libs(app_strings_path: MAIN_STRINGS_PATH, libs_strings_path: lib_to_merge)
+        File.delete(download_path) if File.exist?(download_path)
+      end
+    end
 
-  is_repo_clean = ("git status --porcelain").empty?
-  unless is_repo_clean then
-    commit_strings(options)
-  end
+    is_repo_clean = ("git status --porcelain").empty?
+    unless is_repo_clean then
+      commit_strings(options)
+    end
   end
 
   #####################################################################################


### PR DESCRIPTION
### Description

We'll be doing more work on this lane next, so we want it to be correctly indented. This is followed up by https://github.com/woocommerce/woocommerce-android/pull/6742

### Testing instructions

This is a "whitespace only" change:

<img width="1002" alt="Screen Shot 2022-06-14 at 2 58 13 pm" src="https://user-images.githubusercontent.com/1218433/173496597-dd4fce9c-f002-4b88-9a2c-5e93dc60e935.png">

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->