### PR TITLE
Issue/6761 flipper crash

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android
 
-import android.os.Build
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
@@ -21,7 +20,7 @@ import dagger.hilt.android.HiltAndroidApp
 class WooCommerceDebug : WooCommerce() {
     override fun onCreate() {
         if (FlipperUtils.shouldEnableFlipper(this) &&
-            Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1
+            SystemVersionUtils.isAtLeastM()
         ) {
             SoLoader.init(this, false)
             AndroidFlipperClient.getInstance(this).apply {

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android
 
+import android.os.Build
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
@@ -19,7 +20,9 @@ import dagger.hilt.android.HiltAndroidApp
 @HiltAndroidApp
 class WooCommerceDebug : WooCommerce() {
     override fun onCreate() {
-        if (FlipperUtils.shouldEnableFlipper(this)) {
+        if (FlipperUtils.shouldEnableFlipper(this) &&
+            Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP
+        ) {
             SoLoader.init(this, false)
             AndroidFlipperClient.getInstance(this).apply {
                 addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -21,7 +21,7 @@ import dagger.hilt.android.HiltAndroidApp
 class WooCommerceDebug : WooCommerce() {
     override fun onCreate() {
         if (FlipperUtils.shouldEnableFlipper(this) &&
-            Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP
+            Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1
         ) {
             SoLoader.init(this, false)
             AndroidFlipperClient.getInstance(this).apply {


### PR DESCRIPTION
Fixes #6761 - this PR disables Flipper on older Android devices because it causes a crash. This impacts both Lollipop (v21) and Lollipop M2 (v22). I've verified that Flipper does work on Marshmallow (v23).

A bug report for this crash was [submitted in March](https://github.com/facebook/flipper/issues/3572), but given that it hasn't been addressed yet I decided to simply disable Flipper so I can at least use the app on Lollipop.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.