### PR TITLE
Compose: Add default text color in WCSearchField to make it readable in light and dark mode.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -186,6 +187,7 @@ fun WCSearchField(
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
+        textStyle = TextStyle(color = colorResource(id = R.color.color_on_surface_medium)),
         modifier = modifier
             .defaultMinSize(minHeight = dimensionResource(id = R.dimen.major_250))
             .background(


### PR DESCRIPTION
Closes: #6855
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Entered text inside `WCSearchField` Compose component is unreadable in dark mode. This is especially used in Coupons editing when choosing category or product.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Turn on Coupon Management beta feature
2. Go to Menu > Coupon > Select a coupon > Edit coupon
3. Scroll down to All Products / Select Product Categories
4. Set device to dark mode
5. Tap on the search field and type to search
6. Ensure the entered text is readable in dark mode

### Images/gif
<img width="335" alt="Screen Shot 2022-07-05 at 14 32 19" src="https://user-images.githubusercontent.com/266376/177274341-4ea5048d-0e09-4d9c-b03a-63a2ddd8cd3f.png">

