### PR TITLE
Add sync error message in edit flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -420,8 +420,12 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
     @Suppress("MagicNumber")
     private fun showOrHideErrorSnackBar(show: Boolean) {
         if (show) {
+            val message = when (viewModel.mode) {
+                OrderCreateEditViewModel.Mode.Creation -> getString(R.string.order_creation_price_calculation_failed)
+                is OrderCreateEditViewModel.Mode.Edit -> getString(R.string.order_editing_sync_failed)
+            }
             val orderUpdateFailureSnackBar = orderUpdateFailureSnackBar ?: uiMessageResolver.getIndefiniteActionSnack(
-                message = getString(R.string.order_creation_price_calculation_failed),
+                message = message,
                 actionText = getString(R.string.retry),
                 actionListener = { viewModel.onRetryPaymentsClicked() }
             ).also {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -420,12 +420,8 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
     @Suppress("MagicNumber")
     private fun showOrHideErrorSnackBar(show: Boolean) {
         if (show) {
-            val message = when (viewModel.mode) {
-                OrderCreateEditViewModel.Mode.Creation -> getString(R.string.order_creation_price_calculation_failed)
-                is OrderCreateEditViewModel.Mode.Edit -> getString(R.string.order_editing_sync_failed)
-            }
             val orderUpdateFailureSnackBar = orderUpdateFailureSnackBar ?: uiMessageResolver.getIndefiniteActionSnack(
-                message = message,
+                message = getString(R.string.order_sync_failed),
                 actionText = getString(R.string.retry),
                 actionListener = { viewModel.onRetryPaymentsClicked() }
             ).also {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -393,6 +393,7 @@
     <string name="order_editing_non_editable_title">Parts of this order are not currently editable</string>
     <string name="order_editing_non_editable_message">To edit Products or Payment Details, change the status to Pending Payment.</string>
     <string name="order_editing_locked_content_description">locked</string>
+    <string name="order_editing_sync_failed">Unable to save changes</string>
     <!--
         Order Filters
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -374,7 +374,6 @@
     <string name="order_creation_failure_snackbar">Order creation failed</string>
     <string name="order_creation_success_snackbar">Order created</string>
     <string name="order_creation_payment_tax">Taxes</string>
-    <string name="order_creation_price_calculation_failed">Couldn’t update pricing</string>
     <string name="order_creation_shipping_name">Name</string>
     <string name="order_creation_shipping_title_add">Add Shipping</string>
     <string name="order_creation_add_shipping">Add shipping</string>
@@ -393,7 +392,7 @@
     <string name="order_editing_non_editable_title">Parts of this order are not currently editable</string>
     <string name="order_editing_non_editable_message">To edit Products or Payment Details, change the status to Pending Payment.</string>
     <string name="order_editing_locked_content_description">locked</string>
-    <string name="order_editing_sync_failed">Unable to save changes</string>
+    <string name="order_sync_failed">Unable to save changes</string>
     <!--
         Order Filters
     -->


### PR DESCRIPTION
Part of: #6613

### Description
This small PR updates error messages on the edit flow

### Testing instructions

1. Select Orders 
2. Select a random order -> Edit
3. Turn plain mode on 
4. Made a change in the order
5. Check that the app fails with the message "Unable to save changes"

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="300" src="https://user-images.githubusercontent.com/18119390/179005498-1c039c5a-bc4a-404f-98e2-53d1d6b73191.png" />

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
