### PR TITLE
For the Canadian store, when both WCPay and Stripe extension plugin are installed, proceed with onboarding using WCPay as the preferred plugin

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -123,12 +123,10 @@ class CardReaderOnboardingChecker @Inject constructor(
         val wcPayPluginInfo = wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS)
         val stripePluginInfo = wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY)
 
-        if (isBothPluginsActivated(wcPayPluginInfo, stripePluginInfo)) {
-            PluginType.values().forEach { pluginType ->
-                if (!isPluginSupportedInCountry(pluginType, cardReaderConfig)) {
-                    return PluginIsNotSupportedInTheCountry(pluginType, countryCode!!)
-                }
-            }
+        if (
+            isBothPluginsActivated(wcPayPluginInfo, stripePluginInfo) &&
+            isBothPluginsSupportedInTheCountry(cardReaderConfig)
+        ) {
             if (ippSelectPaymentGateway.isEnabled()) {
                 when {
                     isUserComingFromChoosePaymentGatewayScreen(pluginType) -> {
@@ -271,6 +269,10 @@ class CardReaderOnboardingChecker @Inject constructor(
             selfHostedSiteId = site.selfHostedSiteId,
         )
     }
+
+    private fun isBothPluginsSupportedInTheCountry(cardReaderConfig: CardReaderConfigForSupportedCountry) =
+        isPluginSupportedInCountry(WOOCOMMERCE_PAYMENTS, cardReaderConfig) &&
+            isPluginSupportedInCountry(STRIPE_EXTENSION_GATEWAY, cardReaderConfig)
 
     private fun isBothPluginsActivated(
         wcPayPluginInfo: SitePluginModel?,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -38,8 +38,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock {
         on(it.get()).thenReturn(SiteModel())
     }
-    private val wooStore: WooCommerceStore = mock()
-    private val ippSelectPaymentGateway: IppSelectPaymentGateway = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
     private val countryCode = "US"
@@ -210,12 +208,15 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given payment gateway flag enabled, when multiple plugins installed, then payment provider row is shown`() {
-        whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-            .thenReturn(buildWCPayPluginInfo(isActive = true))
+    fun `when multiple plugins installed, then payment provider row is shown`() {
+        val site = selectedSite.get()
+        whenever(
+            appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                localSiteId = site.id,
+                remoteSiteId = site.siteId,
+                selfHostedSiteId = site.selfHostedSiteId
+            )
+        ).thenReturn(true)
 
         initViewModel()
 
@@ -226,12 +227,15 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given payment gateway flag enabled, when multiple plugins installed, then payment provider icon is shown`() {
-        whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-            .thenReturn(buildWCPayPluginInfo(isActive = true))
+    fun `when multiple plugins installed, then payment provider icon is shown`() {
+        val site = selectedSite.get()
+        whenever(
+            appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                localSiteId = site.id,
+                remoteSiteId = site.siteId,
+                selfHostedSiteId = site.selfHostedSiteId
+            )
+        ).thenReturn(true)
 
         initViewModel()
 
@@ -243,11 +247,14 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given multiple plugins installed, when change payment provider clicked, then trigger onboarding event`() {
-        whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-            .thenReturn(buildWCPayPluginInfo(isActive = true))
+        val site = selectedSite.get()
+        whenever(
+            appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                localSiteId = site.id,
+                remoteSiteId = site.siteId,
+                selfHostedSiteId = site.selfHostedSiteId
+            )
+        ).thenReturn(true)
 
         initViewModel()
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
@@ -262,11 +269,14 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given multiple plugins installed, when payment provider clicked, then clear plugin selected flag`() {
-        whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-            .thenReturn(buildWCPayPluginInfo(isActive = true))
+        val site = selectedSite.get()
+        whenever(
+            appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                localSiteId = site.id,
+                remoteSiteId = site.siteId,
+                selfHostedSiteId = site.selfHostedSiteId
+            )
+        ).thenReturn(true)
 
         initViewModel()
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
@@ -284,11 +294,14 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given multiple plugins installed, when change payment provider clicked, then track event`() {
-        whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(true)
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-            .thenReturn(buildWCPayPluginInfo(isActive = true))
+        val site = selectedSite.get()
+        whenever(
+            appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                localSiteId = site.id,
+                remoteSiteId = site.siteId,
+                selfHostedSiteId = site.selfHostedSiteId
+            )
+        ).thenReturn(true)
 
         initViewModel()
         (viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows
@@ -300,27 +313,15 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given payment flag disabled, when multiple plugins installed, then payment provider row is not shown`() {
-        whenever(ippSelectPaymentGateway.isEnabled()).thenReturn(false)
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeExtensionPluginInfo(isActive = true))
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-            .thenReturn(buildWCPayPluginInfo(isActive = true))
-
-        initViewModel()
-
-        assertThat((viewModel.viewStateData.value as CardReaderHubViewModel.CardReaderHubViewState.Content).rows)
-            .noneMatch {
-                it.label == UiString.UiStringRes(R.string.card_reader_manage_payment_provider)
-            }
-    }
-
-    @Test
-    fun `given payment gateway flag enabled, when single plugin installed, then payment provider row is not shown`() {
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
-            .thenReturn(buildStripeExtensionPluginInfo(isActive = false))
-        whenever(wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-            .thenReturn(buildWCPayPluginInfo(isActive = true))
+    fun `when single plugin installed, then payment provider row is not shown`() {
+        val site = selectedSite.get()
+        whenever(
+            appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                localSiteId = site.id,
+                remoteSiteId = site.siteId,
+                selfHostedSiteId = site.selfHostedSiteId
+            )
+        ).thenReturn(false)
 
         initViewModel()
 
@@ -336,25 +337,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
             inPersonPaymentsCanadaFeatureFlag,
             appPrefsWrapper,
             selectedSite,
-            wooStore,
-            ippSelectPaymentGateway,
             analyticsTrackerWrapper
         )
-    }
-
-    private fun buildWCPayPluginInfo(
-        isActive: Boolean = true,
-        version: String = wcPayPluginVersion
-    ) = SitePluginModel().apply {
-        this.version = version
-        this.setIsActive(isActive)
-    }
-
-    private fun buildStripeExtensionPluginInfo(
-        isActive: Boolean = true,
-        version: String = stripePluginVersion
-    ) = SitePluginModel().apply {
-        this.version = version
-        this.setIsActive(isActive)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.cardreader.InPersonPaymentsCanadaFeatureFlag
-import com.woocommerce.android.ui.cardreader.IppSelectPaymentGateway
 import com.woocommerce.android.ui.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
@@ -25,8 +24,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.plugin.SitePluginModel
-import org.wordpress.android.fluxc.store.WooCommerceStore
 
 class CardReaderHubViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: CardReaderHubViewModel
@@ -41,8 +38,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
     private val countryCode = "US"
-    private val wcPayPluginVersion = "3.3.0"
-    private val stripePluginVersion = "6.6.0"
 
     private val savedState = CardReaderHubFragmentArgs(
         storeCountryCode = countryCode,


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #6882 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before this PR, when both WCPay and Stripe extension is installed on a Canadian store. Onboarding used to fail with "Stripe extension not supported" message.

After this PR, for the Canadian store, when both WCPay and Stripe extension plugins are installed, proceed with onboarding using WCPay as the preferred plugin

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Install both WCPay and Stripe extension on a store with a Canadian address
2. Navigate to settings -> In-Person Payments
3. Ensure the onboarding succeeds using WCPay as the preferred plugin


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
