### PR TITLE
issue/prepare-for-product-sku-search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -108,11 +108,11 @@ class ProductListRepository @Inject constructor(
             offset = if (loadMore) offset + PRODUCT_PAGE_SIZE else 0
             lastSearchQuery = searchQuery
             val payload = WCProductStore.SearchProductsPayload(
-                selectedSite.get(),
-                searchQuery,
-                PRODUCT_PAGE_SIZE,
-                offset,
-                productSortingChoice,
+                site = selectedSite.get(),
+                searchQuery = searchQuery,
+                pageSize = PRODUCT_PAGE_SIZE,
+                offset = offset,
+                sorting = productSortingChoice,
                 excludedProductIds = excludedProductIds
             )
             dispatcher.dispatch(WCProductActionBuilder.newSearchProductsAction(payload))


### PR DESCRIPTION
This tiny PR simply updates `SearchProductsPayload` to use named parameters in preparation for [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2450) which adds an `isSkuSearch` parameter to the payload. Without this PR, when that FluxC PR is merged it would break WCAndroid.

There's really nothing to test here other than verify (as I have) that the app will build.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.