### PR TITLE
Orders search: Support searching for order numbers with # prefix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -159,6 +159,20 @@ class OrderListViewModel @Inject constructor(
     }
 
     /**
+     * Removes the `#` from the start of the search keyword, if present.
+     *
+     *  This allows searching for an order with `#123` and getting the results for order `123`.
+     *  See https://github.com/woocommerce/woocommerce-android/issues/2621
+     *
+     */
+    private fun sanitizeSearchQuery(searchQuery: String): String {
+        if (searchQuery.startsWith("#")) {
+            return searchQuery.drop(1)
+        }
+        return searchQuery
+    }
+
+    /**
      * Refresh the active order list with fresh data from the API as well as refresh order status
      * options and payment gateways if the network is available.
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -153,7 +153,10 @@ class OrderListViewModel @Inject constructor(
      * processing list will always use the same [processingPagedListWrapper].
      */
     fun submitSearchOrFilter(searchQuery: String) {
-        val listDescriptor = WCOrderListDescriptor(selectedSite.get(), searchQuery = searchQuery)
+        val listDescriptor = WCOrderListDescriptor(
+            selectedSite.get(),
+            searchQuery = sanitizeSearchQuery(searchQuery)
+        )
         val pagedListWrapper = listStore.getList(listDescriptor, dataSource, lifecycle)
         activatePagedListWrapper(pagedListWrapper, isFirstInit = true)
     }


### PR DESCRIPTION
Closes: #2621 

### Description
In the Orders tab, we can search for orders using the order number. API only supports searching for orders with a plain order number (e.g. 123). Prefixing the order number with hashtag # doesn't return any results. i.e. Search using `#123` doesn't work.

This PR removes the # from the search query before performing the search, so that `#123` and `123` will return the same search results.

### Testing instructions

1. Open the Orders tab.
2. Tap the search icon to start a search.
3. Search for an order number that exists in your store, such as 123.
4. Validate that the search results display that order.
5. Search for the same order number with the # symbol prefixed in the search query, such as `#123`.
6. Validate that the same search results appear, including that order.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/524475/173503275-54731f3e-921b-4ef1-a5a5-7d46b5e758f1.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.