### PR TITLE
[Screenshot Automation] Update promo screenshot entries

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -91,13 +91,6 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
             .thenTakeScreenshot<OrderCreationScreen>("add-order")
             .goBackToOrdersScreen()
 
-        // Create Products
-        TabNavComponent()
-            .gotoProductsScreen()
-            .tapOnCreateProduct()
-            .thenTakeScreenshot<ProductListScreen>("add-product")
-            .goBackToProductList()
-
         // Capture In-Person Payment
         AppPrefs.setCardReaderWelcomeDialogShown() // Skip card reader welcome screen
         AppPrefs.setShowCardReaderConnectedTutorial(false) // Skip card reader tutorial
@@ -108,6 +101,13 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
             .thenTakeScreenshot<CardReaderPaymentScreen>("in-person-payments")
             .goBackToOrderDetails()
             .goBackToOrdersScreen()
+
+        // Create Products
+        TabNavComponent()
+            .gotoProductsScreen()
+            .tapOnCreateProduct()
+            .thenTakeScreenshot<ProductListScreen>("add-product")
+            .goBackToProductList()
 
         NotificationsScreen(wooNotificationBuilder)
             .thenTakeScreenshot<NotificationsScreen>("push-notifications")

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -31,7 +31,7 @@
     }
   ],
   "entries": [
-    // Your Store in Your Pocket
+    // Track sales and bestselling products
     {
       "device": "Pixel 3",
       "filename": "Pixel 3-01.png",
@@ -39,13 +39,37 @@
       "screenshot": "images/phoneScreenshots/1-order-dashboard-dark.png",
       "text": "playstoreres/metadata/{locale}/promo_screenshot_1.txt"
     },
-    // View and manage orders
+    // Create orders on the fly
     {
       "device": "Pixel 3",
       "filename": "Pixel 3-02.png",
-      "background": "#674399",
-      "screenshot": "images/phoneScreenshots/2-order-list-dark.png",
+      "background": "#C9356E",
+      "screenshot": "images/phoneScreenshots/2-add-order-light.png",
       "text": "playstoreres/metadata/{locale}/promo_screenshot_2.txt"
+    },
+    // Take payments in person
+    {
+      "device": "Pixel 3",
+      "filename": "Pixel 3-03.png",
+      "background": "#674399",
+      "screenshot": "images/phoneScreenshots/3-in-person-payments-dark.png",
+      "text": "playstoreres/metadata/{locale}/promo_screenshot_3.txt"
+    },
+    // Add and edit products with a touch
+    {
+      "device": "Pixel 3",
+      "filename": "Pixel 3-04.png",
+      "background": "#C9356E",
+      "screenshot": "images/phoneScreenshots/4-add-product-light.png",
+      "text": "playstoreres/metadata/{locale}/promo_screenshot_4.txt"
+    },
+    // Get notified of every sale
+    {
+      "device": "Pixel 3",
+      "filename": "Pixel 3-05.png",
+      "background": "#674399",
+      "screenshot": "images/phoneScreenshots/5-push-notifications-dark.png",
+      "text": "playstoreres/metadata/{locale}/promo_screenshot_5.txt"
     }
   ]
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6833 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the entries for promo screenshots, and it's the last in the series of PRs for updating screenshot scenarios.

### Testing instructions
To test the 4 PRs, please follow this:
1. Make sure the dependencies are all installed
    - brew install imagemagick automattic/build-tools/drawText
    - bundle install --with screenshots
    - Install the font Proxima Nova from [here](https://drive.google.com/drive/folders/18vuAG0LWl1nPFTBBO4Ghhs3YTG1HHG_n).
2. Confirm `ANDROID_HOME` environment variable is correctly set.
3. Download promo screenshots metadata:
    `bundle exec fastlane download_promo_strings`
4. Generate screenshots by running the following command:
    `bundle exec fastlane take_screenshots locales:en-US,fr-FR`
5. Generate promo screenshots by running the following command:
    `bundle exec fastlane create_promo_screenshots`

### Images/gif

| | | | | |
| - | - | - | - | - |
| ![Pixel 3-01](https://user-images.githubusercontent.com/1657201/177776845-8575338a-558b-444a-ab50-229e9de96779.png) | ![Pixel 3-02](https://user-images.githubusercontent.com/1657201/177776850-53fb2980-92ce-41dd-ad51-3b30312b727a.png) | ![Pixel 3-03](https://user-images.githubusercontent.com/1657201/177776854-0a624095-54b3-4d74-a703-b11a5b36a8d9.png) | ![Pixel 3-04](https://user-images.githubusercontent.com/1657201/177776856-91bd4160-b47e-402b-b4b0-4ad0eeae904f.png) | ![Pixel 3-05](https://user-images.githubusercontent.com/1657201/177776859-c8992283-16ec-475f-a83a-38927e6ecff2.png) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
