### PR TITLE
[UOE] No price recalculation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -348,7 +348,10 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
                     isNestedScrollingEnabled = false
                 }
             }
-            productsSection.content.productsAdapter?.submitList(products)
+            productsSection.content.productsAdapter?.apply {
+                submitList(products)
+                areProductsEditable = viewModel.currentDraft.isEditable
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -315,7 +315,8 @@ class OrderCreateEditViewModel @Inject constructor(
      */
     private fun monitorOrderChanges() {
         viewModelScope.launch {
-            syncStrategy.syncOrderChanges(_orderDraft.drop(1), retryOrderDraftUpdateTrigger)
+            val changes = if (mode is Mode.Edit) _orderDraft.drop(1) else _orderDraft
+            syncStrategy.syncOrderChanges(changes, retryOrderDraftUpdateTrigger)
                 .collect { updateStatus ->
                     when (updateStatus) {
                         OrderUpdateStatus.PendingDebounce ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -28,6 +28,9 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         orderDetailRepository.stub {
             onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(defaultOrderValue)
         }
+        createUpdateOrderUseCase = mock {
+            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue))
+        }
 
         createSut()
 
@@ -70,8 +73,12 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
 
     @Test
     fun `when isEditable is true on the edit flow the order is editable`() {
+        val order = defaultOrderValue.copy(isEditable = true)
+        orderDetailRepository.stub {
+            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue.copy(isEditable = true)))
+            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
@@ -83,8 +90,12 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
 
     @Test
     fun `when isEditable is false on the edit flow the order is NOT editable`() {
+        val order = defaultOrderValue.copy(isEditable = false)
+        orderDetailRepository.stub {
+            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue.copy(isEditable = false)))
+            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var lastReceivedState: OrderCreateEditViewModel.ViewState? = null


### PR DESCRIPTION
Part of: #6613

### Description
This PR removes the unnecessary price recalculation when an order is opened in the edit flow. Before these changes, we called monitorOrderChanges() before loading the order from the DB, this caused an unnecessary call to the API because of the initial value Order.EMPTY was different from the order we were fetching in the DB. 

### Testing instructions

TC1
- Open Orders 
- Select a Processing Order -> Edit
- Check that we don't call the API
- Check that the non-editable banner is displayed and non-editable fields are disabled

TC2
- Open Orders 
- Select a Pending payment Order -> Edit
- Check that we don't call the API
- Check that the order is editable

TC3
- Check that order creation keeps working as expected


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/178842544-29ca3a5b-6a8b-48ce-97e3-82b5096b9b1d.mp4




- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
