### PR TITLE
[Image Uploads] Fix displaying ongoing uploads in Product details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 9.7
 -----
-
+- [*] Fixed a bug that resulted in not showing ongoing image uploads in product details. [https://github.com/woocommerce/woocommerce-android/pull/6964]
 
 9.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -67,6 +67,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -1639,7 +1640,9 @@ class ProductDetailViewModel @Inject constructor(
     private fun observeImageUploadEvents() {
         imageUploadsJob?.cancel()
         imageUploadsJob = launch {
-            draftChanges.map { getRemoteProductId() }
+            draftChanges
+                .distinctUntilChanged { old, new -> old?.remoteId == new?.remoteId }
+                .map { getRemoteProductId() }
                 .collectLatest { productId ->
                     mediaFileUploadHandler.observeCurrentUploads(productId)
                         .map { list -> list.map { it.toUri() } }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -68,6 +68,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -1643,6 +1644,7 @@ class ProductDetailViewModel @Inject constructor(
             draftChanges
                 .distinctUntilChanged { old, new -> old?.remoteId == new?.remoteId }
                 .map { getRemoteProductId() }
+                .filter { productId -> productId != DEFAULT_ADD_NEW_PRODUCT_ID || isAddFlowEntryPoint }
                 .collectLatest { productId ->
                     mediaFileUploadHandler.observeCurrentUploads(productId)
                         .map { list -> list.map { it.toUri() } }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6963 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This fixes a bug that resulted in not showing the ongoing uploads in product details, the cause is that `getRemoteProductId` depends on the current value of `viewState.productDraft`, and since we load the product asynchronously now, this value is null when we initiate the ViewModel.
The solution is to make sure we listen to changes of `productDraft`, and whenever we have a new value, we re-monitor image uploads using the last value.

This also fixes a bug where ongoing uploads are not displayed after saving a new product as a draft. 

### Testing instructions
#### Product Edit
1. Open product details.
2. Add some images from your device.
3. Go back to order details.
4. Confirm the ongoing uploads are shown in the gallery view.

#### Product creation
1. Open product creation form.
2. Add some images from your device.
3. Go back to order details.
4. Click on menu, and select save as draft, while the upload is ongoing.
5. Confirm the ongoing uploads are still shown in the gallery view.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
