### PR TITLE
Append APP_ to METADATA_DIR_PATH to make it clear it's for the app

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,8 +16,8 @@ end
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
 INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
-METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
-RELEASE_NOTES_PATH = File.join(METADATA_DIR_PATH, 'release_notes.txt')
+APP_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
+RELEASE_NOTES_PATH = File.join(APP_METADATA_DIR_PATH, 'release_notes.txt')
 MAIN_STRINGS_PATH = File.join('WooCommerce', 'src', 'main', 'res', 'values', 'strings.xml')
 RAW_SCREENSHOTS_DIR = File.join(Dir.pwd, 'screenshots', 'raw')
 RAW_SCREENSHOTS_PROCESSING_DIR = File.join(Dir.pwd, 'screenshots', 'raw_tmp')
@@ -152,17 +152,17 @@ platform :android do
 
     files = {
       release_note: RELEASE_NOTES_PATH,
-      play_store_promo: File.join(METADATA_DIR_PATH, 'short_description.txt'),
-      play_store_desc: File.join(METADATA_DIR_PATH, 'full_description.txt'),
-      play_store_app_title: File.join(METADATA_DIR_PATH, 'title.txt'),
-      play_store_screenshot_1: File.join(METADATA_DIR_PATH, 'promo_screenshot_1.txt'),
-      play_store_screenshot_2: File.join(METADATA_DIR_PATH, 'promo_screenshot_2.txt'),
-      play_store_screenshot_3: File.join(METADATA_DIR_PATH, 'promo_screenshot_3.txt'),
-      play_store_screenshot_4: File.join(METADATA_DIR_PATH, 'promo_screenshot_4.txt'),
-      play_store_screenshot_5: File.join(METADATA_DIR_PATH, 'promo_screenshot_5.txt'),
+      play_store_promo: File.join(APP_METADATA_DIR_PATH, 'short_description.txt'),
+      play_store_desc: File.join(APP_METADATA_DIR_PATH, 'full_description.txt'),
+      play_store_app_title: File.join(APP_METADATA_DIR_PATH, 'title.txt'),
+      play_store_screenshot_1: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_1.txt'),
+      play_store_screenshot_2: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_2.txt'),
+      play_store_screenshot_3: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_3.txt'),
+      play_store_screenshot_4: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_4.txt'),
+      play_store_screenshot_5: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_5.txt'),
     }
 
-    po_path = File.join(METADATA_DIR_PATH, 'PlayStoreStrings.pot')
+    po_path = File.join(APP_METADATA_DIR_PATH, 'PlayStoreStrings.pot')
 
     an_update_metadata_source(
       po_file_path: po_path,
@@ -501,9 +501,9 @@ platform :android do
     }
 
     delete_old_changelogs(build: options[:build_number])
-    # Notice that this is a different path from `METADATA_DIR_PATH`.
+    # Notice that this is a different path from `APP_METADATA_DIR_PATH`.
     # This is the path for the Fastlane metadata, i.e. the ones for the Play Store, hence the `Dir.pwd`.
-    # `METADATA_DIR_PATH` is the path of the metadata the app uses at runtime.
+    # `APP_METADATA_DIR_PATH` is the path of the metadata the app uses at runtime.
     download_path = File.join(Dir.pwd, 'metadata', 'android')
     gp_downloadmetadata(
       project_url: GLOTPRESS_PLAYSTORE_METADATA_PROJECT_URL,
@@ -706,7 +706,7 @@ platform :android do
       "promo_screenshot_4.txt",
       "promo_screenshot_5.txt",
     ].each do |filename|
-      source = File.join(METADATA_DIR_PATH, filename)
+      source = File.join(APP_METADATA_DIR_PATH, filename)
       destination = File.join(en_us_path, filename)
       FileUtils.cp(source, destination)
     end
