### PR TITLE
Enable detecting non SDK API usages in Strict Mode

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -11,6 +11,7 @@ import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
+import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import dagger.hilt.android.HiltAndroidApp
@@ -51,6 +52,11 @@ class WooCommerceDebug : WooCommerce() {
                 .detectLeakedClosableObjects()
                 .detectLeakedRegistrationObjects()
                 .penaltyLog()
+                .apply {
+                    if (SystemVersionUtils.isAtLeastP()) {
+                        detectNonSdkApiUsage()
+                    }
+                }
                 .build()
         )
         WooLog.w(T.UTILS, "Strict mode enabled")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtils.kt
@@ -10,6 +10,8 @@ object SystemVersionUtils {
 
     fun isAtLeastQ() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 
+    fun isAtLeastP() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+
     fun isAtLeastO() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
 
     fun isAtLeastN() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N


### PR DESCRIPTION
### Description
This PR simply adds a call to the function [`detectNonSdkApiUsage`](https://developer.android.com/reference/android/os/StrictMode.VmPolicy.Builder#detectNonSdkApiUsage()) to the StrictMode initialization for debug builds.
This action is a result of the discussion paqN3M-pI-p2#comment-956

### Testing instructions
This shouldn't have any impact, as we are not using any non-SDK API currently.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->