### PR TITLE
[Screenshots Automation] Fix locales switching

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -263,7 +263,7 @@ dependencies {
         // See https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
         exclude group: 'com.squareup.okhttp3'
     }
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android-core:2.9.1'
 
     // Dependencies for local unit tests
     testImplementation "junit:junit:$jUnitVersion"

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -40,10 +40,10 @@ class ScreenshotTest : TestBase() {
     val composeTestRule = createComposeRule()
 
     @get:Rule(order = 3)
-    var activityRule = ActivityTestRule(MainActivity::class.java)
-
-    @Rule @JvmField
     val localeTestRule = LocaleTestRule()
+
+    @get:Rule(order = 4)
+    var activityRule = ActivityTestRule(MainActivity::class.java)
 
     @Before
     fun setUp() {

--- a/WooCommerce/src/debug/AndroidManifest.xml
+++ b/WooCommerce/src/debug/AndroidManifest.xml
@@ -1,29 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.woocommerce.android"
-          xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.woocommerce.android">
 
     <!-- Allows unlocking your device and activating its screen so UI tests can succeed -->
-    <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
-    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <!-- Allows for storing and retrieving screenshots -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <!-- Allows changing locales -->
-    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" tools:ignore="ProtectedPermissions" />
+    <uses-permission
+        android:name="android.permission.CHANGE_CONFIGURATION"
+        tools:ignore="ProtectedPermissions" />
 
     <!-- Clean the status bar for screenshots automation
     See https://docs.fastlane.tools/actions/screengrab/#clean-status-bar -->
     <!-- Indicates the use of the clean status bar feature -->
     <uses-feature android:name="tools.fastlane.screengrab.cleanstatusbar" />
     <!-- Allows for changing the status bar -->
-    <uses-permission android:name="android.permission.DUMP" tools:ignore="ProtectedPermissions" />
+    <uses-permission
+        android:name="android.permission.DUMP"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:name=".WooCommerceDebug"
-        tools:replace="android:name" />
+        tools:replace="android:name">
+        <provider
+            android:name=".LeakCanaryInstaller"
+            android:authorities="${applicationId}.leakcanary-installer"
+            android:exported="false" />
+    </application>
 
 </manifest>

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/LeakCanaryInstaller.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/LeakCanaryInstaller.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android
+
+import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import com.woocommerce.android.util.PackageUtils
+import com.woocommerce.android.util.WooLog
+import leakcanary.AppWatcher
+
+internal class LeakCanaryInstaller : ContentProvider() {
+    override fun onCreate(): Boolean {
+        if (!PackageUtils.isTesting()) {
+            WooLog.v(WooLog.T.DEVICE, "Installing LeakCanary")
+            val application = context!!.applicationContext as Application
+            AppWatcher.manualInstall(application)
+        }
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projectionArg: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, contentValues: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int = 0
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -90,7 +90,7 @@ class ZendeskHelper(
         enableLogs: Boolean = BuildConfig.DEBUG
     ) {
         if (isZendeskEnabled) {
-            if (PackageUtils.isUITesting()) return
+            if (PackageUtils.isTesting()) return
             else error("Zendesk shouldn't be initialized more than once!")
         }
         if (zendeskUrl.isEmpty() || applicationId.isEmpty() || oauthClientId.isEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
@@ -24,7 +24,7 @@ class MoreMenuRepository @Inject constructor(
 
     suspend fun isInboxEnabled(): Boolean =
         withContext(Dispatchers.IO) {
-            if (!FeatureFlag.MORE_MENU_INBOX.isEnabled()) return@withContext false
+            if (!selectedSite.exists() || !FeatureFlag.MORE_MENU_INBOX.isEnabled()) return@withContext false
 
             val currentWooCoreVersion =
                 wooCommerceStore.getSitePlugin(selectedSite.get(), WOO_CORE)?.version ?: "0.0"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
@@ -20,22 +20,13 @@ object PackageUtils {
     fun isTesting(): Boolean {
         if (isTesting == null) {
             isTesting = try {
-                Class.forName("com.woocommerce.android.viewmodel.BaseUnitTest")
+                Class.forName("org.junit.Test")
                 true
             } catch (e: ClassNotFoundException) {
                 false
             }
         }
         return isTesting!!
-    }
-
-    fun isUITesting(): Boolean {
-        return try {
-            Class.forName("com.woocommerce.android.helpers.TestBase")
-            true
-        } catch (e: ClassNotFoundException) {
-            false
-        }
     }
 
     fun isBetaBuild(context: Context): Boolean {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -613,11 +613,6 @@ platform :android do
         map { |locale|  locale[:google_play] }
     end
 
-    # Override the locales array with one locale until
-    # https://github.com/fastlane/fastlane/issues/19521
-    # is fixed:
-    locales = ["en-EN"]
-
     UI.message("Attempting screenshots for locales: #{locales}")
 
     screenshot_options = {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6833
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes locale switching for screenshot generation, it adds the following changes to do so:
- Fixes a crash that happens during a second launch of UI tests 
- Makes sure LeakCanary is not initialized in UI test builds (this fixes the issue described in https://github.com/fastlane/fastlane/issues/19521)

Regarding the last point, I [asked](https://github.com/square/leakcanary/issues/1552#issuecomment-1170185596) in the LeakCanary repo about their opinion about integrating the same logic in the library itself, as the heap dumping ana analysis is already disabled by the library during tests, it's just that it attaches the watchers.

### Testing instructions
##### Confirm Locale switching works as expected
1. Execute the following command: `bundle exec fastlane take_screenshots`
2. Confirm the UI tests are executed and the device's language is changed for each iteration.

##### Confirm LeakCanary is initialized well for debug builds
1. Launch a debug build of the app.
2. Check logcat and confirm the presence of line: "Installing LeakCanary"


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
