### PR TITLE
Coupons: Make Empty Product Selector Screen be Scrollable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -127,7 +127,10 @@ private fun EmptyProductList(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = dimensionResource(id = dimen.major_200)),
+            .padding(
+                horizontal = dimensionResource(id = dimen.major_200),
+                vertical = dimensionResource(id = dimen.major_200)
+            ),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
@@ -124,6 +126,7 @@ private fun EmptyProductList(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = dimensionResource(id = dimen.major_200)),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6854
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Turn on Coupon Management beta feature
2. Use landscape mode > Go to Menu > Coupon > Select a coupon > Edit coupon
3. Scroll down to All Products / Select Product Categories
4. Filter by something that will not return any results
5. This will show the empty product screen. Make sure the screen is scrollable and the "Clear Filters" button can be seen and tapped.

### Video
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/266376/177297957-5ea42087-2e74-4923-9668-bff4441d59ec.mov


