### PR TITLE
Login Enhancement: Handle Successful Jetpack Connection

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -48,7 +48,19 @@
         <activity
             android:name=".ui.login.LoginActivity"
             android:theme="@style/LoginTheme"
-            android:windowSoftInputMode="adjustResize"></activity>
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="jetpack-connected"
+                    android:scheme="woocommerce" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".ui.login.MagicLinkInterceptActivity"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -77,7 +77,7 @@ class LoginActivity :
         private const val FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword"
         private const val MAGIC_LOGIN = "magic-login"
         private const val TOKEN_PARAMETER = "token"
-        private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect/"
+        private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect"
         private const val JETPACK_CONNECTED_REDIRECT_URL = "woocommerce://jetpack-connected"
 
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
@@ -103,7 +103,9 @@ class LoginActivity :
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        if (hasMagicLinkLoginIntent()) {
+        if (hasJetpackConnectedIntent()) {
+            startLoginViaWPCom()
+        } else if (hasMagicLinkLoginIntent()) {
             getAuthTokenFromIntent()?.let { showMagicLinkInterceptFragment(it) }
         } else if (savedInstanceState == null) {
             loginAnalyticsListener.trackLoginAccessed()
@@ -156,6 +158,13 @@ class LoginActivity :
             .replace(R.id.fragment_container, fragment, LoginPrologueFragment.TAG)
             .addToBackStack(null)
             .commitAllowingStateLoss()
+    }
+
+    private fun hasJetpackConnectedIntent(): Boolean {
+        val action = intent.action
+        val uri = intent.data
+
+        return Intent.ACTION_VIEW == action && uri.toString() == JETPACK_CONNECTED_REDIRECT_URL
     }
 
     private fun slideInFragment(fragment: Fragment, shouldAddToBackStack: Boolean, tag: String) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part 02 of #7003

⚠️  Please do not merge before #7004 is merged.

<!-- Id number of the GitHub issue this PR addresses. -->

### Description

This PR continues from #7004. Once Jetpack Connect flow in the Custom Tab is completed, it will automatically redirect back to the app. Specifically, it will then open the "Login via WPCom email" screen.

### Testing
1. Create a self-hosted test site with WooCommerce but no Jetpack.
2. Start app, skip initial carousel,
3. On the login screen, select "Enter your store address",
4. Enter the site address created on step 1,
5. On the next screen, enter site username / password,
6. On the next screen, ensure "Install Jetpack" button shows up, then tap it,
7. A Chrome Custom Tab will open with the Jetpack Connect screen in it,
8. Follow the steps in the screen, which will involve entering site credentials, installing Jetpack, activating Jetpack, logging in to WPCom account, and accepting connection,
9. Eventually the connection process will complete, in which case the screen will redirect automatically back to the app, opening the "Login with WPCom email" flow.


### Video

(Please note that at 1:19 in the video below, WordPress.com login is not shown because I was already logged in to WPcom in my device's Chrome. During your testing phase, this area might show a WordPress.com login form first).

https://user-images.githubusercontent.com/266376/180404478-71c0b7f9-0920-46bf-b313-e2a02abe5206.mov


