### PR TITLE
[Screenshot Automation] Update screenshots (part 1) + Store listing metada

### DIFF
--- a/WooCommerce/metadata/full_description.txt
+++ b/WooCommerce/metadata/full_description.txt
@@ -1,22 +1,22 @@
-Manage your business on the go with the WooCommerce Mobile App. Create products, process orders, and keep an eye on key stats in real-time. 
+Manage your business on the go with the WooCommerce Mobile App. Add products, create orders, take quick payments, and keep an eye on new sales and key stats in real time.
 
-ADD PRODUCTS
-Create, group, and publish products directly from your favorite Android mobile devices. Capture your creativity in the moment – turn your ideas into products in seconds, or save them as drafts for later.
+Add and edit products with a touch
+Get started in seconds! Create, group, and publish products directly from your iPhone or iPad. Capture your creativity the moment it strikes – turn your ideas into products immediately, or save them as drafts for later.
 
-GET NOTIFIED
-Never miss an order or a review. Keep that FOMO at bay by enabling real-time alerts – and listen out for that addictive “cha-ching” sound that comes with every new sale!
+Create orders on the fly
+Once you have some products created, it’s simple. Choose items from your catalog, add shipping, and then fill in customer details to quickly create an order that syncs with your inventory.
 
-VIEW AND MODIFY ORDERS
-Scroll the summaries, or search by customer or order specifics. Tap into the details to see itemized billing, begin fulfillment, and change order status. Add notes to the order or email customers directly to follow up.
+Take payments in person
+Collect physical payments using WooCommerce In-Person Payments and a card reader (available in the US and Canada). Start a new order – or find an existing one that’s pending payment – and collect payment using the card reader or a digital wallet, such as Apple Pay.
 
-TRACK YOUR STATS
-See which products are winning at a glance. Keep tabs on overall revenue, order count, and visitor data by week, month, and year. Knowledge = power!
+Get notified of every sale
+Now that you’re actively selling, never miss an order or a review. Keep yourself in the loop by enabling real-time alerts – and listen for that addictive “cha-ching” sound that comes with each new sale!
 
-SWITCH BETWEEN STORES
-For those with more than one, toggle seamlessly between your businesses in seconds.
+Track sales and bestselling products
+See which products are winning at a glance. Keep tabs on your overall revenue, order count, and visitor data by week, month, and year. Knowledge = power.
 
 WooCommerce is the world’s most customizable open-source eCommerce platform. Whether you’re launching a business, taking brick-and-mortar retail online, or developing sites for clients, use WooCommerce for a store that powerfully blends content and commerce.
 
-Requirements: WooCommerce v3.5+, the Jetpack plugin.
+Requirements: WooCommerce v3.5+. Jetpack is also required to receive notifications.
 
 View the Privacy Notice for California users at https://automattic.com/privacy/#california-consumer-privacy-act-ccpa.

--- a/WooCommerce/metadata/promo_screenshot_1.txt
+++ b/WooCommerce/metadata/promo_screenshot_1.txt
@@ -1,2 +1,2 @@
-Your Store
-in Your Pocket
+Track sales and
+bestselling products

--- a/WooCommerce/metadata/promo_screenshot_1_b.txt
+++ b/WooCommerce/metadata/promo_screenshot_1_b.txt
@@ -1,2 +1,0 @@
-Made with 💜
-at Automattic

--- a/WooCommerce/metadata/promo_screenshot_2.txt
+++ b/WooCommerce/metadata/promo_screenshot_2.txt
@@ -1,1 +1,2 @@
-View and manage orders
+Create orders
+on the fly

--- a/WooCommerce/metadata/promo_screenshot_3.txt
+++ b/WooCommerce/metadata/promo_screenshot_3.txt
@@ -1,1 +1,2 @@
-Get real-time order alerts
+Take payments
+in person

--- a/WooCommerce/metadata/promo_screenshot_4.txt
+++ b/WooCommerce/metadata/promo_screenshot_4.txt
@@ -1,1 +1,2 @@
-Track order status
+Add and edit products
+with a touch

--- a/WooCommerce/metadata/promo_screenshot_5.txt
+++ b/WooCommerce/metadata/promo_screenshot_5.txt
@@ -1,2 +1,2 @@
-Scroll through, filter,
-or look up specific orders
+Get notified of
+every sale

