### PR TITLE
Adds rmagick to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.2)
     rexml (3.2.5)
+    rmagick (4.2.5)
     rouge (2.0.7)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -272,6 +273,7 @@ DEPENDENCIES
   fastlane (~> 2)
   fastlane-plugin-wpmreleasetoolkit (~> 4.1)
   nokogiri
+  rmagick (~> 4.1)
 
 BUNDLED WITH
    2.3.8


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While trying to `code_freeze`, `Bundler` complains that `rmagick` is missing. This gem is supposed to be optional, but we couldn't figure out a way around it, so at least temporarily, we are adding it to `Gemfile.lock` to complete the code freeze.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N/A

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
