### PR TITLE
6995-order-list-tracking-crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -246,7 +246,7 @@ class OrderListViewModel @Inject constructor(
                         // amount of custom fields in the order
                         it.size,
                         // total size in bytes of all custom fields in the order
-                        it.reduce(Long::plus)
+                        if (it.isEmpty()) 0 else it.reduce(Long::plus)
                     )
                 }
 


### PR DESCRIPTION
Closes: #6995

This PR fixes a crash in order detail that was caused by attempting to `reduce` an empty list. To test:

* Go to the order list
* Tap an order that doesn't have any metadata
* Verify that the app doesn't go boom

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.