--- a/WooCommerce/metadata/promo_screenshot_6.txt
+++ b/WooCommerce/metadata/promo_screenshot_6.txt
@@ -1,2 +1,0 @@
-View store data by week,
-month, and year

--- a/WooCommerce/metadata/promo_screenshot_7.txt
+++ b/WooCommerce/metadata/promo_screenshot_7.txt
@@ -1,2 +1,0 @@
-Check which products are
-performing best

--- a/WooCommerce/metadata/promo_screenshot_8.txt
+++ b/WooCommerce/metadata/promo_screenshot_8.txt
@@ -1,2 +1,0 @@
-Get notified about new
-customer reviews

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -7,15 +7,9 @@ import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.helpers.InitializationRule
 import com.woocommerce.android.helpers.TestBase
 import com.woocommerce.android.screenshots.login.WelcomeScreen
-import com.woocommerce.android.screenshots.moremenu.MoreMenuScreen
 import com.woocommerce.android.screenshots.mystore.MyStoreScreen
-import com.woocommerce.android.screenshots.orders.OrderListScreen
-import com.woocommerce.android.screenshots.orders.OrderSearchScreen
-import com.woocommerce.android.screenshots.orders.SingleOrderScreen
+import com.woocommerce.android.screenshots.orders.OrderCreationScreen
 import com.woocommerce.android.screenshots.products.ProductListScreen
