### PR TITLE
Track event about the onboarding failure when collecting payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -87,7 +87,10 @@ class CardReaderOnboardingViewModel @Inject constructor(
     init {
         when (val onboardingParam = arguments.cardReaderOnboardingParam) {
             is Check -> refreshState()
-            is Failed -> showOnboardingState(onboardingParam.onboardingState)
+            is Failed -> {
+                cardReaderTracker.trackOnboardingState(onboardingParam.onboardingState)
+                showOnboardingState(onboardingParam.onboardingState)
+            }
         }.exhaustive
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -8,7 +8,20 @@ import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.CardReaderTracker
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.GenericError
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.NoConnectionError
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.PluginIsNotSupportedInTheCountry
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.PluginUnsupportedVersion
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.SetupNotCompleted
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.StripeAccountCountryNotSupported
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.StripeAccountOverdueRequirement
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.StripeAccountPendingRequirement
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.StripeAccountRejected
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.StripeAccountUnderReview
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.WcpayAndStripeActivated
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.WcpayNotActivated
+import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingState.WcpayNotInstalled
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingEvent
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.GenericErrorState
@@ -121,6 +134,359 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given country not supported incoming, when view model init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = CardReaderOnboardingState.StoreCountryNotSupported(""),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(CardReaderOnboardingState.StoreCountryNotSupported(""))
+        }
+
+    @Test
+    fun `given stripe is not supported in country, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = PluginIsNotSupportedInTheCountry(
+                            STRIPE_EXTENSION_GATEWAY,
+                            ""
+                        ),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                PluginIsNotSupportedInTheCountry(
+                    STRIPE_EXTENSION_GATEWAY,
+                    ""
+                )
+            )
+        }
+
+    @Test
+    fun `given wcpay is not supported in country, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = PluginIsNotSupportedInTheCountry(
+                            WOOCOMMERCE_PAYMENTS,
+                            ""
+                        ),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                PluginIsNotSupportedInTheCountry(
+                    WOOCOMMERCE_PAYMENTS,
+                    ""
+                )
+            )
+        }
+
+    @Test
+    fun `given wcpay is installed, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = WcpayNotInstalled,
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                WcpayNotInstalled
+            )
+        }
+
+    @Test
+    fun `given wcpay unsupported version, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = PluginUnsupportedVersion(WOOCOMMERCE_PAYMENTS),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                PluginUnsupportedVersion(WOOCOMMERCE_PAYMENTS)
+            )
+        }
+
+    @Test
+    fun `given stripe unsupported version, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
+            )
+        }
+
+    @Test
+    fun `given wcpay not activated, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = WcpayNotActivated,
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                WcpayNotActivated
+            )
+        }
+
+    @Test
+    fun `given wcpay setup not completed, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = SetupNotCompleted(WOOCOMMERCE_PAYMENTS),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                SetupNotCompleted(WOOCOMMERCE_PAYMENTS)
+            )
+        }
+
+    @Test
+    fun `given stripe setup not completed, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = SetupNotCompleted(STRIPE_EXTENSION_GATEWAY),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                SetupNotCompleted(STRIPE_EXTENSION_GATEWAY)
+            )
+        }
+
+    @Test
+    fun `given wcpay in test mode with live account, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = PluginInTestModeWithLiveStripeAccount(
+                            WOOCOMMERCE_PAYMENTS
+                        ),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                PluginInTestModeWithLiveStripeAccount(
+                    WOOCOMMERCE_PAYMENTS
+                )
+            )
+        }
+
+    @Test
+    fun `given stripe in test mode with live account, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = PluginInTestModeWithLiveStripeAccount(
+                            STRIPE_EXTENSION_GATEWAY
+                        ),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                PluginInTestModeWithLiveStripeAccount(
+                    STRIPE_EXTENSION_GATEWAY
+                )
+            )
+        }
+
+    @Test
+    fun `given stripe account under review, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = StripeAccountUnderReview(STRIPE_EXTENSION_GATEWAY),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                StripeAccountUnderReview(STRIPE_EXTENSION_GATEWAY)
+            )
+        }
+
+    @Test
+    fun `given stripe account pending requirement, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = StripeAccountPendingRequirement(
+                            null,
+                            STRIPE_EXTENSION_GATEWAY,
+                            null,
+                            "US"
+                        ),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                StripeAccountPendingRequirement(
+                    null,
+                    STRIPE_EXTENSION_GATEWAY,
+                    null,
+                    "US"
+                )
+            )
+        }
+
+    @Test
+    fun `given stripe account overdue requirement, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = StripeAccountOverdueRequirement(
+                            STRIPE_EXTENSION_GATEWAY
+                        ),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                StripeAccountOverdueRequirement(
+                    STRIPE_EXTENSION_GATEWAY
+                ),
+            )
+        }
+
+    @Test
+    fun `given stripe account rejected, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = StripeAccountRejected(
+                            STRIPE_EXTENSION_GATEWAY
+                        ),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                StripeAccountRejected(
+                    STRIPE_EXTENSION_GATEWAY
+                ),
+            )
+        }
+
+    @Test
+    fun `given generic error, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = GenericError,
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(GenericError)
+        }
+
+    @Test
+    fun `given no connection error, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = NoConnectionError,
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(NoConnectionError)
+        }
+
+    @Test
+    fun `given stripe account country not supported, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = StripeAccountCountryNotSupported(WOOCOMMERCE_PAYMENTS, "US"),
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(
+                StripeAccountCountryNotSupported(WOOCOMMERCE_PAYMENTS, "US")
+            )
+        }
+
+    @Test
+    fun `given wcpay and stripe activated, when init, then track onboarding state is called`() =
+        testBlocking {
+            createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = mock(),
+                        onboardingState = WcpayAndStripeActivated,
+                    )
+                ).initSavedStateHandle()
+            )
+
+            verify(tracker).trackOnboardingState(WcpayAndStripeActivated)
+        }
+
+    @Test
     fun `given country not supported incoming, when view model init, then country not supported state shown`() =
         testBlocking {
             val viewModel = createVM(
@@ -210,7 +576,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.WcpayNotInstalled,
+                        onboardingState = WcpayNotInstalled,
                     )
                 ).initSavedStateHandle()
             )
@@ -222,7 +588,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when stripe account country not supported, then country not supported state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
+                .thenReturn(StripeAccountCountryNotSupported(mock(), ""))
 
             val viewModel = createVM()
 
@@ -238,7 +604,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""),
+                        onboardingState = StripeAccountCountryNotSupported(mock(), ""),
                     )
                 ).initSavedStateHandle()
             )
@@ -437,7 +803,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `given stripe account country not supported, when learn more clicked, then app shows learn more section`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
+                .thenReturn(StripeAccountCountryNotSupported(mock(), ""))
             val viewModel = createVM()
 
             (viewModel.viewStateData.value as UnsupportedErrorState.StripeAccountInUnsupportedCountry)
@@ -451,7 +817,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `given stripe account country not supported, when contact support clicked, then app navs to support screen`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountCountryNotSupported(mock(), ""))
+                .thenReturn(StripeAccountCountryNotSupported(mock(), ""))
             val viewModel = createVM()
 
             (viewModel.viewStateData.value as UnsupportedErrorState.StripeAccountInUnsupportedCountry)
@@ -463,7 +829,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when wcpay not installed, then wcpay not installed state shown`() =
         testBlocking {
-            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WcpayNotInstalled)
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(WcpayNotInstalled)
 
             val viewModel = createVM()
 
