### PR TITLE
Order editing loading indicator

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -2,8 +2,6 @@ package com.woocommerce.android.ui.orders.creation
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.transition.AutoTransition
-import android.transition.TransitionManager
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -63,16 +61,6 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
         currencyFormatter.buildBigDecimalFormatter(
             currencyCode = viewModel.currentDraft.currency
         )
-    }
-
-    private val transition by lazy {
-        AutoTransition().apply {
-            excludeChildren(R.id.order_status_view, true)
-            excludeChildren(R.id.products_section, true)
-            excludeChildren(R.id.payment_section, true)
-            excludeChildren(R.id.customer_section, true)
-            excludeChildren(R.id.notes_section, true)
-        }
     }
 
     override val activityAppBarStatus: AppBarStatus
@@ -239,7 +227,6 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                 createOrderMenuItem?.isEnabled = it
             }
             new.isIdle.takeIfNotEqualTo(old?.isIdle) { enabled ->
-                TransitionManager.beginDelayedTransition(binding.root, transition)
                 when (viewModel.mode) {
                     OrderCreationViewModel.Mode.Creation -> {
                         binding.paymentSection.loadingProgress.isVisible = !enabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.creation
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.transition.TransitionManager
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -227,7 +228,15 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                 createOrderMenuItem?.isEnabled = it
             }
             new.isIdle.takeIfNotEqualTo(old?.isIdle) { enabled ->
-                binding.paymentSection.loadingProgress.isVisible = !enabled
+                TransitionManager.beginDelayedTransition(binding.root)
+                when(viewModel.mode){
+                    OrderCreationViewModel.Mode.Creation -> {
+                        binding.paymentSection.loadingProgress.isVisible = !enabled
+                    }
+                    is OrderCreationViewModel.Mode.Edit -> {
+                        binding.loadingProgress.isVisible = !enabled
+                    }
+                }
                 if (new.isEditable) {
                     binding.paymentSection.shippingButton.isEnabled = enabled
                     binding.paymentSection.feeButton.isEnabled = enabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -229,7 +229,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
             }
             new.isIdle.takeIfNotEqualTo(old?.isIdle) { enabled ->
                 TransitionManager.beginDelayedTransition(binding.root)
-                when(viewModel.mode){
+                when (viewModel.mode) {
                     OrderCreationViewModel.Mode.Creation -> {
                         binding.paymentSection.loadingProgress.isVisible = !enabled
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.creation
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.transition.AutoTransition
 import android.transition.TransitionManager
 import android.view.Menu
 import android.view.MenuInflater
@@ -62,6 +63,16 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
         currencyFormatter.buildBigDecimalFormatter(
             currencyCode = viewModel.currentDraft.currency
         )
+    }
+
+    private val transition by lazy {
+        AutoTransition().apply {
+            excludeChildren(R.id.order_status_view, true)
+            excludeChildren(R.id.products_section, true)
+            excludeChildren(R.id.payment_section, true)
+            excludeChildren(R.id.customer_section, true)
+            excludeChildren(R.id.notes_section, true)
+        }
     }
 
     override val activityAppBarStatus: AppBarStatus
@@ -228,7 +239,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
                 createOrderMenuItem?.isEnabled = it
             }
             new.isIdle.takeIfNotEqualTo(old?.isIdle) { enabled ->
-                TransitionManager.beginDelayedTransition(binding.root)
+                TransitionManager.beginDelayedTransition(binding.root, transition)
                 when (viewModel.mode) {
                     OrderCreationViewModel.Mode.Creation -> {
                         binding.paymentSection.loadingProgress.isVisible = !enabled

--- a/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_creation_form.xml
@@ -1,55 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.LinearLayoutCompat
-        android:id="@+id/order_creation_root"
-        android:layout_width="match_parent"
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/loadingProgress"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:indeterminate="true"
+        app:layout_constraintBottom_toTopOf="@+id/scrollView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"/>
 
-        <com.woocommerce.android.ui.common.ExpandableMessageView
-            android:id="@+id/message_no_editable_fields"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/loadingProgress">
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:id="@+id/order_creation_root"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_lock"
-            app:message="@string/order_editing_non_editable_message"
-            app:title="@string/order_editing_non_editable_title" />
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-        <com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
-            android:id="@+id/order_status_view"
-            style="@style/Woo.Card"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            <com.woocommerce.android.ui.common.ExpandableMessageView
+                android:id="@+id/message_no_editable_fields"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:icon="@drawable/ic_lock"
+                app:message="@string/order_editing_non_editable_message"
+                app:title="@string/order_editing_non_editable_title" />
 
-        <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
-            android:id="@+id/products_section"
-            style="@style/Woo.Card"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:hasEditButton="false"
-            app:header="@string/products"
-            app:keepAddButtons="true" />
+            <com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
+                android:id="@+id/order_status_view"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-        <include
-            android:id="@+id/payment_section"
-            layout="@layout/order_creation_payment_section" />
+            <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
+                android:id="@+id/products_section"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:hasEditButton="false"
+                app:header="@string/products"
+                app:keepAddButtons="true" />
 
-        <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
-            android:id="@+id/customer_section"
-            style="@style/Woo.Card"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:header="@string/order_creation_customer" />
+            <include
+                android:id="@+id/payment_section"
+                layout="@layout/order_creation_payment_section" />
 
-        <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
-            android:id="@+id/notes_section"
-            style="@style/Woo.Card"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:header="@string/order_creation_customer_note" />
+            <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
+                android:id="@+id/customer_section"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:header="@string/order_creation_customer" />
 
-    </androidx.appcompat.widget.LinearLayoutCompat>
-</androidx.core.widget.NestedScrollView>
+            <com.woocommerce.android.ui.orders.creation.views.OrderCreationSectionView
+                android:id="@+id/notes_section"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:header="@string/order_creation_customer_note" />
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+    </androidx.core.widget.NestedScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>
+
+
+

--- a/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_payment_section.xml
@@ -42,7 +42,8 @@
                 android:layout_width="@dimen/major_200"
                 android:layout_height="@dimen/major_200"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                android:visibility="gone"/>
 
         </androidx.appcompat.widget.LinearLayoutCompat>
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6812 

### Description
This PR adds a new progress indicator on top of the screen when updating an order.

### Testing instructions
TC 1
1. Select Orders -> Create order
2. Made some changes affecting the price of the order (add a product or fee)
3. Check that the circular progress indicator is displayed in the Payment section

TC 2
1. Select Orders -> Select an order -> More menu (3 dots) -> Edit
2. Made some changes to the order
3. Check that the linear progress indicator is displayed at the top of the screen

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/176536892-4fb20632-5334-41c6-8cb8-ea0fc03f2179.mp4


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
