### PR TITLE
issue/6782-simple-payments-backstack

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/simplepayments/TakePaymentFragment.kt
@@ -73,7 +73,8 @@ class TakePaymentFragment : BaseFragment(R.layout.fragment_take_payment) {
                     uiMessageResolver.showSnack(event.message)
                 }
                 is MultiLiveEvent.Event.Exit -> {
-                    findNavController().navigateSafely(R.id.orders)
+                    val action = TakePaymentFragmentDirections.actionTakePaymentFragmentToOrderList()
+                    findNavController().navigateSafely(action)
                 }
                 is OrderNavigationTarget.StartCardReaderPaymentFlow -> {
                     val action = TakePaymentFragmentDirections.actionTakePaymentFragmentToCardReaderFlow(

--- a/WooCommerce/src/main/res/navigation/nav_graph_simple_payments.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_simple_payments.xml
@@ -65,9 +65,8 @@
         </action>
         <action
             android:id="@+id/action_takePaymentFragment_to_orderList"
-            app:destination="@+id/orders"
-            app:popUpTo="@+id/simplePaymentsFragment"
-            app:popUpToInclusive="true" />
+            app:popUpTo="@+id/orders"
+            app:popUpToInclusive="false" />
     </fragment>
     <include app:graph="@navigation/nav_graph_card_reader_flow" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_simple_payments.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_simple_payments.xml
@@ -63,6 +63,11 @@
                 app:argType="com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam"
                 app:nullable="false" />
         </action>
+        <action
+            android:id="@+id/action_takePaymentFragment_to_orderList"
+            app:destination="@+id/orders"
+            app:popUpTo="@+id/simplePaymentsFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <include app:graph="@navigation/nav_graph_card_reader_flow" />
 </navigation>


### PR DESCRIPTION
Closes: #6782 - prior to this PR, after creating a simple payment and taking a cash payment, the back stack wasn't being cleared. This meant that tapping the back button on the order list would return to the take payment screen.

This PR addresses this by adding a navigatIon action to return to the order list which clears the backstack.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.