@@ -473,7 +839,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when wcpay not activated, then wcpay not activated state shown`() =
         testBlocking {
-            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WcpayNotActivated)
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(WcpayNotActivated)
 
             val viewModel = createVM()
 
@@ -487,7 +853,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.WcpayNotActivated
+                        onboardingState = WcpayNotActivated
                     )
                 ).initSavedStateHandle()
             )
@@ -499,7 +865,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when wcpay not setup, then wcpay not setup state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.SetupNotCompleted(WOOCOMMERCE_PAYMENTS))
+                .thenReturn(SetupNotCompleted(WOOCOMMERCE_PAYMENTS))
 
             val viewModel = createVM()
 
@@ -513,7 +879,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.SetupNotCompleted(WOOCOMMERCE_PAYMENTS),
+                        onboardingState = SetupNotCompleted(WOOCOMMERCE_PAYMENTS),
                     )
                 ).initSavedStateHandle()
             )
@@ -525,7 +891,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when stripe extension not setup, then stripe extension not setup state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.SetupNotCompleted(STRIPE_EXTENSION_GATEWAY))
+                .thenReturn(SetupNotCompleted(STRIPE_EXTENSION_GATEWAY))
 
             val viewModel = createVM()
 
@@ -538,7 +904,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when stripe extension not setup, then correct labels and illustrations shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.SetupNotCompleted(STRIPE_EXTENSION_GATEWAY))
+                .thenReturn(SetupNotCompleted(STRIPE_EXTENSION_GATEWAY))
 
             val viewModel = createVM()
 
@@ -563,7 +929,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when unsupported wcpay version installed, then unsupported wcpay version state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.PluginUnsupportedVersion(WOOCOMMERCE_PAYMENTS))
+                .thenReturn(PluginUnsupportedVersion(WOOCOMMERCE_PAYMENTS))
 
             val viewModel = createVM()
 
@@ -574,7 +940,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when wcpay in test mode with live stripe account, then wcpay in test mode state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(mock()))
+                .thenReturn(PluginInTestModeWithLiveStripeAccount(mock()))
 
             val viewModel = createVM()
 
@@ -590,7 +956,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.PluginInTestModeWithLiveStripeAccount(mock()),
+                        onboardingState = PluginInTestModeWithLiveStripeAccount(mock()),
                     )
                 ).initSavedStateHandle()
             )
@@ -604,7 +970,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when unsupported stripe extension installed, then unsupported stripe extension state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
+                PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
             )
 
             val viewModel = createVM()
@@ -618,7 +984,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when stripe extension outdated, then correct labels and illustrations shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
+                PluginUnsupportedVersion(STRIPE_EXTENSION_GATEWAY)
             )
 
             val viewModel = createVM()
@@ -656,7 +1022,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when wcpay and stripe extension installed-activated, then wcpay and stripe extension activated state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
 
             val viewModel = createVM()
@@ -670,7 +1036,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `given user is admin, when wcpay and stripe extension active, then open wpadmin button shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
 
             val viewModel = createVM()
