### PR TITLE
Take covered view's top position into account

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/SkeletonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/SkeletonView.kt
@@ -55,6 +55,11 @@ class SkeletonView {
         skeletonView = viewSkeleton
         shimmerView.addView(skeletonView)
 
+        // take the replaced view's top position into account
+        if (actualView.top > 0) {
+            (skeletonView.layoutParams as? ViewGroup.MarginLayoutParams)?.topMargin = actualView.top
+        }
+
         // hide the actual data view
         actualView.visibility = View.GONE
 


### PR DESCRIPTION
Closes #6838

When we call `skeletonView.show` we pass in the view we want to cover with the skeleton, and the skeleton is added to the covered view's parent. The problem with this is it assumes the covered view is at the top of its parent.

This PR addresses this by taking the top position of the covered view into account.

Note that I discovered this bug while working on product search by SKU (#6838) and couldn't find another area where it occurs, so to test I recommend trying out that PR without this change to see the overlap, then add this change to see if it fixes the problem.


![Screenshot_20220707-165942](https://user-images.githubusercontent.com/3903757/178068166-dd2881b9-642c-4123-9e54-80ad2cc6d443.png)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.