### PR TITLE
[Screenshot Automation] Fix issue with non-latin languages

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats-day.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats-day.json
@@ -8,10 +8,10 @@
       },
       "path": {
         "matches": "/wc-analytics/reports/revenue/stats/(.*)"
-      },     
+      },
       "query": {
         "matches": "(.*)interval\":\"day(.*)"
-      },          
+      },
       "locale": {
           "matches": "(.*)"
       }
@@ -44,13 +44,13 @@
             // will always start today (imagine a month starting on 19 of Oct).
             // It's not realistic, but it ensures that the data will look the same at any time.
             //
-            // Alternatively, we would have to calculate the closest Sunday (week start) from the past/today 
+            // Alternatively, we would have to calculate the closest Sunday (week start) from the past/today
             // with a helper (that does not exist) and use it as a first day of week (and offset it for the other six days).
-            "interval": "{{#assign 'customformat'}}yyyy-MM-dd{{/assign}}{{now format=customformat}}",
-            "date_start": "{{now format=customformat}} 00:00:00",
-            "date_start_gmt": "{{now format=customformat}} 00:00:00",
-            "date_end": "{{now format=customformat}} 23:59:59",
-            "date_end_gmt": "{{now format=customformat}} 23:59:59",
+            "interval": "{{#assign 'customformat'}}yyyy-MM-dd{{/assign}}{{fnow format=customformat}}",
+            "date_start": "{{fnow format=customformat}} 00:00:00",
+            "date_start_gmt": "{{fnow format=customformat}} 00:00:00",
+            "date_end": "{{fnow format=customformat}} 23:59:59",
+            "date_end_gmt": "{{fnow format=customformat}} 23:59:59",
             "subtotals": {
               "orders_count": 2,
               "num_items_sold": 0,

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats-hour.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats-hour.json
@@ -8,10 +8,10 @@
       },
       "path": {
         "matches": "/wc-analytics/reports/revenue/stats(.*)"
-      },     
+      },
       "query": {
         "matches": "(.*)interval\":\"hour(.*)"
-      },          
+      },
       "locale": {
           "matches": "(.*)"
       }
@@ -41,7 +41,7 @@
           "segments": []
         },
         "intervals": [{
-          "interval": "{{#assign 'currentDay'}}{{now format='yyyy-MM-dd'}}{{/assign}}{{currentDay}} 00",          
+          "interval": "{{#assign 'currentDay'}}{{fnow format='yyyy-MM-dd'}}{{/assign}}{{currentDay}} 00",
           "date_start": "{{currentDay}} 00:00:00",
           "date_start_gmt": "{{currentDay}} 00:00:00",
           "date_end": "{{currentDay}} 00:59:59",

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats-month.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats-month.json
@@ -8,10 +8,10 @@
       },
       "path": {
         "matches": "/wc-analytics/reports/revenue/stats/(.*)"
-      },     
+      },
       "query": {
         "matches": "(.*)interval\":\"month(.*)"
-      },          
+      },
       "locale": {
           "matches": "(.*)"
       }
@@ -39,7 +39,7 @@
           "segments": []
         },
         "intervals": [{
-          "interval": "{{#assign 'currentYear'}}{{now format='yyyy'}}{{/assign}}{{currentYear}}-01",
+          "interval": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-01",
           "date_start": "{{currentYear}}-01-01 00:00:00",
           "date_start_gmt": "{{currentYear}}-01-01 00:00:00",
           "date_end": "{{currentYear}}-01-31 23:59:59",

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_all_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_all_detailed.json
@@ -100,7 +100,7 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
-                "date_created_gmt": "{{#assign 'currentYear'}}{{now format='yyyy'}}{{/assign}}{{currentYear}}-10-31T13:13:57",
+                "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-10-31T13:13:57",
                 "date_modified_gmt": "{{currentYear}}-10-31T13:13:57",
                 "date_paid_gmt": null
             }, {
@@ -1170,7 +1170,7 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
-                "date_created_gmt": "{{#assign 'currentYear'}}{{now format='yyyy'}}{{/assign}}{{currentYear}}-01-31T11:26:08",
+                "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-01-31T11:26:08",
                 "date_modified_gmt": "{{currentYear}}-02-03T15:34:32",
                 "date_paid_gmt": "{{currentYear}}-01-28T11:26:54"
             }, {

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_any.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_any.json
@@ -8,10 +8,10 @@
             },
             "path": {
                 "matches": "/wc/v3/orders/(.*)"
-            },            
+            },
             "query": {
                 "matches": "(.*)status\":\"any(.*)_fields\":\"id,date_created_gmt,date_modified_gmt(.*)"
-            },            
+            },
             "locale": {
                 "matches": "(.*)"
             }
