### PR TITLE
Fix wording on order paid with cash dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -255,6 +255,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD = "payment_method"
 
         const val VALUE_ORDER_PAYMENTS_FLOW = "order_payment"
+        const val VALUE_ORDER_PAYMENTS_COLLECT_CASH = "cash"
 
         // -- Downloadable Files
         const val KEY_DOWNLOADABLE_FILE_ACTION = "action"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -255,7 +255,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD = "payment_method"
 
         const val VALUE_ORDER_PAYMENTS_FLOW = "order_payment"
-        const val VALUE_ORDER_PAYMENTS_COLLECT_CASH = "cash"
 
         // -- Downloadable Files
         const val KEY_DOWNLOADABLE_FILE_ACTION = "action"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
@@ -93,7 +93,6 @@ class SelectPaymentMethodViewModel @Inject constructor(
 
     fun onCashPaymentClicked() {
         when (cardReaderPaymentFlowParam.paymentType) {
-
             SIMPLE -> {
                 analyticsTrackerWrapper.track(
                     AnalyticsEvent.PAYMENTS_FLOW_COLLECT,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
@@ -92,50 +92,28 @@ class SelectPaymentMethodViewModel @Inject constructor(
     }
 
     fun onCashPaymentClicked() {
-        when (cardReaderPaymentFlowParam.paymentType) {
-            SIMPLE -> {
-                analyticsTrackerWrapper.track(
-                    AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
-                    mapOf(
-                        AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_CASH,
-                        cardReaderPaymentFlowParam.toAnalyticsFlowParams(),
-                    )
-                )
-
-                triggerEvent(
-                    MultiLiveEvent.Event.ShowDialog(
-                        titleId = R.string.simple_payments_cash_dlg_title,
-                        messageId = R.string.simple_payments_cash_dlg_message,
-                        positiveButtonId = R.string.simple_payments_cash_dlg_button,
-                        positiveBtnAction = { _, _ ->
-                            onCashPaymentConfirmed()
-                        },
-                        negativeButtonId = R.string.cancel
-                    )
-                )
-            }
-            ORDER -> {
-                analyticsTrackerWrapper.track(
-                    AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
-                    mapOf(
-                        AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_ORDER_PAYMENTS_COLLECT_CASH,
-                        cardReaderPaymentFlowParam.toAnalyticsFlowParams(),
-                    )
-                )
-
-                triggerEvent(
-                    MultiLiveEvent.Event.ShowDialog(
-                        titleId = R.string.simple_payments_cash_dlg_title,
-                        messageId = R.string.existing_order_cash_dlg_message,
-                        positiveButtonId = R.string.simple_payments_cash_dlg_button,
-                        positiveBtnAction = { _, _ ->
-                            onCashPaymentConfirmed()
-                        },
-                        negativeButtonId = R.string.cancel
-                    )
-                )
-            }
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
+            mapOf(
+                AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_CASH,
+                cardReaderPaymentFlowParam.toAnalyticsFlowParams(),
+            )
+        )
+        val messageIdForPaymentType = when (cardReaderPaymentFlowParam.paymentType) {
+            SIMPLE -> R.string.simple_payments_cash_dlg_message
+            ORDER -> R.string.existing_order_cash_dlg_message
         }
+        triggerEvent(
+            MultiLiveEvent.Event.ShowDialog(
+                titleId = R.string.simple_payments_cash_dlg_title,
+                messageId = messageIdForPaymentType,
+                positiveButtonId = R.string.simple_payments_cash_dlg_button,
+                positiveBtnAction = { _, _ ->
+                    onCashPaymentConfirmed()
+                },
+                negativeButtonId = R.string.cancel
+            )
+        )
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_PAYMENTS_COLLECT_CASH
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CARD
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CASH
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK
@@ -91,24 +92,51 @@ class SelectPaymentMethodViewModel @Inject constructor(
     }
 
     fun onCashPaymentClicked() {
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
-            mapOf(
-                AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_CASH,
-                cardReaderPaymentFlowParam.toAnalyticsFlowParams(),
-            )
-        )
-        triggerEvent(
-            MultiLiveEvent.Event.ShowDialog(
-                titleId = R.string.simple_payments_cash_dlg_title,
-                messageId = R.string.simple_payments_cash_dlg_message,
-                positiveButtonId = R.string.simple_payments_cash_dlg_button,
-                positiveBtnAction = { _, _ ->
-                    onCashPaymentConfirmed()
-                },
-                negativeButtonId = R.string.cancel
-            )
-        )
+        when (cardReaderPaymentFlowParam.paymentType) {
+
+            SIMPLE -> {
+                analyticsTrackerWrapper.track(
+                    AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
+                    mapOf(
+                        AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_SIMPLE_PAYMENTS_COLLECT_CASH,
+                        cardReaderPaymentFlowParam.toAnalyticsFlowParams(),
+                    )
+                )
+
+                triggerEvent(
+                    MultiLiveEvent.Event.ShowDialog(
+                        titleId = R.string.simple_payments_cash_dlg_title,
+                        messageId = R.string.simple_payments_cash_dlg_message,
+                        positiveButtonId = R.string.simple_payments_cash_dlg_button,
+                        positiveBtnAction = { _, _ ->
+                            onCashPaymentConfirmed()
+                        },
+                        negativeButtonId = R.string.cancel
+                    )
+                )
+            }
+            ORDER -> {
+                analyticsTrackerWrapper.track(
+                    AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
+                    mapOf(
+                        AnalyticsTracker.KEY_PAYMENT_METHOD to VALUE_ORDER_PAYMENTS_COLLECT_CASH,
+                        cardReaderPaymentFlowParam.toAnalyticsFlowParams(),
+                    )
+                )
+
+                triggerEvent(
+                    MultiLiveEvent.Event.ShowDialog(
+                        titleId = R.string.simple_payments_cash_dlg_title,
+                        messageId = R.string.existing_order_cash_dlg_message,
+                        positiveButtonId = R.string.simple_payments_cash_dlg_button,
+                        positiveBtnAction = { _, _ ->
+                            onCashPaymentConfirmed()
+                        },
+                        negativeButtonId = R.string.cancel
+                    )
+                )
+            }
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_PAYMENTS_COLLECT_CASH
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CARD
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CASH
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -331,6 +331,7 @@
     <string name="simple_payments_choose_method">Choose your payment method</string>
     <string name="simple_payments_cash_dlg_title">Mark as paid?</string>
     <string name="simple_payments_cash_dlg_message">This will create your order and mark it as paid if you received payment outside of WooCommerce</string>
+    <string name="existing_order_cash_dlg_message">This will mark this order as paid if you received payment outside of WooCommerce</string>
     <string name="simple_payments_cash_dlg_button">Mark as paid</string>
     <string name="simple_payments_share_payment_link">Share payment link</string>
     <string name="simple_payments_share_payment_dialog_title">Checkout - %s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -162,7 +162,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when on cash payment clicked, then show dialog event emitted`() = testBlocking {
+    fun `given order payment flow, when on cash payment clicked, then show dialog event emitted`() = testBlocking {
         // GIVEN
         val orderId = 1L
         val viewModel = initViewModel(Payment(orderId, ORDER))
@@ -174,10 +174,29 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         val events = viewModel.event.captureValues()
         assertThat(events.last()).isInstanceOf(ShowDialog::class.java)
         assertThat((events.last() as ShowDialog).titleId).isEqualTo(R.string.simple_payments_cash_dlg_title)
-        assertThat((events.last() as ShowDialog).messageId).isEqualTo(R.string.simple_payments_cash_dlg_message)
+        assertThat((events.last() as ShowDialog).messageId).isEqualTo(R.string.existing_order_cash_dlg_message)
         assertThat((events.last() as ShowDialog).positiveButtonId).isEqualTo(R.string.simple_payments_cash_dlg_button)
         assertThat((events.last() as ShowDialog).negativeButtonId).isEqualTo(R.string.cancel)
     }
+
+    @Test
+    fun `given simple payment flow, when on cash payment clicked, then show dialog event emitted` () =
+        testBlocking {
+            // Given
+            val orderId = 1L
+            val viewModel = initViewModel(Payment(orderId, SIMPLE))
+
+            // When
+            viewModel.onCashPaymentClicked()
+
+            // Then
+            val events = viewModel.event.captureValues()
+            assertThat(events.last()).isInstanceOf(ShowDialog::class.java)
+            assertThat((events.last() as ShowDialog).titleId).isEqualTo(R.string.simple_payments_cash_dlg_title)
+            assertThat((events.last() as ShowDialog).messageId).isEqualTo(R.string.simple_payments_cash_dlg_message)
+            assertThat((events.last() as ShowDialog).positiveButtonId).isEqualTo(R.string.simple_payments_cash_dlg_button)
+            assertThat((events.last() as ShowDialog).negativeButtonId).isEqualTo(R.string.cancel)
+        }
 
     @Test
     fun `given order payment flow, when on cash payment clicked, then collect tracked with order payment flow`() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -182,14 +182,14 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     @Test
     fun `given simple payment flow, when on cash payment clicked, then show dialog event emitted`() =
         testBlocking {
-            // Given
+            // GIVEN
             val orderId = 1L
             val viewModel = initViewModel(Payment(orderId, SIMPLE))
 
-            // When
+            // WHEN
             viewModel.onCashPaymentClicked()
 
-            // Then
+            // THEN
             val events = viewModel.event.captureValues()
             assertThat(events.last()).isInstanceOf(ShowDialog::class.java)
             assertThat((events.last() as ShowDialog).titleId).isEqualTo(R.string.simple_payments_cash_dlg_title)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -180,7 +180,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given simple payment flow, when on cash payment clicked, then show dialog event emitted` () =
+    fun `given simple payment flow, when on cash payment clicked, then show dialog event emitted`() =
         testBlocking {
             // Given
             val orderId = 1L
@@ -194,7 +194,9 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             assertThat(events.last()).isInstanceOf(ShowDialog::class.java)
             assertThat((events.last() as ShowDialog).titleId).isEqualTo(R.string.simple_payments_cash_dlg_title)
             assertThat((events.last() as ShowDialog).messageId).isEqualTo(R.string.simple_payments_cash_dlg_message)
-            assertThat((events.last() as ShowDialog).positiveButtonId).isEqualTo(R.string.simple_payments_cash_dlg_button)
+            assertThat((events.last() as ShowDialog).positiveButtonId).isEqualTo(
+                R.string.simple_payments_cash_dlg_button
+            )
             assertThat((events.last() as ShowDialog).negativeButtonId).isEqualTo(R.string.cancel)
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6946 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR changes the text of the cash payment dialog based on if the payment was generated from an existing order or a simple payment.
context: p5T066-3oX-p2#comment-12933

It also adds a tracker for cash payments collected from an existing order ( #6949 )
context: p1657805095414379-slack-CGPNUU63E

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to an unpaid existing order and click on collect payment - Cash
2. confirm the text says: `This will mark this order as paid if you received payment outside of WooCommerce`
3. Create a simple payment  order and click on collect payment - cash
4. confirm the text says: `This will create your order and mark it as paid if you received payment outside of WooCommerce`

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Simple Payment | Existing Order |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/179012182-f53cf61f-5949-4d94-9cc9-92f02801b5ac.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/179012238-bee19abf-b528-48fe-8dba-59d203fb2fa7.png" width="350"/> |





- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->