### PR TITLE
Fix product list search empty view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -306,7 +306,7 @@ class ProductListViewModel @Inject constructor(
             }
 
         val shouldShowEmptyView = if (isSearching()) {
-            viewState.query?.isNotEmpty() == true
+            viewState.query?.isNotEmpty() == true && _productList.value?.isEmpty() == true
         } else {
             _productList.value?.isEmpty() == true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -352,9 +352,15 @@ class ProductListViewModel @Inject constructor(
         loadMore: Boolean = false,
         scrollToTop: Boolean = false
     ) {
-        if (searchQuery.isNullOrEmpty()) {
-            _productList.value = productRepository.fetchProductList(loadMore, productFilterOptions)
-        } else {
+        if (!isSearching()) {
+            val products = productRepository.fetchProductList(loadMore, productFilterOptions)
+            // don't update the product list if a search was initiated while fetching
+            if (isSearching()) {
+                WooLog.i(WooLog.T.PRODUCTS, "Search initiated while fetching products")
+            } else {
+                _productList.value = products
+            }
+        } else if (searchQuery?.isNotEmpty() == true) {
             productRepository.searchProductList(searchQuery, loadMore)?.let { fetchedProducts ->
                 // make sure the search query hasn't changed while the fetch was processing
                 if (searchQuery == productRepository.lastSearchQuery) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -305,13 +305,19 @@ class ProductListViewModel @Inject constructor(
                 !isSearching()
             }
 
+        val shouldShowEmptyView = if (isSearching()) {
+            viewState.query?.isNotEmpty() == true
+        } else {
+            _productList.value?.isEmpty() == true
+        }
+
         viewState = viewState.copy(
             isSkeletonShown = false,
             isLoading = false,
             isLoadingMore = false,
             isRefreshing = false,
             canLoadMore = productRepository.canLoadMoreProducts,
-            isEmptyViewVisible = _productList.value?.isEmpty() == true,
+            isEmptyViewVisible = shouldShowEmptyView,
             isAddProductButtonVisible = shouldShowAddProductButton,
             displaySortAndFilterCard = !isSearching() &&
                 (productFilterOptions.isNotEmpty() || _productList.value?.isNotEmpty() == true)


### PR DESCRIPTION
Closes: #6841

This PR addresses two problems related to the product list search:

1. Sometimes when you tap the search icon, the empty view appears with the message, "We're sorry, we couldn't find results for """. This was caused by not checking whether the search query is empty when showing the empty view.
2. If you tap the search icon immediately after entering the product list, the product list is fully populated even though it should remain empty. This was caused by the user initiating a search while the products were still being fetched.

To test, verify that neither of those situations is happening.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.