### PR TITLE
Issue/6886 enable multiple plugins for all

### DIFF
--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -2,5 +2,5 @@ We keep adding new functionality to our experimental Coupon Management feature! 
 
 We also fixed a bug that was making it hard for some of you to search orders. Thanks to everyone who reported this! Your feedback is vital to us!'
 
-[***] In-Person Payments: Enabled ability to choose a payment gateway when multiple payment gateway is installed on a site for all!
+[***] In-Person Payments: Enabled ability to choose a payment gateway when multiple payment gateway is installed on a site for all! (https://github.com/woocommerce/woocommerce-android/pull/6887)
 

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,4 +1,6 @@
 We keep adding new functionality to our experimental Coupon Management feature! This release includes editing and deleting coupons along with several improvements on viewing. Turn this feature on for early access in the More tab, Settings, Beta Features.
 
-We also fixed a bug that was making it hard for some of you to search orders. Thanks to everyone who reported this! Your feedback is vital to us!
+We also fixed a bug that was making it hard for some of you to search orders. Thanks to everyone who reported this! Your feedback is vital to us!'
+
+[***] In-Person Payments: Enabled ability to choose a payment gateway when multiple payment gateway is installed on a site for all!
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -23,12 +23,12 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
             JETPACK_CP,
+            IPP_SELECT_PAYMENT_GATEWAY,
             IN_PERSON_PAYMENTS_CANADA -> true
             ANALYTICS_HUB,
             MORE_MENU_INBOX,
             COUPONS_M2,
             WC_SHIPPING_BANNER,
-            IPP_SELECT_PAYMENT_GATEWAY,
             UNIFIED_ORDER_EDITING -> PackageUtils.isDebugBuild()
             ORDER_CREATION_CUSTOMER_SEARCH -> {
                 UNIFIED_ORDER_EDITING.isEnabled()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6886 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Enabled ability to choose a payment gateway when multiple payment gateways is installed on a site for all. This PR returns true for the `IPP_SELECT_PAYMENT_GATEWAY` feature flag regardless of the build type.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Ensure IPP onboarding happy flow works as expected.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
