### PR TITLE
Feature/login local notification ii

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -627,4 +627,9 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     COUPON_UPDATE_FAILED,
     COUPON_DELETE_SUCCESS,
     COUPON_DELETE_FAILED,
+
+    // Login help scheduled notifications
+    LOGIN_LOCAL_NOTIFICATION_DISPLAYED(siteless = true),
+    LOGIN_LOCAL_NOTIFICATION_TAPPED(siteless = true),
+    LOGIN_LOCAL_NOTIFICATION_DISMISSED(siteless = true),
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
@@ -4,13 +4,16 @@ import android.content.Context
 import android.os.Build
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED
 import com.woocommerce.android.analytics.AnalyticsEvent.PUSH_NOTIFICATION_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.NotificationReceivedEvent
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.model.isOrderNotification
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.support.ZendeskHelper
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.util.NotificationsParser
 import com.woocommerce.android.util.WooLog.T.NOTIFS
 import com.woocommerce.android.util.WooLogWrapper
@@ -61,6 +64,9 @@ class NotificationMessageHandler @Inject constructor(
     @Synchronized
     fun onNotificationDismissed(localPushId: Int) {
         removeNotificationByPushIdFromSystemsBar(localPushId)
+        if (localPushId == LOGIN_HELP_NOTIFICATION_ID) {
+            AnalyticsTracker.track(AnalyticsEvent.LOGIN_LOCAL_NOTIFICATION_DISMISSED)
+        }
     }
 
     @Suppress("ReturnCount", "ComplexMethod")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
@@ -96,6 +96,11 @@ class WooNotificationBuilder @Inject constructor(private val context: Context) {
                 )
             }
             setLargeIcon(getLargeIconBitmap(context, notification.icon, channelType.shouldCircularizeNoteIcon()))
+            // Call processing service when notification is dismissed
+            val pendingDeleteIntent = NotificationsProcessingService.getPendingIntentForNotificationDismiss(
+                context, notificationLocalId
+            )
+            setDeleteIntent(pendingDeleteIntent)
             NotificationManagerCompat.from(context).notify(
                 LoginNotificationScheduler.LOGIN_HELP_NOTIFICATION_TAG,
                 notificationLocalId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
@@ -17,7 +17,7 @@ import androidx.core.content.ContextCompat
 import com.bumptech.glide.Glide
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Notification
-import com.woocommerce.android.support.HelpActivity
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.WooLog
@@ -76,27 +76,31 @@ class WooNotificationBuilder @Inject constructor(private val context: Context) {
         }
     }
 
