### PR TITLE
Show edit button in the toolbar

### DIFF
--- a/WooCommerce/src/main/res/menu/menu_order_detail.xml
+++ b/WooCommerce/src/main/res/menu/menu_order_detail.xml
@@ -5,5 +5,5 @@
         android:id="@+id/menu_edit_order"
         android:title="@string/edit"
         android:visible="false"
-        app:showAsAction="never" />
+        app:showAsAction="always" />
 </menu>


### PR DESCRIPTION
Closes: #6996

This small PR moves the order detail Edit menu item out of the options menu to make it more visible.

![edit](https://user-images.githubusercontent.com/3903757/180038604-03ac93a0-4fe4-4f90-8461-6cb5ff1f9716.png)

[Related iOS PR](https://github.com/woocommerce/woocommerce-ios/pull/7312)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
