### PR TITLE
Exclude tracks experiments dependency from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,4 @@ updates:
       - dependency-name: "org.wordpress.fluxc.plugins:woocommerce"
       - dependency-name: "org.wordpress:login"
       - dependency-name: "com.automattic:Automattic-Tracks-Android"
+      - dependency-name: "com.automattic.tracks:experimentation"


### PR DESCRIPTION
As `com.automattic.tracks:experimentation` dependency is our in-house library, it doesn't follow semantic versioning rules. Therefore, we don't want Dependabot to prepare PRs with version bumps, like other in-house libraries, e.g., FluxC.