### PR TITLE
Write unit test to verify track event is triggered properly in OrderCreationRepository

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepository.kt
@@ -83,7 +83,7 @@ class OrderCreationRepository @Inject constructor(
         return when {
             result.isError -> {
                 WooLog.e(WooLog.T.ORDERS, "${result.error.type.name}: ${result.error.message}")
-                AnalyticsTracker.track(
+                analyticsTrackerWrapper.track(
                     AnalyticsEvent.SIMPLE_PAYMENTS_FLOW_FAILED,
                     mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT)
                 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.creation
 
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
@@ -19,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.OrderUpdateStore
+import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class OrderCreationRepositoryTest : BaseUnitTest() {
@@ -46,6 +48,11 @@ class OrderCreationRepositoryTest : BaseUnitTest() {
             } doReturn WooResult(
                 WooError(WooErrorType.API_ERROR, BaseRequest.GenericErrorType.NETWORK_ERROR, DEFAULT_ERROR_MESSAGE)
             )
+            onBlocking {
+                createSimplePayment(eq(siteModel), eq("1"), eq(true), eq(null))
+            } doReturn WooResult(
+                WooError(WooErrorType.API_ERROR, BaseRequest.GenericErrorType.NETWORK_ERROR, DEFAULT_ERROR_MESSAGE)
+            )
         }
 
         sut = OrderCreationRepository(
@@ -69,6 +76,16 @@ class OrderCreationRepositoryTest : BaseUnitTest() {
             errorContext = eq(sut.javaClass.simpleName),
             errorType = eq(WooErrorType.API_ERROR.name),
             errorDescription = eq(DEFAULT_ERROR_MESSAGE)
+        )
+    }
+
+    @Test
+    fun `given simple payment order created, when error, then error track event is tracked`() = testBlocking {
+        sut.createSimplePaymentOrder(BigDecimal.ONE)
+
+        verify(trackerWrapper).track(
+            AnalyticsEvent.SIMPLE_PAYMENTS_FLOW_FAILED,
+            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT)
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6756 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Write unit tests to verify track events in OrderCreationRepository are triggered properly when simple payment order creation fails.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Green CI should be enough :)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