@@ -766,7 +766,7 @@ platform :android do
     # Run screenshots generator tool
     promo_screenshots(
       orig_folder: RAW_SCREENSHOTS_PROCESSING_DIR,
-      metadata_folder: METADATA_DIR_PATH,
+      metadata_folder: APP_METADATA_DIR_PATH,
       output_folder: PROMO_SCREENSHOTS_DIR,
       force: options[:force],
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,8 +16,8 @@ end
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
 INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
-ORIGINAL_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
-RELEASE_NOTES_PATH = File.join(ORIGINAL_METADATA_DIR_PATH, 'release_notes.txt')
+ORIGINALS_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
+RELEASE_NOTES_PATH = File.join(ORIGINALS_METADATA_DIR_PATH, 'release_notes.txt')
 MAIN_STRINGS_PATH = File.join('WooCommerce', 'src', 'main', 'res', 'values', 'strings.xml')
 # The metadata for the Play Store live in the Fastlane folder, hence the `Dir.pwd`
 PLAY_STORE_METADATA_DIR_PATH = File.join(Dir.pwd, 'metadata', 'android')
@@ -154,17 +154,17 @@ platform :android do
 
     files = {
       release_note: RELEASE_NOTES_PATH,
-      play_store_promo: File.join(ORIGINAL_METADATA_DIR_PATH, 'short_description.txt'),
-      play_store_desc: File.join(ORIGINAL_METADATA_DIR_PATH, 'full_description.txt'),
-      play_store_app_title: File.join(ORIGINAL_METADATA_DIR_PATH, 'title.txt'),
-      play_store_screenshot_1: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_1.txt'),
-      play_store_screenshot_2: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_2.txt'),
-      play_store_screenshot_3: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_3.txt'),
-      play_store_screenshot_4: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_4.txt'),
-      play_store_screenshot_5: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_5.txt'),
+      play_store_promo: File.join(ORIGINALS_METADATA_DIR_PATH, 'short_description.txt'),
+      play_store_desc: File.join(ORIGINALS_METADATA_DIR_PATH, 'full_description.txt'),
+      play_store_app_title: File.join(ORIGINALS_METADATA_DIR_PATH, 'title.txt'),
+      play_store_screenshot_1: File.join(ORIGINALS_METADATA_DIR_PATH, 'promo_screenshot_1.txt'),
+      play_store_screenshot_2: File.join(ORIGINALS_METADATA_DIR_PATH, 'promo_screenshot_2.txt'),
+      play_store_screenshot_3: File.join(ORIGINALS_METADATA_DIR_PATH, 'promo_screenshot_3.txt'),
+      play_store_screenshot_4: File.join(ORIGINALS_METADATA_DIR_PATH, 'promo_screenshot_4.txt'),
+      play_store_screenshot_5: File.join(ORIGINALS_METADATA_DIR_PATH, 'promo_screenshot_5.txt'),
     }
 
-    po_path = File.join(ORIGINAL_METADATA_DIR_PATH, 'PlayStoreStrings.pot')
+    po_path = File.join(ORIGINALS_METADATA_DIR_PATH, 'PlayStoreStrings.pot')
 
     an_update_metadata_source(
       po_file_path: po_path,
@@ -705,7 +705,7 @@ platform :android do
       "promo_screenshot_4.txt",
       "promo_screenshot_5.txt",
     ].each do |filename|
-      source = File.join(ORIGINAL_METADATA_DIR_PATH, filename)
+      source = File.join(ORIGINALS_METADATA_DIR_PATH, filename)
       destination = File.join(en_us_path, filename)
       FileUtils.cp(source, destination)
     end
@@ -765,7 +765,7 @@ platform :android do
     # Run screenshots generator tool
     promo_screenshots(
       orig_folder: RAW_SCREENSHOTS_PROCESSING_DIR,
-      metadata_folder: ORIGINAL_METADATA_DIR_PATH,
+      metadata_folder: ORIGINALS_METADATA_DIR_PATH,
       output_folder: PROMO_SCREENSHOTS_DIR,
       force: options[:force],
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,6 +19,8 @@ INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
 APP_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
 RELEASE_NOTES_PATH = File.join(APP_METADATA_DIR_PATH, 'release_notes.txt')
 MAIN_STRINGS_PATH = File.join('WooCommerce', 'src', 'main', 'res', 'values', 'strings.xml')
+# The metadata for the Play Store live in the Fastlane folder, hence the `Dir.pwd`
+PLAY_STORE_METADATA_DIR_PATH = File.join(Dir.pwd, 'metadata', 'android')
 RAW_SCREENSHOTS_DIR = File.join(Dir.pwd, 'screenshots', 'raw')
 RAW_SCREENSHOTS_PROCESSING_DIR = File.join(Dir.pwd, 'screenshots', 'raw_tmp')
 PROMO_SCREENSHOTS_DIR = File.join(Dir.pwd, "screenshots", "promo_screenshots")
@@ -501,10 +503,7 @@ platform :android do
     }
 
     delete_old_changelogs(build: options[:build_number])
-    # Notice that this is a different path from `APP_METADATA_DIR_PATH`.
-    # This is the path for the Fastlane metadata, i.e. the ones for the Play Store, hence the `Dir.pwd`.
-    # `APP_METADATA_DIR_PATH` is the path of the metadata the app uses at runtime.
-    download_path = File.join(Dir.pwd, 'metadata', 'android')
+    download_path = PLAY_STORE_METADATA_DIR_PATH
     gp_downloadmetadata(
       project_url: GLOTPRESS_PLAYSTORE_METADATA_PROJECT_URL,
       target_files: files,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,8 +16,8 @@ end
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
 INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
-APP_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
-RELEASE_NOTES_PATH = File.join(APP_METADATA_DIR_PATH, 'release_notes.txt')
+ORIGINAL_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
+RELEASE_NOTES_PATH = File.join(ORIGINAL_METADATA_DIR_PATH, 'release_notes.txt')
 MAIN_STRINGS_PATH = File.join('WooCommerce', 'src', 'main', 'res', 'values', 'strings.xml')
 # The metadata for the Play Store live in the Fastlane folder, hence the `Dir.pwd`
 PLAY_STORE_METADATA_DIR_PATH = File.join(Dir.pwd, 'metadata', 'android')
@@ -154,17 +154,17 @@ platform :android do
 
     files = {
       release_note: RELEASE_NOTES_PATH,
-      play_store_promo: File.join(APP_METADATA_DIR_PATH, 'short_description.txt'),
-      play_store_desc: File.join(APP_METADATA_DIR_PATH, 'full_description.txt'),
-      play_store_app_title: File.join(APP_METADATA_DIR_PATH, 'title.txt'),
-      play_store_screenshot_1: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_1.txt'),
-      play_store_screenshot_2: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_2.txt'),
-      play_store_screenshot_3: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_3.txt'),
-      play_store_screenshot_4: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_4.txt'),
-      play_store_screenshot_5: File.join(APP_METADATA_DIR_PATH, 'promo_screenshot_5.txt'),
+      play_store_promo: File.join(ORIGINAL_METADATA_DIR_PATH, 'short_description.txt'),
+      play_store_desc: File.join(ORIGINAL_METADATA_DIR_PATH, 'full_description.txt'),
+      play_store_app_title: File.join(ORIGINAL_METADATA_DIR_PATH, 'title.txt'),
+      play_store_screenshot_1: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_1.txt'),
+      play_store_screenshot_2: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_2.txt'),
+      play_store_screenshot_3: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_3.txt'),
+      play_store_screenshot_4: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_4.txt'),
+      play_store_screenshot_5: File.join(ORIGINAL_METADATA_DIR_PATH, 'promo_screenshot_5.txt'),
     }
 
-    po_path = File.join(APP_METADATA_DIR_PATH, 'PlayStoreStrings.pot')
+    po_path = File.join(ORIGINAL_METADATA_DIR_PATH, 'PlayStoreStrings.pot')
 
     an_update_metadata_source(
       po_file_path: po_path,
@@ -705,7 +705,7 @@ platform :android do
       "promo_screenshot_4.txt",
       "promo_screenshot_5.txt",
     ].each do |filename|
-      source = File.join(APP_METADATA_DIR_PATH, filename)
+      source = File.join(ORIGINAL_METADATA_DIR_PATH, filename)
       destination = File.join(en_us_path, filename)
       FileUtils.cp(source, destination)
     end
@@ -765,7 +765,7 @@ platform :android do
     # Run screenshots generator tool
     promo_screenshots(
       orig_folder: RAW_SCREENSHOTS_PROCESSING_DIR,
-      metadata_folder: APP_METADATA_DIR_PATH,
+      metadata_folder: ORIGINAL_METADATA_DIR_PATH,
       output_folder: PROMO_SCREENSHOTS_DIR,
       force: options[:force],
     )


### PR DESCRIPTION
### Description

That is, so we won't confuse it with the metadata Fastlane uses. See https://github.com/woocommerce/woocommerce-android/pull/6814#discussion_r907027309.

We now have `APP_METADATA_DIR_PATH` for `WooCommerce/metadata` and `PLAY_STORE_METADATA_DIR_PATH` for `fastlane/metadata/android`. The second is used only once, but will be used again once I work on using `supply` to upload the release notes.

### Testing instructions

This PR touches four lanes. I tested three of them and pushed the result to make sure the paths didn't change:

- `update_appstore_strings` https://github.com/woocommerce/woocommerce-android/pull/6908/commits/82fe8e8b54a990aa02db4ddb659a603f1adfeb08
- `download_metadata_strings` https://github.com/woocommerce/woocommerce-android/pull/6908/commits/9667c0e30ffa2588d154116f06855d40816a759a
- `download_promo_strings` https://github.com/woocommerce/woocommerce-android/pull/6908/commits/329d3c6b0f8517b59fe6d6a6b5e0a2f1a7ad9790 – This creates a lot of new files, but it's because those were never tracked in the first place. Also notice how the `en-US` subfolder has the right values coming from `WooCommerce/metadata`.

The fourth is `create_promo_screenshots` which I didn't run because 1) I don't have screenshots locally, 2) it would have taken a lot of time for something that can be verified by reading the code, and 3) I noticed a possible issue with the path used which, if correct, would invalidate the manual test.

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – It does not

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