@@ -22,7 +22,7 @@
         "jsonBody": {
             "data": [{
                 "id": 2789,
-                "date_created_gmt": "{{#assign 'currentYear'}}{{now format='yyyy'}}{{/assign}}{{currentYear}}-10-31T13:13:57",
+                "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-10-31T13:13:57",
                 "date_modified_gmt": "{{currentYear}}-10-31T13:13:57"
             }, {
                 "id": 2788,

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_completed_pending_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_completed_pending_detailed.json
@@ -11,7 +11,7 @@
             },
             "query": {
                 "matches": "(.*)include\":\"(.*)2198, 75, 62, 38(.*)"
-            },             
+            },
             "locale": {
                 "matches": "(.*)"
             }
@@ -81,7 +81,7 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
-                "date_created_gmt": "{{#assign 'currentYear'}}{{now format='yyyy'}}{{/assign}}{{currentYear}}-01-26T11:28:00",
+                "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-01-26T11:28:00",
                 "date_modified_gmt": "{{currentYear}}-01-28T11:28:51",
                 "date_paid_gmt": "{{currentYear}}-01-28T11:28:30"
             }, {

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_processing.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_processing.json
@@ -11,7 +11,7 @@
             },
             "query": {
                 "matches": "(.*)status\":\"processing(.*)_fields\":\"id,date_created_gmt,date_modified_gmt(.*)"
-            },            
+            },
             "locale": {
                 "matches": "(.*)"
             }
@@ -22,7 +22,7 @@
         "jsonBody": {
             "data": [{
                 "id": 2192,
-                "date_created_gmt": "{{#assign 'currentYear'}}{{now format='yyyy'}}{{/assign}}{{currentYear}}-01-31T11:26:08",
+                "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-01-31T11:26:08",
                 "date_modified_gmt": "{{currentYear}}-02-03T15:34:32"
             }, {
                 "id": 2145,

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_processing_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_processing_detailed.json
@@ -11,7 +11,7 @@
             },
             "query": {
                 "matches": "(.*)include\":\"2192, 2145, 2155, 37, 36(.*)"
-            },             
+            },
             "locale": {
                 "matches": "(.*)"
             }
@@ -97,7 +97,7 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
-                "date_created_gmt": "{{#assign 'currentYear'}}{{now format='yyyy'}}{{/assign}}{{currentYear}}-01-31T11:26:08",
+                "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-01-31T11:26:08",
                 "date_modified_gmt": "{{currentYear}}-02-03T15:34:32",
                 "date_paid_gmt": "{{currentYear}}-01-28T11:26:54"
             }, {

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-month.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-month.json
@@ -20,10 +20,10 @@
     "response": {
         "status": 200,
         "jsonBody": {
-            "date": "{{#assign 'currentYear'}}{{now format='yyyy'}}{{/assign}}{{currentYear}}-10-01",
+            "date": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-10-01",
             "unit": "month",
             "fields": [
-                "period", 
+                "period",
                 "visitors"
             ],
             "data": [

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.screenshots
 
+import android.util.Log
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
@@ -25,6 +26,7 @@ import tools.fastlane.screengrab.Screengrab
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy
 import tools.fastlane.screengrab.cleanstatusbar.CleanStatusBar
 import tools.fastlane.screengrab.locale.LocaleTestRule
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 @HiltAndroidTest
@@ -48,7 +50,11 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
 
     @Before
     fun setUp() {
-        CleanStatusBar.enableWithDefaults()
+        try {
+            CleanStatusBar.enableWithDefaults()
+        } catch (e: TimeoutException) {
+            Log.w("ScreenshotTest", e)
+        }
         rule.inject()
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -52,8 +52,10 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
     fun setUp() {
         try {
             CleanStatusBar.enableWithDefaults()
-        } catch (e: TimeoutException) {
-            Log.w("ScreenshotTest", e)
+        } catch (e: RuntimeException) {
+            if (e.cause is TimeoutException) {
+                Log.w("ScreenshotTest", e)
+            } else throw e
         }
         rule.inject()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6833 

### Description
This PR adds two changes:
1. Fixes screenshot testing when using a non-latin language (like Arabic) by making sure the date formatting on the WireMock responses is done using a latin language.
I used the `fnow` helper we already had.
2. Catch the `TimeoutException` that `CleanStatusBar` throws sometimes. This happened to me a few times when using a device with Android 12, it seems `CleanStatusBar` times out when waiting for confirmation about the demo mode status.

### Testing instructions
The same steps as the last PR, just for all languages now:

1. Make sure the dependencies are all installed
     - `brew install imagemagick automattic/build-tools/drawText`
     - `bundle install --with screenshots`
     - Install the font Proxima Nova from [here](https://drive.google.com/drive/folders/18vuAG0LWl1nPFTBBO4Ghhs3YTG1HHG_n).
2. Confirm ANDROID_HOME environment variable is correctly set.
3. Download promo screenshots metadata:
    `bundle exec fastlane download_promo_strings`
4. Generate screenshots by running the following command:
    `bundle exec fastlane take_screenshots` (alternatively generates them just for Arabic using locales:ar)
5. Generate promo screenshots by running the following command:
    `bundle exec fastlane create_promo_screenshots`

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