-    fun buildAndDisplayPreLoginLocalNotification(
+    fun buildAndDisplayLoginHelpNotification(
         notificationLocalId: Int,
         channelId: String,
         notification: Notification,
+        notificationTappedIntent: Intent,
+        actions: List<Pair<String, Intent>> = emptyList()
     ) {
         val channelType = notification.channelType
         getNotificationBuilder(channelId, notification).apply {
-            setLargeIcon(getLargeIconBitmap(context, notification.icon, channelType.shouldCircularizeNoteIcon()))
-        }.apply {
-            val flags = if (SystemVersionUtils.isAtLeastS()) {
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            } else {
-                PendingIntent.FLAG_UPDATE_CURRENT
+            val notificationContentIntent =
+                buildPendingIntentForGivenIntent(notificationLocalId, notificationTappedIntent)
+            setContentIntent(notificationContentIntent)
+            actions.forEach { action ->
+                addAction(
+                    R.drawable.ic_woo_w_notification,
+                    action.first,
+                    buildPendingIntentForGivenIntent(notificationLocalId, action.second)
+                )
             }
-            val pendingIntent = PendingIntent.getActivity(
-                context, notificationLocalId,
-                HelpActivity.createIntent(context, HelpActivity.Origin.LOGIN_LOCAL_NOTIFICATION, null),
-                flags
+            setLargeIcon(getLargeIconBitmap(context, notification.icon, channelType.shouldCircularizeNoteIcon()))
+            NotificationManagerCompat.from(context).notify(
+                LoginNotificationScheduler.LOGIN_HELP_NOTIFICATION_TAG,
+                notificationLocalId,
+                build()
             )
-            setContentIntent(pendingIntent)
-            NotificationManagerCompat.from(context).notify(notificationLocalId, build())
         }
     }
 
@@ -190,6 +194,15 @@ class WooNotificationBuilder @Inject constructor(private val context: Context) {
             // see https://github.com/woocommerce/woocommerce-android/issues/920
             WooLog.e(WooLog.T.NOTIFS, e)
         }
+    }
+
+    private fun buildPendingIntentForGivenIntent(notificationLocalId: Int, intent: Intent): PendingIntent {
+        val flags = if (SystemVersionUtils.isAtLeastS()) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        return PendingIntent.getActivity(context, notificationLocalId, intent, flags)
     }
 
     fun createNotificationChannels() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -190,7 +190,7 @@ class HelpActivity : AppCompatActivity() {
         NotificationManagerCompat.from(this).cancel(LOGIN_HELP_NOTIFICATION_TAG, LOGIN_HELP_NOTIFICATION_ID)
         AnalyticsTracker.track(
             AnalyticsEvent.LOGIN_LOCAL_NOTIFICATION_TAPPED,
-            mapOf(AnalyticsTracker.KEY_TYPE to LOGIN_SITE_ADDRESS_ERROR.name) //TODO REMOVE HARDCODED VALUE FOR TYPE
+            mapOf(AnalyticsTracker.KEY_TYPE to LOGIN_SITE_ADDRESS_ERROR.name)
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -15,8 +15,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivityHelpBinding
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_TAG
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
@@ -79,10 +79,7 @@ class HelpActivity : AppCompatActivity() {
             showZendeskTickets()
         }
 
-        NotificationManagerCompat.from(this).cancel(
-            LoginNotificationScheduler.LOGIN_HELP_NOTIFICATION_TAG,
-            LOGIN_HELP_NOTIFICATION_ID
-        )
+        NotificationManagerCompat.from(this).cancel(LOGIN_HELP_NOTIFICATION_TAG, LOGIN_HELP_NOTIFICATION_ID)
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.app.NotificationManagerCompat
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
@@ -14,6 +15,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivityHelpBinding
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
@@ -75,6 +78,11 @@ class HelpActivity : AppCompatActivity() {
         if (savedInstanceState == null && originFromExtras == Origin.ZENDESK_NOTIFICATION) {
             showZendeskTickets()
         }
+
+        NotificationManagerCompat.from(this).cancel(
+            LoginNotificationScheduler.LOGIN_HELP_NOTIFICATION_TAG,
+            LOGIN_HELP_NOTIFICATION_ID
+        )
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_TAG
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
@@ -79,7 +80,9 @@ class HelpActivity : AppCompatActivity() {
             showZendeskTickets()
         }
 
-        NotificationManagerCompat.from(this).cancel(LOGIN_HELP_NOTIFICATION_TAG, LOGIN_HELP_NOTIFICATION_ID)
+        if (originFromExtras == Origin.LOGIN_HELP_NOTIFICATION) {
+            handleOpenedFromLoginHelpNotification()
+        }
     }
 
     override fun onResume() {
@@ -183,6 +186,14 @@ class HelpActivity : AppCompatActivity() {
         startActivity(Intent(this, SSRActivity::class.java))
     }
 
+    private fun handleOpenedFromLoginHelpNotification() {
+        NotificationManagerCompat.from(this).cancel(LOGIN_HELP_NOTIFICATION_TAG, LOGIN_HELP_NOTIFICATION_ID)
+        AnalyticsTracker.track(
+            AnalyticsEvent.LOGIN_LOCAL_NOTIFICATION_TAPPED,
+            mapOf(AnalyticsTracker.KEY_TYPE to LOGIN_SITE_ADDRESS_ERROR.name) //TODO REMOVE HARDCODED VALUE FOR TYPE
+        )
+    }
+
     enum class Origin(private val stringValue: String) {
         UNKNOWN("origin:unknown"),
         SETTINGS("origin:settings"),
@@ -203,7 +214,7 @@ class HelpActivity : AppCompatActivity() {
         SIGNUP_EMAIL("origin:signup-email"),
         SIGNUP_MAGIC_LINK("origin:signup-magic-link"),
         JETPACK_INSTALLATION("origin:jetpack-installation"),
-        LOGIN_LOCAL_NOTIFICATION("origin:login-local-notification");
+        LOGIN_HELP_NOTIFICATION("origin:login-local-notification");
 
         override fun toString(): String {
             return stringValue

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -27,8 +27,8 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow.LOGIN_SITE_ADDRESS
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Source
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker.LoginSupportNotificationType
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
 import com.woocommerce.android.ui.main.MainActivity
@@ -87,7 +87,7 @@ class LoginActivity :
     @Inject internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
     @Inject internal lateinit var zendeskHelper: ZendeskHelper
     @Inject internal lateinit var urlUtils: UrlUtils
-    @Inject internal lateinit var loginFlowUsageTracker: LoginFlowUsageTracker
+    @Inject internal lateinit var loginNotificationScheduler: LoginNotificationScheduler
 
     private var loginMode: LoginMode? = null
 
@@ -249,7 +249,7 @@ class LoginActivity :
     }
 
     private fun showMainActivityAndFinish() {
-        loginFlowUsageTracker.onLoginSuccess()
+        loginNotificationScheduler.onLoginSuccess()
         val intent = Intent(this, MainActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         startActivity(intent)
@@ -725,7 +725,7 @@ class LoginActivity :
                 shouldAddToBackStack = true,
                 tag = LoginSiteCheckErrorFragment.TAG
             )
-            loginFlowUsageTracker.scheduleNotification(LoginSupportNotificationType.LOGIN_SITE_ADDRESS_ERROR)
+            loginNotificationScheduler.scheduleNotification(LoginSupportNotificationType.LOGIN_SITE_ADDRESS_ERROR)
         } else {
             // Just in case we use this method for a different scenario in the future
             TODO("Handle a new error scenario")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -30,6 +30,8 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow.LOGIN_SITE_ADDR
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Source
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_TAG
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
@@ -135,8 +137,8 @@ class LoginActivity :
     private fun processLoginHelpNotification() {
         startLoginViaWPCom()
         NotificationManagerCompat.from(this).cancel(
-            LoginNotificationScheduler.LOGIN_HELP_NOTIFICATION_TAG,
-            LoginNotificationScheduler.LOGIN_HELP_NOTIFICATION_ID
+            LOGIN_HELP_NOTIFICATION_TAG,
+            LOGIN_HELP_NOTIFICATION_ID
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LocalNotificationWorker.kt
@@ -12,12 +12,13 @@ import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.push.WooNotificationBuilder
 import com.woocommerce.android.push.WooNotificationType
 import com.woocommerce.android.support.HelpActivity
+import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_NOTIFICATION_TYPE_KEY
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType.DEFAULT_SUPPORT
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType.LOGIN_SITE_ADDRESS_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType.valueOf
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.DEFAULT_HELP
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.valueOf
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -32,7 +33,7 @@ class LocalNotificationWorker @AssistedInject constructor(
 ) : Worker(appContext, workerParams) {
     override fun doWork(): Result {
         when (getNotificationType()) {
-            DEFAULT_SUPPORT -> defaultLoginSupportNotification()
+            DEFAULT_HELP -> defaultLoginSupportNotification()
             LOGIN_SITE_ADDRESS_ERROR -> siteAddressErrorNotification()
         }
         prefsWrapper.setPreLoginNotificationDisplayed(displayed = true)
@@ -73,13 +74,19 @@ class LocalNotificationWorker @AssistedInject constructor(
     private fun buildOpenSupportScreenIntent(): Intent =
         HelpActivity.createIntent(appContext, HelpActivity.Origin.LOGIN_LOCAL_NOTIFICATION, null)
 
+    private fun buildOpenLoginWithEmailScreenIntent(): Intent =
+        LoginActivity.createIntent(appContext, LOGIN_SITE_ADDRESS_ERROR)
+
+
     private fun getActionsForSiteAddressErrorNotification(): List<Pair<String, Intent>> =
         listOf(
             resourceProvider.getString(R.string.login_local_notification_contact_support_button)
-                to buildOpenSupportScreenIntent()
+                to buildOpenSupportScreenIntent(),
+            resourceProvider.getString(R.string.login_local_notification_wordpress_login_button)
+                to buildOpenLoginWithEmailScreenIntent()
         )
 
-    private fun getNotificationType(): LoginSupportNotificationType = runCatching {
+    private fun getNotificationType(): LoginHelpNotificationType = runCatching {
         valueOf(inputData.getString(LOGIN_NOTIFICATION_TYPE_KEY).orEmpty())
-    }.getOrDefault(DEFAULT_SUPPORT)
+    }.getOrDefault(DEFAULT_HELP)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LocalNotificationWorker.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.localnotifications
 
 import android.content.Context
+import android.content.Intent
 import androidx.hilt.work.HiltWorker
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -10,6 +11,8 @@ import com.woocommerce.android.model.Notification
 import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.push.WooNotificationBuilder
 import com.woocommerce.android.push.WooNotificationType
+import com.woocommerce.android.support.HelpActivity
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_NOTIFICATION_TYPE_KEY
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType.DEFAULT_SUPPORT
@@ -27,36 +30,54 @@ class LocalNotificationWorker @AssistedInject constructor(
     private val resourceProvider: ResourceProvider,
     private val prefsWrapper: AppPrefsWrapper
 ) : Worker(appContext, workerParams) {
-    companion object {
-        const val PRE_LOGIN_LOCAL_NOTIFICATION_ID = 1
-    }
-
     override fun doWork(): Result {
         when (getNotificationType()) {
             DEFAULT_SUPPORT -> defaultLoginSupportNotification()
-            LOGIN_SITE_ADDRESS_ERROR -> defaultLoginSupportNotification()
+            LOGIN_SITE_ADDRESS_ERROR -> siteAddressErrorNotification()
         }
         prefsWrapper.setPreLoginNotificationDisplayed(displayed = true)
         return Result.success()
     }
 
     private fun defaultLoginSupportNotification() {
-        wooNotificationBuilder.buildAndDisplayPreLoginLocalNotification(
-            notificationLocalId = PRE_LOGIN_LOCAL_NOTIFICATION_ID,
+        wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
+            notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
             appContext.getString(R.string.notification_channel_pre_login_id),
-            notification = Notification(
-                noteId = PRE_LOGIN_LOCAL_NOTIFICATION_ID,
-                uniqueId = 0,
-                remoteNoteId = 0,
-                remoteSiteId = 0,
-                icon = null,
-                noteTitle = resourceProvider.getString(R.string.login_local_notification_no_interaction_title),
-                noteMessage = resourceProvider.getString(R.string.login_local_notification_no_interaction_description),
-                noteType = WooNotificationType.PRE_LOGIN,
-                channelType = NotificationChannelType.PRE_LOGIN
-            )
+            notification = buildDefaultLoginNotification(),
+            notificationTappedIntent = buildOpenSupportScreenIntent()
         )
     }
+
+    private fun siteAddressErrorNotification() {
+        wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
+            notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
+            appContext.getString(R.string.notification_channel_pre_login_id),
+            notification = buildDefaultLoginNotification(),
+            notificationTappedIntent = buildOpenSupportScreenIntent(),
+            actions = getActionsForSiteAddressErrorNotification()
+        )
+    }
+
+    private fun buildDefaultLoginNotification() = Notification(
+        noteId = LOGIN_HELP_NOTIFICATION_ID,
+        uniqueId = 0,
+        remoteNoteId = 0,
+        remoteSiteId = 0,
+        icon = null,
+        noteTitle = resourceProvider.getString(R.string.login_local_notification_no_interaction_title),
+        noteMessage = resourceProvider.getString(R.string.login_local_notification_no_interaction_description),
+        noteType = WooNotificationType.PRE_LOGIN,
+        channelType = NotificationChannelType.PRE_LOGIN
+    )
+
+    private fun buildOpenSupportScreenIntent(): Intent =
+        HelpActivity.createIntent(appContext, HelpActivity.Origin.LOGIN_LOCAL_NOTIFICATION, null)
+
+    private fun getActionsForSiteAddressErrorNotification(): List<Pair<String, Intent>> =
+        listOf(
+            resourceProvider.getString(R.string.login_local_notification_contact_support_button)
+                to buildOpenSupportScreenIntent()
+        )
 
     private fun getNotificationType(): LoginSupportNotificationType = runCatching {
         valueOf(inputData.getString(LOGIN_NOTIFICATION_TYPE_KEY).orEmpty())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LocalNotificationWorker.kt
@@ -10,13 +10,11 @@ import com.woocommerce.android.model.Notification
 import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.push.WooNotificationBuilder
 import com.woocommerce.android.push.WooNotificationType
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker.Companion.LOGIN_NOTIFICATION_TYPE_KEY
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker.LoginSupportNotificationType
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker.LoginSupportNotificationType.DEFAULT_SUPPORT
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker.LoginSupportNotificationType.LOGIN_ERROR_WRONG_EMAIL
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker.LoginSupportNotificationType.LOGIN_SITE_ADDRESS_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker.LoginSupportNotificationType.NO_LOGIN_INTERACTION
-import com.woocommerce.android.ui.login.localnotifications.LoginFlowUsageTracker.LoginSupportNotificationType.valueOf
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_NOTIFICATION_TYPE_KEY
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType.DEFAULT_SUPPORT
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType.LOGIN_SITE_ADDRESS_ERROR
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginSupportNotificationType.valueOf
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -35,8 +33,6 @@ class LocalNotificationWorker @AssistedInject constructor(
 
     override fun doWork(): Result {
         when (getNotificationType()) {
-            NO_LOGIN_INTERACTION -> noInteractionNotification()
-            LOGIN_ERROR_WRONG_EMAIL -> wrongEmailNotification()
             DEFAULT_SUPPORT -> defaultLoginSupportNotification()
             LOGIN_SITE_ADDRESS_ERROR -> defaultLoginSupportNotification()
         }
@@ -60,14 +56,6 @@ class LocalNotificationWorker @AssistedInject constructor(
                 channelType = NotificationChannelType.PRE_LOGIN
             )
         )
-    }
-
-    private fun wrongEmailNotification() {
-        TODO("Not yet implemented")
-    }
-
-    private fun noInteractionNotification() {
-        TODO("Not yet implemented")
     }
 
     private fun getNotificationType(): LoginSupportNotificationType = runCatching {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -87,9 +87,9 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
 
     private fun getActionsForSiteAddressErrorNotification(): List<Pair<String, Intent>> =
         listOf(
+            resourceProvider.getString(R.string.login_local_notification_wordpress_login_button)
+                to buildOpenLoginWithEmailScreenIntent(),
             resourceProvider.getString(R.string.login_local_notification_contact_support_button)
                 to buildOpenSupportScreenIntent(),
-            resourceProvider.getString(R.string.login_local_notification_wordpress_login_button)
-                to buildOpenLoginWithEmailScreenIntent()
         )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.login.localnotifications
 
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.StringRes
 import androidx.hilt.work.HiltWorker
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -52,7 +53,10 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
             notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
             appContext.getString(R.string.notification_channel_pre_login_id),
-            notification = buildDefaultLoginNotification(),
+            notification = buildLoginNotification(
+                title = R.string.login_help_notification_default_title,
+                description = R.string.login_help_notification_no_interaction_default_description
+            ),
             notificationTappedIntent = buildOpenSupportScreenIntent()
         )
     }
@@ -61,20 +65,26 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
             notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
             appContext.getString(R.string.notification_channel_pre_login_id),
-            notification = buildDefaultLoginNotification(),
+            notification = buildLoginNotification(
+                title = R.string.login_help_notification_default_title,
+                description = R.string.login_help_notification_site_error_description
+            ),
             notificationTappedIntent = buildOpenLoginWithEmailScreenIntent(),
             actions = getActionsForSiteAddressErrorNotification()
         )
     }
 
-    private fun buildDefaultLoginNotification() = Notification(
+    private fun buildLoginNotification(
+        @StringRes title: Int,
+        @StringRes description: Int
+    ) = Notification(
         noteId = LOGIN_HELP_NOTIFICATION_ID,
         uniqueId = 0,
         remoteNoteId = 0,
         remoteSiteId = 0,
         icon = null,
-        noteTitle = resourceProvider.getString(R.string.login_local_notification_no_interaction_title),
-        noteMessage = resourceProvider.getString(R.string.login_local_notification_no_interaction_description),
+        noteTitle = resourceProvider.getString(title),
+        noteMessage = resourceProvider.getString(description),
         noteType = WooNotificationType.PRE_LOGIN,
         channelType = NotificationChannelType.PRE_LOGIN
     )
@@ -87,9 +97,9 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
 
     private fun getActionsForSiteAddressErrorNotification(): List<Pair<String, Intent>> =
         listOf(
-            resourceProvider.getString(R.string.login_local_notification_wordpress_login_button)
+            resourceProvider.getString(R.string.login_help_notification_wordpress_login_button)
                 to buildOpenLoginWithEmailScreenIntent(),
-            resourceProvider.getString(R.string.login_local_notification_contact_support_button)
+            resourceProvider.getString(R.string.login_help_notification_contact_support_button)
                 to buildOpenSupportScreenIntent(),
         )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -62,7 +62,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
             notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
             appContext.getString(R.string.notification_channel_pre_login_id),
             notification = buildDefaultLoginNotification(),
-            notificationTappedIntent = buildOpenSupportScreenIntent(),
+            notificationTappedIntent = buildOpenLoginWithEmailScreenIntent(),
             actions = getActionsForSiteAddressErrorNotification()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -85,7 +85,6 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
     private fun buildOpenLoginWithEmailScreenIntent(): Intent =
         LoginActivity.createIntent(appContext, LOGIN_SITE_ADDRESS_ERROR)
 
-
     private fun getActionsForSiteAddressErrorNotification(): List<Pair<String, Intent>> =
         listOf(
             resourceProvider.getString(R.string.login_local_notification_contact_support_button)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -24,7 +24,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
 @HiltWorker
-class LocalNotificationWorker @AssistedInject constructor(
+class LoginHelpNotificationWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val wooNotificationBuilder: WooNotificationBuilder,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -18,7 +18,7 @@ class LoginNotificationScheduler @Inject constructor(
 ) {
     companion object {
         const val LOGIN_NOTIFICATION_TYPE_KEY = "Notification-type"
-        const val NOTIFICATION_TEST_DELAY_IN_SECONDS = 5L // TODO SET THIS TO 24H BEFORE MERGE
+        const val NOTIFICATION_TEST_DELAY_IN_HOURS = 24L
         const val LOGIN_HELP_NOTIFICATION_ID = 987612345
         const val LOGIN_HELP_NOTIFICATION_TAG = "login-help-notification"
     }
@@ -42,7 +42,7 @@ class LoginNotificationScheduler @Inject constructor(
             val workRequest: WorkRequest =
                 OneTimeWorkRequestBuilder<LoginHelpNotificationWorker>()
                     .setInputData(notificationData)
-                    .setInitialDelay(NOTIFICATION_TEST_DELAY_IN_SECONDS, TimeUnit.SECONDS)
+                    .setInitialDelay(NOTIFICATION_TEST_DELAY_IN_HOURS, TimeUnit.HOURS)
                     .build()
 
             prefsWrapper.setPreLoginNotificationWorkRequestId(workRequest.id.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -14,13 +14,13 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-class LoginFlowUsageTracker @Inject constructor(
+class LoginNotificationScheduler @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val prefsWrapper: AppPrefsWrapper
 ) {
     companion object {
         const val LOGIN_NOTIFICATION_TYPE_KEY = "Notification-type"
-        const val NOTIFICATION_TEST_DELAY_IN_SECONDS = 5L
+        const val NOTIFICATION_TEST_DELAY_IN_SECONDS = 5L //TODO SET THIS TO 24H BEFORE MERGE
     }
 
     private val workManager = WorkManager.getInstance(appContext)
@@ -56,8 +56,6 @@ class LoginFlowUsageTracker @Inject constructor(
     }
 
     enum class LoginSupportNotificationType(val notification: String) {
-        NO_LOGIN_INTERACTION("no_login_interaction"),
-        LOGIN_ERROR_WRONG_EMAIL("wrong_email"),
         LOGIN_SITE_ADDRESS_ERROR("site_address_error"),
         DEFAULT_SUPPORT("default_support")
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -34,8 +34,8 @@ class LoginNotificationScheduler @Inject constructor(
         )
     }
 
-    fun scheduleNotification(notificationType: LoginSupportNotificationType) {
-        if (FeatureFlag.PRE_LOGIN_NOTIFICATIONS.isEnabled() && !prefsWrapper.hasPreLoginNotificationBeenDisplayed()) {
+    fun scheduleNotification(notificationType: LoginHelpNotificationType) {
+        if (FeatureFlag.PRE_LOGIN_NOTIFICATIONS.isEnabled()) { //TODO RE-ENABLE !prefsWrapper.hasPreLoginNotificationBeenDisplayed()
             cancelCurrentNotificationWorkRequest()
             val notificationData = workDataOf(
                 LOGIN_NOTIFICATION_TYPE_KEY to notificationType.name
@@ -59,8 +59,8 @@ class LoginNotificationScheduler @Inject constructor(
         }
     }
 
-    enum class LoginSupportNotificationType(val notification: String) {
+    enum class LoginHelpNotificationType(val notification: String) {
         LOGIN_SITE_ADDRESS_ERROR("site_address_error"),
-        DEFAULT_SUPPORT("default_support")
+        DEFAULT_HELP("default_support")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -20,7 +20,7 @@ class LoginNotificationScheduler @Inject constructor(
     companion object {
         const val LOGIN_NOTIFICATION_TYPE_KEY = "Notification-type"
         const val NOTIFICATION_TEST_DELAY_IN_SECONDS = 5L //TODO SET THIS TO 24H BEFORE MERGE
-        const val LOGIN_HELP_NOTIFICATION_ID = 1
+        const val LOGIN_HELP_NOTIFICATION_ID = 987612345
         const val LOGIN_HELP_NOTIFICATION_TAG = "login-help-notification"
     }
 
@@ -38,7 +38,7 @@ class LoginNotificationScheduler @Inject constructor(
         if (FeatureFlag.PRE_LOGIN_NOTIFICATIONS.isEnabled()) { //TODO RE-ENABLE !prefsWrapper.hasPreLoginNotificationBeenDisplayed()
             cancelCurrentNotificationWorkRequest()
             val notificationData = workDataOf(
-                LOGIN_NOTIFICATION_TYPE_KEY to notificationType.name
+                LOGIN_NOTIFICATION_TYPE_KEY to notificationType.toString()
             )
             val workRequest: WorkRequest =
                 OneTimeWorkRequestBuilder<LoginHelpNotificationWorker>()
@@ -59,8 +59,21 @@ class LoginNotificationScheduler @Inject constructor(
         }
     }
 
-    enum class LoginHelpNotificationType(val notification: String) {
+    enum class LoginHelpNotificationType(private val typeName: String) {
         LOGIN_SITE_ADDRESS_ERROR("site_address_error"),
-        DEFAULT_HELP("default_support")
+        DEFAULT_HELP("default_support");
+
+        override fun toString(): String {
+            return typeName
+        }
+
+        companion object {
+            fun fromString(string: String?): LoginHelpNotificationType =
+                when (string) {
+                    LOGIN_SITE_ADDRESS_ERROR.typeName -> LOGIN_SITE_ADDRESS_ERROR
+                    DEFAULT_HELP.typeName -> DEFAULT_HELP
+                    else -> DEFAULT_HELP
+                }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -19,7 +19,7 @@ class LoginNotificationScheduler @Inject constructor(
 ) {
     companion object {
         const val LOGIN_NOTIFICATION_TYPE_KEY = "Notification-type"
-        const val NOTIFICATION_TEST_DELAY_IN_SECONDS = 5L //TODO SET THIS TO 24H BEFORE MERGE
+        const val NOTIFICATION_TEST_DELAY_IN_SECONDS = 5L // TODO SET THIS TO 24H BEFORE MERGE
         const val LOGIN_HELP_NOTIFICATION_ID = 987612345
         const val LOGIN_HELP_NOTIFICATION_TAG = "login-help-notification"
     }
@@ -35,7 +35,7 @@ class LoginNotificationScheduler @Inject constructor(
     }
 
     fun scheduleNotification(notificationType: LoginHelpNotificationType) {
-        if (FeatureFlag.PRE_LOGIN_NOTIFICATIONS.isEnabled()) { //TODO RE-ENABLE !prefsWrapper.hasPreLoginNotificationBeenDisplayed()
+        if (FeatureFlag.PRE_LOGIN_NOTIFICATIONS.isEnabled() && !prefsWrapper.hasPreLoginNotificationBeenDisplayed()) {
             cancelCurrentNotificationWorkRequest()
             val notificationData = workDataOf(
                 LOGIN_NOTIFICATION_TYPE_KEY to notificationType.toString()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -41,7 +41,7 @@ class LoginNotificationScheduler @Inject constructor(
                 LOGIN_NOTIFICATION_TYPE_KEY to notificationType.name
             )
             val workRequest: WorkRequest =
-                OneTimeWorkRequestBuilder<LocalNotificationWorker>()
+                OneTimeWorkRequestBuilder<LoginHelpNotificationWorker>()
                     .setInputData(notificationData)
                     .setInitialDelay(NOTIFICATION_TEST_DELAY_IN_SECONDS, TimeUnit.SECONDS)
                     .build()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -7,7 +7,6 @@ import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import androidx.work.workDataOf
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.util.FeatureFlag
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -35,7 +34,7 @@ class LoginNotificationScheduler @Inject constructor(
     }
 
     fun scheduleNotification(notificationType: LoginHelpNotificationType) {
-        if (FeatureFlag.PRE_LOGIN_NOTIFICATIONS.isEnabled() && !prefsWrapper.hasPreLoginNotificationBeenDisplayed()) {
+        if (!prefsWrapper.hasPreLoginNotificationBeenDisplayed()) {
             cancelCurrentNotificationWorkRequest()
             val notificationData = workDataOf(
                 LOGIN_NOTIFICATION_TYPE_KEY to notificationType.toString()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -7,7 +7,6 @@ import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import androidx.work.workDataOf
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.ui.login.localnotifications.LocalNotificationWorker.Companion.PRE_LOGIN_LOCAL_NOTIFICATION_ID
 import com.woocommerce.android.util.FeatureFlag
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.UUID
@@ -21,13 +20,18 @@ class LoginNotificationScheduler @Inject constructor(
     companion object {
         const val LOGIN_NOTIFICATION_TYPE_KEY = "Notification-type"
         const val NOTIFICATION_TEST_DELAY_IN_SECONDS = 5L //TODO SET THIS TO 24H BEFORE MERGE
+        const val LOGIN_HELP_NOTIFICATION_ID = 1
+        const val LOGIN_HELP_NOTIFICATION_TAG = "login-help-notification"
     }
 
     private val workManager = WorkManager.getInstance(appContext)
 
     fun onLoginSuccess() {
         cancelCurrentNotificationWorkRequest()
-        NotificationManagerCompat.from(appContext).cancel(PRE_LOGIN_LOCAL_NOTIFICATION_ID)
+        NotificationManagerCompat.from(appContext).cancel(
+            LOGIN_HELP_NOTIFICATION_TAG,
+            LOGIN_HELP_NOTIFICATION_ID
+        )
     }
 
     fun scheduleNotification(notificationType: LoginSupportNotificationType) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2110,6 +2110,7 @@
     <string name="login_local_notification_no_interaction_title">Problems with logging in?</string>
     <string name="login_local_notification_no_interaction_description">Get some help!</string>
     <string name="login_local_notification_contact_support_button">Contact support</string>
+    <string name="login_local_notification_wordpress_login_button">Login with WordPress.com</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2107,10 +2107,11 @@
     <string name="install_wc_shipping_extension_name">WooCommerce Shipping</string>
 
     <!-- Login local notifications -->
-    <string name="login_local_notification_no_interaction_title">Problems with logging in?</string>
-    <string name="login_local_notification_no_interaction_description">Get some help!</string>
-    <string name="login_local_notification_contact_support_button">Contact support</string>
-    <string name="login_local_notification_wordpress_login_button">Login with WordPress.com</string>
+    <string name="login_help_notification_default_title">Problems with logging in?</string>
+    <string name="login_help_notification_no_interaction_default_description">Get some help!</string>
+    <string name="login_help_notification_site_error_description">Try login with your WordPress.com account</string>
+    <string name="login_help_notification_contact_support_button">Contact support</string>
+    <string name="login_help_notification_wordpress_login_button">Login with WordPress.com</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2107,9 +2107,8 @@
     <string name="install_wc_shipping_extension_name">WooCommerce Shipping</string>
 
     <!-- Login local notifications -->
-    <string name="login_local_notification_no_interaction_title">Trouble login in?</string>
-    <string name="login_local_notification_no_interaction_description">If you are experiencing issues login into your store from the app, please contact support so we can help you.</string>
-
+    <string name="login_local_notification_no_interaction_title">Problems with logging in?</string>
+    <string name="login_local_notification_no_interaction_description">Get some help!</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2109,6 +2109,7 @@
     <!-- Login local notifications -->
     <string name="login_local_notification_no_interaction_title">Problems with logging in?</string>
     <string name="login_local_notification_no_interaction_description">Get some help!</string>
+    <string name="login_local_notification_contact_support_button">Contact support</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part II: #6989

Part I is already merged and can be [checked here](https://github.com/woocommerce/woocommerce-android/pull/6990#event-7038429826). 

### Description
Iteration 1 pe5sF9-h9-p2 for login scheduled notifications:

- Display notification after 24h of the user experiencing an error when introducing their site address
- Notifications will have 2 CTAs
   - Contact Support
   - Login with WordPress.com
- Adds tracking for notification interactions

These changes are hidden under a feature flag until we confirm we want to activate this feature in Sprint 2022.14

### Testing instructions
- Open login flow
- Click login with site address and input a "non wordpress" site address. Like `google.com`
- Click continue
-  Wait around 5 secs for the notification to appear. 
- Check logcat `login_local_notification_displayed, Properties: {"type":"site_address_error","is_debug":true}`
- Click on "Contact Support" CTA and check it opens help/support section. NOTE: notification may appear collapsed, so buttons might not be visible until you expand. 


- Repeat the same flow and check that the notification is not shown again.
- Clear app data and repeat the same flow to display the notification again
- Click on "Login with WordPress.com" and check it opens Login with WordPress.com screen
- Check logcat for: `login_local_notification_tapped, Properties: {"type":"site_address_error","is_debug":true}`


- Repeat flow to make notification appear again by clearing app data
- Dismiss the notification
- Check logcat: `login_local_notification_dismissed, Properties: {"is_debug":true}`

### Images/gif

https://user-images.githubusercontent.com/2663464/180444011-cc85cd91-c1d6-4d36-8868-cea072094dbf.mp4



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.