### PR TITLE
 Check if selected site exists before showing the eligibility screen (targeting 9.4)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -259,7 +259,7 @@ class MainActivity :
             return
         }
 
-        if (!presenter.isUserEligible()) {
+        if (selectedSite.exists() && !presenter.isUserEligible()) {
             showUserEligibilityErrorScreen()
             return
         }


### PR DESCRIPTION
⚠️ This is the same PR as #6806, just targetting `9.4` as it was decided we won't have a `9.3.2` release.

@nbradbury I'm assigning this to you for approval, as you already reviewed it in the previous PR 🙏.

Closes: #6805 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The crash occurs when the user is not eligible for site, and then they get disconnected from the same site, on this case, they can't recover from the crash, as the app will keep crashing on startup, this PR fixes this by checking if the selected site exists before showing the user eligibility screen.

### Testing instructions
1. Perform the following on `release/9.3.2` branch to reproduce the crash.
2. Create a user with role `Editor` on your site and connect it to Jetpack.
3. Open the app and sign in using the selected user.
4. Confirm the user eligibility fragment is shown.
5. Go back to wp-admin, and disconnect the new user.
6. Close and re-open the app (you may need to repeat it twice to allow fetching the sites to happen before showing `UserEligibilityFragment`).
7. Notice the crash with the same stacktrace as the issue.
8. Now check out this branch.
9. Open the app, and confirm it correctly navigates to the correct screen: the site picker.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
