### PR TITLE
Login Enhancement: Install and Connect Jetpack via Chrome Custom Tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -667,6 +667,10 @@ class LoginActivity :
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG)
     }
 
+    override fun startJetpackInstall(siteAddress: String?) {
+        TODO("Not yet implemented")
+    }
+
     override fun gotUnregisteredEmail(email: String?) {
         // Show the 'No WordPress.com account found' screen
         val fragment = LoginNoWPcomAccountFoundFragment.newInstance(email)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -80,7 +80,6 @@ class LoginActivity :
         private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect/"
         private const val JETPACK_CONNECTED_REDIRECT_URL = "woocommerce://jetpack-connected"
 
-
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
         private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -77,6 +77,9 @@ class LoginActivity :
         private const val FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword"
         private const val MAGIC_LOGIN = "magic-login"
         private const val TOKEN_PARAMETER = "token"
+        private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect/"
+        private const val JETPACK_CONNECTED_REDIRECT_URL = "woocommerce://jetpack-connected"
+
 
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
         private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
@@ -668,7 +671,10 @@ class LoginActivity :
     }
 
     override fun startJetpackInstall(siteAddress: String?) {
-        TODO("Not yet implemented")
+        siteAddress?.let {
+            val url = "$JETPACK_CONNECT_URL?url=$it&mobile_redirect=$JETPACK_CONNECTED_REDIRECT_URL&from=mobile"
+            ChromeCustomTabUtils.launchUrl(this, url)
+        }
     }
 
     override fun gotUnregisteredEmail(email: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -151,10 +151,9 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
         }
 
         with(btnBinding.buttonPrimary) {
-            text = getString(R.string.login_jetpack_view_setup_instructions)
+            text = getString(R.string.login_jetpack_install)
             setOnClickListener {
-                AnalyticsTracker.track(AnalyticsEvent.LOGIN_NO_JETPACK_VIEW_INSTRUCTIONS_BUTTON_TAPPED)
-                jetpackLoginListener?.showJetpackInstructions()
+                jetpackLoginListener?.startJetpackInstall(siteAddress)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackListener.kt
@@ -11,4 +11,5 @@ interface LoginNoJetpackListener {
         inputUsername: String?,
         inputPassword: String?
     )
+    fun startJetpackInstall(siteAddress: String? = null)
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@
     <string name="login_jetpack_what_is_description">Jetpack is a free WordPress plugin that connects your store with the tools needed to give you the best mobile experience, including push notifications and stats</string>
     <string name="login_jetpack_installed_sign_in">Already have Jetpack? %1$s</string>
     <string name="login_jetpack_not_found">Jetpack not found. Please try again</string>
+    <string name="login_jetpack_install">Install Jetpack</string>
     <string name="login_sign_in">Sign in</string>
     <string name="login_need_help_finding_email">Need help finding the connected email?</string>
     <string name="login_email_help_title">What email do I use to sign in?</string>


### PR DESCRIPTION
Part 01 of #7003 

### Description

This PR adds an Install Jetpack button to the screen that's shown when merchants enter a site with no Jetpack.

The button itself will open a Chrome Custom Tab to go to the WordPress.com Jetpack Connect flow.

As the feature is still incomplete, this targets a feature branch.

### Testing
1. Create a self-hosted test site with WooCommerce but no Jetpack.
2. Start app, skip initial carousel,
3. On the login screen, select "Enter your store address",
4. Enter the site address created on step 1,
5. On the next screen, enter site username / password,
6. On the next screen, ensure "Install Jetpack" button shows up, then tap it,
7. Ensure that it opens a Custom Tab window opening to the Jetpack Connect screen (see video below for example)

### Video

https://user-images.githubusercontent.com/266376/180343270-ca488fd0-afc0-4c12-a273-31994cb79b4f.mov


