### PR TITLE
Fix Addons survey URL

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -33,6 +33,8 @@ object AppUrls {
 
     const val ORDER_CREATION_SURVEY = "https://automattic.survey.fm/woo-app-order-creation-production"
 
+    const val ADDONS_SURVEY = "https://automattic.survey.fm/woo-app-addons-production"
+
     const val COUPONS_SURVEY_DEBUG = "https://automattic.survey.fm/woo-app-coupon-management-testing"
 
     // Will be used later when the feature is fully launched.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -10,7 +10,8 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     SIMPLE_PAYMENTS(AppUrls.SIMPLE_PAYMENTS_SURVEY, 1),
     ORDER_CREATION(AppUrls.ORDER_CREATION_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
-    COUPONS(AppUrls.COUPONS_SURVEY);
+    COUPONS(AppUrls.COUPONS_SURVEY),
+    ADDONS(AppUrls.ADDONS_SURVEY);
 
     val url
         get() = "$untaggedUrl?$platformTag$appVersionTag$milestoneTag"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -94,7 +94,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         when (event) {
             is ShowSurveyView ->
                 NavGraphMainDirections
-                    .actionGlobalFeedbackSurveyFragment(SurveyType.PRODUCT)
+                    .actionGlobalFeedbackSurveyFragment(SurveyType.ADDONS)
                     .apply { findNavController().navigateSafely(this) }
         }
     }


### PR DESCRIPTION
Summary
==========
Fix the Add-on survey issue where the feedback request banner was opening the Survey for the Products feature, mixing the survey data for us.

Thanks @anitaa1990 for detecting this problem 🙇 

How to Test
==========
1. Make sure the Add-ons experimental toggle is active
2. Go to a Order containing add-ons
3. Select the `Give feedback` option in the feature banner
4. Verify that the Survey works as expected in the app

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.