### PR TITLE
Fix `metadata_path` in `create_promo_screenshots` lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,10 @@ RELEASE_NOTES_PATH = File.join(ORIGINALS_METADATA_DIR_PATH, 'release_notes.txt')
 MAIN_STRINGS_PATH = File.join('WooCommerce', 'src', 'main', 'res', 'values', 'strings.xml')
 # The metadata for the Play Store live in the Fastlane folder, hence the `Dir.pwd`
 PLAY_STORE_METADATA_DIR_PATH = File.join(Dir.pwd, 'metadata', 'android')
+# Currently, the strings to use for the screenshots live in yet another metadata folder.
+# This is suboptimal and could lead to confusion.
+# See suggestions for how to improve at: https://github.com/woocommerce/woocommerce-android/pull/6907#discussion_r918144990
+SCREENSHOTS_METADATA_DIR_PATH = File.join(Dir.pwd, 'playstoreres', 'metadata')
 RAW_SCREENSHOTS_DIR = File.join(Dir.pwd, 'screenshots', 'raw')
 RAW_SCREENSHOTS_PROCESSING_DIR = File.join(Dir.pwd, 'screenshots', 'raw_tmp')
 PROMO_SCREENSHOTS_DIR = File.join(Dir.pwd, "screenshots", "promo_screenshots")
@@ -692,10 +696,10 @@ platform :android do
                         target_files: files,
                         locales: locales,
                         source_locale: "en-US",
-                        download_path: File.join(Dir.pwd, "/playstoreres/metadata"))
+                        download_path: SCREENSHOTS_METADATA_DIR_PATH)
 
     # Copy metadata (screenshot-related) txt files into `en-US`
-    en_us_path = File.join(Dir.pwd, "/playstoreres/metadata", "en-US")
+    en_us_path = File.join(SCREENSHOTS_METADATA_DIR_PATH, 'en-US')
     FileUtils.mkdir_p(en_us_path)
 
     [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -769,7 +769,7 @@ platform :android do
     # Run screenshots generator tool
     promo_screenshots(
       orig_folder: RAW_SCREENSHOTS_PROCESSING_DIR,
-      metadata_folder: ORIGINALS_METADATA_DIR_PATH,
+      metadata_folder: SCREENSHOTS_METADATA_DIR_PATH,
       output_folder: PROMO_SCREENSHOTS_DIR,
       force: options[:force],
     )


### PR DESCRIPTION
> **Note** This PR builds on top of [#6907](https://github.com/woocommerce/woocommerce-android/pull/6907)

### Description
The previous value, which resolved to `WooCommerce/metadata`, worked because the lane currently only runs for `en-US` and that location contains the `.txt` files for that locale. But, once this will run for other locales, the values there will be incorrect. The fix is to use the folder in which the localized screenshots strings are downloaded, which in the current setup is `fastlane/playstoreres/metadata`.

Notice that there is still room for improvement, as discussed in https://github.com/woocommerce/woocommerce-android/pull/6907#discussion_r918144990

### Testing instructions
_I haven't tested this yet. It should be a matter of running through the screenshots automation workflow and verifying the screenshots have the correct copy._

<!-- ### Images/gif -->

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.
