### PR TITLE
Extract 'com.woocommerce.android' to `APP_PACKAGE_NAME` in `Fastfile`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,6 +45,8 @@ GLOTPRESS_APP_STRINGS_PROJECT_URL = 'https://translate.wordpress.com/projects/wo
 # URL of the GlotPress project containing the Play Store metadata (title, keywords, release notes, …)
 GLOTPRESS_PLAYSTORE_METADATA_PROJECT_URL = 'https://translate.wordpress.com/projects/woocommerce/woocommerce-android/release-notes/'
 
+APP_PACKAGE_NAME = 'com.woocommerce.android'
+
 ########################################################################
 # Environment
 ########################################################################
@@ -358,7 +360,7 @@ platform :android do
   UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
 
   upload_to_play_store(
-    package_name: 'com.woocommerce.android',
+    package_name: APP_PACKAGE_NAME,
     aab: aab_file_path,
     track: 'production',
     release_status: 'draft',
@@ -399,7 +401,7 @@ platform :android do
     UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
 
     upload_to_play_store(
-      package_name: 'com.woocommerce.android',
+      package_name: APP_PACKAGE_NAME,
       aab: aab_file_path,
       track: 'beta',
       release_status: 'draft',
@@ -615,10 +617,10 @@ platform :android do
 
     screenshot_options = {
       output_directory: RAW_SCREENSHOTS_DIR,
-      app_package_name: "com.woocommerce.android",
+      app_package_name: APP_PACKAGE_NAME,
       app_apk_path: "WooCommerce/build/outputs/apk/vanilla/debug/WooCommerce-vanilla-debug.apk",
       tests_apk_path: "WooCommerce/build/outputs/apk/androidTest/vanilla/debug/WooCommerce-vanilla-debug-androidTest.apk",
-      use_tests_in_classes: "com.woocommerce.android.screenshots.ScreenshotTest",
+      use_tests_in_classes: "#{APP_PACKAGE_NAME}.screenshots.ScreenshotTest",
       reinstall_app: false,
       # By default, don't clear previous because we differentiate between light
       # and dark mode
@@ -627,7 +629,7 @@ platform :android do
       use_adb_root: true,
       locales: locales,
       use_timestamp_suffix: false,
-      test_instrumentation_runner: "com.woocommerce.android.WooCommerceTestRunner",
+      test_instrumentation_runner: "#{APP_PACKAGE_NAME}.WooCommerceTestRunner",
       # Don't care about the .html summary
       skip_open_summary: true
     }


### PR DESCRIPTION
### Description

I noticed this while working on the implementation for using `upload_to_play_store` (`supply`) to upload the release notes and other metadata to the Play Store.

Admittedly, we could have lived with the package name being hard coded, as it's not likely to change anytime soon (or ever?). Still, it's useful to have it centralized. I wasn't sure what value to use when writing my code and it would have been handy to have a constant at hand.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
I think this is a PR that is safe to code review only.
---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.
