### PR TITLE
Enable customer search for all

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 9.7
 -----
 - [***] Orders: Orders can now be edited within the app. [https://github.com/woocommerce/woocommerce-android/pull/6987]
+- [**] You can now search customers when creating or editing an order. [https://github.com/woocommerce/woocommerce-android/pull/6999]
 - [*] Fixed a bug that resulted in not showing ongoing image uploads in product details. [https://github.com/woocommerce/woocommerce-android/pull/6964]
 
 9.6

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -25,11 +25,11 @@ enum class FeatureFlag {
             COUPONS_M2,
             JETPACK_CP,
             IN_PERSON_PAYMENTS_CANADA,
+            ORDER_CREATION_CUSTOMER_SEARCH,
             UNIFIED_ORDER_EDITING -> true
             ANALYTICS_HUB,
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            ORDER_CREATION_CUSTOMER_SEARCH,
             ORDER_METADATA -> PackageUtils.isDebugBuild()
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Enables the experimental customer search feature (https://github.com/woocommerce/woocommerce-android/pull/6748). Looks like this didn't get enabled along with UOE.

<!-- Id number of the GitHub issue this PR addresses. -->

### Testing instructions

1. Run with release variant. 
2. Create an order
3. Tap Add customer details
4. Confirm the search button is visible and accessible at the top right


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