-import com.woocommerce.android.screenshots.products.SingleProductScreen
-import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
-import com.woocommerce.android.screenshots.reviews.SingleReviewScreen
 import com.woocommerce.android.ui.main.MainActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -81,38 +75,43 @@ class ScreenshotTest : TestBase() {
             .stats.switchToStatsDashboardWeekTab()
             .thenTakeScreenshot<MyStoreScreen>("order-dashboard")
 
-        // Orders
+        // Create Orders
         TabNavComponent()
             .gotoOrdersScreen()
-            .thenTakeScreenshot<OrderListScreen>("order-list")
-            .selectOrder(7)
-            .thenTakeScreenshot<SingleOrderScreen>("order-detail")
+            .createFABTap()
+            .newOrderTap()
+            .thenTakeScreenshot<OrderCreationScreen>("add-order")
             .goBackToOrdersScreen()
-            .openSearchPane()
-            .thenTakeScreenshot<OrderSearchScreen>("order-search")
-            .cancel()
 
-        // More Menu
-        TabNavComponent()
-            .gotoMoreMenuScreen()
-            .thenTakeScreenshot<MoreMenuScreen>("more-menu")
 
-        // Reviews
-        TabNavComponent()
-            .gotoMoreMenuScreen()
-            .openReviewsListScreen(composeTestRule)
-            .thenTakeScreenshot<ReviewsListScreen>("review-list")
-            .selectReviewByIndex(4)
-            .thenTakeScreenshot<SingleReviewScreen>("review-details")
-            .goBackToReviewsScreen()
-            .goBackToMoreMenuScreen()
-
-        // Products
+        // Create Products
         TabNavComponent()
             .gotoProductsScreen()
-            .thenTakeScreenshot<ProductListScreen>("product-list")
-            .selectProductByName("Akoya Pearl shades")
-            .thenTakeScreenshot<SingleProductScreen>("product-details")
-            .goBackToProductsScreen()
+            .tapOnCreateProduct()
+            .thenTakeScreenshot<ProductListScreen>("add-product")
+            .goBackToProductList()
+
+//        // More Menu
+//        TabNavComponent()
+//            .gotoMoreMenuScreen()
+//            .thenTakeScreenshot<MoreMenuScreen>("more-menu")
+//
+//        // Reviews
+//        TabNavComponent()
+//            .gotoMoreMenuScreen()
+//            .openReviewsListScreen(composeTestRule)
+//            .thenTakeScreenshot<ReviewsListScreen>("review-list")
+//            .selectReviewByIndex(4)
+//            .thenTakeScreenshot<SingleReviewScreen>("review-details")
+//            .goBackToReviewsScreen()
+//            .goBackToMoreMenuScreen()
+//
+//        // Products
+//        TabNavComponent()
+//            .gotoProductsScreen()
+//            .thenTakeScreenshot<ProductListScreen>("product-list")
+//            .selectProductByName("Akoya Pearl shades")
+//            .thenTakeScreenshot<SingleProductScreen>("product-details")
+//            .goBackToProductsScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -72,7 +72,7 @@ class ScreenshotTest : TestBase() {
 
         // My Store
         MyStoreScreen()
-            .stats.switchToStatsDashboardWeekTab()
+            .stats.switchToStatsDashboardMonthTab()
             .thenTakeScreenshot<MyStoreScreen>("order-dashboard")
 
         // Create Orders

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -83,35 +83,11 @@ class ScreenshotTest : TestBase() {
             .thenTakeScreenshot<OrderCreationScreen>("add-order")
             .goBackToOrdersScreen()
 
-
         // Create Products
         TabNavComponent()
             .gotoProductsScreen()
             .tapOnCreateProduct()
             .thenTakeScreenshot<ProductListScreen>("add-product")
             .goBackToProductList()
-
-//        // More Menu
-//        TabNavComponent()
-//            .gotoMoreMenuScreen()
-//            .thenTakeScreenshot<MoreMenuScreen>("more-menu")
-//
-//        // Reviews
-//        TabNavComponent()
-//            .gotoMoreMenuScreen()
-//            .openReviewsListScreen(composeTestRule)
-//            .thenTakeScreenshot<ReviewsListScreen>("review-list")
-//            .selectReviewByIndex(4)
-//            .thenTakeScreenshot<SingleReviewScreen>("review-details")
-//            .goBackToReviewsScreen()
-//            .goBackToMoreMenuScreen()
-//
-//        // Products
-//        TabNavComponent()
-//            .gotoProductsScreen()
-//            .thenTakeScreenshot<ProductListScreen>("product-list")
-//            .selectProductByName("Akoya Pearl shades")
-//            .thenTakeScreenshot<SingleProductScreen>("product-details")
-//            .goBackToProductsScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/StatsComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/StatsComponent.kt
@@ -39,4 +39,12 @@ class StatsComponent : Screen(STATS_DASHBOARD) {
 
         return MyStoreScreen()
     }
+
+    fun switchToStatsDashboardMonthTab(): MyStoreScreen {
+        selectItemWithTitleInTabLayout(R.string.this_month, R.id.app_bar_layout)
+        waitForGraphToLoad()
+
+        return MyStoreScreen()
+    }
+
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/StatsComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/StatsComponent.kt
@@ -46,5 +46,4 @@ class StatsComponent : Screen(STATS_DASHBOARD) {
 
         return MyStoreScreen()
     }
-
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderCreationScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderCreationScreen.kt
@@ -3,7 +3,10 @@ package com.woocommerce.android.screenshots.orders
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.util.Screen
 
@@ -38,5 +41,16 @@ class OrderCreationScreen : Screen {
     fun assertNewOrderScreenWithProduct(productName: String): OrderCreationScreen {
         Espresso.onView(withText(productName)).check(matches(isDisplayed()))
         return assertNewOrderScreen()
+    }
+
+    fun goBackToOrdersScreen(): OrderListScreen {
+        pressBack()
+
+        val discard = getTranslatedString(R.string.discard)
+        if (isElementDisplayed(discard)) {
+            clickButtonInDialogWithTitle(discard)
+        }
+
+        return OrderListScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/ProductListScreen.kt
@@ -25,6 +25,24 @@ class ProductListScreen : Screen {
         return SingleProductScreen()
     }
 
+    fun tapOnCreateProduct(): ProductListScreen {
+        clickOn(R.id.addProductButton)
+        return this
+    }
+
+    fun goBackToProductList(): ProductListScreen {
+        while (!isElementDisplayed(R.id.productsRecycler)) {
+            pressBack()
+        }
+
+        return this
+    }
+
+    fun openSearchPane(): ProductListScreen {
+        clickOn(R.id.menu_search)
+        return this
+    }
+
     fun assertProductCard(product: ProductData): ProductListScreen {
         Espresso.onView(
             Matchers.allOf(

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/Screen.kt
@@ -3,11 +3,15 @@ package com.woocommerce.android.screenshots.util
 import android.app.Activity
 import android.content.res.Configuration
 import android.view.View
+import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.*
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -15,7 +19,14 @@ import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.withClassName
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage.RESUMED
@@ -54,6 +65,10 @@ open class Screen {
         // screen we are dealing with.
         fun isElementDisplayed(elementID: Int): Boolean {
             return isElementDisplayed(onView(withId(elementID)))
+        }
+
+        fun isElementDisplayed(text: String): Boolean {
+            return isElementDisplayed(onView(withText(text)))
         }
 
         private fun isElementDisplayed(element: ViewInteraction): Boolean {
@@ -223,8 +238,12 @@ open class Screen {
             .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(index, click()))
     }
 
-    fun clickButtonInDialogWithTitle(resourceID: Int) {
+    fun clickButtonInDialogWithTitle(@StringRes resourceID: Int) {
         val title = getTranslatedString(resourceID)
+        clickButtonInDialogWithTitle(title)
+    }
+
+    fun clickButtonInDialogWithTitle(title: String) {
         val dialogButton = onView(ViewMatchers.withText(title)).inRoot(isDialog())
         clickOn(dialogButton)
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,14 +156,10 @@ platform :android do
       play_store_desc: File.join(METADATA_DIR_PATH, 'full_description.txt'),
       play_store_app_title: File.join(METADATA_DIR_PATH, 'title.txt'),
       play_store_screenshot_1: File.join(METADATA_DIR_PATH, 'promo_screenshot_1.txt'),
-      play_store_screenshot_1_b: File.join(METADATA_DIR_PATH, 'promo_screenshot_1_b.txt'),
       play_store_screenshot_2: File.join(METADATA_DIR_PATH, 'promo_screenshot_2.txt'),
       play_store_screenshot_3: File.join(METADATA_DIR_PATH, 'promo_screenshot_3.txt'),
       play_store_screenshot_4: File.join(METADATA_DIR_PATH, 'promo_screenshot_4.txt'),
       play_store_screenshot_5: File.join(METADATA_DIR_PATH, 'promo_screenshot_5.txt'),
-      play_store_screenshot_6: File.join(METADATA_DIR_PATH, 'promo_screenshot_6.txt'),
-      play_store_screenshot_7: File.join(METADATA_DIR_PATH, 'promo_screenshot_7.txt'),
-      play_store_screenshot_8: File.join(METADATA_DIR_PATH, 'promo_screenshot_8.txt')
     }
 
     po_path = File.join(METADATA_DIR_PATH, 'PlayStoreStrings.pot')
@@ -671,14 +667,10 @@ platform :android do
     # "<key in .po file>" => { desc: "<name of txt file>" }
     files = {
       'app_store_screenshot-1': { desc: "promo_screenshot_1.txt" },
-      'app_store_screenshot-1_b': { desc: "promo_screenshot_1_b.txt" },
       'app_store_screenshot-2': { desc: "promo_screenshot_2.txt" },
       'app_store_screenshot-3': { desc: "promo_screenshot_3.txt" },
       'app_store_screenshot-4': { desc: "promo_screenshot_4.txt" },
       'app_store_screenshot-5': { desc: "promo_screenshot_5.txt" },
-      'app_store_screenshot-6': { desc: "promo_screenshot_6.txt" },
-      'app_store_screenshot-7': { desc: "promo_screenshot_7.txt" },
-      'app_store_screenshot-8': { desc: "promo_screenshot_8.txt" },
     }
 
     locales = SUPPORTED_LOCALES
@@ -697,14 +689,10 @@ platform :android do
 
     [
       "promo_screenshot_1.txt",
-      "promo_screenshot_1_b.txt",
       "promo_screenshot_2.txt",
       "promo_screenshot_3.txt",
       "promo_screenshot_4.txt",
       "promo_screenshot_5.txt",
-      "promo_screenshot_6.txt",
-      "promo_screenshot_7.txt",
-      "promo_screenshot_8.txt",
     ].each do |filename|
       source = File.join(METADATA_DIR_PATH, filename)
       destination = File.join(en_us_path, filename)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6833
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This is the first PR for updating the list of Play Store screenshots, this PR adds the following changes:
1. Updates the screenshots of Products and Orders screens.
2. Updates the promo screenshots metadata.
3. Updates the play store listing full description

The updated store listing details can be found in this document p91TBi-9eM-p2

### Testing instructions
I think it's better to do one last test with all PRs done.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->