### PR TITLE
[Coupons] Product selector filtering

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -112,4 +112,12 @@ sealed class ProductNavigationTarget : Event() {
         val productId: Long,
         val selectedVariationIds: Set<Long>
     ) : ProductNavigationTarget()
+
+    data class NavigateToProductFilter(
+        val stockStatus: String?,
+        val productType: String?,
+        val productStatus: String?,
+        val productCategory: String?,
+        val productCategoryName: String?
+    ) : ProductNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.AddProductAtt
 import com.woocommerce.android.ui.products.ProductNavigationTarget.AddProductCategory
 import com.woocommerce.android.ui.products.ProductNavigationTarget.AddProductDownloadableFile
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ExitProduct
+import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToProductFilter
 import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToVariationSelector
 import com.woocommerce.android.ui.products.ProductNavigationTarget.RenameProductAttribute
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ShareProduct
@@ -348,6 +349,18 @@ class ProductNavigator @Inject constructor() {
                     ProductSelectorFragmentDirections.actionProductSelectorFragmentToVariationSelectorFragment(
                         target.productId,
                         target.selectedVariationIds.toLongArray()
+                    )
+                )
+            }
+
+            is NavigateToProductFilter -> {
+                fragment.findNavController().navigateSafely(
+                    ProductSelectorFragmentDirections.actionProductSelectorFragmentToNavGraphProductFilters(
+                        target.stockStatus,
+                        target.productType,
+                        target.productStatus,
+                        target.productCategory,
+                        target.productCategoryName
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
@@ -2,10 +2,12 @@ package com.woocommerce.android.ui.products.selector
 
 import com.woocommerce.android.model.Product
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import javax.inject.Inject
 
 class ProductListHandler @Inject constructor(private val repository: ProductSelectorRepository) {
@@ -20,23 +22,27 @@ class ProductListHandler @Inject constructor(private val repository: ProductSele
     private val searchQuery = MutableStateFlow("")
     private val searchResults = MutableStateFlow(emptyList<Product>())
 
-    val productsFlow = searchQuery.flatMapLatest { query ->
+    private val productFilters = MutableStateFlow(mapOf<ProductFilterOption, String>())
+
+    val productsFlow = combine(searchQuery, productFilters) { query, filters ->
         if (query.isEmpty()) {
-            repository.observeProducts()
+            repository.observeProducts(filters)
         } else {
             searchResults
         }
-    }
+    }.flatMapLatest { it }
 
     suspend fun fetchProducts(
         searchQuery: String = "",
-        forceRefresh: Boolean = false
+        forceRefresh: Boolean = false,
+        filters: Map<ProductFilterOption, String> = emptyMap()
     ): Result<Unit> = mutex.withLock {
         // Reset the offset
         offset = 0
         canLoadMore = true
 
         this.searchQuery.value = searchQuery
+        this.productFilters.value = filters
         return if (searchQuery.isEmpty()) {
             if (forceRefresh) {
                 loadProducts()
@@ -59,7 +65,7 @@ class ProductListHandler @Inject constructor(private val repository: ProductSele
     }
 
     private suspend fun loadProducts(): Result<Unit> {
-        return repository.fetchProducts(offset, PAGE_SIZE).onSuccess {
+        return repository.fetchProducts(offset, PAGE_SIZE, productFilters.value).onSuccess {
             canLoadMore = it
             offset += PAGE_SIZE
         }.map { }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.products.ProductFilterResult
+import com.woocommerce.android.ui.products.ProductListFragment.Companion.PRODUCT_FILTER_RESULT_KEY
 import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductNavigator
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorFragment
@@ -71,6 +73,16 @@ class ProductSelectorFragment : BaseFragment() {
     private fun handleResults() {
         handleResult<VariationSelectionResult>(VariationSelectorFragment.VARIATION_SELECTOR_RESULT) {
             viewModel.onSelectedVariationsUpdated(it)
+        }
+
+        handleResult<ProductFilterResult>(PRODUCT_FILTER_RESULT_KEY) { result ->
+            viewModel.onFiltersChanged(
+                stockStatus = result.stockStatus,
+                productStatus = result.productStatus,
+                productType = result.productType,
+                productCategory = result.productCategory,
+                productCategoryName = result.productCategoryName
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorRepository.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import javax.inject.Inject
 
 class ProductSelectorRepository @Inject constructor(
@@ -43,15 +44,17 @@ class ProductSelectorRepository @Inject constructor(
         }
     }
 
-    fun observeProducts(): Flow<List<Product>> = productStore.observeProducts(selectedSite.get()).map {
-        it.map { product -> product.toAppModel() }
-    }
+    fun observeProducts(filterOptions: Map<ProductFilterOption, String>): Flow<List<Product>> =
+        productStore.observeProducts(selectedSite.get(), filterOptions = filterOptions).map {
+            it.map { product -> product.toAppModel() }
+        }
 
     suspend fun fetchProducts(
         offset: Int,
-        pageSize: Int
+        pageSize: Int,
+        filterOptions: Map<ProductFilterOption, String>
     ): Result<Boolean> {
-        return productStore.fetchProducts(selectedSite.get(), offset, pageSize)
+        return productStore.fetchProducts(selectedSite.get(), offset, pageSize, filterOptions = filterOptions)
             .let { result ->
                 if (result.isError) {
                     WooLog.w(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -43,6 +43,7 @@ import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.FilterState
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.APPENDING
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.IDLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.LOADING
@@ -61,6 +62,7 @@ fun ProductSelectorScreen(viewModel: ProductSelectorViewModel) {
             state = it,
             onDoneButtonClick = viewModel::onDoneButtonClick,
             onClearButtonClick = viewModel::onClearButtonClick,
+            onFilterButtonClick = viewModel::onFilterButtonClick,
             onProductClick = viewModel::onProductClick,
             onLoadMore = viewModel::onLoadMore,
             onSearchQueryChanged = viewModel::onSearchQueryChanged
@@ -73,6 +75,7 @@ fun ProductSelectorScreen(
     state: ViewState,
     onDoneButtonClick: () -> Unit,
     onClearButtonClick: () -> Unit,
+    onFilterButtonClick: () -> Unit,
     onProductClick: (ProductListItem) -> Unit,
     onLoadMore: () -> Unit,
     onSearchQueryChanged: (String) -> Unit
@@ -98,6 +101,7 @@ fun ProductSelectorScreen(
                 state = state,
                 onDoneButtonClick = onDoneButtonClick,
                 onClearButtonClick = onClearButtonClick,
+                onFilterButtonClick = onFilterButtonClick,
                 onProductClick = onProductClick,
                 onLoadMore = onLoadMore
             )
@@ -143,6 +147,7 @@ private fun ProductList(
     state: ViewState,
     onDoneButtonClick: () -> Unit,
     onClearButtonClick: () -> Unit,
+    onFilterButtonClick: () -> Unit,
     onProductClick: (ProductListItem) -> Unit,
     onLoadMore: () -> Unit,
 ) {
@@ -167,8 +172,12 @@ private fun ProductList(
             }
 
             WCTextButton(
-                onClick = { },
-                text = stringResource(id = string.product_selector_filter_button_title),
+                onClick = onFilterButtonClick,
+                text =  StringUtils.getQuantityString(
+                    quantity = state.filterState.filterOptions.size,
+                    default = string.product_selector_filter_button_title_default,
+                    zero = string.product_selector_filter_button_title_zero
+                ),
                 allCaps = false,
                 modifier = Modifier.align(Alignment.CenterEnd)
             )
@@ -329,8 +338,10 @@ fun ProductListPreview() {
             products = products,
             selectedItemsCount = 3,
             loadingState = IDLE,
+            filterState = FilterState(),
             searchQuery = ""
         ),
+        {},
         {},
         {},
         {},

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -72,6 +72,30 @@
         <action
             android:id="@+id/action_productSelectorFragment_to_variationSelectorFragment"
             app:destination="@id/variationSelectorFragment" />
+        <action
+            android:id="@+id/action_productSelectorFragment_to_nav_graph_product_filters"
+            app:destination="@id/nav_graph_product_filters">
+            <argument
+                android:name="selectedStockStatus"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="selectedProductType"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="selectedProductStatus"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="selectedProductCategoryId"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="selectedProductCategoryName"
+                app:argType="string"
+                app:nullable="true" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/variationSelectorFragment"
@@ -100,4 +124,5 @@
             android:name="allowedEmails"
             app:argType="string[]" />
     </fragment>
+    <include app:graph="@navigation/nav_graph_product_filters" />
 </navigation>

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -7,7 +7,7 @@ Language: ar
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">لا ندعم إضافة WooCommerce Stripe في ⁦%1$s⁩</string>
-    <string name="product_selector_filter_button_title">عامل تصفية</string>
+    <string name="product_selector_filter_button_title_zero">عامل تصفية</string>
     <string name="product_selector_clear_button_title">مسح التحديد</string>
     <string name="product_selector_select_button_title_one">تحديد %d منتج</string>
     <string name="product_selector_select_button_title_default">تحديد %d من المنتجات</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -7,7 +7,7 @@ Language: de
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">Die WooCommerce Stripe-Erweiterung wird in %1$s nicht unterstützt</string>
-    <string name="product_selector_filter_button_title">Filtern</string>
+    <string name="product_selector_filter_button_title_zero">Filtern</string>
     <string name="product_selector_clear_button_title">Auswahl löschen</string>
     <string name="product_selector_select_button_title_one">%d Produkt auswählen</string>
     <string name="product_selector_select_button_title_default">%d Produkte auswählen</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -7,7 +7,7 @@ Language: es
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">No admitimos la extensión WooCommerce Stripe en %1$s</string>
-    <string name="product_selector_filter_button_title">Filtro</string>
+    <string name="product_selector_filter_button_title_zero">Filtro</string>
     <string name="product_selector_clear_button_title">Limpiar selección</string>
     <string name="product_selector_select_button_title_one">Elegir %d producto</string>
     <string name="product_selector_select_button_title_default">Elegir %d productos</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -7,7 +7,7 @@ Language: fr
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">Nous ne prenons pas en charge l’extension WooCommerce Stripe en %1$s</string>
-    <string name="product_selector_filter_button_title">Filtrer</string>
+    <string name="product_selector_filter_button_title_zero">Filtrer</string>
     <string name="product_selector_clear_button_title">Effacer la sélection</string>
     <string name="product_selector_select_button_title_one">Sélectionner %d produit</string>
     <string name="product_selector_select_button_title_default">Sélectionner %d produits</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -7,7 +7,7 @@ Language: he_IL
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">אנחנו לא תומכים בהרחבה WooCommerce Stripe בתוך ⁦%1$s⁩</string>
-    <string name="product_selector_filter_button_title">מסנן</string>
+    <string name="product_selector_filter_button_title_zero">מסנן</string>
     <string name="product_selector_clear_button_title">ניקוי בחירה</string>
     <string name="product_selector_select_button_title_one">יש לבחור מוצר %d</string>
     <string name="product_selector_select_button_title_default">יש לבחור %d מוצרים</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -7,7 +7,7 @@ Language: id
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">Kami tidak mendukung ekstensi WooCommerce Stripe di %1$s</string>
-    <string name="product_selector_filter_button_title">Penyaring</string>
+    <string name="product_selector_filter_button_title_zero">Penyaring</string>
     <string name="product_selector_clear_button_title">Hapus Pilihan</string>
     <string name="product_selector_select_button_title_one">Pilih %d Produk</string>
     <string name="product_selector_select_button_title_default">Pilih %d Produk</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -7,7 +7,7 @@ Language: it
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">Non supportiamo l\'estensione WooCommerce Stripe in %1$s</string>
-    <string name="product_selector_filter_button_title">Filtro</string>
+    <string name="product_selector_filter_button_title_zero">Filtro</string>
     <string name="product_selector_clear_button_title">Cancella la selezione</string>
     <string name="product_selector_select_button_title_one">Seleziona %d prodotto</string>
     <string name="product_selector_select_button_title_default">Seleziona %d prodotti</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -7,7 +7,7 @@ Language: ja_JP
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">%1$s では WooCommerce Stripe 拡張機能がサポートされていません</string>
-    <string name="product_selector_filter_button_title">フィルター</string>
+    <string name="product_selector_filter_button_title_zero">フィルター</string>
     <string name="product_selector_clear_button_title">選択を解除</string>
     <string name="product_selector_select_button_title_one">%d件の商品を選択</string>
     <string name="product_selector_select_button_title_default">%d件の商品を選択</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -7,7 +7,7 @@ Language: ko_KR
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">%1$s에서 WooCommerce Stripe 확장 기능은 지원되지 않습니다.</string>
-    <string name="product_selector_filter_button_title">필터</string>
+    <string name="product_selector_filter_button_title_zero">필터</string>
     <string name="product_selector_clear_button_title">선택 지우기</string>
     <string name="product_selector_select_button_title_one">%d개의 제품 선택</string>
     <string name="product_selector_select_button_title_default">%d개의 상품 선택</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -7,7 +7,7 @@ Language: nl
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">Er is geen ondersteuning voor de WooCommerce Stripe-extensie in %1$s</string>
-    <string name="product_selector_filter_button_title">Filteren</string>
+    <string name="product_selector_filter_button_title_zero">Filteren</string>
     <string name="product_selector_clear_button_title">Selectie wissen</string>
     <string name="product_selector_select_button_title_one">%d product selecteren</string>
     <string name="product_selector_select_button_title_default">%d producten selecteren</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -7,7 +7,7 @@ Language: pt_BR
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">Não aceitamos a extensão WooCommerce Stripe em %1$s</string>
-    <string name="product_selector_filter_button_title">Filtrar</string>
+    <string name="product_selector_filter_button_title_zero">Filtrar</string>
     <string name="product_selector_clear_button_title">Limpar seleção</string>
     <string name="product_selector_select_button_title_one">Selecionar %d produto</string>
     <string name="product_selector_select_button_title_default">Selecionar %d produtos</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -7,7 +7,7 @@ Language: ru
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">Расширение WooCommerce Stripe не поддерживается в %1$s</string>
-    <string name="product_selector_filter_button_title">Фильтр</string>
+    <string name="product_selector_filter_button_title_zero">Фильтр</string>
     <string name="product_selector_clear_button_title">Очистить выбор</string>
     <string name="product_selector_select_button_title_one">Выбрать %d товар</string>
     <string name="product_selector_select_button_title_default">Выбрать товары (%d)</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -7,7 +7,7 @@ Language: sv_SE
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">Vi stöder inte WooCommerce Stripe-utökningen i %1$s</string>
-    <string name="product_selector_filter_button_title">Filtrera</string>
+    <string name="product_selector_filter_button_title_zero">Filtrera</string>
     <string name="product_selector_clear_button_title">Rensa val</string>
     <string name="product_selector_select_button_title_one">Välj %d produkt</string>
     <string name="product_selector_select_button_title_default">Välj %d produkter</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -7,7 +7,7 @@ Language: tr
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">%1$s için WooCommerce Stripe uzantısını desteklemiyoruz</string>
-    <string name="product_selector_filter_button_title">Filtre</string>
+    <string name="product_selector_filter_button_title_zero">Filtre</string>
     <string name="product_selector_clear_button_title">Seçimi Temizle</string>
     <string name="product_selector_select_button_title_one">%d Ürün Seç</string>
     <string name="product_selector_select_button_title_default">%d Ürün Seç</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -7,7 +7,7 @@ Language: zh_CN
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">我们在 %1$s 中不支持 WooCommerce Stripe 扩展</string>
-    <string name="product_selector_filter_button_title">过滤器</string>
+    <string name="product_selector_filter_button_title_zero">过滤器</string>
     <string name="product_selector_clear_button_title">清除选择</string>
     <string name="product_selector_select_button_title_one">选择 %d 个商品</string>
     <string name="product_selector_select_button_title_default">选择 %d 个商品</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -7,7 +7,7 @@ Language: zh_TW
 -->
 <resources>
     <string name="card_reader_onboarding_stripe_unsupported_in_country_header">我們未在 %1$s 支援 WooCommerce Stripe 擴充功能</string>
-    <string name="product_selector_filter_button_title">篩選</string>
+    <string name="product_selector_filter_button_title_zero">篩選</string>
     <string name="product_selector_clear_button_title">清除選取項目</string>
     <string name="product_selector_select_button_title_one">選擇 %d 個產品</string>
     <string name="product_selector_select_button_title_default">選擇 %d 個產品</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1556,6 +1556,7 @@
     <string name="orders_empty_message_for_filtered_orders">We\'re sorry, we couldn\'t find any orders</string>
     <string name="empty_message_with_search">We\'re sorry, we couldn\'t find results for \"%s\"</string>
     <string name="reviews_empty_message">No reviews yet!</string>
+    <string name="empty_message_with_filters">We\'re sorry, no products match the selected filters"</string>
     <!--
         Settings
     -->
@@ -2066,6 +2067,7 @@
     <string name="product_selector_loading_failed">Loading products failed</string>
     <string name="product_selector_search_failed">Searching products failed</string>
     <string name="product_selector_empty_state">No products found</string>
+    <string name="product_selector_clear_filters_button_title">Clear Filters</string>
 
     <!-- WC Shipping installation flow -->
     <string name="install_wc_shipping_flow_onboarding_screen_title">Fulfill your orders with WooCommerce Shipping</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2059,7 +2059,8 @@
     <string name="product_selector_select_button_title_default">Select %d Products</string>
     <string name="product_selector_select_button_title_one">Select %d Product</string>
     <string name="product_selector_clear_button_title">Clear Selection</string>
-    <string name="product_selector_filter_button_title">Filter</string>
+    <string name="product_selector_filter_button_title_zero">Filter</string>
+    <string name="product_selector_filter_button_title_default">Filter (%d)</string>
     <string name="product_selector_arrow_content_description">Show details</string>
     <string name="product_selector_search_hint">Search Products</string>
     <string name="product_selector_loading_failed">Loading products failed</string>


### PR DESCRIPTION
This PR adds the last component of the product selector dialog -- product filters.

Filter selection | Filter applied | Empty result
--- | --- | ---
![image](https://user-images.githubusercontent.com/1522856/175565888-61286d46-bbc2-41e7-998e-e5f16845c563.png)| ![image](https://user-images.githubusercontent.com/1522856/175565918-3f9dc4eb-7d98-43b6-8a4a-7c5779ff5580.png) | ![image](https://user-images.githubusercontent.com/1522856/175565956-a125a6b2-478c-4189-8d97-0beb04d6d019.png) |

**To test:**
1. Go to Coupons
2. Tap on Edit Products
3. Tap on Filter
4. Apply any filters
5. Tap no Show products
6. **Observe that the product list is updated matching the selected filters**
7. Go back to the filter screen
8. **Observe the previously selected filters are shown**
9. Apply more filters that don't match any products
10. **Observe that an empty message is shown with a button to clear the filters**
11. Tap on Clear Filters button
12. **Observe that the selector is reloaded with all products again**