### PR TITLE
Add tracks dependency to `quicklogin`

### DIFF
--- a/quicklogin/build.gradle
+++ b/quicklogin/build.gradle
@@ -13,6 +13,7 @@ repositories {
             includeGroup "org.wordpress.wellsql"
             includeGroup "org.wordpress.mediapicker"
             includeGroup "com.automattic"
+            includeGroup "com.automattic.tracks"
         }
     }
     maven {


### PR DESCRIPTION
This PR fixes an issue with building `quicklogin` module. The reason is that #6055 we've added support for fetching Tracks from the S3 repository, but we didn't add the repository declaration to the `quicklogin` module.

To ensure we don't have similar issues in the future, I suggest using a common repository configuration for all modules. I'll prepare a Platform9 request for that. 

#### How to test
Run `./gradlew :quicklogin:assembleDebug` and see if it works. 