### PR TITLE
Shipping Labels Onboarding: Installation UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -10,11 +10,16 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.ExperimentalTransitionApi
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
-import androidx.compose.foundation.border
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -28,7 +33,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -38,9 +42,19 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -103,16 +117,13 @@ private fun AnimatedVisibilityScope.PreInstallationContent(viewState: Installati
                 )
         ) {
             SpacerWithMinHeight(1f, dimensionResource(id = R.dimen.major_100))
-            Box(
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .border(
-                        width = dimensionResource(id = R.dimen.major_75),
-                        color = colorResource(id = R.color.woo_purple_20),
-                        shape = CircleShape
-                    )
-                    .size(dimensionResource(id = R.dimen.image_major_120))
-            ) {
+            Box {
+                InstallationLoadingIndicator(
+                    showLoadingIndicator = false,
+                    modifier = Modifier
+                        .size(dimensionResource(id = R.dimen.image_major_120))
+                )
+
                 Icon(
                     painter = painterResource(id = R.drawable.ic_arrow_forward_rounded),
                     contentDescription = null,
@@ -178,25 +189,52 @@ private fun AnimatedVisibilityScope.InstallationContent(viewState: InstallationO
         // fill equivalent space as the cross-icon
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_300)))
         SpacerWithMinHeight(1f, dimensionResource(id = R.dimen.major_100))
-        Box(
-            modifier = Modifier
-                .clip(CircleShape)
-                .border(
-                    width = dimensionResource(id = R.dimen.major_75),
-                    color = colorResource(id = R.color.woo_purple_20),
-                    shape = CircleShape
-                )
-                .size(dimensionResource(id = R.dimen.image_major_120))
-        ) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_arrow_forward_rounded),
-                contentDescription = null,
-                tint = colorResource(id = R.color.woo_purple_50),
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .size(dimensionResource(id = R.dimen.image_major_64))
+
+        Box(modifier = Modifier.size(dimensionResource(id = R.dimen.image_major_120))) {
+            var isCursorVisible by remember { mutableStateOf(true) }
+            var isShowingLoadingIndicator by remember { mutableStateOf(false) }
+
+            LaunchedEffect(Unit) {
+                isCursorVisible = false
+            }
+            val alpha by animateFloatAsState(
+                targetValue = if (isCursorVisible) 1f else 0f,
+                animationSpec = tween(1000, delayMillis = 1000),
+                finishedListener = {
+                    isShowingLoadingIndicator = true
+                }
             )
+            val rotation by animateFloatAsState(
+                targetValue = if (isCursorVisible) 0f else 180f,
+                animationSpec = keyframes {
+                    if (isCursorVisible) return@keyframes
+                    durationMillis = 2000
+                    0f at 1000
+                    -20f at 1100
+                    180f at 2000
+                }
+            )
+
+            Box {
+                InstallationLoadingIndicator(
+                    showLoadingIndicator = isShowingLoadingIndicator,
+                    modifier = Modifier
+                        .size(dimensionResource(id = R.dimen.image_major_120))
+                )
+
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_arrow_forward_rounded),
+                    contentDescription = null,
+                    tint = colorResource(id = R.color.woo_purple_50),
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .alpha(alpha)
+                        .rotate(rotation)
+                        .size(dimensionResource(id = R.dimen.image_major_64))
+                )
+            }
         }
