### PR TITLE
[Kotlin Warnings As Errors] Card Reader Module - Resolve Warnings & Enable All Warnings as Errors

### DIFF
--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -29,7 +29,6 @@ android {
             allWarningsAsErrors = true
         }
         freeCompilerArgs += [
-                "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                 "-Xopt-in=kotlin.RequiresOptIn"
         ]
     }

--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -26,7 +26,8 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += [
-                "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+                "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                "-Xopt-in=kotlin.RequiresOptIn"
         ]
     }
 }

--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -25,6 +25,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+        kotlinOptions {
+            allWarningsAsErrors = true
+        }
         freeCompilerArgs += [
                 "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                 "-Xopt-in=kotlin.RequiresOptIn"

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -13,14 +13,12 @@ import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverRe
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
 import com.woocommerce.android.cardreader.internal.sendAndLog
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
 private const val DISCOVERY_TIMEOUT_IN_SECONDS = 60
 
-@ExperimentalCoroutinesApi
 internal class DiscoverReadersAction(
     private val terminal: TerminalWrapper,
     private val logWrapper: LogWrapper,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CancelPaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CancelPaymentAction.kt
@@ -4,10 +4,12 @@ import com.stripe.stripeterminal.external.callable.PaymentIntentCallback
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 internal class CancelPaymentAction(private val terminal: TerminalWrapper) {
+    @OptIn(DelicateCoroutinesApi::class)
     fun cancelPayment(paymentIntent: PaymentIntent) {
         // Usage of GlobalScope is intentional since the app should always try to cancel the payment intent
         GlobalScope.launch {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/ProcessPaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/ProcessPaymentAction.kt
@@ -30,13 +30,13 @@ internal class ProcessPaymentAction(private val terminal: TerminalWrapper, priva
                         this@callbackFlow.close()
                     }
 
-                    override fun onFailure(exception: TerminalException) {
+                    override fun onFailure(e: TerminalException) {
                         logWrapper.e(
                             LOG_TAG,
                             "Processing payment failed. " +
-                                "Message: ${exception.errorMessage}, DeclineCode: ${exception.apiError?.declineCode}"
+                                "Message: ${e.errorMessage}, DeclineCode: ${e.apiError?.declineCode}"
                         )
-                        this@callbackFlow.sendAndLog(Failure(exception), logWrapper)
+                        this@callbackFlow.sendAndLog(Failure(e), logWrapper)
                         this@callbackFlow.close()
                     }
                 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderBaseUnitTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderBaseUnitTest.kt
@@ -9,14 +9,13 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 
+@ExperimentalCoroutinesApi
 @Suppress("UnnecessaryAbstractClass")
 @RunWith(MockitoJUnitRunner::class)
 abstract class CardReaderBaseUnitTest(testDispatcher: TestDispatcher = UnconfinedTestDispatcher()) {
-    @ExperimentalCoroutinesApi
     @Rule @JvmField
     val coroutinesTestRule = CardReaderCoroutineTestRule(testDispatcher)
 
-    @ExperimentalCoroutinesApi
     protected fun testBlocking(block: suspend TestScope.() -> Unit) =
         runTest(coroutinesTestRule.testDispatcher) {
             block()

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.cardreader.internal.config
 
 import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class CardReaderConfigFactoryTest : CardReaderBaseUnitTest() {
     private lateinit var cardReaderConfigFactory: CardReaderConfigFactory
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -75,7 +75,6 @@ class ConnectionManagerTest : CardReaderBaseUnitTest() {
     @Test
     fun `given found readers with specified, when readers discovered, then all readers returned`() =
         testBlocking {
-            val dummyReaderId = "12345"
             val discoveredReaders = listOf<Reader>(
                 mock {
                     on { deviceType }.thenReturn(DeviceType.CHIPPER_2X)
@@ -100,7 +99,6 @@ class ConnectionManagerTest : CardReaderBaseUnitTest() {
     @Test
     fun `given found readers with unspecified, when readers discovered, then required readers returned`() =
         testBlocking {
-            val dummyReaderId = "12345"
             val discoveredReaders = listOf<Reader>(
                 mock {
                     on { deviceType }.thenReturn(DeviceType.CHIPPER_2X)

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverRe
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Started
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.first
@@ -26,6 +27,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 class DiscoverReadersActionTest : CardReaderBaseUnitTest() {
     private lateinit var action: DiscoverReadersAction
     private val terminal: TerminalWrapper = mock()

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/firmware/SoftwareUpdateManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/firmware/SoftwareUpdateManagerTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatusE
 import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
 import com.woocommerce.android.cardreader.internal.connection.BluetoothReaderListenerImpl
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
@@ -17,6 +18,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 class SoftwareUpdateManagerTest : CardReaderBaseUnitTest() {
     private val terminalWrapper: TerminalWrapper = mock()
     private val bluetoothReaderListener: BluetoothReaderListenerImpl = mock()

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/AdditionalInfoMapperTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/AdditionalInfoMapperTest.kt
@@ -11,10 +11,12 @@ import com.woocommerce.android.cardreader.payments.CardPaymentStatus.AdditionalI
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.AdditionalInfoType.SWIPE_CARD
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.AdditionalInfoType.TRY_ANOTHER_CARD
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.AdditionalInfoType.TRY_ANOTHER_READ_METHOD
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class AdditionalInfoMapperTest : CardReaderBaseUnitTest() {
     private lateinit var additionalInfoMapper: AdditionalInfoMapper
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/InteracRefundManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/InteracRefundManagerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.payments
 
+import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectInteracRefundAction
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessInteracRefundAction
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus
@@ -15,7 +16,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.withIndex
-import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -38,7 +38,7 @@ private const val TIMEOUT = 1000L
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
-class InteracRefundManagerTest {
+class InteracRefundManagerTest : CardReaderBaseUnitTest() {
     private lateinit var manager: InteracRefundManager
 
     private val collectInteracRefundAction: CollectInteracRefundAction = mock()
@@ -53,7 +53,7 @@ class InteracRefundManagerTest {
     )
 
     @Before
-    fun setUp() = runBlockingTest {
+    fun setUp() = testBlocking {
         manager = InteracRefundManager(
             collectInteracRefundAction,
             processInteracRefundAction,
@@ -63,7 +63,7 @@ class InteracRefundManagerTest {
     }
 
     @Test
-    fun `when interac refund starts, then CollectingInteracRefund is emitted`() = runBlockingTest {
+    fun `when interac refund starts, then CollectingInteracRefund is emitted`() = testBlocking {
         val result = manager.refundInteracPayment(createRefundParams())
             .takeUntil(CardInteracRefundStatus.CollectingInteracRefund::class).toList()
 
@@ -72,7 +72,7 @@ class InteracRefundManagerTest {
 
     @Test
     fun `given collect interac refund success, when refund starts, then ProcessingInteracRefund is emitted`() =
-        runBlockingTest {
+        testBlocking {
             whenever(collectInteracRefundAction.collectRefund(anyOrNull()))
                 .thenReturn(flow { emit(CollectInteracRefundAction.CollectInteracRefundStatus.Success) })
             val result = manager.refundInteracPayment(createRefundParams())
@@ -83,7 +83,7 @@ class InteracRefundManagerTest {
 
     @Test
     fun `given collect interac refund failure, when refund starts, then ProcessingInteracRefund is NOT emitted`() =
-        runBlockingTest {
+        testBlocking {
             whenever(collectInteracRefundAction.collectRefund(anyOrNull()))
                 .thenReturn(flow { emit(CollectInteracRefundAction.CollectInteracRefundStatus.Failure(mock())) })
             whenever(refundErrorMapper.mapTerminalError(any(), any()))
@@ -96,7 +96,7 @@ class InteracRefundManagerTest {
 
     @Test
     fun `given collect interac refund failure, when refund starts, then failure is emitted`() =
-        runBlockingTest {
+        testBlocking {
             whenever(collectInteracRefundAction.collectRefund(anyOrNull()))
                 .thenReturn(flow { emit(CollectInteracRefundAction.CollectInteracRefundStatus.Failure(mock())) })
             whenever(refundErrorMapper.mapTerminalError(any(), any()))
@@ -110,7 +110,7 @@ class InteracRefundManagerTest {
 
     @Test
     fun `given collect interac refund failure, when refund starts, then failure message is captured`() =
-        runBlockingTest {
+        testBlocking {
             val expectedErrorMessage = "Generic Error"
             whenever(collectInteracRefundAction.collectRefund(anyOrNull()))
                 .thenReturn(flow { emit(CollectInteracRefundAction.CollectInteracRefundStatus.Failure(mock())) })
@@ -128,7 +128,7 @@ class InteracRefundManagerTest {
 
     @Test
     fun `given collect interac refund failure, when refund starts, then failure type is captured`() =
-        runBlockingTest {
+        testBlocking {
             val expectedErrorType = DeclinedByBackendError.Unknown
             whenever(collectInteracRefundAction.collectRefund(anyOrNull()))
                 .thenReturn(flow { emit(CollectInteracRefundAction.CollectInteracRefundStatus.Failure(mock())) })
@@ -146,7 +146,7 @@ class InteracRefundManagerTest {
 
     @Test
     fun `given collect interac refund failure, when refund starts, then refund params is captured`() =
-        runBlockingTest {
+        testBlocking {
             val expectedRefundParams = createRefundParams()
             whenever(collectInteracRefundAction.collectRefund(anyOrNull()))
                 .thenReturn(flow { emit(CollectInteracRefundAction.CollectInteracRefundStatus.Failure(mock())) })
@@ -168,7 +168,7 @@ class InteracRefundManagerTest {
 
     @Test
     fun `given collect interac refund failure, when refund starts, then flow terminates`() =
-        runBlockingTest {
+        testBlocking {
             whenever(collectInteracRefundAction.collectRefund(anyOrNull()))
                 .thenReturn(flow { emit(CollectInteracRefundAction.CollectInteracRefundStatus.Failure(mock())) })
             val result = withTimeoutOrNull(TIMEOUT) {

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapperTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapperTest.kt
@@ -11,12 +11,14 @@ import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPayment
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.Generic
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.NoNetwork
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.Server
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 class PaymentErrorMapperTest : CardReaderBaseUnitTest() {
     private lateinit var mapper: PaymentErrorMapper
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtilsTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtilsTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader.internal.payments
 import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForCanada
 import com.woocommerce.android.cardreader.internal.config.CardReaderConfigForUSA
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.math.BigDecimal
@@ -10,6 +11,7 @@ import java.math.BigDecimal
 private const val NONE_USD_CURRENCY = "CZK"
 private const val USD_CURRENCY = "USD"
 
+@ExperimentalCoroutinesApi
 class PaymentUtilsTest : CardReaderBaseUnitTest() {
     private val paymentUtils = PaymentUtils()
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectInteracRefundActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectInteracRefundActionTest.kt
@@ -2,16 +2,15 @@ package com.woocommerce.android.cardreader.internal.payments.actions
 
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.Cancelable
+import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectInteracRefundAction.CollectInteracRefundStatus.Failure
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectInteracRefundAction.CollectInteracRefundStatus.Success
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -24,7 +23,7 @@ import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
-class CollectInteracRefundActionTest {
+class CollectInteracRefundActionTest : CardReaderBaseUnitTest() {
     private lateinit var action: CollectInteracRefundAction
     private val terminal: TerminalWrapper = mock()
 
@@ -34,7 +33,7 @@ class CollectInteracRefundActionTest {
     }
 
     @Test
-    fun `when collecting interac refund succeeds, then Success is emitted`() = runBlockingTest {
+    fun `when collecting interac refund succeeds, then Success is emitted`() = testBlocking {
         whenever(terminal.refundPayment(any(), any())).thenAnswer {
             (it.arguments[1] as Callback).onSuccess()
             mock<Cancelable>()
@@ -46,7 +45,7 @@ class CollectInteracRefundActionTest {
     }
 
     @Test
-    fun `when collecting interac refund fails, then Failure is emitted`() = runBlockingTest {
+    fun `when collecting interac refund fails, then Failure is emitted`() = testBlocking {
         whenever(terminal.refundPayment(any(), any())).thenAnswer {
             (it.arguments[1] as Callback).onFailure(mock())
             mock<Cancelable>()
@@ -58,7 +57,7 @@ class CollectInteracRefundActionTest {
     }
 
     @Test
-    fun `when collecting interac refund succeeds, then flow is terminated`() = runBlockingTest {
+    fun `when collecting interac refund succeeds, then flow is terminated`() = testBlocking {
         whenever(terminal.refundPayment(any(), any())).thenAnswer {
             (it.arguments[1] as Callback).onSuccess()
             mock<Cancelable>()
@@ -70,7 +69,7 @@ class CollectInteracRefundActionTest {
     }
 
     @Test
-    fun `when collecting interac refund fails, then flow is terminated`() = runBlockingTest {
+    fun `when collecting interac refund fails, then flow is terminated`() = testBlocking {
         whenever(terminal.refundPayment(any(), any())).thenAnswer {
             (it.arguments[1] as Callback).onFailure(mock())
             mock<Cancelable>()
@@ -82,7 +81,7 @@ class CollectInteracRefundActionTest {
     }
 
     @Test
-    fun `given flow not terminated, when job canceled, then interac refund gets canceled`() = runBlockingTest {
+    fun `given flow not terminated, when job canceled, then interac refund gets canceled`() = testBlocking {
         val cancelable = mock<Cancelable>()
         whenever(cancelable.isCompleted).thenReturn(false)
         whenever(terminal.refundPayment(any(), any())).thenAnswer { cancelable }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -170,7 +170,7 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
     }
 
     @Test
-    fun `when statement descriptor "", then PaymentIntent setStatementDescriptor NOT invoked`() = testBlocking {
+    fun `when statement descriptor empty, then PaymentIntent setStatementDescriptor NOT invoked`() = testBlocking {
         val expected = ""
 
         action.createPaymentIntent(createPaymentInfo(statementDescriptor = expected)).toList()

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/ProcessInteracRefundActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/ProcessInteracRefundActionTest.kt
@@ -2,12 +2,12 @@ package com.woocommerce.android.cardreader.internal.payments.actions
 
 import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.RefundCallback
+import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessInteracRefundAction.ProcessRefundStatus
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -19,7 +19,7 @@ import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
-class ProcessInteracRefundActionTest {
+class ProcessInteracRefundActionTest : CardReaderBaseUnitTest() {
     private lateinit var action: ProcessInteracRefundAction
     private val terminal: TerminalWrapper = mock()
 
@@ -29,7 +29,7 @@ class ProcessInteracRefundActionTest {
     }
 
     @Test
-    fun `when processing interac refund succeeds, then Success is emitted`() = runBlockingTest {
+    fun `when processing interac refund succeeds, then Success is emitted`() = testBlocking {
         whenever(terminal.processRefund(any())).thenAnswer {
             (it.arguments[0] as RefundCallback).onSuccess(mock())
             mock<Cancelable>()
@@ -41,7 +41,7 @@ class ProcessInteracRefundActionTest {
     }
 
     @Test
-    fun `when processing interac refund fails, then Failure is emitted`() = runBlockingTest {
+    fun `when processing interac refund fails, then Failure is emitted`() = testBlocking {
         whenever(terminal.processRefund(any())).thenAnswer {
             (it.arguments[0] as RefundCallback).onFailure(mock())
             mock<Cancelable>()
@@ -53,7 +53,7 @@ class ProcessInteracRefundActionTest {
     }
 
     @Test
-    fun `when processing interac refund succeeds, then flow is terminated`() = runBlockingTest {
+    fun `when processing interac refund succeeds, then flow is terminated`() = testBlocking {
         whenever(terminal.processRefund(any())).thenAnswer {
             (it.arguments[0] as RefundCallback).onSuccess(mock())
             mock<Cancelable>()
@@ -65,7 +65,7 @@ class ProcessInteracRefundActionTest {
     }
 
     @Test
-    fun `when processing interac refund fails, then flow is terminated`() = runBlockingTest {
+    fun `when processing interac refund fails, then flow is terminated`() = testBlocking {
         whenever(terminal.processRefund(any())).thenAnswer {
             (it.arguments[0] as RefundCallback).onFailure(mock())
             mock<Cancelable>()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent: #6816
Closes: #6818

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR resolves a couple of warnings for the `cardreader` module and then enables all warnings as errors on it as well.

Warnings Resolution List:
1. [Resolve global scope delicate coroutines api warning.](https://github.com/woocommerce/woocommerce-android/commit/f64ccbacbdcc5ecfc9f6bd35e54f074cc366ecb0)
2. [Resolve on failure named arguments function calling problem.](https://github.com/woocommerce/woocommerce-android/commit/b926d89c5c4792466adeb548804a4fab3862330b)

The `allWarningsAsErrors` configuration is currently applied on the module level in order to make sure that, as the overall [Kotlin Warnings as Errors](https://github.com/woocommerce/woocommerce-android/issues/6816) work is progressing, no new warnings are added to this module, which is already free of warnings.

When the overall [Kotlin Warnings as Errors](https://github.com/woocommerce/woocommerce-android/issues/6816) work is complete on all modules, then this module level `allWarningsAsErrors` configuration will be replaced by a root level `allWarningsAsErrors` configuration that will be applied by default to all modules from there after (see [here](https://github.com/woocommerce/woocommerce-android/issues/6820)).

-----

PS: @wzieba I added you as the main reviewer, that is, in addition to the @woocommerce/owl-team team itself, but randomly, since I just wanted someone from the `Woo Android` team to sing-off on that change for WCAndroid as well. PS: I am going to randomly add more of you in those PRs just so you become more aware of this change and how close we are on enabling `allWarningsAsErrors` by default everywhere. 🥇 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
