### PR TITLE
Replace AnalyticsTracker with AnalyticsTrackerWrapper, write tests in OrderFullFillViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_ADD
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.Item
@@ -42,7 +43,8 @@ class OrderFulfillViewModel @Inject constructor(
     private val appPrefs: AppPrefs,
     private val networkStatus: NetworkStatus,
     private val resourceProvider: ResourceProvider,
-    private val repository: OrderDetailRepository
+    private val repository: OrderDetailRepository,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState) {
     companion object {
         const val KEY_ORDER_FULFILL_RESULT = "key_order_fulfill_result"
@@ -141,7 +143,7 @@ class OrderFulfillViewModel @Inject constructor(
     }
 
     fun onNewShipmentTrackingAdded(shipmentTracking: OrderShipmentTracking) {
-        AnalyticsTracker.track(
+        analyticsTrackerWrapper.track(
             ORDER_TRACKING_ADD,
             mapOf(
                 AnalyticsTracker.KEY_ID to order.id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.fulfill
 
 import android.os.Parcelable
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -194,17 +195,18 @@ class OrderFulfillViewModel @Inject constructor(
         _shipmentTrackings.value = shipmentTrackings
     }
 
-    private fun deleteOrderShipmentTracking(shipmentTracking: OrderShipmentTracking) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun deleteOrderShipmentTracking(shipmentTracking: OrderShipmentTracking) {
         launch {
             val onOrderChanged = repository.deleteOrderShipmentTracking(
                 navArgs.orderId, shipmentTracking.toDataModel()
             )
             if (!onOrderChanged.isError) {
-                AnalyticsTracker.track(AnalyticsEvent.ORDER_TRACKING_DELETE_SUCCESS)
+                analyticsTrackerWrapper.track(AnalyticsEvent.ORDER_TRACKING_DELETE_SUCCESS)
                 viewState = viewState.copy(shouldRefreshShipmentTracking = true)
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_delete_success))
             } else {
-                AnalyticsTracker.track(
+                analyticsTrackerWrapper.track(
                     AnalyticsEvent.ORDER_TRACKING_DELETE_FAILED,
                     prepareTracksEventsDetails(onOrderChanged)
                 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -434,6 +434,29 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given onOrderChanged success, when tracking is deleted,then event triggered with valid data`() = testBlocking {
+        val shipmentTracking = OrderShipmentTracking(
+            trackingProvider = "testProvider",
+            trackingNumber = "123456",
+            dateShipped = DateUtils.getCurrentDateString()
+        )
+        val onOrderChanged = WCOrderStore.OnOrderChanged(
+            statusFilter = "",
+            canLoadMore = false,
+            causeOfChange = null,
+            orderError = null
+        )
+        doReturn(onOrderChanged).whenever(repository).deleteOrderShipmentTracking(any(), any())
+        val addedShipmentTrackings = testOrderShipmentTrackings.toMutableList()
+        addedShipmentTrackings.add(shipmentTracking)
+
+        viewModel.start()
+        viewModel.deleteOrderShipmentTracking(shipmentTracking)
+
+        assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(string.order_shipment_tracking_delete_success))
+    }
+
+    @Test
     fun `handle onBackButtonClicked when new shipment tracking is added`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -359,6 +359,32 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given onOrderChanged error, when order tracking is deleted, then proper event is triggered`() = testBlocking {
+        val shipmentTracking = OrderShipmentTracking(
+            trackingProvider = "testProvider",
+            trackingNumber = "123456",
+            dateShipped = DateUtils.getCurrentDateString()
+        )
+        val onOrderChanged = WCOrderStore.OnOrderChanged(
+            statusFilter = "",
+            canLoadMore = false,
+            causeOfChange = null,
+            orderError = WCOrderStore.OrderError(
+                type = WCOrderStore.OrderErrorType.GENERIC_ERROR,
+                message = "generic error"
+            )
+        )
+        doReturn(onOrderChanged).whenever(repository).deleteOrderShipmentTracking(any(), any())
+        val addedShipmentTrackings = testOrderShipmentTrackings.toMutableList()
+        addedShipmentTrackings.add(shipmentTracking)
+
+        viewModel.start()
+        viewModel.deleteOrderShipmentTracking(shipmentTracking)
+
+        assertThat(viewModel.event.value).isInstanceOf(ShowSnackbar::class.java)
+    }
+
+    @Test
     fun `handle onBackButtonClicked when new shipment tracking is added`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -385,6 +385,29 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given onOrderChanged success, when tracking is deleted, then proper event is triggered`() = testBlocking {
+        val shipmentTracking = OrderShipmentTracking(
+            trackingProvider = "testProvider",
+            trackingNumber = "123456",
+            dateShipped = DateUtils.getCurrentDateString()
+        )
+        val onOrderChanged = WCOrderStore.OnOrderChanged(
+            statusFilter = "",
+            canLoadMore = false,
+            causeOfChange = null,
+            orderError = null
+        )
+        doReturn(onOrderChanged).whenever(repository).deleteOrderShipmentTracking(any(), any())
+        val addedShipmentTrackings = testOrderShipmentTrackings.toMutableList()
+        addedShipmentTrackings.add(shipmentTracking)
+
+        viewModel.start()
+        viewModel.deleteOrderShipmentTracking(shipmentTracking)
+
+        assertThat(viewModel.event.value).isInstanceOf(ShowSnackbar::class.java)
+    }
+
+    @Test
     fun `handle onBackButtonClicked when new shipment tracking is added`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -408,6 +408,32 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given onOrderChanged error, when tracking is deleted, then event triggered with valid data`() = testBlocking {
+        val shipmentTracking = OrderShipmentTracking(
+            trackingProvider = "testProvider",
+            trackingNumber = "123456",
+            dateShipped = DateUtils.getCurrentDateString()
+        )
+        val onOrderChanged = WCOrderStore.OnOrderChanged(
+            statusFilter = "",
+            canLoadMore = false,
+            causeOfChange = null,
+            orderError = WCOrderStore.OrderError(
+                type = WCOrderStore.OrderErrorType.GENERIC_ERROR,
+                message = "generic error"
+            )
+        )
+        doReturn(onOrderChanged).whenever(repository).deleteOrderShipmentTracking(any(), any())
+        val addedShipmentTrackings = testOrderShipmentTrackings.toMutableList()
+        addedShipmentTrackings.add(shipmentTracking)
+
+        viewModel.start()
+        viewModel.deleteOrderShipmentTracking(shipmentTracking)
+
+        assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(string.order_shipment_tracking_delete_error))
+    }
+
+    @Test
     fun `handle onBackButtonClicked when new shipment tracking is added`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -303,7 +303,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given onOrderChanged error, when order tracking is deleted, then proper event is triggered`() = testBlocking {
+    fun `given onOrderChanged error, when order tracking is deleted, then track event is triggered`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",
             trackingNumber = "123456",
@@ -336,7 +336,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given onOrderChanged success, when tracking is deleted, then proper event is triggered`() = testBlocking {
+    fun `given onOrderChanged success, when tracking is deleted, then track is triggered`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",
             trackingNumber = "123456",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -303,7 +303,7 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when shipment order tracking is deleted, then proper track event is triggered`() = testBlocking {
+    fun `given onOrderChanged error, when order tracking is deleted, then proper event is triggered`() = testBlocking {
         val shipmentTracking = OrderShipmentTracking(
             trackingProvider = "testProvider",
             trackingNumber = "123456",
@@ -333,6 +333,29 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_ERROR_DESC to "generic error"
             )
         )
+    }
+
+    @Test
+    fun `given onOrderChanged success, when tracking is deleted, then proper event is triggered`() = testBlocking {
+        val shipmentTracking = OrderShipmentTracking(
+            trackingProvider = "testProvider",
+            trackingNumber = "123456",
+            dateShipped = DateUtils.getCurrentDateString()
+        )
+        val onOrderChanged = WCOrderStore.OnOrderChanged(
+            statusFilter = "",
+            canLoadMore = false,
+            causeOfChange = null,
+            orderError = null
+        )
+        doReturn(onOrderChanged).whenever(repository).deleteOrderShipmentTracking(any(), any())
+        val addedShipmentTrackings = testOrderShipmentTrackings.toMutableList()
+        addedShipmentTrackings.add(shipmentTracking)
+
+        viewModel.start()
+        viewModel.deleteOrderShipmentTracking(shipmentTracking)
+
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_TRACKING_DELETE_SUCCESS)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6752 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replace hardcoded AnalyticsTracker with AnalyticsTrackerWrapper (by injecting it) in OrderFullFillViewModel. Doing this change helps us in writing unit tests that verify proper tracks events are being fired as expected with appropriate parameters.

Additionally, this PR also adds tests that verify that proper UI events along with the proper message are being triggered when the shipment tracking is deleted successfully/failure



### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Ensure that the order fulfillment screen and its logic behave as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
