### PR TITLE
Fix parsing of the variations field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.44.0'
+    fluxCVersion = '1.44.2'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6737 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates FluxC to bring the changes of the PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2439 to handle different states of the `variations` field inside the `/products` response, and avoid crashing the app.

### Testing instructions
I don't know which plugin causes the response to have this format, and IMO the mocked tests in FluxC are enough for simulating the response.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
