### PR TITLE
Update edit flow title

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -426,7 +426,13 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
         progressDialog = null
     }
 
-    override fun getFragmentTitle() = getString(R.string.order_creation_fragment_title)
+    override fun getFragmentTitle() = when (viewModel.mode) {
+        OrderCreationViewModel.Mode.Creation -> getString(R.string.order_creation_fragment_title)
+        is OrderCreationViewModel.Mode.Edit -> {
+            val orderId = (viewModel.mode as OrderCreationViewModel.Mode.Edit).orderId
+            getString(R.string.orderdetail_orderstatus_ordernum, orderId)
+        }
+    }
 
     override fun onRequestAllowBackPress(): Boolean {
         viewModel.onBackButtonClicked()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -429,7 +429,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
     override fun getFragmentTitle() = when (viewModel.mode) {
         OrderCreationViewModel.Mode.Creation -> getString(R.string.order_creation_fragment_title)
         is OrderCreationViewModel.Mode.Edit -> {
-            val orderId = (viewModel.mode as OrderCreationViewModel.Mode.Edit).orderId
+            val orderId = (viewModel.mode as OrderCreationViewModel.Mode.Edit).orderId.toString()
             getString(R.string.orderdetail_orderstatus_ordernum, orderId)
         }
     }


### PR DESCRIPTION
‼️ Don't merge until https://github.com/woocommerce/woocommerce-android/pull/6798 gets merged

Closes: #6801

### Description
This small PR  updates the title to Order #[id] when the order is in the edit flow.

### Testing instructions

TC 1
1. Select the Orders section -> open an order -> select more menu (3 dots) -> select Edit
2. Check the action bar title is Order #[order id] eg. Order 1234

TC2
1. Select the Orders section -> press the add button (+) -> select Create order
2. Check the action bar title is New order

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Edit flow  | Create flow |
| ------------- | ------------- |
| <img width = "350" src="https://user-images.githubusercontent.com/18119390/175421145-df03ed65-a0ff-4e63-9c82-f5cbe695bf7b.png" />  | <img width = "350" src="https://user-images.githubusercontent.com/18119390/175422432-f7bb7fb1-a709-4790-8135-37275536ac67.png" />  |

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
