### PR TITLE
Refactor order creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -26,7 +26,7 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProdu
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewShipmentTrackingProviders
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewShippingLabelFormatOptions
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewShippingLabelPaperSizes
-import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel
+import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelFragmentDirections
 import com.woocommerce.android.ui.orders.tracking.AddOrderShipmentTrackingFragmentDirections
@@ -181,8 +181,10 @@ class OrderNavigator @Inject constructor() {
             is EditOrder -> {
                 OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToOrderCreationFragment(
-                        OrderCreationViewModel.Mode.Edit(target.orderId)
-                    ).let { fragment.findNavController().navigateSafely(it) }
+                        OrderCreateEditViewModel.Mode.Edit(target.orderId)
+                    ).let {
+                        fragment.findNavController().navigateSafely(it)
+                    }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContext.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContext.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.orders.creation
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel.MultipleLinesContext
+import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.MultipleLinesContext
 import com.woocommerce.android.viewmodel.ResourceProvider
 import java.util.Locale
 import javax.inject.Inject

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1,0 +1,321 @@
+package com.woocommerce.android.ui.orders.creation
+
+import android.os.Parcelable
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.runWithContext
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.OrderNavigationTarget
+import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@ExperimentalCoroutinesApi
+abstract class OrderCreateEditViewModel(
+    savedState: SavedStateHandle,
+    private val dispatchers: CoroutineDispatchers,
+    private val orderDetailRepository: OrderDetailRepository,
+    private val mapItemToProductUiModel: MapItemToProductUiModel,
+    private val createOrderItem: CreateOrderItem
+) : ScopedViewModel(savedState) {
+    companion object {
+        const val PARAMETERS_KEY = "parameters_key"
+        const val ORDER_CUSTOM_FEE_NAME = "order_custom_fee"
+    }
+
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
+    protected var viewState by viewStateData
+
+    protected val _orderDraft: MutableStateFlow<Order> = savedState.getStateFlow(viewModelScope, Order.EMPTY)
+    val orderDraft = _orderDraft.asLiveData()
+
+    val orderStatusData: LiveData<Order.OrderStatus> = _orderDraft
+        .map { it.status }
+        .distinctUntilChanged()
+        .map { status ->
+            withContext(dispatchers.io) {
+                orderDetailRepository.getOrderStatus(status.value)
+            }
+        }.asLiveData()
+
+    val products: LiveData<List<ProductUIModel>> = _orderDraft
+        .map { order -> order.items.filter { it.quantity > 0 } }
+        .distinctUntilChanged()
+        .map { items ->
+            items.map { item -> mapItemToProductUiModel(item) }
+        }.asLiveData()
+
+    protected val retryOrderDraftUpdateTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    protected abstract val syncStrategy: SyncStrategy
+
+    fun getProductUIModelFromItem(item: Order.Item) = runBlocking {
+        mapItemToProductUiModel(item)
+    }
+
+    val currentDraft
+        get() = _orderDraft.value
+
+    fun onCustomerNoteEdited(newNote: String) = _orderDraft.update { it.copy(customerNote = newNote) }
+
+    fun onIncreaseProductsQuantity(id: Long) = _orderDraft.update { it.adjustProductQuantity(id, +1) }
+
+    fun onDecreaseProductsQuantity(id: Long) {
+        _orderDraft.value.items
+            .find { it.itemId == id }
+            ?.takeIf { it.quantity == 1F }
+            ?.let { onProductClicked(it) }
+            ?: _orderDraft.update { it.adjustProductQuantity(id, -1) }
+    }
+
+    fun onOrderStatusChanged(status: Order.Status) {
+        AnalyticsTracker.track(
+            AnalyticsEvent.ORDER_STATUS_CHANGE,
+            mapOf(
+                AnalyticsTracker.KEY_FROM to _orderDraft.value.status.value,
+                AnalyticsTracker.KEY_TO to status.value,
+                AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_FLOW_CREATION
+            )
+        )
+        _orderDraft.update { it.copy(status = status) }
+    }
+
+    fun onRemoveProduct(item: Order.Item) {
+        _orderDraft.update {
+            it.adjustProductQuantity(item.itemId, -item.quantity.toInt())
+        }
+    }
+
+    fun onProductSelected(remoteProductId: Long, variationId: Long? = null) {
+        AnalyticsTracker.track(
+            AnalyticsEvent.ORDER_PRODUCT_ADD,
+            mapOf(AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_FLOW_CREATION)
+        )
+
+        viewModelScope.launch {
+            _orderDraft.value.items.toMutableList().apply {
+                add(createOrderItem(remoteProductId, variationId))
+            }.let { items ->
+                _orderDraft.update { it.updateItems(items) }
+            }
+        }
+    }
+
+    fun onCustomerAddressEdited(billingAddress: Address, shippingAddress: Address) {
+        val hasDifferentShippingDetails = _orderDraft.value.shippingAddress != _orderDraft.value.billingAddress
+        AnalyticsTracker.track(
+            AnalyticsEvent.ORDER_CUSTOMER_ADD,
+            mapOf(
+                AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_FLOW_CREATION,
+                AnalyticsTracker.KEY_HAS_DIFFERENT_SHIPPING_DETAILS to hasDifferentShippingDetails
+            )
+        )
+
+        _orderDraft.update {
+            it.copy(
+                billingAddress = billingAddress,
+                shippingAddress = shippingAddress.takeIf { it != Address.EMPTY } ?: billingAddress
+            )
+        }
+    }
+
+    fun onEditOrderStatusClicked(currentStatus: Order.OrderStatus) {
+        launch(dispatchers.io) {
+            orderDetailRepository
+                .getOrderStatusOptions().toTypedArray()
+                .runWithContext(dispatchers.main) {
+                    triggerEvent(
+                        OrderNavigationTarget.ViewOrderStatusSelector(
+                            currentStatus = currentStatus.statusKey,
+                            orderStatusList = it
+                        )
+                    )
+                }
+        }
+    }
+
+    fun onCustomerClicked() {
+        triggerEvent(OrderCreationNavigationTarget.EditCustomer)
+    }
+
+    fun onCustomerNoteClicked() {
+        triggerEvent(OrderCreationNavigationTarget.EditCustomerNote)
+    }
+
+    fun onAddProductClicked() {
+        triggerEvent(OrderCreationNavigationTarget.AddProduct)
+    }
+
+    fun onProductClicked(item: Order.Item) {
+        // Don't show details if the product is not synced yet
+        if (!item.isSynced()) return
+        triggerEvent(OrderCreationNavigationTarget.ShowProductDetails(item))
+    }
+
+    fun onRetryPaymentsClicked() {
+        retryOrderDraftUpdateTrigger.tryEmit(Unit)
+    }
+
+    fun onFeeButtonClicked() {
+        val order = _orderDraft.value
+        val currentFee = order.feesLines.firstOrNull()
+
+        val currentFeeValue = currentFee?.total
+        val currentFeeTotalValue = currentFee?.getTotalValue() ?: BigDecimal.ZERO
+
+        val orderSubtotal = order.total - currentFeeTotalValue
+        triggerEvent(OrderCreationNavigationTarget.EditFee(orderSubtotal, currentFeeValue))
+    }
+
+    fun onShippingButtonClicked() {
+        triggerEvent(OrderCreationNavigationTarget.EditShipping(currentDraft.shippingLines.firstOrNull { it.methodId != null }))
+    }
+
+    fun onShippingEdited(amount: BigDecimal, name: String) {
+        AnalyticsTracker.track(
+            AnalyticsEvent.ORDER_SHIPPING_METHOD_ADD,
+            mapOf(AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_FLOW_CREATION)
+        )
+
+        _orderDraft.update { draft ->
+            val shipping: List<Order.ShippingLine> = draft.shippingLines.mapIndexed { index, shippingLine ->
+                if (index == 0) {
+                    shippingLine.copy(total = amount, methodTitle = name)
+                } else {
+                    shippingLine
+                }
+            }.ifEmpty {
+                listOf(Order.ShippingLine(methodId = "other", total = amount, methodTitle = name))
+            }
+
+            draft.copy(shippingLines = shipping)
+        }
+    }
+
+    fun onShippingRemoved() {
+        _orderDraft.update { draft ->
+            draft.copy(
+                shippingLines = draft.shippingLines.mapIndexed { index, shippingLine ->
+                    if (index == 0) {
+                        // Setting methodId to null will remove the shipping line in core
+                        shippingLine.copy(methodId = null)
+                    } else {
+                        shippingLine
+                    }
+                }
+            )
+        }
+    }
+
+    fun onFeeEdited(feeValue: BigDecimal) {
+        AnalyticsTracker.track(
+            AnalyticsEvent.ORDER_FEE_ADD,
+            mapOf(AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_FLOW_CREATION)
+        )
+
+        _orderDraft.update { draft ->
+            val fees: List<Order.FeeLine> = draft.feesLines.mapIndexed { index, feeLine ->
+                if (index == 0) {
+                    feeLine.copy(total = feeValue)
+                } else {
+                    feeLine
+                }
+            }.ifEmpty {
+                listOf(
+                    Order.FeeLine.EMPTY.copy(
+                        name = ORDER_CUSTOM_FEE_NAME,
+                        total = feeValue
+                    )
+                )
+            }
+
+            draft.copy(feesLines = fees)
+        }
+    }
+
+    fun onFeeRemoved() {
+        _orderDraft.update { draft ->
+            draft.copy(
+                feesLines = draft.feesLines.mapIndexed { index, feeLine ->
+                    if (index == 0) {
+                        feeLine.copy(name = null)
+                    } else {
+                        feeLine
+                    }
+                }
+            )
+        }
+    }
+
+    abstract fun onSaveOrderClicked()
+    abstract fun onBackButtonClicked()
+    protected abstract fun monitorOrderChanges()
+    protected abstract fun trackOrderSaveFailure(it: Throwable)
+    protected abstract fun trackSaveOrderButtonClick()
+
+    @Parcelize
+    data class ViewState(
+        val isProgressDialogShown: Boolean = false,
+        val willUpdateOrderDraft: Boolean = false,
+        val isUpdatingOrderDraft: Boolean = false,
+        val showOrderUpdateSnackbar: Boolean = false,
+        val isEditable: Boolean = true,
+        val multipleLinesContext: MultipleLinesContext = MultipleLinesContext.None
+    ) : Parcelable {
+        @IgnoredOnParcel
+        val canCreateOrder: Boolean = !willUpdateOrderDraft && !isUpdatingOrderDraft && !showOrderUpdateSnackbar
+
+        @IgnoredOnParcel
+        val isIdle: Boolean = !isUpdatingOrderDraft && !willUpdateOrderDraft
+    }
+
+    sealed class Mode : Parcelable {
+        @Parcelize
+        object Creation : Mode()
+
+        @Parcelize
+        data class Edit(val orderId: Long) : Mode()
+    }
+
+    sealed class MultipleLinesContext : Parcelable {
+        @Parcelize
+        object None : MultipleLinesContext()
+
+        @Parcelize
+        data class Warning(
+            val header: String,
+            val explanation: String,
+        ) : MultipleLinesContext()
+    }
+}
+
+data class ProductUIModel(
+    val item: Order.Item,
+    val imageUrl: String,
+    val isStockManaged: Boolean,
+    val stockQuantity: Double,
+    val stockStatus: ProductStockStatus
+)
+
+fun Order.Item.isSynced() = this.itemId != 0L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationViewModel.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.orders.creation
 
-import android.os.Parcelable
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R.string
 import com.woocommerce.android.WooException
@@ -12,296 +9,97 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FLOW
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FROM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_CUSTOMER_DETAILS
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_DIFFERENT_SHIPPING_DETAILS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_FEES
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_SHIPPING_METHOD
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATUS
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_TO
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_CREATION
-import com.woocommerce.android.extensions.runWithContext
-import com.woocommerce.android.model.Address
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.Order.OrderStatus
-import com.woocommerce.android.model.Order.ShippingLine
-import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus
-import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.AddProduct
-import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.EditCustomer
-import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.EditCustomerNote
-import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.EditFee
-import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.EditShipping
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.ShowCreatedOrder
-import com.woocommerce.android.ui.orders.creation.navigation.OrderCreationNavigationTarget.ShowProductDetails
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.products.ParameterRepository
-import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
-import com.woocommerce.android.viewmodel.ScopedViewModel
-import com.woocommerce.android.viewmodel.getStateFlow
-import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
-import kotlinx.parcelize.IgnoredOnParcel
-import kotlinx.parcelize.Parcelize
-import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
+@ExperimentalCoroutinesApi
 class OrderCreationViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    private val dispatchers: CoroutineDispatchers,
-    private val orderDetailRepository: OrderDetailRepository,
+    dispatchers: CoroutineDispatchers,
+    orderDetailRepository: OrderDetailRepository,
+    mapItemToProductUiModel: MapItemToProductUiModel,
+    createOrderItem: CreateOrderItem,
     private val orderCreationRepository: OrderCreationRepository,
-    private val mapItemToProductUiModel: MapItemToProductUiModel,
-    private val createOrderItem: CreateOrderItem,
     private val determineMultipleLinesContext: DetermineMultipleLinesContext,
-    autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
     parameterRepository: ParameterRepository
-) : ScopedViewModel(savedState) {
-    companion object {
-        private const val PARAMETERS_KEY = "parameters_key"
-        private const val ORDER_CUSTOM_FEE_NAME = "order_custom_fee"
-    }
-
-    val viewStateData = LiveDataDelegate(savedState, ViewState())
-    private var viewState by viewStateData
-
-    private val args: OrderCreationFormFragmentArgs by savedState.navArgs()
-    val mode: Mode = args.mode
-
-    private val _orderDraft = savedState.getStateFlow(viewModelScope, Order.EMPTY)
-    val orderDraft = _orderDraft
-        .asLiveData()
-
-    val orderStatusData: LiveData<OrderStatus> = _orderDraft
-        .map { it.status }
-        .distinctUntilChanged()
-        .map { status ->
-            withContext(dispatchers.io) {
-                orderDetailRepository.getOrderStatus(status.value)
-            }
-        }.asLiveData()
-
-    val products: LiveData<List<ProductUIModel>> = _orderDraft
-        .map { order -> order.items.filter { it.quantity > 0 } }
-        .distinctUntilChanged()
-        .map { items ->
-            items.map { item -> mapItemToProductUiModel(item) }
-        }.asLiveData()
-
-    private val retryOrderDraftUpdateTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-
-    private val syncStrategy =
-        when (mode) {
-            Mode.Creation -> autoSyncPriceModifier
-            is Mode.Edit -> autoSyncOrder
-        }
-
-    fun getProductUIModelFromItem(item: Order.Item) = runBlocking {
-        mapItemToProductUiModel(item)
-    }
-
-    val currentDraft
-        get() = _orderDraft.value
-
+) : OrderCreateEditViewModel(
+    savedState,
+    dispatchers,
+    orderDetailRepository,
+    mapItemToProductUiModel,
+    createOrderItem,
+) {
+    override val syncStrategy: SyncStrategy = autoSyncPriceModifier
     init {
         _orderDraft.update {
             it.copy(currency = parameterRepository.getParameters(PARAMETERS_KEY, savedState).currencyCode.orEmpty())
         }
         monitorOrderChanges()
-
-        if (mode is Mode.Edit)
-            viewModelScope.launch {
-                orderDetailRepository.getOrderById(mode.orderId).let {
-                    if (it != null) {
-                        _orderDraft.value = it
-                    }
-                }
-            }
     }
 
-    fun onCustomerNoteEdited(newNote: String) = _orderDraft.update { it.copy(customerNote = newNote) }
-
-    fun onIncreaseProductsQuantity(id: Long) = _orderDraft.update { it.adjustProductQuantity(id, +1) }
-
-    fun onDecreaseProductsQuantity(id: Long) {
-        _orderDraft.value.items
-            .find { it.itemId == id }
-            ?.takeIf { it.quantity == 1F }
-            ?.let { onProductClicked(it) }
-            ?: _orderDraft.update { it.adjustProductQuantity(id, -1) }
-    }
-
-    fun onOrderStatusChanged(status: Order.Status) {
-        AnalyticsTracker.track(
-            AnalyticsEvent.ORDER_STATUS_CHANGE,
-            mapOf(
-                KEY_FROM to _orderDraft.value.status.value,
-                KEY_TO to status.value,
-                KEY_FLOW to VALUE_FLOW_CREATION
-            )
-        )
-        _orderDraft.update { it.copy(status = status) }
-    }
-
-    fun onRemoveProduct(item: Order.Item) = _orderDraft.update {
-        it.adjustProductQuantity(item.itemId, -item.quantity.toInt())
-    }
-
-    fun onProductSelected(remoteProductId: Long, variationId: Long? = null) {
-        AnalyticsTracker.track(
-            AnalyticsEvent.ORDER_PRODUCT_ADD,
-            mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
-        )
-
-        viewModelScope.launch {
-            _orderDraft.value.items.toMutableList().apply {
-                add(createOrderItem(remoteProductId, variationId))
-            }.let { items -> _orderDraft.update { it.updateItems(items) } }
-        }
-    }
-
-    fun onCustomerAddressEdited(billingAddress: Address, shippingAddress: Address) {
-        val hasDifferentShippingDetails = _orderDraft.value.shippingAddress != _orderDraft.value.billingAddress
-        AnalyticsTracker.track(
-            AnalyticsEvent.ORDER_CUSTOMER_ADD,
-            mapOf(
-                KEY_FLOW to VALUE_FLOW_CREATION,
-                KEY_HAS_DIFFERENT_SHIPPING_DETAILS to hasDifferentShippingDetails
-            )
-        )
-
-        _orderDraft.update {
-            it.copy(
-                billingAddress = billingAddress,
-                shippingAddress = shippingAddress.takeIf { it != Address.EMPTY } ?: billingAddress
-            )
-        }
-    }
-
-    fun onEditOrderStatusClicked(currentStatus: OrderStatus) {
-        launch(dispatchers.io) {
-            orderDetailRepository
-                .getOrderStatusOptions().toTypedArray()
-                .runWithContext(dispatchers.main) {
-                    triggerEvent(
-                        ViewOrderStatusSelector(
-                            currentStatus = currentStatus.statusKey,
-                            orderStatusList = it
-                        )
-                    )
-                }
-        }
-    }
-
-    fun onCustomerClicked() {
-        triggerEvent(EditCustomer)
-    }
-
-    fun onCustomerNoteClicked() {
-        triggerEvent(EditCustomerNote)
-    }
-
-    fun onAddProductClicked() {
-        triggerEvent(AddProduct)
-    }
-
-    fun onProductClicked(item: Order.Item) {
-        // Don't show details if the product is not synced yet
-        if (!item.isSynced()) return
-        triggerEvent(ShowProductDetails(item))
-    }
-
-    fun onRetryPaymentsClicked() {
-        retryOrderDraftUpdateTrigger.tryEmit(Unit)
-    }
-
-    fun onFeeButtonClicked() {
+    override fun onSaveOrderClicked() {
         val order = _orderDraft.value
-        val currentFee = order.feesLines.firstOrNull()
+        trackSaveOrderButtonClick()
+        viewModelScope.launch {
+            viewState = viewState.copy(isProgressDialogShown = true)
+            orderCreationRepository.placeOrder(order).fold(
+                onSuccess = {
+                    AnalyticsTracker.track(AnalyticsEvent.ORDER_CREATION_SUCCESS)
+                    triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
+                    triggerEvent(ShowCreatedOrder(it.id))
+                },
+                onFailure = {
+                    trackOrderSaveFailure(it)
+                    viewState = viewState.copy(isProgressDialogShown = false)
+                    triggerEvent(ShowSnackbar(string.order_creation_failure_snackbar))
+                }
+            )
+        }
 
-        val currentFeeValue = currentFee?.total
-        val currentFeeTotalValue = currentFee?.getTotalValue() ?: BigDecimal.ZERO
-
-        val orderSubtotal = order.total - currentFeeTotalValue
-        triggerEvent(EditFee(orderSubtotal, currentFeeValue))
     }
 
-    fun onShippingButtonClicked() {
-        triggerEvent(EditShipping(currentDraft.shippingLines.firstOrNull { it.methodId != null }))
-    }
-
-    fun onCreateOrderClicked(order: Order) {
-        trackCreateOrderButtonClick()
-        when (mode) {
-            Mode.Creation -> viewModelScope.launch {
-                viewState = viewState.copy(isProgressDialogShown = true)
-                orderCreationRepository.placeOrder(order).fold(
-                    onSuccess = {
-                        AnalyticsTracker.track(AnalyticsEvent.ORDER_CREATION_SUCCESS)
-                        triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
-                        triggerEvent(ShowCreatedOrder(it.id))
-                    },
-                    onFailure = {
-                        trackOrderCreationFailure(it)
-                        viewState = viewState.copy(isProgressDialogShown = false)
-                        triggerEvent(ShowSnackbar(string.order_creation_failure_snackbar))
+    override fun onBackButtonClicked() {
+        if (_orderDraft.value.isEmpty()) {
+            triggerEvent(Exit)
+        } else {
+            triggerEvent(
+                ShowDialog.buildDiscardDialogEvent(
+                    positiveBtnAction = { _, _ ->
+                        val draft = _orderDraft.value
+                        if (draft.id != 0L) {
+                            launch { orderCreationRepository.deleteDraftOrder(draft) }
+                        }
+                        triggerEvent(Exit)
                     }
                 )
-            }
-            is Mode.Edit -> {
-                triggerEvent(Exit)
-            }
-        }
-    }
-
-    fun onBackButtonClicked() {
-        when (mode) {
-            Mode.Creation -> {
-                if (_orderDraft.value.isEmpty()) {
-                    triggerEvent(Exit)
-                } else {
-                    triggerEvent(
-                        ShowDialog.buildDiscardDialogEvent(
-                            positiveBtnAction = { _, _ ->
-                                val draft = _orderDraft.value
-                                if (draft.id != 0L) {
-                                    launch { orderCreationRepository.deleteDraftOrder(draft) }
-                                }
-                                triggerEvent(Exit)
-                            }
-                        )
-                    )
-                }
-            }
-            is Mode.Edit -> {
-                triggerEvent(Exit)
-            }
+            )
         }
     }
 
     /**
      * Monitor order changes, and update the remote draft to update price totals
      */
-    private fun monitorOrderChanges() {
+    override fun monitorOrderChanges() {
         viewModelScope.launch {
-            syncStrategy.syncOrderChanges(_orderDraft.drop(1), retryOrderDraftUpdateTrigger)
+            syncStrategy.syncOrderChanges(_orderDraft, retryOrderDraftUpdateTrigger)
                 .collect { updateStatus ->
                     when (updateStatus) {
                         OrderUpdateStatus.PendingDebounce ->
@@ -314,7 +112,7 @@ class OrderCreationViewModel @Inject constructor(
                             viewState = viewState.copy(
                                 isUpdatingOrderDraft = false,
                                 showOrderUpdateSnackbar = false,
-                                isEditable = updateStatus.order.isEditable || mode is Mode.Creation,
+                                isEditable = true,
                                 multipleLinesContext = determineMultipleLinesContext(updateStatus.order)
                             )
                             _orderDraft.update { currentDraft ->
@@ -327,7 +125,7 @@ class OrderCreationViewModel @Inject constructor(
         }
     }
 
-    private fun trackOrderCreationFailure(it: Throwable) {
+    override fun trackOrderSaveFailure(it: Throwable) {
         AnalyticsTracker.track(
             AnalyticsEvent.ORDER_CREATION_FAILED,
             mapOf(
@@ -338,7 +136,7 @@ class OrderCreationViewModel @Inject constructor(
         )
     }
 
-    private fun trackCreateOrderButtonClick() {
+    override fun trackSaveOrderButtonClick() {
         AnalyticsTracker.track(
             AnalyticsEvent.ORDER_CREATE_BUTTON_TAPPED,
             mapOf(
@@ -350,125 +148,4 @@ class OrderCreationViewModel @Inject constructor(
             )
         )
     }
-
-    fun onShippingEdited(amount: BigDecimal, name: String) {
-        AnalyticsTracker.track(
-            AnalyticsEvent.ORDER_SHIPPING_METHOD_ADD,
-            mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
-        )
-
-        _orderDraft.update { draft ->
-            val shipping: List<ShippingLine> = draft.shippingLines.mapIndexed { index, shippingLine ->
-                if (index == 0) {
-                    shippingLine.copy(total = amount, methodTitle = name)
-                } else {
-                    shippingLine
-                }
-            }.ifEmpty {
-                listOf(ShippingLine(methodId = "other", total = amount, methodTitle = name))
-            }
-
-            draft.copy(shippingLines = shipping)
-        }
-    }
-
-    fun onShippingRemoved() {
-        _orderDraft.update { draft ->
-            draft.copy(
-                shippingLines = draft.shippingLines.mapIndexed { index, shippingLine ->
-                    if (index == 0) {
-                        // Setting methodId to null will remove the shipping line in core
-                        shippingLine.copy(methodId = null)
-                    } else {
-                        shippingLine
-                    }
-                }
-            )
-        }
-    }
-
-    fun onFeeEdited(feeValue: BigDecimal) {
-        AnalyticsTracker.track(
-            AnalyticsEvent.ORDER_FEE_ADD,
-            mapOf(KEY_FLOW to VALUE_FLOW_CREATION)
-        )
-
-        _orderDraft.update { draft ->
-            val fees: List<Order.FeeLine> = draft.feesLines.mapIndexed { index, feeLine ->
-                if (index == 0) {
-                    feeLine.copy(total = feeValue)
-                } else {
-                    feeLine
-                }
-            }.ifEmpty {
-                listOf(
-                    Order.FeeLine.EMPTY.copy(
-                        name = ORDER_CUSTOM_FEE_NAME,
-                        total = feeValue
-                    )
-                )
-            }
-
-            draft.copy(feesLines = fees)
-        }
-    }
-
-    fun onFeeRemoved() {
-        _orderDraft.update { draft ->
-            draft.copy(
-                feesLines = draft.feesLines.mapIndexed { index, feeLine ->
-                    if (index == 0) {
-                        feeLine.copy(name = null)
-                    } else {
-                        feeLine
-                    }
-                }
-            )
-        }
-    }
-
-    @Parcelize
-    data class ViewState(
-        val isProgressDialogShown: Boolean = false,
-        val willUpdateOrderDraft: Boolean = false,
-        val isUpdatingOrderDraft: Boolean = false,
-        val showOrderUpdateSnackbar: Boolean = false,
-        val isEditable: Boolean = true,
-        val multipleLinesContext: MultipleLinesContext = MultipleLinesContext.None
-    ) : Parcelable {
-        @IgnoredOnParcel
-        val canCreateOrder: Boolean = !willUpdateOrderDraft && !isUpdatingOrderDraft && !showOrderUpdateSnackbar
-
-        @IgnoredOnParcel
-        val isIdle: Boolean = !isUpdatingOrderDraft && !willUpdateOrderDraft
-    }
-
-    sealed class Mode : Parcelable {
-        @Parcelize
-        object Creation : Mode()
-
-        @Parcelize
-        data class Edit(val orderId: Long) : Mode()
-    }
-
-    sealed class MultipleLinesContext : Parcelable {
-        @Parcelize
-        object None : MultipleLinesContext()
-
-        @Parcelize
-        data class Warning(
-            val header: String,
-            val explanation: String,
-        ) : MultipleLinesContext()
-    }
 }
-
-data class ProductUIModel(
-    val item: Order.Item,
-    val imageUrl: String,
-    val isStockManaged: Boolean,
-    val stockQuantity: Double,
-    val stockStatus: ProductStockStatus
-)
-
-fun Order.Item.isSynced() = this.itemId != 0L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderEditViewModel.kt
@@ -1,0 +1,95 @@
+package com.woocommerce.android.ui.orders.creation
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+@ExperimentalCoroutinesApi
+class OrderEditViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    dispatchers: CoroutineDispatchers,
+    orderDetailRepository: OrderDetailRepository,
+    mapItemToProductUiModel: MapItemToProductUiModel,
+    createOrderItem: CreateOrderItem,
+    private val determineMultipleLinesContext: DetermineMultipleLinesContext,
+    parameterRepository: ParameterRepository,
+    autoSyncOrder: AutoSyncOrder,
+) : OrderCreateEditViewModel(
+    savedState,
+    dispatchers,
+    orderDetailRepository,
+    mapItemToProductUiModel,
+    createOrderItem,
+) {
+    private val args: OrderCreationFormFragmentArgs by savedState.navArgs()
+    override val syncStrategy: SyncStrategy = autoSyncOrder
+
+    init {
+        viewModelScope.launch {
+            val currency = parameterRepository.getParameters(PARAMETERS_KEY, savedState).currencyCode.orEmpty()
+            val orderId = (args.mode as Mode.Edit).orderId
+            orderDetailRepository.getOrderById(orderId)?.let {
+                _orderDraft.value = it.copy(currency = currency)
+                monitorOrderChanges()
+            }
+        }
+    }
+
+    override fun onSaveOrderClicked() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    override fun onBackButtonClicked() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    override fun monitorOrderChanges() {
+        viewModelScope.launch {
+            syncStrategy.syncOrderChanges(_orderDraft, retryOrderDraftUpdateTrigger)
+                .collect { updateStatus ->
+                    when (updateStatus) {
+                        CreateUpdateOrder.OrderUpdateStatus.PendingDebounce ->
+                            viewState = viewState.copy(willUpdateOrderDraft = true, showOrderUpdateSnackbar = false)
+                        CreateUpdateOrder.OrderUpdateStatus.Ongoing ->
+                            viewState = viewState.copy(willUpdateOrderDraft = false, isUpdatingOrderDraft = true)
+                        CreateUpdateOrder.OrderUpdateStatus.Failed ->
+                            viewState = viewState.copy(isUpdatingOrderDraft = false, showOrderUpdateSnackbar = true)
+                        is CreateUpdateOrder.OrderUpdateStatus.Succeeded -> {
+                            viewState = viewState.copy(
+                                isUpdatingOrderDraft = false,
+                                showOrderUpdateSnackbar = false,
+                                isEditable = updateStatus.order.isEditable,
+                                multipleLinesContext = determineMultipleLinesContext(updateStatus.order)
+                            )
+                            _orderDraft.update { currentDraft ->
+                                // Keep the user's selected status
+                                updateStatus.order.copy(status = currentDraft.status)
+                            }
+                        }
+                    }
+                }
+            _orderDraft.collect{
+                Log.d("Order Id", it.id.toString())
+            }
+        }
+    }
+
+    override fun trackOrderSaveFailure(it: Throwable) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trackSaveOrderButtonClick() {
+        TODO("Not yet implemented")
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -32,7 +32,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
-import com.woocommerce.android.ui.orders.creation.OrderCreationViewModel
+import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.Companion.KEY_ORDER_CREATION_ACTION_RESULT
 import com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment.OrderCreationAction
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
@@ -332,7 +332,7 @@ class OrderListFragment :
         AnalyticsTracker.track(AnalyticsEvent.ORDER_ADD_NEW)
         findNavController().navigateSafely(
             OrderListFragmentDirections.actionOrderListFragmentToOrderCreationFragment(
-                OrderCreationViewModel.Mode.Creation
+                OrderCreateEditViewModel.Mode.Creation
             )
         )
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -68,7 +68,7 @@
             app:popExitAnim="@anim/activity_fade_out" >
             <argument
                 android:name="mode"
-                app:argType="com.woocommerce.android.ui.orders.creation.OrderCreationViewModel$Mode" />
+                app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
         </action>
     </fragment>
     <fragment

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -71,7 +71,7 @@
         </action>
         <argument
             android:name="mode"
-            app:argType="com.woocommerce.android.ui.orders.creation.OrderCreationViewModel$Mode" />
+            app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -241,7 +241,7 @@
             app:popExitAnim="@anim/activity_fade_out" >
             <argument
                 android:name="mode"
-                app:argType="com.woocommerce.android.ui.orders.creation.OrderCreationViewModel$Mode" />
+                app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
         </action>
 
         <action


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6613

### Description
This is still a work in progress of the refactor dividing order creation classes from order editing. Currently, only view model logic is in different classes for each flow.  The next step would be to divide OrderCreationFormFragment.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not yet

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
