### PR TITLE
Fix promo screenshots translation

### DIFF
--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -64,69 +64,37 @@ msgid "WooCommerce"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-1"
+#. No specified characters limit here, but try to keep as short as the source one.
+msgctxt "play_store_screenshot_1"
 msgid ""
 "Your Store\n"
 "in Your Pocket"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-1_b"
-msgid ""
-"Made with 💜\n"
-"at Automattic"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-2"
+#. No specified characters limit here, but try to keep as short as the source one.
+msgctxt "play_store_screenshot_2"
 msgid "View and manage orders"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-3"
+#. No specified characters limit here, but try to keep as short as the source one.
+msgctxt "play_store_screenshot_3"
 msgid "Get real-time order alerts"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-4"
+#. No specified characters limit here, but try to keep as short as the source one.
+msgctxt "play_store_screenshot_4"
 msgid "Track order status"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-5"
+#. No specified characters limit here, but try to keep as short as the source one.
+msgctxt "play_store_screenshot_5"
 msgid ""
 "Scroll through, filter,\n"
 "or look up specific orders"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-6"
-msgid ""
-"View store data by week,\n"
-"month, and year"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-7"
-msgid ""
-"Check which products are\n"
-"performing best"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one. 
-msgctxt "app_store_screenshot-8"
-msgid ""
-"Get notified about new\n"
-"customer reviews"
 msgstr ""
 
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -678,11 +678,11 @@ platform :android do
   lane :download_promo_strings do |options|
     # "<key in .po file>" => { desc: "<name of txt file>" }
     files = {
-      'app_store_screenshot-1': { desc: "promo_screenshot_1.txt" },
-      'app_store_screenshot-2': { desc: "promo_screenshot_2.txt" },
-      'app_store_screenshot-3': { desc: "promo_screenshot_3.txt" },
-      'app_store_screenshot-4': { desc: "promo_screenshot_4.txt" },
-      'app_store_screenshot-5': { desc: "promo_screenshot_5.txt" },
+      play_store_screenshot_1: { desc: "promo_screenshot_1.txt" },
+      play_store_screenshot_2: { desc: "promo_screenshot_2.txt" },
+      play_store_screenshot_3: { desc: "promo_screenshot_3.txt" },
+      play_store_screenshot_4: { desc: "promo_screenshot_4.txt" },
+      play_store_screenshot_5: { desc: "promo_screenshot_5.txt" },
     }
 
     locales = SUPPORTED_LOCALES


### PR DESCRIPTION
### Description
We had some inconsistencies in the Glotpress keys used for promo screenshots metadata:
1. The Glotpress file used the keys `app_store_screenshot-...`
2. The lane `update_appstore_strings` used the keys `play_store_screenshot_...`

This meant that when updating the metadata for the screenshots, it doesn't get picked up by Glotpress.
Kudos to @AliSoftware for finding them (p1657289214780209/1657288205.513029-slack-C6H8C3G23)

This PR fixes the inconsistency by updating the keys in the `pot` file, and fixes the lane `download_promo_strings` accordinely.

### Testing instructions
1. Checkout this branch.
2. Run `bundle exec fastlane update_appstore_strings version:5.6`.
3. Check the last commit, and confirm the pot file was updated correctly with the new metadata.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->