### PR TITLE
Fix crash when signing in to a site with Http Auth enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -22,6 +22,8 @@ import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentLoginNoJetpackBinding
+import com.woocommerce.android.databinding.ViewLoginNoStoresBinding
+import com.woocommerce.android.databinding.ViewLoginUserInfoBinding
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
@@ -101,8 +103,8 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
 
         val binding = FragmentLoginNoJetpackBinding.bind(view)
         val btnBinding = binding.loginEpilogueButtonBar
-        val noStoresBinding = binding.loginNoStores
-        val userInfoBinding = binding.loginUserInfo
+        val noStoresBinding = ViewLoginNoStoresBinding.bind(view)
+        val userInfoBinding = ViewLoginUserInfoBinding.bind(view)
 
         userInfoBinding.textDisplayname.text = mInputUsername
         with(userInfoBinding.textUsername) {

--- a/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
@@ -11,7 +11,8 @@
         android:layout_weight="1"
         android:fillViewport="true">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
+            android:orientation="vertical"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
@@ -21,18 +22,22 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/help"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                android:layout_gravity="end"/>
 
             <include
-                android:id="@+id/login_user_info"
-                layout="@layout/view_login_user_info"/>
+                layout="@layout/view_login_user_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100" />
 
             <include
-                android:id="@+id/login_no_stores"
-                layout="@layout/view_login_no_stores"/>
+                layout="@layout/view_login_no_stores"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
     </ScrollView>
 
     <View


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6803

### Description
This PR fixes the crash of the issue above.
The cause of the crash is that the layouts `view_login_user_info` and `view_login_no_stores` were updated to use the `merge` tag recently, which broke the usage in `LoginNoJetpackFragment`, as it seems using the `merge` tag, causes an issue with `ViewBinding`, where the compilation passes, but it can't find the view with the given `id` when calling `bind`, ~~this seems like a bug of `ViewBinding` but I didn't check~~ this is a `ViewBinding` [bug](https://issuetracker.google.com/issues/147792710), and I found a StackOverflow [question](https://stackoverflow.com/questions/59753930/how-can-i-access-views-from-layout-containing-merge-tag-is-included-in-another-l) that explains the same issue and how to solve it.

I applied the same fix here, while it seems that the better solution would be to start using the views `LoginNoStoresView` and `LoginUserInfoView` instead of the `include` tag, but this requires more changes, and we want the fix ASAP.

### Testing instructions
1. Make sure you clear data in the app.
2. Open the app.
3. Click on login using site address.
4. Enter the site address, and submit.
5. On next screen, click on login using site credentials.
6. Open wp-admin, and enable Http Auth (you can use the following [plugin](https://wordpress.org/plugins/http-auth/) if needed).
7. Go back to the app, and enter your site credentials.
8. Confirm the `LoginNoJetpackFragment` screen shows correctly and doesn't crash.

There may be an easier way to replicate the crash, but this is the one I was able to find from following the code, and different attempts.

### Images/gif
<img width=360 src="https://user-images.githubusercontent.com/1657201/175299288-15483e83-d5ab-4072-9ed8-1cc8895d2348.png" />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
