### PR TITLE
Create shared preference for storing Plugin explicitly selected flag.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -482,4 +482,40 @@ class AppPrefsTest {
             )
         ).isNull()
     }
+
+    @Test
+    fun givenIsPluginExplicitlySelectedIsFalseThenReturnFalse() {
+        AppPrefs.setIsCardReaderPluginExplicitlySelectedFlag(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            isPluginExplicitlySelected = false
+        )
+
+        assertThat(
+            AppPrefs.isCardReaderPluginExplicitlySelected(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L,
+            )
+        ).isFalse
+    }
+
+    @Test
+    fun givenIsPluginExplicitlySelectedIsTrueThenReturnTrue() {
+        AppPrefs.setIsCardReaderPluginExplicitlySelectedFlag(
+            localSiteId = 0,
+            remoteSiteId = 0L,
+            selfHostedSiteId = 0L,
+            isPluginExplicitlySelected = true
+        )
+
+        assertThat(
+            AppPrefs.isCardReaderPluginExplicitlySelected(
+                localSiteId = 0,
+                remoteSiteId = 0L,
+                selfHostedSiteId = 0L,
+            )
+        ).isTrue
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -9,6 +9,7 @@ import android.content.SharedPreferences.Editor
 import androidx.preference.PreferenceManager
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_IS_PLUGIN_EXPLICITLY_SELECTED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_ONBOARDING_COMPLETED_STATUS_V2
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_PREFERRED_PLUGIN
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_PREFERRED_PLUGIN_VERSION
@@ -71,6 +72,7 @@ object AppPrefs {
         USER_EMAIL,
         RECEIPT_PREFIX,
         CARD_READER_ONBOARDING_COMPLETED_STATUS_V2,
+        CARD_READER_IS_PLUGIN_EXPLICITLY_SELECTED,
         CARD_READER_PREFERRED_PLUGIN,
         CARD_READER_PREFERRED_PLUGIN_VERSION,
         CARD_READER_STATEMENT_DESCRIPTOR,
@@ -475,6 +477,19 @@ object AppPrefs {
 
     fun isCardReaderWelcomeDialogShown() = getBoolean(UndeletablePrefKey.CARD_READER_WELCOME_SHOWN, false)
 
+    fun isCardReaderPluginExplicitlySelected(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = getBoolean(
+        getIsPluginExplicitlySelectedKey(
+            localSiteId,
+            remoteSiteId,
+            selfHostedSiteId
+        ),
+        false
+    )
+
     fun getCardReaderPreferredPlugin(
         localSiteId: Int,
         remoteSiteId: Long,
@@ -534,11 +549,29 @@ object AppPrefs {
         }
     }
 
+    fun setIsCardReaderPluginExplicitlySelectedFlag(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long,
+        isPluginExplicitlySelected: Boolean
+    ) {
+        setBoolean(
+            getIsPluginExplicitlySelectedKey(localSiteId, remoteSiteId, selfHostedSiteId),
+            isPluginExplicitlySelected
+        )
+    }
+
     private fun getCardReaderOnboardingStatusKey(
         localSiteId: Int,
         remoteSiteId: Long,
         selfHostedSiteId: Long
     ) = PrefKeyString("$CARD_READER_ONBOARDING_COMPLETED_STATUS_V2:$localSiteId:$remoteSiteId:$selfHostedSiteId")
+
+    private fun getIsPluginExplicitlySelectedKey(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = PrefKeyString("$CARD_READER_IS_PLUGIN_EXPLICITLY_SELECTED:$localSiteId:$remoteSiteId:$selfHostedSiteId")
 
     private fun getCardReaderPreferredPluginKey(
         localSiteId: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -27,6 +27,9 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun isCardReaderWelcomeDialogShown() = AppPrefs.isCardReaderWelcomeDialogShown()
 
+    fun isCardReaderPluginExplicitlySelected(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long) =
+        AppPrefs.isCardReaderPluginExplicitlySelected(localSiteId, remoteSiteId, selfHostedSiteId)
+
     fun getCardReaderPreferredPlugin(
         localSiteId: Int,
         remoteSiteId: Long,
@@ -56,6 +59,20 @@ class AppPrefsWrapper @Inject constructor() {
             remoteSiteId,
             selfHostedSiteId,
             data,
+        )
+    }
+
+    fun setIsCardReaderPluginExplicitlySelectedFlag(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long,
+        isPluginExplicitlySelected: Boolean = false
+    ) {
+        AppPrefs.setIsCardReaderPluginExplicitlySelectedFlag(
+            localSiteId,
+            remoteSiteId,
+            selfHostedSiteId,
+            isPluginExplicitlySelected
         )
     }
 


### PR DESCRIPTION
**NOTE:** Please ensure the parent PR #6774 is merged to `trunk` before merging this PR!
<!-- Remember about a good descriptive title. -->

Closes: #6624 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR creates a shared preference to store a boolean value. This boolean value indicates whether the user explicitly selected the plugin or not.

This flag helps us in determining whether [we need to show the “Choose payment provider” screen during onboarding](https://github.com/woocommerce/woocommerce-android/issues/pdfdoF-Tn-p2#preferred-extension-not-selected-extension-setup-completed) or [not](https://github.com/woocommerce/woocommerce-android/issues/pdfdoF-Tn-p2#preferred-extension-selected-extension-setup-completed). Also, this flag helps us to decide whether to show the “Choose payment provider” screen when [the merchant installs a second payment gateway after using the first payment gateway for a while](https://github.com/woocommerce/woocommerce-android/issues/pdfdoF-Tn-p2#only-one-extension-installed-ipp-have-been-used-user-installs-a-second-payment-gateway).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
No functional UI yet. Green CI should be enough.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
