### PR TITLE
[UOE] Display day time in order editing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -128,8 +128,12 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
     }
 
     private fun FragmentOrderCreateEditFormBinding.initOrderStatusView() {
+        val mode =   when (viewModel.mode) {
+            OrderCreateEditViewModel.Mode.Creation -> OrderDetailOrderStatusView.Mode.OrderCreation
+            is OrderCreateEditViewModel.Mode.Edit -> OrderDetailOrderStatusView.Mode.OrderEdit
+        }
         orderStatusView.initView(
-            mode = OrderDetailOrderStatusView.Mode.OrderCreation,
+            mode = mode,
             editOrderStatusClickListener = {
                 viewModel.orderStatusData.value?.let {
                     viewModel.onEditOrderStatusClicked(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -128,7 +128,7 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
     }
 
     private fun FragmentOrderCreateEditFormBinding.initOrderStatusView() {
-        val mode =   when (viewModel.mode) {
+        val mode = when (viewModel.mode) {
             OrderCreateEditViewModel.Mode.Creation -> OrderDetailOrderStatusView.Mode.OrderCreation
             is OrderCreateEditViewModel.Mode.Edit -> OrderDetailOrderStatusView.Mode.OrderEdit
         }


### PR DESCRIPTION
Closes: #6955
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This small PR fixes the order status date display based on the current flow (Creation / Editing)

### Testing instructions
TC 1
1. Open orders
2. Tap the (+) button -> Create order
3. Check that the order status view displays only the date and not the time

TC2

1. Open orders
2. Select a random order
3. Tap the more menu (3 dots) -> Edit
4. Check that the order status view displays the date & time


### Images/gif
| Order creation  | Order editing |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/18119390/179543928-818d73b6-f472-48ae-9a0c-ac813f12f899.png"> | <img width="300" src="https://user-images.githubusercontent.com/18119390/179543919-c7734ad4-384f-4e0a-b536-4bccfde49a2b.png"> |

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