@@ -684,7 +1050,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when wcpay and stripe extension active, then refresh screen button shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
 
             val viewModel = createVM()
@@ -697,7 +1063,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when refresh clicked, then loading screen shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
             val viewModel = createVM()
             val receivedViewStates = mutableListOf<OnboardingViewState>()
@@ -723,7 +1089,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                         }
                 )
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
             val viewModel = createVM()
 
@@ -745,7 +1111,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                     }
             )
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
             val viewModel = createVM()
 
@@ -766,7 +1132,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 }
             )
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
             val viewModel = createVM()
 
@@ -788,7 +1154,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             )
 
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
             val viewModel = createVM()
 
@@ -809,7 +1175,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 model
             }
             whenever(onboardingChecker.getOnboardingState()).thenReturn(
-                CardReaderOnboardingState.WcpayAndStripeActivated
+                WcpayAndStripeActivated
             )
 
             val viewModel = createVM()
@@ -823,7 +1189,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account rejected, then account rejected state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountRejected(mock()))
+                .thenReturn(StripeAccountRejected(mock()))
 
             val viewModel = createVM()
 
@@ -838,7 +1204,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.StripeAccountRejected(mock()),
+                        onboardingState = StripeAccountRejected(mock()),
                     )
                 ).initSavedStateHandle()
             )
