### PR TITLE
[Screenshot Test] Added support for `Payment Selection` screen.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -98,7 +98,9 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
             .gotoOrdersScreen()
             .selectOrder(2)
             .tapOnCollectPayment()
+            .chooseCardPayment()
             .thenTakeScreenshot<CardReaderPaymentScreen>("in-person-payments")
+            .goBackToPaymentSelection()
             .goBackToOrderDetails()
             .goBackToOrdersScreen()
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/CardReaderPaymentScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/CardReaderPaymentScreen.kt
@@ -8,8 +8,8 @@ class CardReaderPaymentScreen : Screen(HEADER) {
         private const val HEADER = R.id.header_label
     }
 
-    fun goBackToOrderDetails(): SingleOrderScreen {
+    fun goBackToPaymentSelection(): PaymentSelectionScreen {
         pressBack()
-        return SingleOrderScreen()
+        return PaymentSelectionScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/PaymentSelectionScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/PaymentSelectionScreen.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.screenshots.orders
+
+import com.woocommerce.android.R
+import com.woocommerce.android.screenshots.util.Screen
+
+class PaymentSelectionScreen : Screen {
+    companion object {
+        const val CARD_BUTTON = R.id.textCard
+    }
+
+    constructor() : super(CARD_BUTTON)
+
+    fun chooseCardPayment(): CardReaderPaymentScreen {
+        clickOn(CARD_BUTTON)
+        return CardReaderPaymentScreen()
+    }
+
+    fun goBackToOrderDetails(): SingleOrderScreen {
+        pressBack()
+        return SingleOrderScreen()
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
@@ -36,8 +36,8 @@ class SingleOrderScreen : Screen {
         return assertSingleOrderScreen()
     }
 
-    fun tapOnCollectPayment(): CardReaderPaymentScreen {
+    fun tapOnCollectPayment(): PaymentSelectionScreen {
         clickOn(R.id.paymentInfo_collectCardPresentPaymentButton)
-        return CardReaderPaymentScreen()
+        return PaymentSelectionScreen()
     }
 }


### PR DESCRIPTION
Closes: #6912 

### Description

While exploring the usefulness of the other task (#6911) I noticed that the `Collect Payment` workflow has changed after release of `Ducks in a row`. Now, the collect payment with card pop-up is show in this dedicated screen, and not on the Order Details screen, as it was before.


| Before | After |
| ----------- | ----------- |
| ![3-in-person-payments-dark copy](https://user-images.githubusercontent.com/73365754/178289101-53bb5745-fc53-4938-9078-34ac5e908f59.png) | ![3-in-person-payments-dark](https://user-images.githubusercontent.com/73365754/178289133-85c0dce3-0a03-48e4-82bb-e320c5c4d728.png) |

### Questions

Should marketing team be informed? IMO, the "old" screenshot was more interesting and representative of the app.

### Testing instructions

1. Make sure the dependencies are all installed
     - `brew install imagemagick automattic/build-tools/drawText`
     - `bundle install --with screenshots`
     - Install the font Proxima Nova from [here](https://drive.google.com/drive/folders/18vuAG0LWl1nPFTBBO4Ghhs3YTG1HHG_n).
2. Confirm ANDROID_HOME environment variable is correctly set.
3. Download promo screenshots metadata:
    `bundle exec fastlane download_promo_strings`
4. Generate screenshots by running the following command:
    `bundle exec fastlane take_screenshots locales:en-US`
5. Generate promo screenshots by running the following command:
    `bundle exec fastlane create_promo_screenshots`

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.