### PR TITLE
Fix navgraph action

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_card_reader_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_card_reader_flow.xml
@@ -74,7 +74,7 @@
         <action
             android:id="@+id/action_cardReaderHubFragment_to_cardReaderOnboardingFragment"
             app:destination="@id/cardReaderOnboardingFragment"
-            app:popUpTo="@+id/cardReaderStatusCheckerDialogFragment"
+            app:popUpTo="@+id/cardReaderHubFragment"
             app:popUpToInclusive="true"/>
     </fragment>
     <fragment


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR Fixes the back button navigation flow from the hub screen to the app settings screen as opposed to the Hub screen (IPP settings)

### Testing instructions
<!-- Step-by-step testing instructions. When necessary break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

1 - Go to the Menu Screen
2 - Click on In-Person Payments
3 - From the Plugin selection screen select a plugin and click on the confirm button 
4 - it will take you back to the hub screen 
5 - click on Change Payment provider so you can go to the plugin selection screen again
6 - Click on the back button
7 - Make sure the back button navigates back to the app settings screen and not the IPP hub screen

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/177774585-1aadc6de-17f7-4369-8f8d-951a6ce60e40.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/177774618-ca7acb4b-68eb-4b75-a887-ecdf1604b2a5.gif" width="350"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
