### PR TITLE
[Coupons] Handle Coupons disabled situation on Coupons List screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListItem
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListState
 import com.woocommerce.android.ui.coupons.CouponListViewModel.LoadingState
+import com.woocommerce.android.ui.coupons.CouponListViewModel.EnabledState
 import com.woocommerce.android.ui.coupons.components.CouponExpirationLabel
 
 @Composable
@@ -62,6 +63,8 @@ fun CouponListScreen(
     onLoadMore: () -> Unit
 ) {
     when {
+        state.enabledState == EnabledState.Checking -> CouponListSkeleton()
+        state.enabledState == EnabledState.Disabled -> CouponDisabledNotice()
         state.coupons.isNotEmpty() -> CouponList(
             coupons = state.coupons,
             loadingState = state.loadingState,
@@ -72,6 +75,13 @@ fun CouponListScreen(
         state.loadingState == LoadingState.Loading -> CouponListSkeleton()
         state.isSearchOpen -> SearchEmptyList(searchQuery = state.searchQuery.orEmpty())
         else -> EmptyCouponList()
+    }
+}
+
+@Composable
+private fun CouponDisabledNotice() {
+    Column {
+        /* TODO */
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -68,6 +68,7 @@ fun CouponListScreen(
     when {
         state.enabledState == EnabledState.Checking -> CouponListSkeleton()
         state.enabledState == EnabledState.Disabled -> CouponDisabledNotice(onEnableCouponsButtonClick)
+        state.enabledState == EnabledState.Enabling -> CouponDisabledNotice(onEnableCouponsButtonClick, true)
         state.coupons.isNotEmpty() -> CouponList(
             coupons = state.coupons,
             loadingState = state.loadingState,
@@ -82,7 +83,10 @@ fun CouponListScreen(
 }
 
 @Composable
-private fun CouponDisabledNotice(onEnableCouponsButtonClick: () -> Unit) {
+private fun CouponDisabledNotice(
+    onEnableCouponsButtonClick: () -> Unit,
+    isEnabling: Boolean = false
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -120,7 +124,7 @@ private fun CouponDisabledNotice(onEnableCouponsButtonClick: () -> Unit) {
             modifier = Modifier
                 .padding(horizontal = dimensionResource(id = R.dimen.major_100))
                 .fillMaxWidth(),
-            enabled = true
+            enabled = !isEnabling
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -40,8 +40,8 @@ import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListItem
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListState
-import com.woocommerce.android.ui.coupons.CouponListViewModel.LoadingState
 import com.woocommerce.android.ui.coupons.CouponListViewModel.EnabledState
+import com.woocommerce.android.ui.coupons.CouponListViewModel.LoadingState
 import com.woocommerce.android.ui.coupons.components.CouponExpirationLabel
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -37,6 +37,7 @@ import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
+import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListItem
 import com.woocommerce.android.ui.coupons.CouponListViewModel.CouponListState
 import com.woocommerce.android.ui.coupons.CouponListViewModel.LoadingState
@@ -110,6 +111,15 @@ private fun CouponDisabledNotice() {
                     start = dimensionResource(id = R.dimen.major_150),
                     end = dimensionResource(id = R.dimen.major_150)
                 )
+            )
+            Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
+            WCColoredButton(
+                onClick = { },
+                text = stringResource(id = R.string.coupon_list_coupon_enable_button),
+                modifier = Modifier
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+                    .fillMaxWidth(),
+                enabled = true
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -83,47 +83,45 @@ fun CouponListScreen(
 
 @Composable
 private fun CouponDisabledNotice(onEnableCouponsButtonClick: () -> Unit) {
-    Column {
-        Column(
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = dimensionResource(id = R.dimen.major_200)),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(id = R.string.coupon_list_coupon_disabled_heading),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.h6,
+            modifier = Modifier.padding(
+                start = dimensionResource(id = R.dimen.major_150),
+                end = dimensionResource(id = R.dimen.major_150)
+            )
+        )
+        Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
+        Image(
+            painter = painterResource(id = R.drawable.img_empty_coupon_list),
+            contentDescription = null,
+        )
+        Text(
+            text = stringResource(id = R.string.coupon_list_coupon_disabled_message),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body1,
+            modifier = Modifier.padding(
+                start = dimensionResource(id = R.dimen.major_150),
+                end = dimensionResource(id = R.dimen.major_150)
+            )
+        )
+        Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
+        WCColoredButton(
+            onClick = onEnableCouponsButtonClick,
+            text = stringResource(id = R.string.coupon_list_coupon_enable_button),
             modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = dimensionResource(id = R.dimen.major_200)),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = stringResource(id = R.string.coupon_list_coupon_disabled_heading),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.h6,
-                modifier = Modifier.padding(
-                    start = dimensionResource(id = R.dimen.major_150),
-                    end = dimensionResource(id = R.dimen.major_150)
-                )
-            )
-            Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
-            Image(
-                painter = painterResource(id = R.drawable.img_empty_coupon_list),
-                contentDescription = null,
-            )
-            Text(
-                text = stringResource(id = R.string.coupon_list_coupon_disabled_message),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.body1,
-                modifier = Modifier.padding(
-                    start = dimensionResource(id = R.dimen.major_150),
-                    end = dimensionResource(id = R.dimen.major_150)
-                )
-            )
-            Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
-            WCColoredButton(
-                onClick = onEnableCouponsButtonClick,
-                text = stringResource(id = R.string.coupon_list_coupon_enable_button),
-                modifier = Modifier
-                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-                    .fillMaxWidth(),
-                enabled = true
-            )
-        }
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+                .fillMaxWidth(),
+            enabled = true
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -52,7 +52,8 @@ fun CouponListScreen(viewModel: CouponListViewModel) {
         state = couponListState,
         onCouponClick = viewModel::onCouponClick,
         onRefresh = viewModel::onRefresh,
-        onLoadMore = viewModel::onLoadMore
+        onLoadMore = viewModel::onLoadMore,
+        onEnableCouponsButtonClick = viewModel::onEnableCouponsButtonClick
     )
 }
 
@@ -61,11 +62,12 @@ fun CouponListScreen(
     state: CouponListState,
     onCouponClick: (Long) -> Unit,
     onRefresh: () -> Unit,
-    onLoadMore: () -> Unit
+    onLoadMore: () -> Unit,
+    onEnableCouponsButtonClick: () -> Unit
 ) {
     when {
         state.enabledState == EnabledState.Checking -> CouponListSkeleton()
-        state.enabledState == EnabledState.Disabled -> CouponDisabledNotice()
+        state.enabledState == EnabledState.Disabled -> CouponDisabledNotice(onEnableCouponsButtonClick)
         state.coupons.isNotEmpty() -> CouponList(
             coupons = state.coupons,
             loadingState = state.loadingState,
@@ -80,7 +82,7 @@ fun CouponListScreen(
 }
 
 @Composable
-private fun CouponDisabledNotice() {
+private fun CouponDisabledNotice(onEnableCouponsButtonClick: () -> Unit) {
     Column {
         Column(
             modifier = Modifier
@@ -114,7 +116,7 @@ private fun CouponDisabledNotice() {
             )
             Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
             WCColoredButton(
-                onClick = { },
+                onClick = onEnableCouponsButtonClick,
                 text = stringResource(id = R.string.coupon_list_coupon_enable_button),
                 modifier = Modifier
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListScreen.kt
@@ -81,7 +81,37 @@ fun CouponListScreen(
 @Composable
 private fun CouponDisabledNotice() {
     Column {
-        /* TODO */
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = dimensionResource(id = R.dimen.major_200)),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(id = R.string.coupon_list_coupon_disabled_heading),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.h6,
+                modifier = Modifier.padding(
+                    start = dimensionResource(id = R.dimen.major_150),
+                    end = dimensionResource(id = R.dimen.major_150)
+                )
+            )
+            Spacer(Modifier.size(dimensionResource(id = R.dimen.major_325)))
+            Image(
+                painter = painterResource(id = R.drawable.img_empty_coupon_list),
+                contentDescription = null,
+            )
+            Text(
+                text = stringResource(id = R.string.coupon_list_coupon_disabled_message),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier.padding(
+                    start = dimensionResource(id = R.dimen.major_150),
+                    end = dimensionResource(id = R.dimen.major_150)
+                )
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -10,7 +10,9 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CouponUtils
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -110,7 +112,7 @@ class CouponListViewModel @Inject constructor(
         viewModelScope.launch {
             loadingState.value = LoadingState.Appending
             couponListHandler.loadMore().onFailure {
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.coupon_list_loading_failed))
+                triggerEvent(ShowSnackbar(R.string.coupon_list_loading_failed))
             }
             loadingState.value = LoadingState.Idle
         }
@@ -133,7 +135,7 @@ class CouponListViewModel @Inject constructor(
         loadingState.value = LoadingState.Refreshing
         couponListHandler.fetchCoupons(forceRefresh = true)
             .onFailure {
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.coupon_list_loading_failed))
+                triggerEvent(ShowSnackbar(R.string.coupon_list_loading_failed))
             }
         loadingState.value = LoadingState.Idle
     }
@@ -142,7 +144,7 @@ class CouponListViewModel @Inject constructor(
         loadingState.value = LoadingState.Loading
         couponListHandler.fetchCoupons(forceRefresh = true)
             .onFailure {
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.coupon_list_loading_failed))
+                triggerEvent(ShowSnackbar(R.string.coupon_list_loading_failed))
             }
         loadingState.value = LoadingState.Idle
     }
@@ -167,7 +169,7 @@ class CouponListViewModel @Inject constructor(
                         couponListHandler.fetchCoupons(searchQuery = query)
                             .onFailure {
                                 triggerEvent(
-                                    MultiLiveEvent.Event.ShowSnackbar(
+                                    ShowSnackbar(
                                         if (query == null) R.string.coupon_list_loading_failed
                                         else R.string.coupon_list_search_failed
                                     )
@@ -190,7 +192,11 @@ class CouponListViewModel @Inject constructor(
                 optionId = SETTINGS_ENABLE_COUPONS_OPTION
             )
             if(result.isError) {
-                /* TODO Show error snackbar */
+                WooLog.e(
+                    WooLog.T.COUPONS,
+                    "Unable to enable Coupons: $result.error.message"
+                )
+                triggerEvent(ShowSnackbar(R.string.coupon_list_coupon_enable_button_failure))
             } else {
                 val settings = wooCommerceStore.getSiteSettings(selectedSite.get())
                 if (settings?.couponsEnabled == REQUEST_VALUE) enabledState.value = EnabledState.Enabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.model.settings.UpdateSettingRequest
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.util.Date
 import javax.inject.Inject
@@ -40,6 +41,9 @@ class CouponListViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val LOADING_STATE_DELAY = 100L
+        private const val REQUEST_VALUE = "yes"
+        private const val SETTINGS_GROUP = "general"
+        private const val SETTINGS_ENABLE_COUPONS_OPTION = "woocommerce_enable_coupons"
     }
 
     private val currencyCode by lazy {
@@ -173,6 +177,24 @@ class CouponListViewModel @Inject constructor(
                         loadingState.value = LoadingState.Idle
                     }
                 }
+        }
+    }
+
+    fun onEnableCouponsButtonClick() {
+        launch {
+            val request = UpdateSettingRequest(value = REQUEST_VALUE)
+            val result = wooCommerceStore.updateSiteSettingOption(
+                site = selectedSite.get(),
+                request = request,
+                groupId = SETTINGS_GROUP,
+                optionId = SETTINGS_ENABLE_COUPONS_OPTION
+            )
+            if(result.isError) {
+                /* TODO Show error snackbar */
+            } else {
+                val settings = wooCommerceStore.getSiteSettings(selectedSite.get())
+                if (settings?.couponsEnabled == REQUEST_VALUE) enabledState.value = EnabledState.Enabled
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -68,15 +68,25 @@ class CouponListViewModel @Inject constructor(
             loadingState = loadingState,
             coupons = coupons,
             searchQuery = searchQuery,
-            isEnabled = enabledState
+            enabledState = enabledState
         )
     }.asLiveData()
 
     init {
-        if (searchQuery.value == null) {
-            fetchCoupons()
+        launch {
+            val settings = wooCommerceStore.fetchSiteGeneralSettings(selectedSite.get())
+            settings.model?.let {
+                if (it.couponsEnabled == "yes") {
+                    enabledState.value = EnabledState.Enabled
+                    if (searchQuery.value == null) {
+                        fetchCoupons()
+                    }
+                    monitorSearchQuery()
+                } else {
+                    enabledState.value = EnabledState.Disabled
+                }
+            }
         }
-        monitorSearchQuery()
     }
 
     private fun Coupon.toUiModel(): CouponListItem {
@@ -167,7 +177,7 @@ class CouponListViewModel @Inject constructor(
     }
 
     data class CouponListState(
-        val isEnabled: EnabledState = EnabledState.Checking,
+        val enabledState: EnabledState = EnabledState.Checking,
         val loadingState: LoadingState = LoadingState.Idle,
         val searchQuery: String? = null,
         val coupons: List<CouponListItem> = emptyList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -191,7 +191,7 @@ class CouponListViewModel @Inject constructor(
                 groupId = SETTINGS_GROUP,
                 optionId = SETTINGS_ENABLE_COUPONS_OPTION
             )
-            if(result.isError) {
+            if (result.isError) {
                 WooLog.e(
                     WooLog.T.COUPONS,
                     "Unable to enable Coupons: $result.error.message"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -54,7 +54,7 @@ class CouponListViewModel @Inject constructor(
 
     private val searchQuery = savedState.getNullableStateFlow(this, null, clazz = String::class.java)
     private val loadingState = MutableStateFlow(LoadingState.Idle)
-    private val enabledState = MutableStateFlow(EnabledState.Checking)
+    private val enabledState = MutableStateFlow(EnabledState.Unknown)
 
     val couponsState = combine(
         flow = couponListHandler.couponsFlow
@@ -80,6 +80,7 @@ class CouponListViewModel @Inject constructor(
 
     init {
         launch {
+            enabledState.value = EnabledState.Checking
             val settings = wooCommerceStore.fetchSiteGeneralSettings(selectedSite.get())
             settings.model?.let {
                 if (it.couponsEnabled == "yes") {
@@ -207,7 +208,7 @@ class CouponListViewModel @Inject constructor(
     }
 
     data class CouponListState(
-        val enabledState: EnabledState = EnabledState.Checking,
+        val enabledState: EnabledState = EnabledState.Unknown,
         val loadingState: LoadingState = LoadingState.Idle,
         val searchQuery: String? = null,
         val coupons: List<CouponListItem> = emptyList()
@@ -227,7 +228,7 @@ class CouponListViewModel @Inject constructor(
     }
 
     enum class EnabledState {
-        Checking, Enabling, Enabled, Disabled
+        Unknown, Checking, Enabling, Enabled, Disabled
     }
 
     data class NavigateToCouponDetailsEvent(val couponId: Long) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -184,6 +184,7 @@ class CouponListViewModel @Inject constructor(
 
     fun onEnableCouponsButtonClick() {
         launch {
+            enabledState.value = EnabledState.Enabling
             val request = UpdateSettingRequest(value = REQUEST_VALUE)
             val result = wooCommerceStore.updateSiteSettingOption(
                 site = selectedSite.get(),
@@ -192,6 +193,7 @@ class CouponListViewModel @Inject constructor(
                 optionId = SETTINGS_ENABLE_COUPONS_OPTION
             )
             if (result.isError) {
+                enabledState.value = EnabledState.Disabled
                 WooLog.e(
                     WooLog.T.COUPONS,
                     "Unable to enable Coupons: $result.error.message"
@@ -225,7 +227,7 @@ class CouponListViewModel @Inject constructor(
     }
 
     enum class EnabledState {
-        Checking, Enabled, Disabled
+        Checking, Enabling, Enabled, Disabled
     }
 
     data class NavigateToCouponDetailsEvent(val couponId: Long) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -48,6 +48,7 @@ class CouponListViewModel @Inject constructor(
 
     private val searchQuery = savedState.getNullableStateFlow(this, null, clazz = String::class.java)
     private val loadingState = MutableStateFlow(LoadingState.Idle)
+    private val enabledState = MutableStateFlow(EnabledState.Checking)
 
     val couponsState = combine(
         flow = couponListHandler.couponsFlow
@@ -60,12 +61,14 @@ class CouponListViewModel @Inject constructor(
                 } else 0L
             }
             .map { it.value },
-        flow3 = searchQuery
-    ) { coupons, loadingState, searchQuery ->
+        flow3 = searchQuery,
+        flow4 = enabledState
+    ) { coupons, loadingState, searchQuery, enabledState ->
         CouponListState(
             loadingState = loadingState,
             coupons = coupons,
-            searchQuery = searchQuery
+            searchQuery = searchQuery,
+            isEnabled = enabledState
         )
     }.asLiveData()
 
@@ -164,6 +167,7 @@ class CouponListViewModel @Inject constructor(
     }
 
     data class CouponListState(
+        val isEnabled: EnabledState = EnabledState.Checking,
         val loadingState: LoadingState = LoadingState.Idle,
         val searchQuery: String? = null,
         val coupons: List<CouponListItem> = emptyList()
@@ -180,6 +184,10 @@ class CouponListViewModel @Inject constructor(
 
     enum class LoadingState {
         Idle, Loading, Refreshing, Appending
+    }
+
+    enum class EnabledState {
+        Checking, Enabled, Disabled
     }
 
     data class NavigateToCouponDetailsEvent(val couponId: Long) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1961,6 +1961,8 @@
     <string name="coupon_list_view_coupon">View coupon summary</string>
     <string name="coupon_list_loading_failed">Fetching coupons failed</string>
     <string name="coupon_list_search_failed">Searching coupons failed</string>
+    <string name="coupon_list_coupon_disabled_heading">Everyone loves a deal</string>
+    <string name="coupon_list_coupon_disabled_message">You currently have Coupons disabled for this store. Enable Coupons to get started.</string>
     <string name="coupon_details_heading">Coupon Summary</string>
     <string name="coupon_details_minimum_spend">Minimum spend of %s</string>
     <string name="coupon_details_maximum_spend">Maximum spend of %s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1964,6 +1964,7 @@
     <string name="coupon_list_coupon_disabled_heading">Everyone loves a deal</string>
     <string name="coupon_list_coupon_disabled_message">You currently have Coupons disabled for this store. Enable Coupons to get started.</string>
     <string name="coupon_list_coupon_enable_button">Enable Coupons</string>
+    <string name="coupon_list_coupon_enable_button_failure">Failed to enable Coupons. Please try again or enable in wp-admin.</string>
     <string name="coupon_details_heading">Coupon Summary</string>
     <string name="coupon_details_minimum_spend">Minimum spend of %s</string>
     <string name="coupon_details_maximum_spend">Maximum spend of %s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1963,6 +1963,7 @@
     <string name="coupon_list_search_failed">Searching coupons failed</string>
     <string name="coupon_list_coupon_disabled_heading">Everyone loves a deal</string>
     <string name="coupon_list_coupon_disabled_message">You currently have Coupons disabled for this store. Enable Coupons to get started.</string>
+    <string name="coupon_list_coupon_enable_button">Enable Coupons</string>
     <string name="coupon_details_heading">Coupon Summary</string>
     <string name="coupon_details_minimum_spend">Minimum spend of %s</string>
     <string name="coupon_details_maximum_spend">Maximum spend of %s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
@@ -29,6 +29,8 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCSettingsModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WooCommerceStore
 
 class CouponsListViewModelTests : BaseUnitTest() {
@@ -42,7 +44,19 @@ class CouponsListViewModelTests : BaseUnitTest() {
     private val couponListHandler: CouponListHandler = mock {
         on { couponsFlow } doReturn couponsStateFlow
     }
-    private val wooCommerceStore: WooCommerceStore = mock()
+    private val wooCommerceStore: WooCommerceStore = mock {
+        onBlocking { fetchSiteGeneralSettings(any()) } doReturn WooResult(
+            WCSettingsModel(
+                localSiteId = 1,
+                currencyCode = "$",
+                currencyPosition = WCSettingsModel.CurrencyPosition.LEFT,
+                currencyThousandSeparator = ".",
+                currencyDecimalSeparator = ",",
+                currencyDecimalNumber = 2,
+                couponsEnabled = "yes"
+            )
+        )
+    }
     private val currencyFormatter: CurrencyFormatter = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.45.1'
+    fluxCVersion = '2449-5836662f803f509df8614e86b60019c3a6a47016'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6359 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Coupons is a feature that can be enabled/disabled in wp-admin.

This PR allows the app to gracefully handle the situation where Coupons is disabled in wp-admin. The app will:
- Show a screen informing merchants that Coupons is disabled,
- Also add a button for enabling Coupons directly from the app.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Disable Coupons in wp-admin by unchecking the option in WooCommerce > Settings > General tab > "Enable coupons",
2. Run app and make sure **Coupons Management** is enabled in Settings > Beta Features.
3. Go to Hub Menu > Coupons,
4. Make sure the Coupons disabled notice screen is shown,
5. Tap the **Enable Coupons** button,
6. Once it is done, make sure the screen either loads some Coupons (if you already have some in the test site), or show the empty Coupons screen.


### Video
<!-- Include before and after images or gifs when appropriate. -->



https://user-images.githubusercontent.com/266376/175510819-535bfec9-b71a-49b7-8c6d-62633f712af8.mov


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
