### PR TITLE
Fix stroke select payment gateway buttons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -133,7 +133,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
             binding.icCheckmarkWcPay.visibility = View.VISIBLE
             binding.icCheckmarkStripe.visibility = View.GONE
             binding.selectStripeButton.strokeColor =
-                ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.gray_5))
+                ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.select_payment_gateway_stroke))
         }
         binding.selectStripeButton.setOnClickListener {
             selectedPluginType = PluginType.STRIPE_EXTENSION_GATEWAY
@@ -142,7 +142,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
             binding.icCheckmarkWcPay.visibility = View.GONE
             binding.icCheckmarkStripe.visibility = View.VISIBLE
             binding.selectWcPayButton.strokeColor =
-                ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.gray_5))
+                ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.select_payment_gateway_stroke))
         }
         binding.confirmPaymentMethod.setOnClickListener {
             state.onConfirmPaymentMethodClicked.invoke(selectedPluginType)

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -116,6 +116,7 @@
         Payment reader
     -->
     <color name="disconnected_state_number_background_color">@color/woo_black_900</color>
+    <color name="select_payment_gateway_stroke">@color/woo_gray_80</color>
 
     <!--
     Jetpack plugin installation dialog

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -173,6 +173,7 @@
         Payment reader
     -->
     <color name="disconnected_state_number_background_color">@color/woo_gray_0</color>
+    <color name="select_payment_gateway_stroke">@color/woo_gray_5</color>
 
     <!--
         Jetpack plugin installation dialog


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6958 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the color of the select payment gateway stroke on dark mode by creating a new colour that has support for dark mode. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open a US-based store that has both Stripe and WCPay plugins activated
2. go to the Menu - IPP settings
3. make sure the stroke of the selected plugin is purple and the unselected it light gray
4. Test the same thing on dark mode. The unselected should be slightly lighter than the background

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/179247066-1d3c5e85-ea13-43a6-a58c-a1bba6a9c33d.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/179246635-05490761-5736-4ff4-a812-88cfa464de83.gif" width="350"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
