### PR TITLE
Replace AnalyticsTracker with AnalyticsTrackerWrapper, write tests in CouponListViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CouponUtils
@@ -35,7 +36,8 @@ class CouponListViewModel @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val selectedSite: SelectedSite,
     private val couponListHandler: CouponListHandler,
-    private val couponUtils: CouponUtils
+    private val couponUtils: CouponUtils,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val LOADING_STATE_DELAY = 100L
@@ -104,7 +106,7 @@ class CouponListViewModel @Inject constructor(
 
     fun onSearchStateChanged(open: Boolean) {
         searchQuery.value = if (open) {
-            AnalyticsTracker.track(AnalyticsEvent.COUPONS_LIST_SEARCH_TAPPED)
+            analyticsTrackerWrapper.track(AnalyticsEvent.COUPONS_LIST_SEARCH_TAPPED)
             searchQuery.value.orEmpty()
         } else {
             null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.tools.SelectedSite

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
@@ -110,7 +110,6 @@ class CouponsListViewModelTests : BaseUnitTest() {
         assertThat(state.isSearchOpen).isTrue()
     }
 
-
     @Test
     fun `when search is opened, then proper track event is triggered`() = testBlocking {
         setup()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.coupons
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.util.CurrencyFormatter
@@ -45,6 +47,7 @@ class CouponsListViewModelTests : BaseUnitTest() {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
         on { getString(any(), anyVararg()) } doAnswer { it.arguments[0].toString() }
     }
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val couponUtils = CouponUtils(
         currencyFormatter = currencyFormatter,
         resourceProvider = resourceProvider
@@ -59,7 +62,8 @@ class CouponsListViewModelTests : BaseUnitTest() {
             couponUtils = couponUtils,
             selectedSite = mock {
                 on { get() } doReturn SiteModel()
-            }
+            },
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
         )
     }
 
@@ -103,6 +107,15 @@ class CouponsListViewModelTests : BaseUnitTest() {
 
         val state = viewModel.couponsState.captureValues().last()
         assertThat(state.isSearchOpen).isTrue()
+    }
+
+    @Test
+    fun `when search is opened, then proper track event is triggered`() = testBlocking {
+        setup()
+
+        viewModel.onSearchStateChanged(true)
+
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.COUPONS_LIST_SEARCH_TAPPED)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -109,6 +110,7 @@ class CouponsListViewModelTests : BaseUnitTest() {
         assertThat(state.isSearchOpen).isTrue()
     }
 
+
     @Test
     fun `when search is opened, then proper track event is triggered`() = testBlocking {
         setup()
@@ -116,6 +118,15 @@ class CouponsListViewModelTests : BaseUnitTest() {
         viewModel.onSearchStateChanged(true)
 
         verify(analyticsTrackerWrapper).track(AnalyticsEvent.COUPONS_LIST_SEARCH_TAPPED)
+    }
+
+    @Test
+    fun `when search is NOT opened, then track event is NOT triggered`() = testBlocking {
+        setup()
+
+        viewModel.onSearchStateChanged(false)
+
+        verify(analyticsTrackerWrapper, never()).track(AnalyticsEvent.COUPONS_LIST_SEARCH_TAPPED)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6750 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replace hardcoded AnalyticsTracker with AnalyticsTrackerWrapper (by injecting it) in CouponListViewModel. Doing this change helps us in writing unit tests that verify proper tracks events are being fired as expected with appropriate parameters.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Ensure that the coupon functionality works as expected.



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
