### PR TITLE
[Kotlin Warnings As Errors] Woo Commerce Module - Resolve Coroutines Warnings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
@@ -21,7 +21,11 @@ import androidx.transition.Transition
 import androidx.transition.TransitionListenerAdapter
 import androidx.transition.TransitionManager
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 
 private const val EXPAND_COLLAPSE_ANIMATION_DURATION_MILLIS = 300L
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
@@ -23,6 +23,8 @@ import androidx.transition.TransitionManager
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.*
 
+private const val EXPAND_COLLAPSE_ANIMATION_DURATION_MILLIS = 300L
+
 fun View.show() {
     this.visibility = View.VISIBLE
 }
@@ -89,7 +91,7 @@ fun View.collapse(duration: Long = 300L) {
 
 fun Group.expand() {
     if (this.isVisible) return
-    val animationDuration = 300L
+    val animationDuration = EXPAND_COLLAPSE_ANIMATION_DURATION_MILLIS
     val parent = parent as ViewGroup
     val transition = ChangeBounds()
         .setDuration(animationDuration)
@@ -100,7 +102,7 @@ fun Group.expand() {
 
 fun Group.collapse() {
     if (!this.isVisible) return
-    val animationDuration = 300L
+    val animationDuration = EXPAND_COLLAPSE_ANIMATION_DURATION_MILLIS
     val parent = parent as ConstraintLayout
     val views = referencedIds.map { parent.getViewById(it) }
     val originalHeights = views.map { it.layoutParams.height }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
@@ -20,7 +20,6 @@ import androidx.transition.ChangeBounds
 import androidx.transition.Transition
 import androidx.transition.TransitionListenerAdapter
 import androidx.transition.TransitionManager
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.*
 
@@ -154,7 +153,6 @@ fun ViewGroup.setEnabledRecursive(enabled: Boolean) {
  * @param handled defines what the [OnTouchListener.onTouch] returns, defaults to returning false
  */
 @SuppressLint("ClickableViewAccessibility")
-@ExperimentalCoroutinesApi
 fun View.touchEvents(
     handled: (MotionEvent) -> Boolean = { false }
 ): Flow<MotionEvent> = callbackFlow {
@@ -171,7 +169,6 @@ fun View.touchEvents(
 /**
  * Returns a Flow of events that are triggered when a scroll is started on a view.
  */
-@ExperimentalCoroutinesApi
 fun View.scrollStartEvents(): Flow<Unit> {
     return touchEvents()
         .map { it.action }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
@@ -51,6 +52,7 @@ class MediaFilesRepository @Inject constructor(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun uploadMedia(localMediaModel: MediaModel, stripLocation: Boolean = true): Flow<UploadResult> {
         return callbackFlow {
             WooLog.d(T.MEDIA, "MediaFilesRepository > Dispatching request to upload ${localMediaModel.filePath}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -11,8 +11,15 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.*
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -20,8 +27,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.store.MediaStore
-import org.wordpress.android.fluxc.store.MediaStore.*
-import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.GENERIC_ERROR
 import org.wordpress.android.mediapicker.MediaPickerUtils
 import java.io.File
 import javax.inject.Inject
@@ -58,14 +63,14 @@ class MediaFilesRepository @Inject constructor(
             WooLog.d(T.MEDIA, "MediaFilesRepository > Dispatching request to upload ${localMediaModel.filePath}")
             val listener = OnMediaUploadListener(this)
             dispatcher.register(listener)
-            val payload = UploadMediaPayload(selectedSite.get(), localMediaModel, stripLocation)
+            val payload = MediaStore.UploadMediaPayload(selectedSite.get(), localMediaModel, stripLocation)
             dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
 
             awaitClose {
                 dispatcher.unregister(listener)
                 // Cancel upload if the collection was cancelled before completion
                 if (!isClosedForSend) {
-                    val payload = CancelMediaPayload(selectedSite.get(), localMediaModel, true)
+                    val payload = MediaStore.CancelMediaPayload(selectedSite.get(), localMediaModel, true)
                     dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload))
                 }
             }
@@ -105,7 +110,7 @@ class MediaFilesRepository @Inject constructor(
         @Suppress("LongMethod")
         @SuppressWarnings("unused")
         @Subscribe(threadMode = ThreadMode.BACKGROUND)
-        fun onMediaUploaded(event: OnMediaUploaded) {
+        fun onMediaUploaded(event: MediaStore.OnMediaUploaded) {
             when {
                 event.isError -> {
                     WooLog.w(
@@ -146,7 +151,7 @@ class MediaFilesRepository @Inject constructor(
                             UploadFailure(
                                 error = MediaUploadException(
                                     event.media,
-                                    GENERIC_ERROR,
+                                    MediaStore.MediaErrorType.GENERIC_ERROR,
                                     resourceProvider.getString(R.string.product_image_service_error_uploading)
                                 )
                             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
 import org.wordpress.android.mediapicker.MediaPickerUtils
 import java.io.File
 import javax.inject.Inject
@@ -110,7 +111,7 @@ class MediaFilesRepository @Inject constructor(
         @Suppress("LongMethod")
         @SuppressWarnings("unused")
         @Subscribe(threadMode = ThreadMode.BACKGROUND)
-        fun onMediaUploaded(event: MediaStore.OnMediaUploaded) {
+        fun onMediaUploaded(event: OnMediaUploaded) {
             when {
                 event.isError -> {
                     WooLog.w(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUploadWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUploadWorker.kt
@@ -30,7 +30,6 @@ import javax.inject.Singleton
  * Uploading media and updating product is done sequentially (using a [Mutex] lock) because our repositories don't
  * play well with parallel requests, due to the use of a single shared continuation.
  */
-@ExperimentalCoroutinesApi
 @Singleton
 class ProductImagesUploadWorker @Inject constructor(
     private val mediaFilesRepository: MediaFilesRepository,
@@ -76,6 +75,7 @@ class ProductImagesUploadWorker @Inject constructor(
             .launchIn(appCoroutineScope)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun handleServiceStatus() {
         pendingWorkList
             .transformLatest { list ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/UnseenReviewsCountHandler.kt
@@ -10,13 +10,13 @@ import org.wordpress.android.fluxc.store.NotificationStore
 import javax.inject.Inject
 import javax.inject.Singleton
 
-@ExperimentalCoroutinesApi
 @Singleton
 class UnseenReviewsCountHandler @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val notificationStore: NotificationStore,
     selectedSite: SelectedSite
 ) {
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val unseenReviewsCount: SharedFlow<Int> =
         selectedSite.observe()
             .flatMapLatest { site ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponRepository.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
@@ -81,6 +82,7 @@ class CouponRepository @Inject constructor(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun observeCoupons(): Flow<List<Coupon>> = store.observeCoupons(selectedSite.get()).map {
         it.map { couponDataModel -> couponDataModel.toAppModel() }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.MediaModel
@@ -26,7 +25,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-@ExperimentalCoroutinesApi
 class MediaFileUploadHandler @Inject constructor(
     private val notificationHandler: ProductImagesNotificationHandler,
     private val worker: ProductImagesUploadWorker,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -10,14 +10,23 @@ import com.woocommerce.android.media.ProductImagesUploadWorker
 import com.woocommerce.android.media.ProductImagesUploadWorker.Event
 import com.woocommerce.android.media.ProductImagesUploadWorker.Work
 import com.woocommerce.android.media.ProductImagesUploadWorker.Work.UploadMedia
-import com.woocommerce.android.ui.media.MediaFileUploadHandler.UploadStatus.*
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.store.MediaStore
@@ -119,10 +128,10 @@ class MediaFileUploadHandler @Inject constructor(
             tag = WooLog.T.MEDIA,
             message = "MediaFileUploadHandler -> uploads finished for product $productId, check if we need to update it"
         )
-        uploadsStatus.value.filter { it.remoteProductId == productId && it.uploadStatus !is Failed }
-            .takeIf { images -> images.none { it.uploadStatus == InProgress } && images.isNotEmpty() }
+        uploadsStatus.value.filter { it.remoteProductId == productId && it.uploadStatus !is UploadStatus.Failed }
+            .takeIf { images -> images.none { it.uploadStatus == UploadStatus.InProgress } && images.isNotEmpty() }
             ?.let { productImages ->
-                val uploadedImages = productImages.map { (it.uploadStatus as UploadSuccess).media }
+                val uploadedImages = productImages.map { (it.uploadStatus as UploadStatus.UploadSuccess).media }
 
                 WooLog.d(
                     WooLog.T.MEDIA,
@@ -137,7 +146,7 @@ class MediaFileUploadHandler @Inject constructor(
     private fun showUploadFailureNotifIfNoObserver(productId: Long, state: List<ProductImageUploadData>) {
         if (!externalObservers.contains(productId)) {
             WooLog.d(WooLog.T.MEDIA, "MediaFileUploadHandler -> post upload failure notification")
-            val errors = state.filter { it.remoteProductId == productId && it.uploadStatus is Failed }
+            val errors = state.filter { it.remoteProductId == productId && it.uploadStatus is UploadStatus.Failed }
             notificationHandler.postUploadFailureNotification(productDetailRepository.getProduct(productId), errors)
         }
     }
@@ -145,7 +154,7 @@ class MediaFileUploadHandler @Inject constructor(
     private fun clearPendingUploads() {
         uploadsStatus.update { list ->
             list.filterNot {
-                it.uploadStatus is InProgress || it.uploadStatus is UploadSuccess
+                it.uploadStatus is UploadStatus.InProgress || it.uploadStatus is UploadStatus.UploadSuccess
             }
         }
     }
@@ -156,7 +165,7 @@ class MediaFileUploadHandler @Inject constructor(
                 ProductImageUploadData(
                     remoteProductId = remoteProductId,
                     localUri = it,
-                    uploadStatus = InProgress
+                    uploadStatus = UploadStatus.InProgress
                 )
             }
         }
@@ -174,7 +183,7 @@ class MediaFileUploadHandler @Inject constructor(
     fun clearImageErrors(remoteProductId: Long) {
         uploadsStatus.update { list ->
             list.filterNot {
-                it.remoteProductId == remoteProductId && it.uploadStatus is Failed
+                it.remoteProductId == remoteProductId && it.uploadStatus is UploadStatus.Failed
             }
         }
         notificationHandler.removeUploadFailureNotification(remoteProductId)
@@ -182,13 +191,13 @@ class MediaFileUploadHandler @Inject constructor(
 
     fun observeCurrentUploadErrors(remoteProductId: Long): Flow<List<ProductImageUploadData>> =
         uploadsStatus.map { list ->
-            list.filter { it.remoteProductId == remoteProductId && it.uploadStatus is Failed }
+            list.filter { it.remoteProductId == remoteProductId && it.uploadStatus is UploadStatus.Failed }
         }
 
     fun observeCurrentUploads(remoteProductId: Long): Flow<List<String>> {
         return uploadsStatus
             .map { list ->
-                list.filter { it.remoteProductId == remoteProductId && it.uploadStatus == InProgress }
+                list.filter { it.remoteProductId == remoteProductId && it.uploadStatus == UploadStatus.InProgress }
                     .map { it.localUri }
             }
     }
@@ -203,12 +212,12 @@ class MediaFileUploadHandler @Inject constructor(
             .onStart {
                 // Start with the pending succeeded uploads, the observer will be able to handle them
                 val pendingSuccessUploads = uploadsStatus.value.filter {
-                    it.remoteProductId == remoteProductId && it.uploadStatus is UploadSuccess
+                    it.remoteProductId == remoteProductId && it.uploadStatus is UploadStatus.UploadSuccess
                 }
                 if (pendingSuccessUploads.isNotEmpty()) {
                     uploadsStatus.update { list -> list - pendingSuccessUploads }
                     pendingSuccessUploads.forEach {
-                        emit((it.uploadStatus as UploadSuccess).media)
+                        emit((it.uploadStatus as UploadStatus.UploadSuccess).media)
                     }
                 }
             }
@@ -226,7 +235,7 @@ class MediaFileUploadHandler @Inject constructor(
         uploadsStatus.update { list ->
             list.map {
                 if (it.remoteProductId == ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID &&
-                    it.uploadStatus is UploadSuccess
+                    it.uploadStatus is UploadStatus.UploadSuccess
                 ) {
                     it.copy(remoteProductId = productId)
                 } else {
@@ -236,7 +245,8 @@ class MediaFileUploadHandler @Inject constructor(
         }
         // Cancel and reschedule ongoing uploads
         val ongoingUploads = uploadsStatus.value.filter {
-            it.remoteProductId == ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID && it.uploadStatus == InProgress
+            it.remoteProductId == ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID && it.uploadStatus ==
+                UploadStatus.InProgress
         }
         if (ongoingUploads.isNotEmpty()) {
             cancelUpload(ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID)
@@ -246,18 +256,18 @@ class MediaFileUploadHandler @Inject constructor(
 
     private fun Event.MediaUploadEvent.toStatus(): ProductImageUploadData {
         val uploadStatus = when (this) {
-            is Event.MediaUploadEvent.FetchFailed -> Failed(
+            is Event.MediaUploadEvent.FetchFailed -> UploadStatus.Failed(
                 media = MediaModel(),
                 mediaErrorMessage = resourceProvider.getString(R.string.product_image_service_error_media_null),
                 mediaErrorType = MediaStore.MediaErrorType.NULL_MEDIA_ARG
             )
-            is Event.MediaUploadEvent.FetchSucceeded -> InProgress
-            is Event.MediaUploadEvent.UploadFailed -> Failed(
+            is Event.MediaUploadEvent.FetchSucceeded -> UploadStatus.InProgress
+            is Event.MediaUploadEvent.UploadFailed -> UploadStatus.Failed(
                 media = error.media,
                 mediaErrorMessage = error.errorMessage,
                 mediaErrorType = error.errorType
             )
-            is Event.MediaUploadEvent.UploadSucceeded -> UploadSuccess(media = media)
+            is Event.MediaUploadEvent.UploadSucceeded -> UploadStatus.UploadSuccess(media = media)
         }
         return ProductImageUploadData(
             remoteProductId = productId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -47,7 +47,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
@@ -56,9 +56,9 @@ import java.util.Calendar
 import javax.inject.Inject
 import kotlin.math.abs
 
-@ExperimentalCoroutinesApi
 @AndroidEntryPoint
 @Suppress("ForbiddenComment")
+@OptIn(FlowPreview::class)
 class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     companion object {
         val TAG: String = MyStoreFragment::class.java.simpleName

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/GetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/GetStats.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.ui.mystore.data.StatsRepository.StatsException
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.*
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.FeatureFlag
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
@@ -20,7 +19,6 @@ class GetStats @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val coroutineDispatchers: CoroutineDispatchers
 ) {
-    @ExperimentalCoroutinesApi
     suspend operator fun invoke(refresh: Boolean, granularity: StatsGranularity): Flow<LoadStatsResult> =
         merge(
             hasOrders(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -64,8 +64,6 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
@@ -79,7 +77,6 @@ import java.text.DecimalFormat
 import javax.inject.Inject
 import kotlin.system.measureTimeMillis
 
-@ExperimentalCoroutinesApi
 @HiltViewModel
 class CreateShippingLabelViewModel @Inject constructor(
     savedState: SavedStateHandle,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.*
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.IgnoredOnParcel
@@ -93,10 +92,8 @@ import it.
 class ShippingLabelsStateMachine @Inject constructor() {
     // the flow can be observed by a ViewModel (similar to LiveData) and it can react by perform actions and update
     // the view states based on the triggered states and side-effects
-    @ExperimentalCoroutinesApi
     private val _transitions = MutableStateFlow(Transition(State.Idle, SideEffect.NoOp))
 
-    @ExperimentalCoroutinesApi
     val transitions: StateFlow<Transition> = _transitions
 
     // the actual state machine behavior is defined by a DSL using the following format:

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandler.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.categories.selector
 
 import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
@@ -25,6 +26,7 @@ class ProductCategoryListHandler @Inject constructor(
     private val searchQuery = MutableStateFlow("")
     private val searchResults = MutableStateFlow(emptyList<ProductCategoryTreeItem>())
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val categories: Flow<List<ProductCategoryTreeItem>> = searchQuery.flatMapLatest { query ->
         if (query.isEmpty()) {
             repository.observeCategories()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.selector
 
 import com.woocommerce.android.model.Product
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
@@ -24,6 +25,7 @@ class ProductListHandler @Inject constructor(private val repository: ProductSele
 
     private val productFilters = MutableStateFlow(mapOf<ProductFilterOption, String>())
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val productsFlow = combine(searchQuery, productFilters) { query, filters ->
         if (query.isEmpty()) {
             repository.observeProducts(filters)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/push/RegisterDeviceTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.fluxc.store.GetDeviceRegistrationStatus
 import org.wordpress.android.fluxc.store.GetDeviceRegistrationStatus.Status.REGISTERED
 import org.wordpress.android.fluxc.store.GetDeviceRegistrationStatus.Status.UNREGISTERED
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@ExperimentalCoroutinesApi
 class RegisterDeviceTest : BaseUnitTest() {
     lateinit var sut: RegisterDevice
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -18,8 +18,8 @@ import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 
+@ExperimentalCoroutinesApi
 class MoreMenuViewModelTests : BaseUnitTest() {
-    @OptIn(ExperimentalCoroutinesApi::class)
     private val unseenReviewsCountHandler: UnseenReviewsCountHandler = mock {
         on { observeUnseenCount() } doReturn flowOf(0)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.data.StatsRepository
 import com.woocommerce.android.ui.mystore.data.StatsRepository.StatsException
-import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.*
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
@@ -53,10 +52,10 @@ class GetStatsTest : BaseUnitTest() {
             givenCheckIfStoreHasNoOrdersFlow(Result.success(true))
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is HasOrders }
+                .filter { it is GetStats.LoadStatsResult.HasOrders }
                 .first()
 
-            assertThat(result).isEqualTo(HasOrders(false))
+            assertThat(result).isEqualTo(GetStats.LoadStatsResult.HasOrders(false))
         }
 
     @Test
@@ -65,10 +64,10 @@ class GetStatsTest : BaseUnitTest() {
             givenCheckIfStoreHasNoOrdersFlow(Result.success(false))
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is HasOrders }
+                .filter { it is GetStats.LoadStatsResult.HasOrders }
                 .first()
 
-            assertThat(result).isEqualTo(HasOrders(true))
+            assertThat(result).isEqualTo(GetStats.LoadStatsResult.HasOrders(true))
         }
 
     @Test
@@ -77,10 +76,10 @@ class GetStatsTest : BaseUnitTest() {
             givenFetchRevenueStats(Result.success(ANY_REVENUE_STATS))
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is RevenueStatsSuccess }
+                .filter { it is GetStats.LoadStatsResult.RevenueStatsSuccess }
                 .first()
 
-            assertThat(result).isEqualTo(RevenueStatsSuccess(ANY_REVENUE_STATS))
+            assertThat(result).isEqualTo(GetStats.LoadStatsResult.RevenueStatsSuccess(ANY_REVENUE_STATS))
         }
 
     @Test
@@ -89,10 +88,10 @@ class GetStatsTest : BaseUnitTest() {
             givenFetchRevenueStats(Result.failure(StatsException(GENERIC_ORDER_STATS_ERROR)))
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is RevenueStatsError }
+                .filter { it is GetStats.LoadStatsResult.RevenueStatsError }
                 .first()
 
-            assertThat(result).isEqualTo(RevenueStatsError)
+            assertThat(result).isEqualTo(GetStats.LoadStatsResult.RevenueStatsError)
         }
 
     @Test
@@ -101,10 +100,10 @@ class GetStatsTest : BaseUnitTest() {
             givenFetchRevenueStats(Result.failure(StatsException(PLUGIN_NOT_ACTIVE_ORDER_STATS_ERROR)))
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is PluginNotActive }
+                .filter { it is GetStats.LoadStatsResult.PluginNotActive }
                 .first()
 
-            assertThat(result).isEqualTo(PluginNotActive)
+            assertThat(result).isEqualTo(GetStats.LoadStatsResult.PluginNotActive)
         }
 
     @Test
@@ -133,10 +132,10 @@ class GetStatsTest : BaseUnitTest() {
             givenFetchVisitorStats(Result.success(ANY_VISITOR_STATS))
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is VisitorsStatsSuccess }
+                .filter { it is GetStats.LoadStatsResult.VisitorsStatsSuccess }
                 .first()
 
-            assertThat(result).isEqualTo(VisitorsStatsSuccess(ANY_VISITOR_STATS))
+            assertThat(result).isEqualTo(GetStats.LoadStatsResult.VisitorsStatsSuccess(ANY_VISITOR_STATS))
         }
 
     @Test
@@ -145,10 +144,10 @@ class GetStatsTest : BaseUnitTest() {
             givenFetchVisitorStats(Result.failure(StatsException(GENERIC_ORDER_STATS_ERROR)))
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is VisitorsStatsError }
+                .filter { it is GetStats.LoadStatsResult.VisitorsStatsError }
                 .first()
 
-            assertThat(result).isEqualTo(VisitorsStatsError)
+            assertThat(result).isEqualTo(GetStats.LoadStatsResult.VisitorsStatsError)
         }
 
     @Test
@@ -157,10 +156,10 @@ class GetStatsTest : BaseUnitTest() {
             givenIsJetpackConnected(true)
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is IsJetPackCPEnabled }
+                .filter { it is GetStats.LoadStatsResult.IsJetPackCPEnabled }
                 .first()
 
-            assertThat(result).isEqualTo(IsJetPackCPEnabled)
+            assertThat(result).isEqualTo(GetStats.LoadStatsResult.IsJetPackCPEnabled)
         }
 
     private suspend fun givenCheckIfStoreHasNoOrdersFlow(result: Result<Boolean>) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationRepositoryTest.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.OrderUpdateStore
 import java.math.BigDecimal
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@ExperimentalCoroutinesApi
 class OrderCreationRepositoryTest : BaseUnitTest() {
     companion object {
         const val DEFAULT_ERROR_MESSAGE = "error_message"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -17,7 +17,7 @@ import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@ExperimentalCoroutinesApi
 class ProductDetailCardBuilderTest : BaseUnitTest() {
     private lateinit var sut: ProductDetailCardBuilder
     private lateinit var productStub: Product

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -225,9 +225,6 @@
     <ID>NoWildcardImports:com.woocommerce.android.ui.mystore.MyStoreViewModel.kt:29</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.mystore.MyStoreViewModelTest.kt:18</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.mystore.data.StatsRepository.kt:15</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.ui.mystore.domain.GetStats.kt:11</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.ui.mystore.domain.GetStats.kt:7</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.ui.mystore.domain.GetStatsTest.kt:7</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.orders.OrderDetailViewModelTest.kt:20</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.orders.OrderDetailViewModelTest.kt:33</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.orders.OrderDetailViewModelTest.kt:36</ID>
@@ -551,8 +548,6 @@
     <ID>WildcardImport:EditShippingLabelPackagesViewModel.kt$import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*</ID>
     <ID>WildcardImport:EditShippingLabelPaymentFragment.kt$import com.woocommerce.android.extensions.*</ID>
     <ID>WildcardImport:FeatureAnnouncementDialogFragment.kt$import android.view.*</ID>
-    <ID>WildcardImport:GetStats.kt$import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.*</ID>
-    <ID>WildcardImport:GetStats.kt$import kotlinx.coroutines.flow.*</ID>
     <ID>WildcardImport:GroupedProductListFragment.kt$import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*</ID>
     <ID>WildcardImport:InfiniteListHandler.kt$import androidx.compose.runtime.*</ID>
     <ID>WildcardImport:JetpackInstallProgressDialog.kt$import com.woocommerce.android.extensions.*</ID>
@@ -580,7 +575,6 @@
     <ID>WildcardImport:MoreMenuFragment.kt$import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.*</ID>
     <ID>WildcardImport:MoveShippingItemViewModel.kt$import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.*</ID>
     <ID>WildcardImport:MyStoreStatsView.kt$import com.woocommerce.android.extensions.*</ID>
-    <ID>WildcardImport:MyStoreViewModel.kt$import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.*</ID>
     <ID>WildcardImport:MyStoreViewModel.kt$import kotlinx.coroutines.flow.*</ID>
     <ID>WildcardImport:Notification.kt$import com.woocommerce.android.push.*</ID>
     <ID>WildcardImport:NotificationChannelType.kt$import com.woocommerce.android.push.NotificationChannelType.*</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -148,9 +148,6 @@
     <ID>NoWildcardImports:com.woocommerce.android.cardreader.internal.payments.PaymentManager.kt:20</ID>
     <ID>NoWildcardImports:com.woocommerce.android.extensions.DateExt.kt:10</ID>
     <ID>NoWildcardImports:com.woocommerce.android.extensions.LiveDataExt.kt:3</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.media.MediaFilesRepository.kt:13</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.media.MediaFilesRepository.kt:14</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.media.MediaFilesRepository.kt:22</ID>
     <ID>NoWildcardImports:com.woocommerce.android.media.ProductImagesUploadWorker.kt:13</ID>
     <ID>NoWildcardImports:com.woocommerce.android.media.ProductImagesUploadWorker.kt:14</ID>
     <ID>NoWildcardImports:com.woocommerce.android.media.ProductImagesUploadWorker.kt:4</ID>
@@ -563,9 +560,6 @@
     <ID>WildcardImport:MainSettingsFragment.kt$import com.woocommerce.android.analytics.AnalyticsEvent.*</ID>
     <ID>WildcardImport:MainSettingsFragment.kt$import com.woocommerce.android.util.*</ID>
     <ID>WildcardImport:MarkAllReviewsAsSeen.kt$import com.woocommerce.android.model.RequestResult.*</ID>
-    <ID>WildcardImport:MediaFilesRepository.kt$import kotlinx.coroutines.channels.*</ID>
-    <ID>WildcardImport:MediaFilesRepository.kt$import kotlinx.coroutines.flow.*</ID>
-    <ID>WildcardImport:MediaFilesRepository.kt$import org.wordpress.android.fluxc.store.MediaStore.*</ID>
     <ID>WildcardImport:MoreMenu.kt$import androidx.compose.foundation.layout.*</ID>
     <ID>WildcardImport:MoreMenu.kt$import androidx.compose.material.*</ID>
     <ID>WildcardImport:MoreMenuFragment.kt$import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.*</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -212,8 +212,6 @@
     <ID>NoWildcardImports:com.woocommerce.android.ui.main.MainActivityViewModelTest.kt:7</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.main.MainActivityViewModelTest.kt:9</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.main.MainPresenterTest.kt:17</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.ui.media.MediaFileUploadHandler.kt:13</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.ui.media.MediaFileUploadHandler.kt:21</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.moremenu.MoreMenu.kt:11</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.moremenu.MoreMenu.kt:17</ID>
     <ID>NoWildcardImports:com.woocommerce.android.ui.moremenu.MoreMenuFragment.kt:18</ID>
@@ -565,8 +563,6 @@
     <ID>WildcardImport:MainSettingsFragment.kt$import com.woocommerce.android.analytics.AnalyticsEvent.*</ID>
     <ID>WildcardImport:MainSettingsFragment.kt$import com.woocommerce.android.util.*</ID>
     <ID>WildcardImport:MarkAllReviewsAsSeen.kt$import com.woocommerce.android.model.RequestResult.*</ID>
-    <ID>WildcardImport:MediaFileUploadHandler.kt$import com.woocommerce.android.ui.media.MediaFileUploadHandler.UploadStatus.*</ID>
-    <ID>WildcardImport:MediaFileUploadHandler.kt$import kotlinx.coroutines.flow.*</ID>
     <ID>WildcardImport:MediaFilesRepository.kt$import kotlinx.coroutines.channels.*</ID>
     <ID>WildcardImport:MediaFilesRepository.kt$import kotlinx.coroutines.flow.*</ID>
     <ID>WildcardImport:MediaFilesRepository.kt$import org.wordpress.android.fluxc.store.MediaStore.*</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -148,7 +148,6 @@
     <ID>NoWildcardImports:com.woocommerce.android.cardreader.internal.payments.PaymentManager.kt:20</ID>
     <ID>NoWildcardImports:com.woocommerce.android.extensions.DateExt.kt:10</ID>
     <ID>NoWildcardImports:com.woocommerce.android.extensions.LiveDataExt.kt:3</ID>
-    <ID>NoWildcardImports:com.woocommerce.android.extensions.ViewExt.kt:25</ID>
     <ID>NoWildcardImports:com.woocommerce.android.media.MediaFilesRepository.kt:13</ID>
     <ID>NoWildcardImports:com.woocommerce.android.media.MediaFilesRepository.kt:14</ID>
     <ID>NoWildcardImports:com.woocommerce.android.media.MediaFilesRepository.kt:22</ID>
@@ -670,7 +669,6 @@
     <ID>WildcardImport:VariationDetailFragment.kt$import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*</ID>
     <ID>WildcardImport:VariationDetailViewModel.kt$import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*</ID>
     <ID>WildcardImport:VariationListAdapter.kt$import com.woocommerce.android.ui.products.ProductStockStatus.*</ID>
-    <ID>WildcardImport:ViewExt.kt$import kotlinx.coroutines.flow.*</ID>
     <ID>WildcardImport:WCMaterialOutlinedCurrencyEditTextView.kt$import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.*</ID>
     <ID>WildcardImport:WooLogViewerScreen.kt$import androidx.compose.foundation.layout.*</ID>
     <ID>WildcardImport:WooLogViewerScreen.kt$import androidx.compose.material.*</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -120,7 +120,6 @@
     <ID>MagicNumber:TimeGroup.kt$TimeGroup.Companion$2</ID>
     <ID>MagicNumber:UiHelpers.kt$UiHelpers$0.8</ID>
     <ID>MagicNumber:UnreadItemDecoration.kt$UnreadItemDecoration$3</ID>
-    <ID>MagicNumber:ViewExt.kt$300L</ID>
     <ID>MagicNumber:ViewUtils.kt$0.5f</ID>
     <ID>MagicNumber:WCEmptyView.kt$WCEmptyView$50L</ID>
     <ID>MagicNumber:WCMaterialOutlinedEditTextView.kt$WCMaterialOutlinedEditTextView$100</ID>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent: #6816
Partially Closes: #6819

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR resolves all `Coroutines` related warnings for the `woocommerce` module:

- 109 warnings x `This declaration is experimental and its usage should be marked with '@kotlinx.coroutines.ExperimentalCoroutinesApi' or '@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)'`
- 15 warnings x `This declaration is in a preview state and can be changed in a backwards-incompatible manner with a best-effort migration. Its usage should be marked with '@kotlinx.coroutines.FlowPreview' or '@OptIn(kotlinx.coroutines.FlowPreview::class)' if you accept the drawback of relying on preview API`

Warnings Resolution List:

1. [Remove redundant experimental coroutines api annotations.](https://github.com/woocommerce/woocommerce-android/commit/dba4e501c96312316974336665dbf24c56e4b54f)
2. [Change direct experimental coroutines api with opt-in.](https://github.com/woocommerce/woocommerce-android/commit/eca01a5448fcb8508800035ecdb5e76ce93938f1)
3. [Resolve opt-in experimental coroutine api warnings.](https://github.com/woocommerce/woocommerce-android/commit/a84836af0e61c90d24dfd14f6837800a4452b60a)
4. [Change opt-in experimental coroutines api to direct for tests.](https://github.com/woocommerce/woocommerce-android/commit/0b422ccb8f8248194ea29fc4922b0c1247332a10)

In addition to the above warning resolution list, the below `Detekt` warnings got resolved as well, leaving Detekt's `baseline.xml` file 19 entries shorter:

1. [Resolve magic number detekt warnings for view ext.](https://github.com/woocommerce/woocommerce-android/pull/6840/commits/53fc8e91d8eb47073ae822d49604aa62ce24432f)
2. [Resolve (no) wildcard imports detekt warnings for view ext.](https://github.com/woocommerce/woocommerce-android/pull/6840/commits/9873d44001123ac2d73a160aab3779488d1269e4)
3. [Resolve (no) wildcard imports detekt warnings for get stats.](https://github.com/woocommerce/woocommerce-android/pull/6840/commits/b1dbb1bb11e792610ea65f21e2d3d3f2c136a2db)
4. [Resolve (no) wildcard imports detekt warnings for media file.](https://github.com/woocommerce/woocommerce-android/pull/6840/commits/8b10aafe54135e85936edb7cb321d959ef678463)
5. [Resolve (no) wildcard imports detekt warnings for media files.](https://github.com/woocommerce/woocommerce-android/pull/6840/commits/3e2279cbfc7f3df26ba52b3ecb8cdce7a8ff0eeb)

Finally, and in addition to the above, the below custom `CheckStyle` warning needed to be resolved as well:

1. [Resolve regexp single line checkstyle error for media files.](https://github.com/woocommerce/woocommerce-android/pull/6840/commits/15a5f0ae0269fa53392e0f7ad4067d2d1d586c6a)

-----

PS: @hichamboushaba I added you as the main reviewer, that is, in addition to the @woocommerce/owl-team team itself, but randomly, since I just wanted someone from the `Woo Android` team to sing-off on that change for WCAndroid as well. PS: I am going to randomly add more of you in those PRs just so you become more aware of this change and how close we are on enabling `allWarningsAsErrors` by default everywhere. 🥇 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
