### PR TITLE
[UOE] Release feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 9.7
 -----
+- [***] Orders: Orders can now be edited within the app. [https://github.com/woocommerce/woocommerce-android/pull/6987]
 - [*] Fixed a bug that resulted in not showing ongoing image uploads in product details. [https://github.com/woocommerce/woocommerce-android/pull/6964]
 
 9.7

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -24,15 +24,13 @@ enum class FeatureFlag {
             }
             COUPONS_M2,
             JETPACK_CP,
-            IN_PERSON_PAYMENTS_CANADA -> true
+            IN_PERSON_PAYMENTS_CANADA,
+            UNIFIED_ORDER_EDITING -> true
             ANALYTICS_HUB,
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            UNIFIED_ORDER_EDITING -> PackageUtils.isDebugBuild()
             ORDER_CREATION_CUSTOMER_SEARCH,
-            ORDER_METADATA -> {
-                UNIFIED_ORDER_EDITING.isEnabled()
-            }
+            ORDER_METADATA-> PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -30,7 +30,7 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             ORDER_CREATION_CUSTOMER_SEARCH,
-            ORDER_METADATA-> PackageUtils.isDebugBuild()
+            ORDER_METADATA -> PackageUtils.isDebugBuild()
         }
     }
 }


### PR DESCRIPTION
Closes: #6657 

### Description
In order to release the feature in the next sprint, this PR:

Sets the `UNIFIED_ORDER_EDITING` to true.
Updates Release notes.

---------------------

### Before Merging:
- [x] Test Plan Definition pe5pgL-8B-p2
- [x] Test Plan Run pe5pgL-8K-p2

---------------------

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
