### PR TITLE
[Coupons] Fix race conditions about loading state during search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListViewModel.kt
@@ -146,19 +146,18 @@ class CouponListViewModel @Inject constructor(
                     if (it.isNullOrEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
                 }
                 .collectLatest { query ->
-                    try {
-                        couponListHandler.fetchCoupons(searchQuery = query)
-                            .onFailure {
-                                triggerEvent(
-                                    MultiLiveEvent.Event.ShowSnackbar(
-                                        if (query == null) R.string.coupon_list_loading_failed
-                                        else R.string.coupon_list_search_failed
-                                    )
+                    // Make sure the loading state is correctly set after debounce too
+                    loadingState.value = LoadingState.Loading
+                    couponListHandler.fetchCoupons(searchQuery = query)
+                        .onFailure {
+                            triggerEvent(
+                                MultiLiveEvent.Event.ShowSnackbar(
+                                    if (query == null) R.string.coupon_list_loading_failed
+                                    else R.string.coupon_list_search_failed
                                 )
-                            }
-                    } finally {
-                        loadingState.value = LoadingState.Idle
-                    }
+                            )
+                        }
+                    loadingState.value = LoadingState.Idle
                 }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
@@ -109,16 +109,15 @@ class ProductCategorySelectorViewModel @Inject constructor(
                     if (it.isNullOrEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
                 }
                 .collectLatest { query ->
-                    try {
-                        listHandler.fetchCategories(searchQuery = query)
-                            .onFailure {
-                                val message = if (query.isEmpty()) R.string.product_category_selector_loading_failed
-                                else R.string.product_category_selector_search_failed
-                                triggerEvent(ShowSnackbar(message))
-                            }
-                    } finally {
-                        loadingState.value = LoadingState.Idle
-                    }
+                    // Make sure the loading state is correctly set after debounce too
+                    loadingState.value = LoadingState.Loading
+                    listHandler.fetchCategories(searchQuery = query)
+                        .onFailure {
+                            val message = if (query.isEmpty()) R.string.product_category_selector_loading_failed
+                            else R.string.product_category_selector_search_failed
+                            triggerEvent(ShowSnackbar(message))
+                        }
+                    loadingState.value = LoadingState.Idle
                 }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -243,16 +243,15 @@ class ProductSelectorViewModel @Inject constructor(
                     if (it.isEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
                 }
                 .collectLatest { query ->
-                    try {
-                        listHandler.fetchProducts(searchQuery = query)
-                            .onFailure {
-                                val message = if (query.isEmpty()) string.product_selector_loading_failed
-                                else string.product_selector_search_failed
-                                triggerEvent(ShowSnackbar(message))
-                            }
-                    } finally {
-                        loadingState.value = IDLE
-                    }
+                    // Make sure the loading state is correctly set after debounce too
+                    loadingState.value = LOADING
+                    listHandler.fetchProducts(searchQuery = query)
+                        .onFailure {
+                            val message = if (query.isEmpty()) string.product_selector_loading_failed
+                            else string.product_selector_search_failed
+                            triggerEvent(ShowSnackbar(message))
+                        }
+                    loadingState.value = IDLE
                 }
         }
     }
@@ -270,15 +269,12 @@ class ProductSelectorViewModel @Inject constructor(
                     loadingState.value = LOADING
                 }
                 .collectLatest { filters ->
-                    try {
-                        listHandler.fetchProducts(filters = filters.filterOptions)
-                            .onFailure {
-                                val message = string.product_selector_loading_failed
-                                triggerEvent(ShowSnackbar(message))
-                            }
-                    } finally {
-                        loadingState.value = IDLE
-                    }
+                    listHandler.fetchProducts(filters = filters.filterOptions)
+                        .onFailure {
+                            val message = string.product_selector_loading_failed
+                            triggerEvent(ShowSnackbar(message))
+                        }
+                    loadingState.value = IDLE
                 }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6856 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes two race conditions about the `loadingState` in the coupons screens with search functionality:
1. We were setting the `loadingState` to `Idle` in a `finally` block, which meant it was executed always even if a new search term was emitted, even though we had it inside a `collectLatest`.
2. There was a race condition between the `debounce` delay and the `fetch` call, which made it possible to have the `Idle` state after the fetch, and skipping the `Loading` state before the `debounce`, the fix is to make sure we set the `Loading` state before fetching always. 

### Testing instructions
1. Turn on Coupon Management beta feature
2. Go to Menu > Coupon > Select a coupon > Edit coupon
3. Go to Select Product Categories
4. Search for part of a word, make sure the loading state is correctly displayed, and the no-results screen is not being shown before showing results.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
