### PR TITLE
Disconnect card reader if connected when switching plugins

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_card_reader_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_card_reader_flow.xml
@@ -74,8 +74,8 @@
         <action
             android:id="@+id/action_cardReaderHubFragment_to_cardReaderOnboardingFragment"
             app:destination="@id/cardReaderOnboardingFragment"
-            app:popUpTo="@+id/cardReaderStatusCheckerDialogFragment"
-            app:popUpToInclusive="true"/>
+            app:popUpTo="@+id/mainSettingsFragment"
+            app:popUpToInclusive="false"/>
     </fragment>
     <fragment
         android:id="@+id/cardReaderDetailFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_card_reader_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_card_reader_flow.xml
@@ -74,8 +74,8 @@
         <action
             android:id="@+id/action_cardReaderHubFragment_to_cardReaderOnboardingFragment"
             app:destination="@id/cardReaderOnboardingFragment"
-            app:popUpTo="@+id/mainSettingsFragment"
-            app:popUpToInclusive="false"/>
+            app:popUpTo="@+id/cardReaderStatusCheckerDialogFragment"
+            app:popUpToInclusive="true"/>
     </fragment>
     <fragment
         android:id="@+id/cardReaderDetailFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
@@ -52,6 +53,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         on(it.get()).thenReturn(SiteModel())
     }
     private val appPrefsWrapper: AppPrefsWrapper = mock()
+    private val cardReaderManager: CardReaderManager = mock()
     private val countryCode = "US"
     private val pluginVersion = "4.0.0"
 
@@ -838,6 +840,62 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given plugin type not null, when user selects wcpay and taps confirm button, then clear last known reader`() =
+        testBlocking {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(
+                CardReaderOnboardingState.ChoosePaymentGatewayProvider
+            )
+            whenever(cardReaderManager.initialized).thenReturn(true)
+
+            val viewModel = createVM()
+
+            val viewStateData = viewModel.viewStateData.value as OnboardingViewState.SelectPaymentPluginState
+            viewStateData.onConfirmPaymentMethodClicked.invoke(WOOCOMMERCE_PAYMENTS)
+
+            verify(appPrefsWrapper).removeLastConnectedCardReaderId()
+        }
+
+    @Test
+    fun `given card reader has inititialized, when user selects wcpay and confirm button, then disconnect reader`() =
+        testBlocking {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(
+                CardReaderOnboardingState.ChoosePaymentGatewayProvider
+            )
+            whenever(cardReaderManager.initialized).thenReturn(true)
+
+            val viewModel = createVM()
+
+            val viewStateData = viewModel.viewStateData.value as OnboardingViewState.SelectPaymentPluginState
+            viewStateData.onConfirmPaymentMethodClicked.invoke(WOOCOMMERCE_PAYMENTS)
+
+            verify(cardReaderManager).disconnectReader()
+        }
+
+    @Test
+    fun `given plugin type null, when view model init, then do not clear last known reader`() =
+        testBlocking {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(
+                CardReaderOnboardingState.ChoosePaymentGatewayProvider
+            )
+
+            createVM()
+
+            verify(appPrefsWrapper, never()).removeLastConnectedCardReaderId()
+        }
+
+    @Test
+    fun `given plugin type null, when view model init, then do not disconnect reader`() =
+        testBlocking {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(
+                CardReaderOnboardingState.ChoosePaymentGatewayProvider
+            )
+
+            createVM()
+
+            verify(cardReaderManager, never()).disconnectReader()
+        }
+
+    @Test
     fun `given wcpay and stripe extension active, when user taps stripe and confirm button, then load screen shown `() =
 
         testBlocking {
@@ -1295,5 +1353,6 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             userEligibilityFetcher,
             selectedSite,
             appPrefsWrapper,
+            cardReaderManager
         )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6769 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR disconnects the card reader (if connected) when the merchant switches their preferred plugin. The disconnection logic runs only when the card reader is connected when the merchant is switching the plugin. Basically, a disconnect should happen when the merchant switches the plugin via the "Change Payment Gateway" option from the IPP settings

Disconnecting the card reader is important when switching the plugin since the connection token is associated with the account.

This PR also fixes the issue mentioned here: https://github.com/woocommerce/woocommerce-android/pull/6858#pullrequestreview-1029717451

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Connect to the card reader
2. Navigate to the IPP settings -> "Change Payment Gateway"
3. Select any one of the plugins
4. Ensure that the card reader gets disconnected either by checking the logs, in the app (Manage card reader) or the physical device.


To test [this](https://github.com/woocommerce/woocommerce-android/pull/6858#pullrequestreview-1029717451) issue:
1. Connect to the card reader
2. Navigate to the IPP settings -> "Change Payment Gateway"
3. Press back
4. Ensure you are navigated back to the main settings and not the IPP settings.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
