### PR TITLE
Replace analyticstracker with analyticstrackerwrapper, write tests in IssueRefundViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -665,7 +665,7 @@ class IssueRefundViewModel @Inject constructor(
         commonState = commonState.copy(refundType = type)
         updateRefundTotal(refundAmount)
 
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_TAB_CHANGED,
             mapOf(
                 AnalyticsTracker.KEY_ORDER_ID to order.id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -560,7 +560,7 @@ class IssueRefundViewModel @Inject constructor(
             triggerEvent(ShowNumberPicker(it))
         }
 
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_ITEM_QUANTITY_DIALOG_OPENED,
             mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -532,7 +532,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     fun onRefundIssued(reason: String) {
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_SUMMARY_REFUND_BUTTON_TAPPED,
             mapOf(
                 AnalyticsTracker.KEY_ORDER_ID to order.id

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.REFUND_CREATE
 import com.woocommerce.android.analytics.AnalyticsEvent.REFUND_CREATE_FAILED
 import com.woocommerce.android.analytics.AnalyticsEvent.REFUND_CREATE_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.calculateTotals
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.isCashPayment
@@ -98,6 +99,7 @@ class IssueRefundViewModel @Inject constructor(
     private val paymentChargeRepository: PaymentChargeRepository,
     private val orderMapper: OrderMapper,
     private val inPersonPaymentsCanadaFeatureFlag: InPersonPaymentsCanadaFeatureFlag,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val DEFAULT_DECIMAL_PRECISION = 2
@@ -308,7 +310,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     fun onNextButtonTappedFromItems() {
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,
             mapOf(
                 AnalyticsTracker.KEY_REFUND_TYPE to ITEMS.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -377,7 +377,7 @@ class IssueRefundViewModel @Inject constructor(
                         refund()
                     }
 
-                    AnalyticsTracker.track(
+                    analyticsTrackerWrapper.track(
                         REFUND_CREATE,
                         mapOf(
                             AnalyticsTracker.KEY_ORDER_ID to order.id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -649,7 +649,7 @@ class IssueRefundViewModel @Inject constructor(
             }
         }
 
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_SELECT_ALL_ITEMS_BUTTON_TAPPED,
             mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -475,7 +475,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     private fun trackRefundError(result: WooResult<WCRefundModel>) {
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             REFUND_CREATE_FAILED,
             mapOf(
                 AnalyticsTracker.KEY_ORDER_ID to order.id,
@@ -499,7 +499,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     private fun trackRefundSuccess(result: WooResult<WCRefundModel>) {
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             REFUND_CREATE_SUCCESS,
             mapOf(
                 AnalyticsTracker.KEY_ORDER_ID to order.id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -322,7 +322,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     fun onNextButtonTappedFromAmounts() {
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,
             mapOf(
                 AnalyticsTracker.KEY_REFUND_TYPE to AMOUNT.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -520,10 +520,10 @@ class IssueRefundViewModel @Inject constructor(
         val note = OrderNote(note = reason, isCustomerNote = false)
         orderDetailRepository.addOrderNote(order.id, note).fold(
             onSuccess = {
-                AnalyticsTracker.track(ORDER_NOTE_ADD_SUCCESS)
+                analyticsTrackerWrapper.track(ORDER_NOTE_ADD_SUCCESS)
             },
             onFailure = {
-                AnalyticsTracker.track(
+                analyticsTrackerWrapper.track(
                     ORDER_NOTE_ADD_FAILED,
                     prepareTracksEventsDetails(it as WooException)
                 )
@@ -584,7 +584,7 @@ class IssueRefundViewModel @Inject constructor(
             )
         )
 
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_PRODUCT_AMOUNT_DIALOG_OPENED,
             mapOf(AnalyticsTracker.KEY_ORDER_ID to order.id)
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -935,4 +935,24 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `when refund quantity is tapped, then proper track event is triggered`() {
+        testBlocking {
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+            whenever(resourceProvider.getString(any())).thenReturn("")
+
+            initViewModel()
+            viewModel.onRefundQuantityTapped(1L)
+
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.CREATE_ORDER_REFUND_ITEM_QUANTITY_DIALOG_OPENED,
+                mapOf(AnalyticsTracker.KEY_ORDER_ID to ORDER_ID)
+            )
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -973,4 +973,26 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `when refund tab is changed to refund type amount, then proper track event is triggered`() {
+        testBlocking {
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+
+            initViewModel()
+            viewModel.onRefundTabChanged(IssueRefundViewModel.RefundType.AMOUNT)
+
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.CREATE_ORDER_REFUND_TAB_CHANGED,
+                mapOf(
+                    AnalyticsTracker.KEY_ORDER_ID to ORDER_ID,
+                    AnalyticsTracker.KEY_TYPE to "AMOUNT"
+                )
+            )
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -40,7 +40,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
-import java.util.*
+import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -757,6 +757,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
                 .thenReturn("Credit/Debit card")
 
             initViewModel()
+            val commonState = viewModel.commonStateLiveData.liveData.value as IssueRefundViewModel.CommonViewState
             viewModel.onRefundConfirmed(true)
 
             verify(analyticsTrackerWrapper).track(
@@ -764,10 +765,10 @@ class IssueRefundViewModelTest : BaseUnitTest() {
                 mapOf(
                     AnalyticsTracker.KEY_ORDER_ID to ORDER_ID,
                     AnalyticsTracker.KEY_REFUND_IS_FULL to
-                        ((viewModel.commonStateLiveData.liveData.value as IssueRefundViewModel.CommonViewState).refundTotal isEqualTo BigDecimal.TEN).toString(),
-                    AnalyticsTracker.KEY_REFUND_TYPE to (viewModel.commonStateLiveData.liveData.value as IssueRefundViewModel.CommonViewState).refundType.name,
+                        ((commonState).refundTotal isEqualTo BigDecimal.TEN).toString(),
+                    AnalyticsTracker.KEY_REFUND_TYPE to (commonState).refundType.name,
                     AnalyticsTracker.KEY_REFUND_METHOD to "manual",
-                    AnalyticsTracker.KEY_AMOUNT to (viewModel.commonStateLiveData.liveData.value as IssueRefundViewModel.CommonViewState).refundTotal.toString()
+                    AnalyticsTracker.KEY_AMOUNT to (commonState).refundTotal.toString()
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -944,13 +944,31 @@ class IssueRefundViewModelTest : BaseUnitTest() {
                 metaData = "[]"
             )
             whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
-            whenever(resourceProvider.getString(any())).thenReturn("")
 
             initViewModel()
             viewModel.onRefundQuantityTapped(1L)
 
             verify(analyticsTrackerWrapper).track(
                 AnalyticsEvent.CREATE_ORDER_REFUND_ITEM_QUANTITY_DIALOG_OPENED,
+                mapOf(AnalyticsTracker.KEY_ORDER_ID to ORDER_ID)
+            )
+        }
+    }
+
+    @Test
+    fun `when select button is tapped, then proper track event is triggered`() {
+        testBlocking {
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+
+            initViewModel()
+            viewModel.onSelectButtonTapped()
+
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.CREATE_ORDER_REFUND_SELECT_ALL_ITEMS_BUTTON_TAPPED,
                 mapOf(AnalyticsTracker.KEY_ORDER_ID to ORDER_ID)
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -705,4 +705,27 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `when next button is tapped from amounts, then verify proper tracks event is triggered `() {
+        testBlocking {
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+            whenever(resourceProvider.getString(any())).thenReturn("")
+
+            initViewModel()
+            viewModel.onNextButtonTappedFromAmounts()
+
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.CREATE_ORDER_REFUND_NEXT_BUTTON_TAPPED,
+                mapOf(
+                    AnalyticsTracker.KEY_REFUND_TYPE to IssueRefundViewModel.RefundType.AMOUNT.name,
+                    AnalyticsTracker.KEY_ORDER_ID to ORDER_ID
+                )
+            )
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -995,4 +995,26 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `when refund tab is changed to refund type items, then proper track event is triggered`() {
+        testBlocking {
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+
+            initViewModel()
+            viewModel.onRefundTabChanged(IssueRefundViewModel.RefundType.ITEMS)
+
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.CREATE_ORDER_REFUND_TAB_CHANGED,
+                mapOf(
+                    AnalyticsTracker.KEY_ORDER_ID to ORDER_ID,
+                    AnalyticsTracker.KEY_TYPE to "ITEMS"
+                )
+            )
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModelTest.kt
@@ -913,4 +913,26 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `when refund is issued, then proper track event is triggered`() {
+        testBlocking {
+            val orderWithMultipleShipping = OrderTestUtils.generateOrderWithMultipleShippingLines().copy(
+                paymentMethod = "cod",
+                metaData = "[]"
+            )
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithMultipleShipping)
+            whenever(resourceProvider.getString(any())).thenReturn("")
+
+            initViewModel()
+            viewModel.onRefundIssued("")
+
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.CREATE_ORDER_REFUND_SUMMARY_REFUND_BUTTON_TAPPED,
+                mapOf(
+                    AnalyticsTracker.KEY_ORDER_ID to ORDER_ID
+                )
+            )
+        }
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6744 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR replaces hardcoded AnalyticsTracker with AnalyticsTrackerWrapper (by injecting it) in IssueRefundViewModel. Doing this change helps us in writing unit tests that verify proper tracks events are being fired as expected with appropriate parameters.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Ensure nothing is broken in the refund screen
2. Ensure refund functionality works as expected



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