+
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
         MainContent(viewState)
         Box(modifier = Modifier.weight(1.5f)) {
@@ -282,6 +320,51 @@ private fun InstallationInfoLink(onClick: () -> Unit, modifier: Modifier = Modif
 private fun ColumnScope.SpacerWithMinHeight(weight: Float, minHeight: Dp) {
     Spacer(modifier = Modifier.height(minHeight))
     Spacer(modifier = Modifier.weight(weight))
+}
+
+@Composable
+private fun InstallationLoadingIndicator(showLoadingIndicator: Boolean, modifier: Modifier = Modifier) {
+    val stroke = with(LocalDensity.current) {
+        Stroke(width = dimensionResource(id = R.dimen.major_75).toPx(), cap = StrokeCap.Round)
+    }
+
+    val circleColor = colorResource(id = R.color.woo_purple_20)
+    val progressColor = colorResource(id = R.color.woo_purple_50)
+
+    val startAngle by if (showLoadingIndicator) {
+        val transition = rememberInfiniteTransition()
+
+        transition.animateFloat(
+            -90f,
+            270f,
+            infiniteRepeatable(
+                animation = tween(1332, easing = LinearEasing)
+            )
+        )
+    } else {
+        remember { mutableStateOf(-90f) }
+    }
+
+    Canvas(modifier) {
+        val size = size.width - stroke.width
+
+        drawCircle(
+            color = circleColor,
+            radius = (size) / 2,
+            style = stroke
+        )
+        if (showLoadingIndicator) {
+            drawArc(
+                color = progressColor,
+                startAngle = startAngle,
+                sweepAngle = 30f,
+                useCenter = false,
+                size = Size(size, size),
+                topLeft = Offset(stroke.width / 2, stroke.width / 2),
+                style = stroke
+            )
+        }
+    }
 }
 
 @Preview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -309,7 +309,7 @@ private fun AnimatedVisibilityScope.MainContent(viewState: InstallationState) {
 private fun InstallationInfoLink(onClick: () -> Unit, modifier: Modifier = Modifier) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
-        modifier = Modifier
+        modifier = modifier
             .clickable(onClick = onClick)
     ) {
         Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -3,18 +3,12 @@
 package com.woocommerce.android.ui.shipping
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.Crossfade
 import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.EnterTransition.Companion
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.ExperimentalTransitionApi
-import androidx.compose.animation.core.Transition
-import androidx.compose.animation.core.animateInt
-import androidx.compose.animation.core.createChildTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -30,7 +24,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -44,9 +37,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -60,10 +50,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.InstallationState
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.InstallationState.InstallationOngoing
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.InstallationState.PreInstallation
@@ -73,7 +61,7 @@ import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.
 fun AnimatedVisibilityScope.InstallWCShippingFlow(viewState: InstallationState) {
     when (viewState) {
         is PreInstallation -> PreInstallationContent(viewState)
-        is InstallationOngoing -> TODO()
+        is InstallationOngoing -> InstallationContent(viewState)
     }
 }
 
@@ -88,13 +76,11 @@ private fun AnimatedVisibilityScope.PreInstallationContent(viewState: Installati
                 vertical = dimensionResource(id = R.dimen.major_150)
             )
     ) {
-        (viewState as? PreInstallation)?.let {
-            IconButton(onClick = viewState.onCancelClick) {
-                Icon(
-                    imageVector = Icons.Default.Clear,
-                    contentDescription = stringResource(id = R.string.cancel)
-                )
-            }
+        IconButton(onClick = viewState.onCancelClick) {
+            Icon(
+                imageVector = Icons.Default.Clear,
+                contentDescription = stringResource(id = R.string.cancel)
+            )
         }
         Column(
             verticalArrangement = Arrangement.Center,
@@ -137,11 +123,20 @@ private fun AnimatedVisibilityScope.PreInstallationContent(viewState: Installati
             }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
             MainContent(viewState)
-            SpacerWithMinHeight(0.75f, dimensionResource(id = R.dimen.major_100))
-            AnimatedVisibility(visible = viewState is PreInstallation) {
-                InstallationInfoLink { (viewState as? PreInstallation)?.onInfoClick?.invoke() }
+            Box(
+                modifier = Modifier.weight(1.5f),
+                contentAlignment = Alignment.Center
+            ) {
+                InstallationInfoLink(
+                    onClick = viewState.onInfoClick,
+                    modifier = Modifier
+                        .padding(vertical = dimensionResource(id = R.dimen.major_100))
+                        .animateEnterExit(
+                            enter = EnterTransition.None,
+                            exit = fadeOut(tween(500))
+                        )
+                )
             }
-            SpacerWithMinHeight(0.75f, dimensionResource(id = R.dimen.major_100))
         }
         (viewState as? PreInstallation)?.let {
             WCColoredButton(
@@ -168,42 +163,102 @@ private fun AnimatedVisibilityScope.PreInstallationContent(viewState: Installati
     }
 }
 
+@Composable
+private fun AnimatedVisibilityScope.InstallationContent(viewState: InstallationOngoing) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_100),
+                vertical = dimensionResource(id = R.dimen.major_150)
+            )
+    ) {
+        // fill equivalent space as the cross-icon
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_300)))
+        SpacerWithMinHeight(1f, dimensionResource(id = R.dimen.major_100))
+        Box(
+            modifier = Modifier
+                .clip(CircleShape)
+                .border(
+                    width = dimensionResource(id = R.dimen.major_75),
+                    color = colorResource(id = R.color.woo_purple_20),
+                    shape = CircleShape
+                )
+                .size(dimensionResource(id = R.dimen.image_major_120))
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_arrow_forward_rounded),
+                contentDescription = null,
+                tint = colorResource(id = R.color.woo_purple_50),
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .size(dimensionResource(id = R.dimen.image_major_64))
+            )
+        }
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
+        MainContent(viewState)
+        Box(modifier = Modifier.weight(1.5f)) {
+            Text(
+                text = viewState.siteUrl,
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .padding(vertical = dimensionResource(id = R.dimen.major_100))
+                    .animateEnterExit(enter = fadeIn(tween(400, delayMillis = 600), initialAlpha = 0.5f))
+            )
+        }
+        // fill equivalent space as the proceed-button
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_300)))
+    }
+}
+
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun AnimatedVisibilityScope.MainContent(viewState: InstallationState) {
     Column {
         val text = when (viewState) {
-            is PreInstallation -> stringResource(id = string.install_wc_shipping_preinstall_title)
+            is PreInstallation -> stringResource(id = R.string.install_wc_shipping_preinstall_title)
             is InstallationOngoing -> "Installing"
         }
         Text(
             text = text,
             style = MaterialTheme.typography.h4,
             fontWeight = FontWeight.Bold,
+            // Animate the step title when starting the installation
             modifier = Modifier.animateEnterExit(
                 enter = if (viewState is InstallationOngoing) {
-                    fadeIn(tween(500, delayMillis = 100))
+                    fadeIn(tween(600, delayMillis = 400))
                 } else EnterTransition.None,
                 exit = ExitTransition.None
             )
+        )
+
+        // Animate the extension and site names when starting the installation
+        val extensionAndNameModifier = Modifier.animateEnterExit(
+            enter = if (viewState is InstallationOngoing) {
+                fadeIn(tween(400, delayMillis = 600), initialAlpha = 0.5f)
+            } else EnterTransition.None,
+            exit = ExitTransition.None
         )
 
         Text(
             text = stringResource(id = viewState.extensionsName),
             style = MaterialTheme.typography.h4,
             fontWeight = FontWeight.Bold,
-            color = colorResource(id = R.color.woo_purple_50)
+            color = colorResource(id = R.color.woo_purple_50),
+            modifier = extensionAndNameModifier
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
         Text(
             text = viewState.siteName,
-            style = MaterialTheme.typography.h4
+            style = MaterialTheme.typography.h4,
+            modifier = extensionAndNameModifier
         )
     }
 }
 
 @Composable
-private fun InstallationInfoLink(onClick: () -> Unit) {
+private fun InstallationInfoLink(onClick: () -> Unit, modifier: Modifier = Modifier) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
         modifier = Modifier
@@ -241,6 +296,22 @@ private fun PreInstallationPreview() {
                     onCancelClick = {},
                     onProceedClick = {},
                     onInfoClick = {}
+                )
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun InstallationOngoingPreview() {
+    WooThemeWithBackground {
+        AnimatedContent(targetState = Unit) {
+            InstallationContent(
+                viewState = InstallationOngoing(
+                    extensionsName = R.string.install_wc_shipping_extension_name,
+                    siteName = "Site",
+                    siteUrl = "URL"
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -135,20 +136,18 @@ private fun AnimatedVisibilityScope.PreInstallationContent(viewState: Installati
             }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
             MainContent(viewState)
-            Box(
-                modifier = Modifier.weight(1.5f),
-                contentAlignment = Alignment.Center
-            ) {
-                InstallationInfoLink(
-                    onClick = viewState.onInfoClick,
-                    modifier = Modifier
-                        .padding(vertical = dimensionResource(id = R.dimen.major_100))
-                        .animateEnterExit(
-                            enter = EnterTransition.None,
-                            exit = fadeOut(tween(500))
-                        )
-                )
-            }
+            SpacerWithMinHeight(0.75f, dimensionResource(id = R.dimen.major_100))
+
+            InstallationInfoLink(
+                onClick = viewState.onInfoClick,
+                modifier = Modifier
+                    .animateEnterExit(
+                        enter = EnterTransition.None,
+                        exit = fadeOut(tween(500))
+                    )
+            )
+
+            SpacerWithMinHeight(0.75f, dimensionResource(id = R.dimen.major_100))
         }
         (viewState as? PreInstallation)?.let {
             WCColoredButton(
@@ -181,6 +180,7 @@ private fun AnimatedVisibilityScope.InstallationContent(viewState: InstallationO
         verticalArrangement = Arrangement.Center,
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(
                 horizontal = dimensionResource(id = R.dimen.major_100),
                 vertical = dimensionResource(id = R.dimen.major_150)
@@ -191,8 +191,8 @@ private fun AnimatedVisibilityScope.InstallationContent(viewState: InstallationO
         SpacerWithMinHeight(1f, dimensionResource(id = R.dimen.major_100))
 
         Box(modifier = Modifier.size(dimensionResource(id = R.dimen.image_major_120))) {
-            var isCursorVisible by remember { mutableStateOf(true) }
-            var isShowingLoadingIndicator by remember { mutableStateOf(false) }
+            var isCursorVisible by rememberSaveable { mutableStateOf(true) }
+            var isShowingLoadingIndicator by rememberSaveable { mutableStateOf(false) }
 
             LaunchedEffect(Unit) {
                 isCursorVisible = false
@@ -237,15 +237,14 @@ private fun AnimatedVisibilityScope.InstallationContent(viewState: InstallationO
 
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
         MainContent(viewState)
-        Box(modifier = Modifier.weight(1.5f)) {
-            Text(
-                text = viewState.siteUrl,
-                style = MaterialTheme.typography.body1,
-                modifier = Modifier
-                    .padding(vertical = dimensionResource(id = R.dimen.major_100))
-                    .animateEnterExit(enter = fadeIn(tween(400, delayMillis = 600), initialAlpha = 0.5f))
-            )
-        }
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_125)))
+        Text(
+            text = viewState.siteUrl,
+            style = MaterialTheme.typography.body1,
+            modifier = Modifier
+                .animateEnterExit(enter = fadeIn(tween(400, delayMillis = 600), initialAlpha = 0.5f))
+        )
+        SpacerWithMinHeight(1.5f, dimensionResource(id = R.dimen.major_100))
         // fill equivalent space as the proceed-button
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_300)))
     }
@@ -275,7 +274,15 @@ private fun AnimatedVisibilityScope.MainContent(viewState: InstallationState) {
         // Animate the extension and site names when starting the installation
         val extensionAndNameModifier = Modifier.animateEnterExit(
             enter = if (viewState is InstallationOngoing) {
-                fadeIn(tween(200, delayMillis = 800, easing = LinearEasing), initialAlpha = 0.5f)
+                fadeIn(
+                    keyframes {
+                        durationMillis = 1000
+                        1f at 0
+                        0.5f at 200
+                        0.5f at 800
+                        1f at 1000
+                    }
+                )
             } else EnterTransition.None,
             exit = ExitTransition.None
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -46,7 +46,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -191,8 +190,8 @@ private fun AnimatedVisibilityScope.InstallationContent(viewState: InstallationO
         SpacerWithMinHeight(1f, dimensionResource(id = R.dimen.major_100))
 
         Box(modifier = Modifier.size(dimensionResource(id = R.dimen.image_major_120))) {
-            var isCursorVisible by rememberSaveable { mutableStateOf(true) }
-            var isShowingLoadingIndicator by rememberSaveable { mutableStateOf(false) }
+            var isCursorVisible by remember { mutableStateOf(true) }
+            var isShowingLoadingIndicator by remember { mutableStateOf(false) }
 
             LaunchedEffect(Unit) {
                 isCursorVisible = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.ExperimentalTransitionApi
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -227,7 +228,7 @@ private fun AnimatedVisibilityScope.MainContent(viewState: InstallationState) {
             // Animate the step title when starting the installation
             modifier = Modifier.animateEnterExit(
                 enter = if (viewState is InstallationOngoing) {
-                    fadeIn(tween(600, delayMillis = 400))
+                    fadeIn(tween(400, delayMillis = 600, easing = LinearEasing))
                 } else EnterTransition.None,
                 exit = ExitTransition.None
             )
@@ -236,7 +237,7 @@ private fun AnimatedVisibilityScope.MainContent(viewState: InstallationState) {
         // Animate the extension and site names when starting the installation
         val extensionAndNameModifier = Modifier.animateEnterExit(
             enter = if (viewState is InstallationOngoing) {
-                fadeIn(tween(400, delayMillis = 600), initialAlpha = 0.5f)
+                fadeIn(tween(200, delayMillis = 800, easing = LinearEasing), initialAlpha = 0.5f)
             } else EnterTransition.None,
             exit = ExitTransition.None
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -22,9 +22,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -43,7 +45,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.InstallationState
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.InstallationState.PreInstallation
@@ -79,6 +80,12 @@ private fun PreInstallationContent(viewState: PreInstallation, transition: Trans
                 vertical = dimensionResource(id = R.dimen.major_150)
             )
     ) {
+        IconButton(onClick = viewState.onCancelClick) {
+            Icon(
+                imageVector = Icons.Default.Clear,
+                contentDescription = stringResource(id = R.string.cancel)
+            )
+        }
         Column(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier
@@ -86,9 +93,6 @@ private fun PreInstallationContent(viewState: PreInstallation, transition: Trans
                 .verticalScroll(rememberScrollState())
                 .offset(y = -offset.dp)
         ) {
-            WCTextButton(onClick = viewState.onCancelClick) {
-                Text(text = stringResource(id = R.string.cancel))
-            }
             SpacerWithMinHeight(1f, dimensionResource(id = R.dimen.major_100))
             Box(
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -1,5 +1,4 @@
 @file:OptIn(ExperimentalAnimationApi::class)
-
 package com.woocommerce.android.ui.shipping
 
 import androidx.compose.animation.AnimatedContent
@@ -9,7 +8,6 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.CubicBezierEasing
-import androidx.compose.animation.core.ExperimentalTransitionApi
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -70,7 +68,6 @@ import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.InstallationState.InstallationOngoing
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.InstallationState.PreInstallation
 
-@OptIn(ExperimentalTransitionApi::class)
 @Composable
 fun AnimatedVisibilityScope.InstallWCShippingFlow(viewState: InstallationState) {
     when (viewState) {
@@ -252,7 +249,6 @@ private fun AnimatedVisibilityScope.InstallationContent(viewState: InstallationO
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun AnimatedVisibilityScope.MainContent(viewState: InstallationState) {
     Column {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingFlow.kt
@@ -4,6 +4,7 @@ package com.woocommerce.android.ui.shipping
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.EnterExitState.PreEnter
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -11,7 +12,6 @@ import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.ExperimentalTransitionApi
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -42,11 +42,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -190,29 +189,33 @@ private fun AnimatedVisibilityScope.InstallationContent(viewState: InstallationO
         SpacerWithMinHeight(1f, dimensionResource(id = R.dimen.major_100))
 
         Box(modifier = Modifier.size(dimensionResource(id = R.dimen.image_major_120))) {
-            var isCursorVisible by remember { mutableStateOf(true) }
-            var isShowingLoadingIndicator by remember { mutableStateOf(false) }
-
-            LaunchedEffect(Unit) {
-                isCursorVisible = false
+            val alpha by transition.animateFloat(
+                transitionSpec = { tween(1000, delayMillis = 1000) },
+                label = "arrowAlpha"
+            ) {
+                when (it) {
+                    PreEnter -> 1f
+                    else -> 0f
+                }
             }
-            val alpha by animateFloatAsState(
-                targetValue = if (isCursorVisible) 1f else 0f,
-                animationSpec = tween(1000, delayMillis = 1000),
-                finishedListener = {
-                    isShowingLoadingIndicator = true
+
+            val rotation by transition.animateFloat(
+                transitionSpec = {
+                    keyframes {
+                        durationMillis = 2000
+                        0f at 1000
+                        -20f at 1100
+                        180f at 2000
+                    }
+                },
+                label = "arrowAlpha"
+            ) {
+                when (it) {
+                    PreEnter -> 0f
+                    else -> 180f
                 }
-            )
-            val rotation by animateFloatAsState(
-                targetValue = if (isCursorVisible) 0f else 180f,
-                animationSpec = keyframes {
-                    if (isCursorVisible) return@keyframes
-                    durationMillis = 2000
-                    0f at 1000
-                    -20f at 1100
-                    180f at 2000
-                }
-            )
+            }
+            val isShowingLoadingIndicator by derivedStateOf { alpha == 0f }
 
             Box {
                 InstallationLoadingIndicator(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingOnboarding.kt
@@ -1,9 +1,12 @@
+@file:OptIn(ExperimentalAnimationApi::class)
+
 package com.woocommerce.android.ui.shipping
 
-import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.animation.core.Transition
-import androidx.compose.animation.core.animateInt
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -12,7 +15,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -21,9 +23,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -39,10 +41,9 @@ import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.InstallWCS
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.Onboarding
 
 @Composable
-fun InstallWcShippingOnboarding(
-    viewState: Onboarding,
-    transition: Transition<Boolean>
-) {
+fun AnimatedVisibilityScope.InstallWcShippingOnboarding(viewState: Onboarding) {
+    val targetExitOffset = with(LocalDensity.current) { 120.dp.roundToPx() }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -51,18 +52,19 @@ fun InstallWcShippingOnboarding(
                 end = dimensionResource(id = R.dimen.major_200)
             )
     ) {
-        val offset by transition.animateInt(
-            transitionSpec = { tween(durationMillis = 500, easing = LinearOutSlowInEasing) },
-            label = "offset"
-        ) {
-            if (it) 0 else 120
-        }
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .weight(1f)
                 .verticalScroll(rememberScrollState())
-                .offset(y = -offset.dp)
+                .animateEnterExit(
+                    enter = EnterTransition.None,
+                    exit = slideOutVertically(
+                        animationSpec =
+                        tween(durationMillis = 500),
+                        targetOffsetY = { -targetExitOffset }
+                    )
+                )
         ) {
             Text(
                 modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_350)),
@@ -93,7 +95,14 @@ fun InstallWcShippingOnboarding(
                     top = dimensionResource(id = R.dimen.major_200),
                     bottom = dimensionResource(id = R.dimen.major_200),
                 )
-                .offset(y = offset.dp)
+                .animateEnterExit(
+                    enter = EnterTransition.None,
+                    exit = slideOutVertically(
+                        animationSpec =
+                        tween(durationMillis = 500),
+                        targetOffsetY = { targetExitOffset }
+                    )
+                )
         ) {
             WCColoredButton(
                 modifier = Modifier.fillMaxWidth(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.ExitTransition.Companion
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.ExperimentalTransitionApi
 import androidx.compose.animation.core.LinearOutSlowInEasing

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
@@ -1,8 +1,7 @@
 package com.woocommerce.android.ui.shipping
 
+import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.ExperimentalTransitionApi
 import androidx.compose.animation.core.LinearOutSlowInEasing
@@ -16,11 +15,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState
 import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.ViewState.InstallationState
+import kotlinx.coroutines.delay
 
 @Composable
 fun InstallWCShippingScreen(viewModel: InstallWCShippingViewModel) {
@@ -43,24 +50,15 @@ fun InstallWCShippingScreen(viewState: ViewState) {
                     fadeIn(tween(500, delayMillis = 500))
                         .with(fadeOut(tween(500, easing = LinearOutSlowInEasing)))
                 } else {
-                    // TODO
-                    EnterTransition.None.with(ExitTransition.None)
+                    // No-op animation, just defining durations
+                    fadeIn(tween(500), initialAlpha = 1f)
+                        .with(fadeOut(tween(500), targetAlpha = 1f))
                 }
             }
         ) { targetState ->
             when (targetState) {
-                is ViewState.Onboarding -> InstallWcShippingOnboarding(
-                    viewState = targetState,
-                    transition = transition.createChildTransition(label = "OnboardingTransition") {
-                        it is ViewState.Onboarding
-                    }
-                )
-                is InstallationState -> InstallWCShippingFlow(
-                    viewState = targetState,
-                    transition = transition.createChildTransition(label = "InstallationTransition") {
-                        it is InstallationState
-                    }
-                )
+                is ViewState.Onboarding -> InstallWcShippingOnboarding(viewState = targetState)
+                is InstallationState -> InstallWCShippingFlow(viewState = targetState)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.shipping
 
 import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.ExitTransition.Companion
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.ExperimentalTransitionApi
 import androidx.compose.animation.core.LinearOutSlowInEasing
@@ -49,9 +52,8 @@ fun InstallWCShippingScreen(viewState: ViewState) {
                     fadeIn(tween(500, delayMillis = 500))
                         .with(fadeOut(tween(500, easing = LinearOutSlowInEasing)))
                 } else {
-                    // No-op animation, just defining durations
-                    fadeIn(tween(500), initialAlpha = 1f)
-                        .with(fadeOut(tween(500), targetAlpha = 1f))
+                    // No-op animation, each screen will define animations for specific components separately
+                    EnterTransition.None.with(ExitTransition.None)
                 }
             }
         ) { targetState ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.ExperimentalTransitionApi
 import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.animation.core.createChildTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.fadeIn
@@ -60,6 +59,64 @@ fun InstallWCShippingScreen(viewState: ViewState) {
                 is ViewState.Onboarding -> InstallWcShippingOnboarding(viewState = targetState)
                 is InstallationState -> InstallWCShippingFlow(viewState = targetState)
             }
+        }
+    }
+}
+
+@SuppressLint("RememberReturnType")
+@Preview
+@Composable
+private fun PreviewInstallWCShippingScreen() {
+    val states = remember {
+        mutableListOf<ViewState>()
+    }
+
+    var state by remember {
+        mutableStateOf(states.getOrNull(0))
+    }
+
+    remember {
+        states.add(
+            ViewState.Onboarding(
+                title = R.string.install_wc_shipping_flow_onboarding_screen_title,
+                subtitle = R.string.install_wc_shipping_flow_onboarding_screen_subtitle,
+                bullets = emptyList(),
+                onInstallClicked = { state = states[1] }
+            )
+        )
+
+        states.add(
+            InstallationState.PreInstallation(
+                extensionsName = R.string.install_wc_shipping_extension_name,
+                siteName = "Site",
+                siteUrl = "URL",
+                onCancelClick = {},
+                onProceedClick = { state = states[2] },
+                onInfoClick = {}
+            )
+        )
+
+        states.add(
+            InstallationState.InstallationOngoing(
+                extensionsName = R.string.install_wc_shipping_extension_name,
+                siteName = "Site",
+                siteUrl = "URL"
+            )
+        )
+
+        state = states[0]
+    }
+
+    LaunchedEffect(state) {
+        if (state is InstallationState.InstallationOngoing) {
+            delay(5000)
+            state = states[0]
+        }
+    }
+
+    WooThemeWithBackground {
+        state?.let {
+            InstallWCShippingScreen(viewState = it)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingViewModel.kt
@@ -7,12 +7,16 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel.Step.Installation
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
@@ -30,6 +34,16 @@ class InstallWCShippingViewModel @Inject constructor(
     val viewState = step
         .map { prepareStep(it) }
         .asLiveData()
+
+    init {
+        launch {
+            // Wait for installation step
+            step.filter { it == Installation }
+                .first()
+
+            // TODO launch plugin installation
+        }
+    }
 
     private fun prepareStep(step: Step): ViewState {
         return when (step) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6587
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the installation UI, with the animations for the transition from the pre-install step, the changes required some refactorings, as I'm learning about Compose animation APIs, and I found out that the usage of `animateEnterExit` made the code a bit cleaner.

The additional change is replacing the `cancel` button with a cross-icon as this was confirmed by the design team.

NB: the installation itself is not implemented yet.

### Testing instructions
1. Make sure your store is in US, and uses USD as the currency, but doesn't have WCShip.
2. Create an order eligible for shipping label creation (ie: not virtual/downloadable and not eligible for IPP).
3. Open the order in the app.
4. Click on the "Get WooCommerce Shipping" button.
5. Click on "Add extension" to the store.
6. Click on "Proceed with installation".
7. Confirm the animation and transition look and work as expected.

You can also run the preview `PreviewInstallWCShippingScreen` if you want to jump directly into the screen.

### Images/gif
https://user-images.githubusercontent.com/1657201/176007989-b83a3ab1-736b-42f5-bb42-f3ae69d4a426.mov

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
