### PR TITLE
[UOE] Handle multiple fee lines

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.ui.products.ProductHelper
@@ -27,7 +28,6 @@ data class Order(
     val shippingTotal: BigDecimal,
     val discountTotal: BigDecimal,
     val refundTotal: BigDecimal,
-    val feesTotal: BigDecimal,
     val currency: String,
     val orderKey: String,
     val customerNote: String,
@@ -66,6 +66,9 @@ data class Order(
 
     val hasMultipleFeeLines: Boolean
         get() = feesLines.size > 1
+
+    @IgnoredOnParcel
+    val feesTotal = feesLines.sumByBigDecimal(FeeLine::total)
 
     @Parcelize
     data class ShippingMethod(
@@ -313,7 +316,6 @@ data class Order(
                 shippingTotal = BigDecimal(0),
                 discountTotal = BigDecimal(0),
                 refundTotal = BigDecimal(0),
-                feesTotal = BigDecimal(0),
                 currency = "",
                 orderKey = "",
                 customerNote = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.model
 
 import com.woocommerce.android.extensions.CASH_PAYMENTS
 import com.woocommerce.android.extensions.fastStripHtml
-import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.model.Order.Item
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.fluxc.model.OrderEntity
@@ -35,8 +34,6 @@ class OrderMapper @Inject constructor(private val getLocations: GetLocations) {
             shippingTotal = databaseEntity.shippingTotal.toBigDecimalOrNull() ?: BigDecimal.ZERO,
             discountTotal = databaseEntity.discountTotal.toBigDecimalOrNull() ?: BigDecimal.ZERO,
             refundTotal = -(databaseEntity.refundTotal), // WCOrderModel.refundTotal is NEGATIVE
-            feesTotal = databaseEntity.getFeeLineList()
-                .sumByBigDecimal { it.total?.toBigDecimalOrNull() ?: BigDecimal.ZERO },
             currency = databaseEntity.currency,
             orderKey = databaseEntity.orderKey,
             customerNote = databaseEntity.customerNote,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationFormFragment.kt
@@ -296,10 +296,7 @@ class OrderCreationFormFragment : BaseFragment(R.layout.fragment_order_creation_
     private fun OrderCreationPaymentSectionBinding.bindFeesSubSection(newOrderData: Order) {
         feeButton.setOnClickListener { viewModel.onFeeButtonClicked() }
 
-        val currentFeeTotal = newOrderData.feesLines
-            .firstOrNull { it.name != null }
-            ?.total
-            ?: BigDecimal.ZERO
+        val currentFeeTotal = newOrderData.feesTotal
 
         val hasFee = currentFeeTotal.isNotEqualTo(BigDecimal.ZERO)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -393,20 +393,37 @@ class OrderCreationViewModel @Inject constructor(
             mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
         )
 
-        val newFee = _orderDraft.value.feesLines.firstOrNull { it.name != null }
-            ?: Order.FeeLine.EMPTY
-
         _orderDraft.update { draft ->
-            listOf(newFee.copy(name = ORDER_CUSTOM_FEE_NAME, total = feeValue))
-                .let { draft.copy(feesLines = it) }
+            val fees: List<Order.FeeLine> = draft.feesLines.mapIndexed { index, feeLine ->
+                if (index == 0) {
+                    feeLine.copy(total = feeValue)
+                } else {
+                    feeLine
+                }
+            }.ifEmpty {
+                listOf(
+                    Order.FeeLine.EMPTY.copy(
+                        name = ORDER_CUSTOM_FEE_NAME,
+                        total = feeValue
+                    )
+                )
+            }
+
+            draft.copy(feesLines = fees)
         }
     }
 
     fun onFeeRemoved() {
         _orderDraft.update { draft ->
-            draft.feesLines
-                .map { it.copy(name = null) }
-                .let { draft.copy(feesLines = it) }
+            draft.copy(
+                feesLines = draft.feesLines.mapIndexed { index, feeLine ->
+                    if (index == 0) {
+                        feeLine.copy(name = null)
+                    } else {
+                        feeLine
+                    }
+                }
+            )
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderTest.kt
@@ -105,7 +105,7 @@ class OrderTest {
             items = listOf(
                 mock { on { quantity }.thenReturn(1F) },
             ),
-            feesLines = listOf(mock())
+            feesLines = listOf(Order.FeeLine.EMPTY)
         )
 
         // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreationViewModelTest.kt
@@ -432,45 +432,90 @@ class CreationFocusedOrderCreationViewModelTest : UnifiedOrderEditViewModelTest(
 
     @Test
     fun `when editing a fee, then reuse the existent one with different value`() {
+        // given
+        createUpdateOrderUseCase = mock {
+            onBlocking { invoke(any(), any()) } doReturn flowOf(
+                Succeeded(
+                    Order.EMPTY.copy(
+                        feesLines = listOf(
+                            Order.FeeLine.EMPTY.copy(id = 1, total = BigDecimal(1)),
+                            Order.FeeLine.EMPTY.copy(id = 2, total = BigDecimal(2)),
+                            Order.FeeLine.EMPTY.copy(id = 3, total = BigDecimal(3)),
+                        )
+                    )
+                )
+            )
+        }
+        createSut()
         var orderDraft: Order? = null
         sut.orderDraft.observeForever {
             orderDraft = it
         }
-
         val newFeeTotal = BigDecimal(123.5)
 
+        // when
         sut.onFeeEdited(BigDecimal(1))
         sut.onFeeEdited(BigDecimal(2))
         sut.onFeeEdited(BigDecimal(3))
         sut.onFeeEdited(newFeeTotal)
 
-        orderDraft?.feesLines
-            ?.takeIf { it.size == 1 }
-            ?.let {
-                val currentFee = it.first()
-                assertThat(currentFee.total).isEqualTo(newFeeTotal)
-                assertThat(currentFee.name).isNotNull
-            } ?: fail("Expected a fee lines list with a single fee with 123.5 as total")
+        // then
+        assertThat(orderDraft?.feesLines)
+            .hasSize(3)
+            .first().satisfies { firstFee ->
+                assertThat(firstFee.total).isEqualTo(newFeeTotal)
+            }
     }
 
     @Test
-    fun `when removing a fee, then mark the existent one with null name`() {
+    fun `when removing a fee, do not remove the rest of fees`() {
+        // given
+        createUpdateOrderUseCase = mock {
+            onBlocking { invoke(any(), any()) } doReturn flowOf(
+                Succeeded(
+                    Order.EMPTY.copy(
+                        feesLines = listOf(
+                            Order.FeeLine.EMPTY.copy(id = 1, total = BigDecimal(1)),
+                            Order.FeeLine.EMPTY.copy(id = 2, total = BigDecimal(2)),
+                            Order.FeeLine.EMPTY.copy(id = 3, total = BigDecimal(3)),
+                        )
+                    )
+                )
+            )
+        }
+        createSut()
         var orderDraft: Order? = null
         sut.orderDraft.observeForever {
             orderDraft = it
         }
 
-        val newFeeTotal = BigDecimal(123.5)
-        sut.onFeeEdited(newFeeTotal)
+        // when
         sut.onFeeRemoved()
 
-        orderDraft?.feesLines
-            ?.takeIf { it.size == 1 }
-            ?.let {
-                val currentFee = it.first()
-                assertThat(currentFee.total).isEqualTo(newFeeTotal)
-                assertThat(currentFee.name).isNull()
-            } ?: fail("Expected a fee lines list with a single fee with 123.5 as total")
+        // then
+        assertThat(orderDraft?.feesLines)
+            .hasSize(3)
+            .extracting("name")
+            .containsOnlyOnce(null)
+            .first().matches {
+                it == null
+            }
+    }
+
+    @Test
+    fun `when editing fees on order without fees, add one`() {
+        // given
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever {
+            orderDraft = it
+        }
+        assert(orderDraft?.feesLines?.isEmpty() == true)
+
+        // when
+        sut.onFeeEdited(BigDecimal(1))
+
+        // then
+        assertThat(orderDraft?.feesLines).hasSize(1)
     }
 
     @Test
@@ -541,10 +586,15 @@ class CreationFocusedOrderCreationViewModelTest : UnifiedOrderEditViewModelTest(
         }
 
         // when
-        sut.onShippingEdited(BigDecimal(1), "1")
+        val newValue = BigDecimal(321)
+        sut.onShippingEdited(newValue, "1")
 
         // then
-        assertThat(orderDraft?.shippingLines).hasSize(3)
+        assertThat(orderDraft?.shippingLines)
+            .hasSize(3)
+            .first().satisfies { firstFee ->
+                assertThat(firstFee.total).isEqualTo(newValue)
+            }
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6654 
<!-- Id number of the GitHub issue this PR addresses. -->

Twin iOS PR: https://github.com/woocommerce/woocommerce-ios/pull/7226

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the same behavior for fee lines, as we added in #6870 . User can edit the last fee and is also able to remove the first fee.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Copied from iOS PR:

1. Create an order with multiple fee lines on Core.
2. Go to the Orders tab, open the order.
3. Wait until order fully loads. Tap "•••" in navbar. Select "Edit".
4. Tap the "Fees" line in "Payment" section.
5. See that only the first fee line is presented and can be edited.
6. Remove that fee line.
7. See that the others fees remain unaltered.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

The order in the video has 2 fees: `1$` and `2$`


https://user-images.githubusercontent.com/5845095/178300335-c8fef074-e3cb-4324-af03-d7816628f37f.mov


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
