### PR TITLE
Adds release management prechecks script

### DIFF
--- a/scripts/release-management-prechecks.sh
+++ b/scripts/release-management-prechecks.sh
@@ -33,7 +33,7 @@ error_project_env_file_missing() {
     echoerr "$PROJECT_ENV_FILE is missing!"
 }
 error_project_env_field_missing() {
-    echoerr "'$1' is missing in $PROJECT_ENV_FILE!"
+    echoerr "'$1' is missing or incorrect in $PROJECT_ENV_FILE!"
 }
 warning_project_env_file_contents() {
     echo \
@@ -47,6 +47,12 @@ Please make sure you have the following information in '$PROJECT_ENV_FILE':
 > $P_ENV_SENTRY_PROJECT_SLUG=$P_ENV_SENTRY_PROJECT_SLUG_VALUE
 >
 > $P_ENV_BUILDKITE_TOKEN={$P_ENV_BUILDKITE_TOKEN}
+
+Here is how to retrieve these values:
+
+$P_ENV_GITHUB_TOKEN: https://github.com/settings/tokens (requires 'repo')
+$P_ENV_SENTRY_AUTH_TOKEN: https://sentry.io/settings/account/api/auth-tokens/ (requires 'event:read, member:read, org:read, project:read, project:releases, team:read, event:admin')
+$P_ENV_BUILDKITE_TOKEN: https://buildkite.com/user/api-access-tokens (requires 'read_builds, write_builds')
 "
 }
 
@@ -100,12 +106,12 @@ else
 
     match_any_word="\w*"
 
-    # These tokens can be any string
+    # These tokens can match to any string
     check_project_env "$P_ENV_GITHUB_TOKEN" "$match_any_word"
     check_project_env "$P_ENV_SENTRY_AUTH_TOKEN" "$match_any_word"
     check_project_env "$P_ENV_BUILDKITE_TOKEN" "$match_any_word"
 
-    # These values are set per project in configuration section
+    # These values are set per project in configuration section and the value is not a secret
     check_project_env "$P_ENV_SENTRY_ORG_SLUG" "$P_ENV_SENTRY_ORG_SLUG_VALUE"
     check_project_env "$P_ENV_SENTRY_PROJECT_SLUG" "$P_ENV_SENTRY_PROJECT_SLUG_VALUE"
 fi

--- a/scripts/release-management-prechecks.sh
+++ b/scripts/release-management-prechecks.sh
@@ -63,8 +63,8 @@ LOG_SEPERATOR="
 # 1. Checking Ruby Version
 # ---------------------------------------------------------------------------------
 
-PROJECT_RUBY_VERSION=`cat $PROJECT_ROOT/.ruby-version`
-LOCAL_RUBY_VERSION=`ruby -e 'puts RUBY_VERSION'`
+PROJECT_RUBY_VERSION=$(cat $PROJECT_ROOT/.ruby-version)
+LOCAL_RUBY_VERSION=$(ruby -e 'puts RUBY_VERSION')
 
 if [ "$LOCAL_RUBY_VERSION" != "$PROJECT_RUBY_VERSION" ]; then
     echo "Local Ruby Version: $LOCAL_RUBY_VERSION"


### PR DESCRIPTION
### Description
Woo developers will start doing release management rotations and this is an attempt at helping them get their local environment ready for it. It adds a bash script to check the Ruby version and the necessary values in project env file `$HOME/.wcandroid-env.default`. As we go through these rotations we'll likely figure out more issues we can check and improve on this script.

I was torn between working on a proper tool to do these checks and using a Bash script and I ended up going with Bash script because it's much faster to introduce and iterate on. We are also hoping to move away from having to run release management commands in local environment, so there is a chance that it might become obsolete. At the moment we are only using this script in WCiOS & WCAndroid, so it's easy to update them together, however if we want to introduce it to other projects or if the script is becoming unmanageable we should port it to a proper distributed tool.

_Note that there is a [WCiOS PR](https://github.com/woocommerce/woocommerce-ios/issues/7131) adding the exact same script except for `PROJECT_ENV_FILE` & `P_ENV_SENTRY_PROJECT_SLUG_VALUE` values._

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Change [`.ruby-version`](https://github.com/woocommerce/woocommerce-android/blob/trunk/.ruby-version) to a value that's not installed on your local environment. You can see the installed versions with the `rbenv versions` command. Then, run the script and verify that it shows an error that `your local ruby version doesn't match the required ruby version.`
2. Remove `$HOME/.wcandroid-env.default` file (remember to create a backup) and run the script. Verify that it says the project env file is missing and prints helpful information about the necessary values. Restore the `$HOME/.wcandroid-env.default` file.
3. Comment out at least 2 required fields in `$HOME/.wcandroid-env.default` file and run the script. Verify that it tells you the missing or incorrect fields.
4. Run the script and verify that it tells you `everything looks good`.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
