### PR TITLE
Use woo_blue_5 for completed order status

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusTag.kt
@@ -27,7 +27,7 @@ class OrderStatusTag(private val orderStatus: OrderStatus) : ITag(orderStatus.st
                 config.bgColor = ContextCompat.getColor(context, R.color.tag_bg_failed)
             }
             CoreOrderStatus.COMPLETED.value -> {
-                config.bgColor = ContextCompat.getColor(context, R.color.tag_bg_other)
+                config.bgColor = ContextCompat.getColor(context, R.color.tag_bg_completed)
             }
             CoreOrderStatus.ON_HOLD.value -> {
                 config.bgColor = ContextCompat.getColor(context, R.color.tag_bg_on_hold)

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -110,6 +110,7 @@
     <color name="tag_bg_processing">@color/woo_celadon_5</color>
     <color name="tag_bg_failed">@color/woo_red_5</color>
     <color name="tag_bg_on_hold">@color/woo_orange_5</color>
+    <color name="tag_bg_completed">@color/woo_blue_5</color>
     <color name="tag_bg_other">@color/woo_gray_5</color>
 
     <!--

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -18,6 +18,7 @@
     <color name="woo_red_30">#F86368</color>
     <color name="woo_red_50">#D63638</color>
 
+    <color name="woo_blue_5">#BBE0FA</color>
     <color name="woo_blue_30">#5198D9</color>
     <color name="woo_blue_40">#1689DB</color>
     <color name="woo_blue_50">#2271B1</color>


### PR DESCRIPTION
Closes: #6849

A recent App Store review pointed out that we use the same color for completed order status and cancelled order status, whereas `wp-admin` uses separate colors. This PR addresses this by changing completed status to `woo_blue_5`, as discussed here: p1656692062233029-slack-CGPNUU63E

Screenshots of the updated order list are below, but note that this changes the completed status color in order detail as well since we use [the same component](https://github.com/woocommerce/woocommerce-android/blob/0a85b39af97b2232000ca33fbd2e22b4f59ecabf/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusTag.kt) to show the order status.

![light](https://user-images.githubusercontent.com/3903757/176939685-9835970e-7dfc-4c91-a062-fcf93ea15b50.png)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.