### PR TITLE
[Screenshot automation] Screenshot for push notifications

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -287,6 +287,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"
     androidTestImplementation "com.google.dagger:hilt-android-testing:$gradle.ext.daggerVersion"
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
     // Dependencies for screenshots
     androidTestImplementation 'tools.fastlane:screengrab:2.1.1'

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -27,7 +27,6 @@ import tools.fastlane.screengrab.cleanstatusbar.CleanStatusBar
 import tools.fastlane.screengrab.locale.LocaleTestRule
 import javax.inject.Inject
 
-
 @HiltAndroidTest
 class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
     @get:Rule(order = 0)
@@ -45,8 +44,7 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
     @get:Rule(order = 4)
     var activityRule = ActivityScenarioRule(MainActivity::class.java)
 
-    @Inject
-    lateinit var wooNotificationBuilder: WooNotificationBuilder
+    @Inject lateinit var wooNotificationBuilder: WooNotificationBuilder
 
     @Before
     fun setUp() {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -7,8 +7,10 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.helpers.InitializationRule
 import com.woocommerce.android.helpers.TestBase
+import com.woocommerce.android.push.WooNotificationBuilder
 import com.woocommerce.android.screenshots.login.WelcomeScreen
 import com.woocommerce.android.screenshots.mystore.MyStoreScreen
+import com.woocommerce.android.screenshots.notifications.NotificationsScreen
 import com.woocommerce.android.screenshots.orders.CardReaderPaymentScreen
 import com.woocommerce.android.screenshots.orders.OrderCreationScreen
 import com.woocommerce.android.screenshots.products.ProductListScreen
@@ -23,6 +25,8 @@ import tools.fastlane.screengrab.Screengrab
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy
 import tools.fastlane.screengrab.cleanstatusbar.CleanStatusBar
 import tools.fastlane.screengrab.locale.LocaleTestRule
+import javax.inject.Inject
+
 
 @HiltAndroidTest
 class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
@@ -41,9 +45,13 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
     @get:Rule(order = 4)
     var activityRule = ActivityScenarioRule(MainActivity::class.java)
 
+    @Inject
+    lateinit var wooNotificationBuilder: WooNotificationBuilder
+
     @Before
     fun setUp() {
         CleanStatusBar.enableWithDefaults()
+        rule.inject()
     }
 
     @After
@@ -94,6 +102,7 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
 
         // Capture In-Person Payment
         AppPrefs.setCardReaderWelcomeDialogShown() // Skip card reader welcome screen
+        AppPrefs.setShowCardReaderConnectedTutorial(false) // Skip card reader tutorial
         TabNavComponent()
             .gotoOrdersScreen()
             .selectOrder(2)
@@ -101,5 +110,9 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
             .thenTakeScreenshot<CardReaderPaymentScreen>("in-person-payments")
             .goBackToOrderDetails()
             .goBackToOrdersScreen()
+
+        NotificationsScreen(wooNotificationBuilder)
+            .thenTakeScreenshot<NotificationsScreen>("push-notifications")
+            .goBackToApp()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/notifications/NotificationsScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/notifications/NotificationsScreen.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.screenshots.util.Screen
  */
 class NotificationsScreen(private val wooNotificationBuilder: WooNotificationBuilder) :
     Screen(TabNavComponent.MY_STORE_BUTTON) {
-
     init {
         displayNotification()
         openNotificationShade()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/notifications/NotificationsScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/notifications/NotificationsScreen.kt
@@ -1,0 +1,58 @@
+package com.woocommerce.android.screenshots.notifications
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Notification
+import com.woocommerce.android.push.NotificationChannelType
+import com.woocommerce.android.push.WooNotificationBuilder
+import com.woocommerce.android.push.WooNotificationType.NEW_ORDER
+import com.woocommerce.android.screenshots.TabNavComponent
+import com.woocommerce.android.screenshots.util.Screen
+
+/**
+ * This is not a screen per-se, as it shows the notification drawer with a push notification.
+ * This is why we provide an [TabNavComponent.MY_STORE_BUTTON] as the [elementID].
+ */
+class NotificationsScreen(private val wooNotificationBuilder: WooNotificationBuilder) :
+    Screen(TabNavComponent.MY_STORE_BUTTON) {
+
+    init {
+        displayNotification()
+        openNotificationShade()
+    }
+
+    private fun displayNotification() {
+        wooNotificationBuilder.buildAndDisplayWooNotification(
+            0,
+            0,
+            getTranslatedString(R.string.notification_channel_order_id),
+            notification = Notification(
+                noteId = 1,
+                uniqueId = 1L,
+                remoteNoteId = 1L,
+                remoteSiteId = 1L,
+                icon = "https://s.wp.com/wp-content/mu-plugins/notes/images/update-payment-2x.png",
+                noteTitle = getTranslatedString(R.string.tests_notification_new_order_title),
+                noteMessage = getTranslatedString(R.string.tests_notification_new_order_message),
+                noteType = NEW_ORDER,
+                channelType = NotificationChannelType.NEW_ORDER
+            ),
+            addCustomNotificationSound = false,
+            isGroupNotification = false
+        )
+    }
+
+    private fun openNotificationShade() {
+        val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        uiDevice.openNotification()
+        idleFor(1000)
+    }
+
+    fun goBackToApp(): TabNavComponent {
+        val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        uiDevice.pressBack()
+
+        return TabNavComponent()
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2505,5 +2505,5 @@
     <string name="lines_incomplete_explanation">To edit all %1$s browse the order in your WooCommerce store admin</string>
     <string name="lines_all_details">the details</string>
     <string name="tests_notification_new_order_title">You have a new order! 🎉</string>
-    <string name="tests_notification_new_order_message">New order for $20 on Your WooCommerce Store</string>
+    <string name="tests_notification_new_order_message">New order for $50 on Your WooCommerce Store</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2504,4 +2504,6 @@
     <string name="lines_incomplete">%1$s are incomplete</string>
     <string name="lines_incomplete_explanation">To edit all %1$s browse the order in your WooCommerce store admin</string>
     <string name="lines_all_details">the details</string>
+    <string name="tests_notification_new_order_title">You have a new order! 🎉</string>
+    <string name="tests_notification_new_order_message">New order for $20 on Your WooCommerce Store</string>
 </resources>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -633,6 +633,12 @@ platform :android do
     }
 
     UI.message("Taking screenshots for Dark theme...")
+    begin
+       adb(command: "shell cmd uimode night yes")
+     rescue => ex
+       # Skip any error here
+       UI.error(ex)
+    end
     screengrab(
       screenshot_options.merge(
         {
@@ -642,6 +648,12 @@ platform :android do
     )
 
     UI.message("Taking screenshots for Light theme...")
+    begin
+       adb(command: "shell cmd uimode night no")
+     rescue => ex
+       # Skip any error here
+       UI.error(ex)
+    end
     screengrab(
       screenshot_options.merge(
         {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6833

### Description
This PR adds a test scenario to take a screenshot of push notifications.
There were two possibilities to showcase the push notification:
1. Lockscreen.
2. Notification drawer.

It was decided to go with the notification drawer since the notification is expanded there by default, which would showcase the content better.

### Testing instructions
Test instructions for all PRs in the following one.

### Images/gif
| | |
| - | - |
| ![image](https://user-images.githubusercontent.com/1657201/177733337-45f3c8d7-7be4-45e2-8882-d7d51b9ce5a8.png) | ![image](https://user-images.githubusercontent.com/1657201/177733356-3e88df9b-1d49-44de-b574-a454d8607bfb.png) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