@@ -852,7 +1218,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
-                    CardReaderOnboardingState.StripeAccountPendingRequirement(
+                    StripeAccountPendingRequirement(
                         0L,
                         WOOCOMMERCE_PAYMENTS,
                         pluginVersion,
@@ -872,7 +1238,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
-                    CardReaderOnboardingState.StripeAccountPendingRequirement(
+                    StripeAccountPendingRequirement(
                         0L,
                         WOOCOMMERCE_PAYMENTS,
                         pluginVersion,
@@ -893,7 +1259,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
-                    CardReaderOnboardingState.StripeAccountPendingRequirement(
+                    StripeAccountPendingRequirement(
                         0L,
                         WOOCOMMERCE_PAYMENTS,
                         pluginVersion,
@@ -922,7 +1288,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     cardReaderOnboardingParam = CardReaderOnboardingParams.Failed(
                         CardReaderFlowParam.PaymentOrRefund.Payment(1L),
-                        onboardingState = CardReaderOnboardingState.StripeAccountPendingRequirement(
+                        onboardingState = StripeAccountPendingRequirement(
                             0L,
                             WOOCOMMERCE_PAYMENTS,
                             pluginVersion,
@@ -943,7 +1309,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
-                    CardReaderOnboardingState.StripeAccountPendingRequirement(
+                    StripeAccountPendingRequirement(
                         0L,
                         WOOCOMMERCE_PAYMENTS,
                         pluginVersion,
@@ -962,7 +1328,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account overdue requirements, then account overdue requirements state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountOverdueRequirement(mock()))
+                .thenReturn(StripeAccountOverdueRequirement(mock()))
 
             val viewModel = createVM()
 
@@ -978,7 +1344,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.StripeAccountOverdueRequirement(mock()),
+                        onboardingState = StripeAccountOverdueRequirement(mock()),
                     )
                 ).initSavedStateHandle()
             )
@@ -992,7 +1358,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account under review, then account under review state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountUnderReview(mock()))
+                .thenReturn(StripeAccountUnderReview(mock()))
 
             val viewModel = createVM()
 
@@ -1008,7 +1374,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.StripeAccountUnderReview(mock()),
+                        onboardingState = StripeAccountUnderReview(mock()),
                     )
                 ).initSavedStateHandle()
             )
@@ -1022,7 +1388,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when onboarding check fails, then generic state shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.GenericError)
+                .thenReturn(GenericError)
 
             val viewModel = createVM()
 
@@ -1036,7 +1402,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.GenericError,
+                        onboardingState = GenericError,
                     )
                 ).initSavedStateHandle()
             )
@@ -1048,7 +1414,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when network not available, then no connection error shown`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.NoConnectionError)
+                .thenReturn(NoConnectionError)
 
             val viewModel = createVM()
 
@@ -1062,7 +1428,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 CardReaderOnboardingFragmentArgs(
                     CardReaderOnboardingParams.Failed(
                         cardReaderFlowParam = mock(),
-                        onboardingState = CardReaderOnboardingState.NoConnectionError,
+                        onboardingState = NoConnectionError,
                     )
                 ).initSavedStateHandle()
             )
@@ -1075,7 +1441,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when learn more tapped, then event tracked`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.GenericError)
+                .thenReturn(GenericError)
             val viewModel = createVM()
 
             (viewModel.viewStateData.value as GenericErrorState).onLearnMoreActionClicked.invoke()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6836 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the broken onboarding failure tracks events when coming from the order detail screen. 

The onboarding failure events were tracked when navigated via the IPP settings screen. However, it was broken when navigated via order detail screen. This PR fixes that.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Install both WCPay and Stripe extension plugins on your site
2. Navigate to order detail -> collect payment
3. Ensure that `card_present_select_payment_gateway_show` event is tracked in the logs

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
