### PR TITLE
Order details do not show mark order complete for unpaid order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -193,9 +193,6 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
                 showOrderDetail(it.order!!, it.isPaymentCollectableWithCardReader, it.isReceiptButtonsVisible)
             }
             new.orderStatus?.takeIfNotEqualTo(old?.orderStatus) { showOrderStatus(it) }
-            new.isMarkOrderCompleteButtonVisible?.takeIfNotEqualTo(old?.isMarkOrderCompleteButtonVisible) {
-                showMarkOrderCompleteButton(it)
-            }
             new.isCreateShippingLabelButtonVisible?.takeIfNotEqualTo(old?.isCreateShippingLabelButtonVisible) {
                 showShippingLabelButton(it)
             }
@@ -353,13 +350,6 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
 
     private fun showOrderStatus(orderStatus: OrderStatus) {
         binding.orderDetailOrderStatus.updateStatus(orderStatus)
-    }
-
-    private fun showMarkOrderCompleteButton(isVisible: Boolean) {
-        binding.orderDetailProductList.showMarkOrderCompleteButton(
-            isVisible,
-            viewModel::onMarkOrderCompleteButtonTapped
-        )
     }
 
     private fun showShippingLabelButton(isVisible: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -702,9 +702,6 @@ final class OrderDetailViewModel @Inject constructor(
         val isProductListMenuVisible: Boolean? = null,
         val wcShippingBannerVisible: Boolean? = null
     ) : Parcelable {
-        val isMarkOrderCompleteButtonVisible: Boolean?
-            get() = if (orderStatus != null) orderStatus.statusKey == CoreOrderStatus.PROCESSING.value else null
-
         val isCreateShippingLabelBannerVisible: Boolean
             get() = isCreateShippingLabelButtonVisible == true && isProductListVisible == true
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -481,11 +481,6 @@ final class OrderDetailViewModel @Inject constructor(
         triggerEvent(StartShippingLabelCreationFlow(order.id))
     }
 
-    fun onMarkOrderCompleteButtonTapped() {
-        trackerWrapper.track(ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
-        triggerEvent(ViewOrderFulfillInfo(order.id))
-    }
-
     fun onViewOrderedAddonButtonTapped(orderItem: Order.Item) {
         trackerWrapper.track(PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED)
         triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -9,7 +9,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_PULLED_TO_REFRESH
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE_FAILED
@@ -48,7 +47,6 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.RefundShippingLab
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartPaymentFlow
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartShippingLabelCreationFlow
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewCreateShippingLabelInfo
-import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderFulfillInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderedAddons
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintCustomsForm

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
@@ -90,14 +90,6 @@ class OrderDetailProductListView @JvmOverloads constructor(
         }
     }
 
-    fun showMarkOrderCompleteButton(
-        isVisible: Boolean,
-        onMarkOrderCompleteButtonTapped: () -> Unit
-    ) {
-        binding.productListBtnMarkOrderComplete.isVisible = isVisible
-        binding.productListBtnMarkOrderComplete.setOnClickListener { onMarkOrderCompleteButtonTapped() }
-    }
-
     fun showCreateShippingLabelButton(
         isVisible: Boolean,
         onCreateShippingLabelButtonTapped: () -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillFragment.kt
@@ -157,7 +157,6 @@ class OrderFulfillFragment :
         products.whenNotNullNorEmpty {
             with(binding.orderDetailProductList) {
                 showProductListMenuButton(false)
-                showMarkOrderCompleteButton(false) { }
                 updateProductList(
                     orderItems = products,
                     productImageMap = productImageMap,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillFragment.kt
@@ -144,9 +144,6 @@ class OrderFulfillFragment :
             isVirtualOrder = viewModel.hasVirtualProductsOnly(),
             isReadOnly = true
         )
-        binding.buttonMarkOrderCompete.setOnClickListener {
-            viewModel.onMarkOrderCompleteButtonClicked()
-        }
     }
 
     private fun showOrderProducts(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
-import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -116,19 +115,6 @@ class OrderFulfillViewModel @Inject constructor(
             val remoteProductIds = order.getProductIds()
             repository.hasVirtualProductsOnly(remoteProductIds)
         } else false
-    }
-
-    fun onMarkOrderCompleteButtonClicked() {
-        if (networkStatus.isConnected()) {
-            triggerEvent(
-                ExitWithResult(
-                    data = OrderDetailViewModel.OrderStatusUpdateSource.FullFillScreen(oldStatus = order.status.value),
-                    key = KEY_ORDER_FULFILL_RESULT
-                )
-            )
-        } else {
-            triggerEvent(ShowSnackbar(string.offline_error))
-        }
     }
 
     fun onAddShipmentTrackingClicked() {

--- a/WooCommerce/src/main/res/layout/fragment_order_fulfill.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_fulfill.xml
@@ -52,16 +52,5 @@
             android:layout_marginEnd="@dimen/major_100"
             android:layout_marginBottom="@dimen/major_100"
             android:text="@string/order_fulfill_email_info"/>
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/button_mark_order_compete"
-            style="@style/Woo.Button.Colored"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:text="@string/order_mark_complete"/>
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/WooCommerce/src/main/res/layout/order_detail_product_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_list.xml
@@ -50,7 +50,6 @@
             tools:listitem="@layout/order_detail_product_list_item"
             tools:targetApi="lollipop" />
 
-        <!-- Button: Mark order complete -->
         <com.google.android.material.button.MaterialButton
             android:id="@+id/productList_btnCreateShippingLabel"
             style="@style/Woo.Button.Colored"
@@ -60,34 +59,19 @@
             android:layout_marginEnd="@dimen/major_100"
             android:text="@string/orderdetail_shipping_label_create_shipping_label"
             android:visibility="gone"
+            tools:visibility="visible"
             app:layout_goneMarginBottom="@dimen/major_100"
-            app:layout_constraintBottom_toTopOf="@id/productList_btnMarkOrderComplete"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/productList_products" />
-
-        <!-- Button: Mark order complete -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/productList_btnMarkOrderComplete"
-            style="@style/Woo.Button.Outlined"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            app:layout_goneMarginBottom="@dimen/major_100"
-            android:text="@string/order_mark_complete"
             app:layout_constraintBottom_toTopOf="@id/productList_shippingLabelsNotice"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/productList_btnCreateShippingLabel"
-            tools:visibility="gone" />
+            app:layout_constraintTop_toBottomOf="@+id/productList_products" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/productList_shippingLabelsNotice"
             style="@style/Woo.TextView.Body2"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            tools:visibility="visible"
             android:layout_marginBottom="@dimen/major_100"
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginEnd="@dimen/major_100"
@@ -99,7 +83,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/productList_btnMarkOrderComplete" />
+            app:layout_constraintTop_toBottomOf="@id/productList_btnCreateShippingLabel" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1199,22 +1199,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED)
         }
 
-    @Test
-    fun `when user taps a mark order complete button, then event tracked`() =
-        testBlocking {
-            // Given
-            doReturn(order).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
-            doReturn(false).whenever(orderDetailRepository).fetchOrderNotes(any())
-            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
-            viewModel.start()
 
-            // When
-            viewModel.onMarkOrderCompleteButtonTapped()
-
-            // Then
-            verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
-        }
 
     @Test
     fun `when user taps a view order addon button, then event tracked`() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1199,8 +1199,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED)
         }
 
-
-
     @Test
     fun `when user taps a view order addon button, then event tracked`() =
         testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -74,7 +74,6 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-
         viewModel = spy(
             OrderFulfillViewModel(
                 savedState,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFullfillViewModelTest.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.model.Refund
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
-import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
 import com.woocommerce.android.ui.orders.fulfill.OrderFulfillFragmentArgs
 import com.woocommerce.android.ui.orders.fulfill.OrderFulfillViewModel
 import com.woocommerce.android.ui.orders.fulfill.OrderFulfillViewModel.ViewState
@@ -75,7 +74,6 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        doReturn(true).whenever(networkStatus).isConnected()
 
         viewModel = spy(
             OrderFulfillViewModel(
@@ -204,48 +202,6 @@ class OrderFullfillViewModelTest : BaseUnitTest() {
             viewModel.start()
             assertThat(orderData?.isShipmentTrackingAvailable).isFalse()
         }
-
-    @Test
-    fun `Update order status when network connected`() = testBlocking {
-        doReturn(order).whenever(repository).getOrderById(any())
-        doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
-
-        var snackBar: ShowSnackbar? = null
-        var exit: ExitWithResult<*>? = null
-        viewModel.event.observeForever {
-            if (it is ExitWithResult<*>) exit = it
-            else if (it is ShowSnackbar) snackBar = it
-        }
-
-        viewModel.start()
-        viewModel.onMarkOrderCompleteButtonClicked()
-
-        assertThat(exit).isEqualTo(
-            ExitWithResult(
-                OrderDetailViewModel.OrderStatusUpdateSource.FullFillScreen(order.status.value),
-                OrderFulfillViewModel.KEY_ORDER_FULFILL_RESULT
-            )
-        )
-        assertNull(snackBar)
-    }
-
-    @Test
-    fun `Do not update order status when not connected`() = testBlocking {
-        doReturn(false).whenever(networkStatus).isConnected()
-
-        var snackbar: ShowSnackbar? = null
-        var exit: ExitWithResult<*>? = null
-        viewModel.event.observeForever {
-            if (it is ExitWithResult<*>) exit = it
-            else if (it is ShowSnackbar) snackbar = it
-        }
-
-        viewModel.order = order
-        viewModel.onMarkOrderCompleteButtonClicked()
-
-        assertNull(exit)
-        assertThat(snackbar).isEqualTo(ShowSnackbar(string.offline_error))
-    }
 
     @Test
     fun `refresh shipping tracking items when an item is added`() = testBlocking {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6779
<!-- Id number of the GitHub issue this PR addresses. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR removes "mark order complete" button in "process"  status, which means that it removes it completely because we never show that aside of this case
The PR removes "mark order complete" button from the order details screen. We were showing it only for `PROCESSING` orders

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* In the current duck-in-row branch notice that the button is visible in processing state
* In the current branch notice that it's gone
* Make sure that "create shipping button" positioned the same as before these changes

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="256" alt="image" src="https://user-images.githubusercontent.com/4923871/175290680-bfd85e41-c54e-47b2-a5fd-1677d78e28ed.png">

