### PR TITLE
Refactor CardReaderOnboardingChecker to allow user to choose between multiple plugins

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.cardreader.onboarding.toInPersonPaymentsPluginType
 import com.woocommerce.android.util.CapturePaymentResponseMapper
 import com.woocommerce.android.util.WooLog
@@ -84,4 +85,7 @@ class CardReaderModule {
     @Provides
     @Reusable
     fun provideCardReaderConfigFactory() = CardReaderConfigFactory()
+
+    @Provides
+    fun providePluginType() = PluginType.valueOf("")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigFactory
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.cardreader.onboarding.toInPersonPaymentsPluginType
 import com.woocommerce.android.util.CapturePaymentResponseMapper
 import com.woocommerce.android.util.WooLog

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -85,7 +85,4 @@ class CardReaderModule {
     @Provides
     @Reusable
     fun provideCardReaderConfigFactory() = CardReaderConfigFactory()
-
-    @Provides
-    fun providePluginType() = PluginType.valueOf("")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/CardReaderTracker.kt
@@ -140,7 +140,7 @@ class CardReaderTracker @Inject constructor(
             is CardReaderOnboardingState.GenericError -> "generic_error"
             is CardReaderOnboardingState.NoConnectionError -> "no_connection_error"
             is CardReaderOnboardingState.WcpayAndStripeActivated -> "wcpay_and_stripe_installed_and_activated"
-            CardReaderOnboardingState.ChoosePaymentProvider ->
+            CardReaderOnboardingState.ChoosePaymentGatewayProvider ->
                 "wcpay_and_stripe_installed_and_activated_choose_payment_provider"
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/CardReaderTracker.kt
@@ -140,6 +140,8 @@ class CardReaderTracker @Inject constructor(
             is CardReaderOnboardingState.GenericError -> "generic_error"
             is CardReaderOnboardingState.NoConnectionError -> "no_connection_error"
             is CardReaderOnboardingState.WcpayAndStripeActivated -> "wcpay_and_stripe_installed_and_activated"
+            CardReaderOnboardingState.ChoosePaymentProvider ->
+                "wcpay_and_stripe_installed_and_activated_choose_payment_provider"
         }
 
     private fun getPluginNameReasonPrefix(pluginType: PluginType): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -142,7 +142,9 @@ class CardReaderOnboardingChecker @Inject constructor(
                 return WcpayAndStripeActivated
             }
         } else {
-            updatePluginExplicitlySelectedFlag(false)
+            if (ippSelectPaymentGateway.isEnabled()) {
+                updatePluginExplicitlySelectedFlag(false)
+            }
         }
 
         val preferredPlugin = getUserSelectedPluginOrActivatedPlugin(wcPayPluginInfo, stripePluginInfo)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -209,8 +209,7 @@ class CardReaderOnboardingChecker @Inject constructor(
 
     private fun getMultipleGatewayProviderState(): CardReaderOnboardingState {
         return when {
-            !isPluginExplicitlySelected() &&
-                    !hasUserAlreadySelectedThePlugin() -> ChoosePaymentGatewayProvider
+            !isPluginExplicitlySelected() && !hasUserAlreadySelectedThePlugin() -> ChoosePaymentGatewayProvider
             else -> throw IllegalStateException(
                 "Developer error: plugin selected flag is true even when the user hasn't selected the plugin"
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.ui.cardreader.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.cardreader.IppSelectPaymentGateway
-import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentProvider
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentGatewayProvider
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.GenericError
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.NoConnectionError
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.OnboardingCompleted
@@ -130,7 +130,7 @@ class CardReaderOnboardingChecker @Inject constructor(
                 }
             }
             if (ippSelectPaymentGateway.isEnabled() && !isPluginExplicitlySelected()) {
-                return ChoosePaymentProvider
+                return ChoosePaymentGatewayProvider
             }
             return WcpayAndStripeActivated
         }
@@ -403,7 +403,7 @@ sealed class CardReaderOnboardingState(
      * provider in this state.
      */
     @Parcelize
-    object ChoosePaymentProvider : CardReaderOnboardingState()
+    object ChoosePaymentGatewayProvider : CardReaderOnboardingState()
 
     /**
      * This is a bit special case: WCPay is set to "dev mode" but the connected Stripe account is in live mode.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -76,6 +76,7 @@ class CardReaderOnboardingChecker @Inject constructor(
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper,
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
     private val ippSelectPaymentGateway: IppSelectPaymentGateway,
+    private val userSelectedPlugin: PluginType? = null,
 ) {
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         if (!networkStatus.isConnected()) return NoConnectionError
@@ -129,13 +130,18 @@ class CardReaderOnboardingChecker @Inject constructor(
                     return PluginIsNotSupportedInTheCountry(pluginType, countryCode!!)
                 }
             }
-            if (ippSelectPaymentGateway.isEnabled() && !isPluginExplicitlySelected()) {
-                return ChoosePaymentGatewayProvider
+            if (ippSelectPaymentGateway.isEnabled()) {
+                if (hasUserAlreadySelectedThePlugin()) {
+                    updatePluginExplicitlySelectedFlag(true)
+                } else {
+                    return getMultipleGatewayProviderState()
+                }
+            } else {
+                return WcpayAndStripeActivated
             }
-            return WcpayAndStripeActivated
         }
 
-        val preferredPlugin = getPreferredPlugin(stripePluginInfo, wcPayPluginInfo)
+        val preferredPlugin = getUserSelectedPluginOrActivatedPlugin(wcPayPluginInfo, stripePluginInfo)
 
         if (!isPluginInstalled(preferredPlugin)) when (preferredPlugin.type) {
             WOOCOMMERCE_PAYMENTS -> return WcpayNotInstalled
@@ -192,6 +198,44 @@ class CardReaderOnboardingChecker @Inject constructor(
             preferredPlugin.info?.version,
             requireNotNull(countryCode)
         )
+    }
+
+    private fun hasUserAlreadySelectedThePlugin(): Boolean {
+        if (userSelectedPlugin != null) {
+            return true
+        }
+        return false
+    }
+
+    private fun getMultipleGatewayProviderState(): CardReaderOnboardingState {
+        return when {
+            !isPluginExplicitlySelected() &&
+                    !hasUserAlreadySelectedThePlugin() -> ChoosePaymentGatewayProvider
+            else -> throw IllegalStateException(
+                "Developer error: plugin selected flag is true even when the user hasn't selected the plugin"
+            )
+        }
+    }
+
+    private fun getUserSelectedPluginOrActivatedPlugin(
+        wcPayPluginInfo: SitePluginModel?,
+        stripePluginInfo: SitePluginModel?,
+    ): PluginWrapper {
+        return when {
+            hasUserAlreadySelectedThePlugin() -> {
+                getUserSelectedPluginWrapper(wcPayPluginInfo, stripePluginInfo)
+            }
+            else -> {
+                getPreferredPlugin(stripePluginInfo, wcPayPluginInfo)
+            }
+        }
+    }
+
+    private fun getUserSelectedPluginWrapper(
+        wcPayPluginInfo: SitePluginModel?,
+        stripePluginInfo: SitePluginModel?,
+    ): PluginWrapper {
+        return PluginWrapper(userSelectedPlugin!!, userSelectedPlugin.getPluginInfo(wcPayPluginInfo, stripePluginInfo))
     }
 
     private fun isPluginSupportedInCountry(
@@ -335,6 +379,12 @@ enum class PluginType {
     WOOCOMMERCE_PAYMENTS,
     STRIPE_EXTENSION_GATEWAY
 }
+
+fun PluginType.getPluginInfo(wcPayPluginInfo: SitePluginModel?, stripePluginInfo: SitePluginModel?) =
+    when (this) {
+        WOOCOMMERCE_PAYMENTS -> wcPayPluginInfo
+        STRIPE_EXTENSION_GATEWAY -> stripePluginInfo
+    }
 
 private fun PluginType.toSupportedExtensionType() =
     when (this) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -132,6 +132,11 @@ class CardReaderOnboardingChecker @Inject constructor(
             if (ippSelectPaymentGateway.isEnabled()) {
                 when {
                     isUserComingFromChoosePaymentGatewayScreen(pluginType) -> {
+                        updateSharedPreferences(
+                            CARD_READER_ONBOARDING_NOT_COMPLETED,
+                            pluginType,
+                            null
+                        )
                         updatePluginExplicitlySelectedFlag(true)
                     }
                     !isPluginExplicitlySelected() -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -129,8 +129,7 @@ class CardReaderOnboardingChecker @Inject constructor(
                     return PluginIsNotSupportedInTheCountry(pluginType, countryCode!!)
                 }
             }
-            val isPluginExplicitlySelected = isPluginExplicitlySelected()
-            if (ippSelectPaymentGateway.isEnabled() && !isPluginExplicitlySelected) {
+            if (ippSelectPaymentGateway.isEnabled() && !isPluginExplicitlySelected()) {
                 return ChoosePaymentProvider
             }
             return WcpayAndStripeActivated

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.ui.cardreader.CardReaderTrackingInfoKeeper
+import com.woocommerce.android.ui.cardreader.IppSelectPaymentGateway
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.GenericError
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.NoConnectionError
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.OnboardingCompleted
@@ -73,6 +74,7 @@ class CardReaderOnboardingChecker @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper,
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
+    private val ippSelectPaymentGateway: IppSelectPaymentGateway,
 ) {
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         if (!networkStatus.isConnected()) return NoConnectionError
@@ -83,7 +85,9 @@ class CardReaderOnboardingChecker @Inject constructor(
                     is OnboardingCompleted -> CARD_READER_ONBOARDING_COMPLETED to it.version
                     is StripeAccountPendingRequirement -> CARD_READER_ONBOARDING_PENDING to it.version
                     else -> {
-                        updatePluginExplicitlySelectedFlag(false)
+                        if (ippSelectPaymentGateway.isEnabled()) {
+                            updatePluginExplicitlySelectedFlag(false)
+                        }
                         CARD_READER_ONBOARDING_NOT_COMPLETED to null
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -141,6 +141,8 @@ class CardReaderOnboardingChecker @Inject constructor(
             } else {
                 return WcpayAndStripeActivated
             }
+        } else {
+            updatePluginExplicitlySelectedFlag(false)
         }
 
         val preferredPlugin = getUserSelectedPluginOrActivatedPlugin(wcPayPluginInfo, stripePluginInfo)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -82,7 +82,10 @@ class CardReaderOnboardingChecker @Inject constructor(
                 val (status, version) = when (it) {
                     is OnboardingCompleted -> CARD_READER_ONBOARDING_COMPLETED to it.version
                     is StripeAccountPendingRequirement -> CARD_READER_ONBOARDING_PENDING to it.version
-                    else -> CARD_READER_ONBOARDING_NOT_COMPLETED to null
+                    else -> {
+                        updatePluginExplicitlySelectedFlag(false)
+                        CARD_READER_ONBOARDING_NOT_COMPLETED to null
+                    }
                 }
                 updateSharedPreferences(
                     status,
@@ -281,6 +284,16 @@ class CardReaderOnboardingChecker @Inject constructor(
             remoteSiteId = site.siteId,
             selfHostedSiteId = site.selfHostedSiteId,
             PersistentOnboardingData(status, preferredPlugin, version),
+        )
+    }
+
+    private fun updatePluginExplicitlySelectedFlag(isPluginExplicitlySelected: Boolean) {
+        val site = selectedSite.get()
+        appPrefsWrapper.setIsCardReaderPluginExplicitlySelectedFlag(
+            localSiteId = site.id,
+            remoteSiteId = site.siteId,
+            selfHostedSiteId = site.selfHostedSiteId,
+            isPluginExplicitlySelected = isPluginExplicitlySelected
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -264,7 +264,10 @@ sealed class CardReaderOnboardingParams : Parcelable {
     abstract val cardReaderFlowParam: CardReaderFlowParam
 
     @Parcelize
-    data class Check(override val cardReaderFlowParam: CardReaderFlowParam) : CardReaderOnboardingParams()
+    data class Check(
+        override val cardReaderFlowParam: CardReaderFlowParam,
+        val pluginType: PluginType? = null
+    ) : CardReaderOnboardingParams()
 
     @Parcelize
     data class Failed(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingParams.Check
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingParams.Failed
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentProvider
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.GenericError
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.NoConnectionError
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.OnboardingCompleted
@@ -199,6 +200,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     ::onLearnMoreClicked
                 )
             WcpayAndStripeActivated -> updateUiWithWcPayAndStripeActivated()
+            ChoosePaymentProvider -> TODO()
         }.exhaustive
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -15,7 +15,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingParams.Check
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingParams.Failed
-import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentProvider
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentGatewayProvider
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.GenericError
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.NoConnectionError
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.OnboardingCompleted
@@ -200,7 +200,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     ::onLearnMoreClicked
                 )
             WcpayAndStripeActivated -> updateUiWithWcPayAndStripeActivated()
-            ChoosePaymentProvider -> TODO()
+            ChoosePaymentGatewayProvider -> TODO()
         }.exhaustive
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -87,15 +87,15 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     init {
         when (val onboardingParam = arguments.cardReaderOnboardingParam) {
-            is Check -> refreshState()
+            is Check -> refreshState(onboardingParam.pluginType)
             is Failed -> showOnboardingState(onboardingParam.onboardingState)
         }.exhaustive
     }
 
-    private fun refreshState() {
+    private fun refreshState(pluginType: PluginType? = null) {
         launch {
             viewState.value = OnboardingViewState.LoadingState
-            val state = cardReaderChecker.getOnboardingState()
+            val state = cardReaderChecker.getOnboardingState(pluginType)
             cardReaderTracker.trackOnboardingState(state)
             showOnboardingState(state)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1154,6 +1154,24 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `when onboarding completed, then do not clear pluginExplicitlySelected flag`() = testBlocking {
+        whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+            .thenReturn(buildWCPayPluginInfo(isActive = true))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+            .thenReturn(null)
+
+        checker.getOnboardingState()
+
+        verify(appPrefsWrapper, never()).setIsCardReaderPluginExplicitlySelectedFlag(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            anyBoolean(),
+        )
+    }
+
     private fun buildPaymentAccountResult(
         status: WCPaymentAccountResult.WCPaymentAccountStatus = WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE,
         hasPendingRequirements: Boolean = false,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.any
@@ -1131,6 +1132,26 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             captor.capture(),
         )
         assertThat(captor.firstValue).isFalse()
+    }
+
+    @Test
+    fun `when onboarding has pending requirements, then do not clear pluginExplicitlySelected flag`() = testBlocking {
+        whenever(wcInPersonPaymentsStore.loadAccount(any(), any())).thenReturn(
+            buildPaymentAccountResult(
+                WCPaymentAccountResult.WCPaymentAccountStatus.RESTRICTED,
+                hasPendingRequirements = true,
+                hadOverdueRequirements = false
+            )
+        )
+
+        checker.getOnboardingState()
+
+        verify(appPrefsWrapper, never()).setIsCardReaderPluginExplicitlySelectedFlag(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            anyBoolean(),
+        )
     }
 
     private fun buildPaymentAccountResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1115,6 +1115,24 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         assertThat((result as PreferredPluginResult.Success).type).isEqualTo(PluginType.WOOCOMMERCE_PAYMENTS)
     }
 
+    //region - Multiple Plugins detected tests
+
+    @Test
+    fun `when onboarding not completed, then clear pluginExplicitlySelected flag`() = testBlocking {
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn("unsupported country abc")
+
+        checker.getOnboardingState()
+
+        val captor = argumentCaptor<Boolean>()
+        verify(appPrefsWrapper).setIsCardReaderPluginExplicitlySelectedFlag(
+            anyInt(),
+            anyLong(),
+            anyLong(),
+            captor.capture(),
+        )
+        assertThat(captor.firstValue).isFalse()
+    }
+
     private fun buildPaymentAccountResult(
         status: WCPaymentAccountResult.WCPaymentAccountStatus = WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE,
         hasPendingRequirements: Boolean = false,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1229,26 +1229,6 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             assertThat(result).isEqualTo(CardReaderOnboardingState.ChoosePaymentGatewayProvider)
         }
 
-    @Test(expected = IllegalStateException::class)
-    fun `given no plugin selected and selected flag true, when multiple plugins, then throw exception`() =
-        testBlocking {
-            whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
-            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
-            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
-            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-                .thenReturn(buildWCPayPluginInfo(isActive = true))
-            whenever(
-                appPrefsWrapper.isCardReaderPluginExplicitlySelected(
-                    anyInt(),
-                    anyLong(),
-                    anyLong(),
-                )
-            ).thenReturn(true)
-
-            checker.getOnboardingState()
-        }
-
     @Test
     fun `given plugin selected, when multiple plugins, then set plugin flag`() =
         testBlocking {
@@ -1299,6 +1279,66 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
                 anyLong(),
                 anyBoolean()
             )
+        }
+
+    @Test
+    fun `given plugin selected, when navigating to onboarding, then select the plugin from shared preference`() =
+        testBlocking {
+            whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(isActive = true))
+            whenever(
+                appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                    anyInt(),
+                    anyLong(),
+                    anyLong(),
+                )
+            ).thenReturn(true)
+            whenever(
+                appPrefsWrapper.getCardReaderPreferredPlugin(
+                    anyInt(),
+                    anyLong(),
+                    anyLong(),
+                )
+            ).thenReturn(STRIPE_EXTENSION_GATEWAY)
+
+            checker.getOnboardingState()
+
+            verify(appPrefsWrapper).getCardReaderPreferredPlugin(
+                anyInt(),
+                anyLong(),
+                anyLong(),
+            )
+        }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given plugin selected flag is true, when no plugin found in shared preference , then throw exception`() =
+        testBlocking {
+            whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(isActive = true))
+            whenever(
+                appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                    anyInt(),
+                    anyLong(),
+                    anyLong(),
+                )
+            ).thenReturn(true)
+            whenever(
+                appPrefsWrapper.getCardReaderPreferredPlugin(
+                    anyInt(),
+                    anyLong(),
+                    anyLong(),
+                )
+            ).thenReturn(null)
+
+            checker.getOnboardingState()
         }
 
     //endregion

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1192,6 +1192,21 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given feature flag is enabled, when wcpay and stripe activated, then ChoosePaymentProvider returned`() =
+        testBlocking {
+            whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(isActive = true))
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(CardReaderOnboardingState.ChoosePaymentProvider)
+        }
+
     private fun buildPaymentAccountResult(
         status: WCPaymentAccountResult.WCPaymentAccountStatus = WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE,
         hasPendingRequirements: Boolean = false,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1285,8 +1285,9 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given single plugin, when onboarding checks, then clear plugin selected flag`() =
+    fun `given single plugin, when payment gateway feature is enabled, then clear plugin selected flag`() =
         testBlocking {
+            whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
                 .thenReturn(null)
@@ -1300,6 +1301,25 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
                 anyLong(),
                 anyLong(),
                 eq(false)
+            )
+        }
+
+    @Test
+    fun `given single plugin, when payment gateway feature is disabled, then don't clear plugin selected flag`() =
+        testBlocking {
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(null)
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(isActive = true))
+
+            checker.getOnboardingState()
+
+            verify(appPrefsWrapper, never()).setIsCardReaderPluginExplicitlySelectedFlag(
+                anyInt(),
+                anyLong(),
+                anyLong(),
+                anyBoolean(),
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1207,6 +1207,8 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             assertThat(result).isEqualTo(CardReaderOnboardingState.ChoosePaymentProvider)
         }
 
+    //endregion
+
     private fun buildPaymentAccountResult(
         status: WCPaymentAccountResult.WCPaymentAccountStatus = WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE,
         hasPendingRequirements: Boolean = false,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1388,6 +1388,46 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             )
         }
 
+    @Test
+    fun `when navigating to onboarding via payment gateway screen, then store the plugin to the shared preference`() =
+        testBlocking {
+            whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+                .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
+            whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+                .thenReturn(buildWCPayPluginInfo(isActive = true))
+            whenever(
+                appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                    anyInt(),
+                    anyLong(),
+                    anyLong(),
+                )
+            ).thenReturn(true)
+            whenever(
+                appPrefsWrapper.getCardReaderPreferredPlugin(
+                    anyInt(),
+                    anyLong(),
+                    anyLong(),
+                )
+            ).thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
+
+            checker.getOnboardingState(PluginType.WOOCOMMERCE_PAYMENTS)
+
+            verify(appPrefsWrapper).setCardReaderOnboardingData(
+                anyInt(),
+                anyLong(),
+                anyLong(),
+                eq(
+                    PersistentOnboardingData(
+                        CARD_READER_ONBOARDING_NOT_COMPLETED,
+                        PluginType.WOOCOMMERCE_PAYMENTS,
+                        null
+                    )
+                )
+            )
+        }
+
     @Test(expected = IllegalStateException::class)
     fun `given plugin selected flag is true, when no plugin found in shared preference , then throw exception`() =
         testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1204,7 +1204,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.ChoosePaymentProvider)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.ChoosePaymentGatewayProvider)
         }
 
     //endregion


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6626 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR does the following:
1. Introduce the IPP Payment Gateway feature flag into the `CardReaderOnboardingChecker` class
2. Inject `PluginType` into `CardReaderOnboardingChecker` class
3. Updates the "isPluginExplicitlySelected" flag to `false` when the onboarding fails for any reason.
4. Adds a new state `ChoosePaymentGatewayProvider`
5. Returns `ChoosePaymentGatewayProvider` when the IPP Payment Gateway feature flag is enabled and the "isPluginExplicitlySelected" flag is set to `false` and user hasn't selected the plugin yet.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
ViewModel and the UI aren't connected to this logic yet. Green CI should be enough.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
