### PR TITLE
WCSettingsModel Crash Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-f44a381615f6d850e9c95071469424fbde6daff8'
+    fluxCVersion = '2463-1e60c43ea811eee0ad26f075e13e7d8669c4f471'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2463-1e60c43ea811eee0ad26f075e13e7d8669c4f471'
+    fluxCVersion = '2463-2f38b2c9f738fd28c0a820039a43c41ffca2f692'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ Please do not merge yet: this needs a companion [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2463) to be merged together

---

This fixes a crash situation in current `trunk` caused by an erroneous FluxC migration script (more details in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2463).


### To test:
1. Build and run WC Android from `trunk` and confirm that a crash happen from start, with error message similar to below:
```
2022-07-05 17:49:43.468 15763-15763/com.woocommerce.android.dev E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.woocommerce.android.dev, PID: 15763
    java.lang.RuntimeException: Unable to create application com.woocommerce.android.WooCommerceDebug: android.database.sqlite.SQLiteException: Cannot add a NOT NULL column with default value NULL (code 1 SQLITE_ERROR)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6710)
        at android.app.ActivityThread.access$1500(ActivityThread.java:249)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2060)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7813)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: android.database.sqlite.SQLiteException: Cannot add a NOT NULL column with default value NULL (code 1 SQLITE_ERROR)
```

2. Switch to this PR's branch `wcsettingsmodel-crash-fix`, build and run WC Android again and ensure the app does not crash anymore.

