### PR TITLE
Login Enhancement: Analytics for Jetpack Installation via Login Flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -99,6 +99,9 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     UNIFIED_LOGIN_FAILURE(siteless = true),
     UNIFIED_LOGIN_INTERACTION(siteless = true),
     LOGIN_NEW_TO_WOO_BUTTON_TAPPED(siteless = true),
+    LOGIN_JETPACK_SETUP_BUTTON_TAPPED(siteless = true),
+    LOGIN_JETPACK_SETUP_DISMISSED(siteless = true),
+    LOGIN_JETPACK_SETUP_COMPLETED(siteless = true),
 
     // -- Site Picker
     SITE_PICKER_STORES_SHOWN(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -354,6 +354,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_COUPON_EXPIRY_DATE_UPDATED = "expiry_date_updated"
         const val KEY_COUPON_USAGE_RESTRICTIONS_UPDATED = "usage_restrictions_updated"
 
+        // -- Jetpack Installation
+        const val VALUE_JETPACK_INSTALLATION_SOURCE_WEB = "web"
+        const val VALUE_JETPACK_INSTALLATION_SOURCE_NATIVE = "native"
+
         var sendUsageStats: Boolean = true
             set(value) {
                 if (value != field) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -15,6 +15,8 @@ import com.woocommerce.android.AppUrls.LOGIN_WITH_EMAIL_WHAT_IS_WORDPRESS_COM_AC
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_JETPACK_INSTALLATION_SOURCE_WEB
 import com.woocommerce.android.databinding.ActivityLoginBinding
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -104,6 +106,10 @@ class LoginActivity :
         setContentView(binding.root)
 
         if (hasJetpackConnectedIntent()) {
+            AnalyticsTracker.track(
+                stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_COMPLETED,
+                properties = mapOf(KEY_SOURCE to VALUE_JETPACK_INSTALLATION_SOURCE_WEB)
+            )
             startLoginViaWPCom()
         } else if (hasMagicLinkLoginIntent()) {
             getAuthTokenFromIntent()?.let { showMagicLinkInterceptFragment(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -100,7 +100,10 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
             mInputPassword = it.getString(ARG_INPUT_PASSWORD, null)
             userAvatarUrl = it.getString(ARG_USER_AVATAR_URL, null)
             mCheckJetpackAvailability = it.getBoolean(ARG_CHECK_JETPACK_AVAILABILITY)
-            isJetpackConnectCustomTabOpened = it.getBoolean(ARG_IS_JETPACK_CONNECT_CUSTOM_TAB_OPENED)
+        }
+
+        savedInstanceState?.let { bundle ->
+            isJetpackConnectCustomTabOpened = bundle.getBoolean(ARG_IS_JETPACK_CONNECT_CUSTOM_TAB_OPENED)
         }
     }
 
@@ -267,5 +270,10 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
         jetpackLoginListener?.showUsernamePasswordScreen(
             siteAddress, siteXmlRpcAddress, mInputUsername, mInputPassword
         )
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(ARG_IS_JETPACK_CONNECT_CUSTOM_TAB_OPENED, isJetpackConnectCustomTabOpened)
+        super.onSaveInstanceState(outState)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -22,6 +22,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_JETPACK_INSTALLATION_SOURCE_WEB
 import com.woocommerce.android.databinding.FragmentLoginNoJetpackBinding
 import com.woocommerce.android.databinding.ViewLoginNoStoresBinding
 import com.woocommerce.android.databinding.ViewLoginUserInfoBinding
@@ -41,6 +43,7 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
         private const val ARG_INPUT_PASSWORD = "ARG_INPUT_PASSWORD"
         private const val ARG_USER_AVATAR_URL = "ARG_USER_AVATAR_URL"
         private const val ARG_CHECK_JETPACK_AVAILABILITY = "ARG_CHECK_JETPACK_AVAILABILITY"
+        private const val ARG_IS_JETPACK_CONNECT_CUSTOM_TAB_OPENED = "ARG_IS_JETPACK_CONNECT_CUSTOM_TAB_OPENED"
 
         fun newInstance(
             siteAddress: String,
@@ -70,6 +73,7 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
     private var mInputUsername: String? = null
     private var mInputPassword: String? = null
     private var userAvatarUrl: String? = null
+    private var isJetpackConnectCustomTabOpened = false
 
     @Suppress("DEPRECATION") private var progressDialog: ProgressDialog? = null
 
@@ -96,6 +100,7 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
             mInputPassword = it.getString(ARG_INPUT_PASSWORD, null)
             userAvatarUrl = it.getString(ARG_USER_AVATAR_URL, null)
             mCheckJetpackAvailability = it.getBoolean(ARG_CHECK_JETPACK_AVAILABILITY)
+            isJetpackConnectCustomTabOpened = it.getBoolean(ARG_IS_JETPACK_CONNECT_CUSTOM_TAB_OPENED)
         }
     }
 
@@ -153,6 +158,7 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
         with(btnBinding.buttonPrimary) {
             text = getString(R.string.login_jetpack_install)
             setOnClickListener {
+                isJetpackConnectCustomTabOpened = true
                 AnalyticsTracker.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_BUTTON_TAPPED)
                 jetpackLoginListener?.startJetpackInstall(siteAddress)
             }
@@ -202,6 +208,16 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
         AnalyticsTracker.track(AnalyticsEvent.LOGIN_NO_JETPACK_SCREEN_VIEWED)
+
+        // This is used to track whether the Jetpack Connect Custom Tab is dismissed
+        // before connection is finished.
+        if (isJetpackConnectCustomTabOpened) {
+            AnalyticsTracker.track(
+                stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_DISMISSED,
+                properties = mapOf(KEY_SOURCE to VALUE_JETPACK_INSTALLATION_SOURCE_WEB)
+            )
+            isJetpackConnectCustomTabOpened = false
+        }
     }
 
     private fun initializeViewModel() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -153,6 +153,7 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
         with(btnBinding.buttonPrimary) {
             text = getString(R.string.login_jetpack_install)
             setOnClickListener {
+                AnalyticsTracker.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_BUTTON_TAPPED)
                 jetpackLoginListener?.startJetpackInstall(siteAddress)
             }
         }


### PR DESCRIPTION
Part 03 of #7003
⚠️  Please do not merge before #7007 is merged.
Once this is merged, branch [feature/install-jetpack-from-login](https://github.com/woocommerce/woocommerce-android/tree/feature/install-jetpack-from-login) will need to be merged to `trunk`.


### Description

This PR adds analytics to the Jetpack setup flow:

Event | Trigger | Properties
-- | -- | --
login_jetpack_setup_button_tapped | The user taps the Install Jetpack button on the Jetpack error screen. |  
login_jetpack_setup_dismissed | The user taps the Cancel button or swipes down to dismiss the modal. | source: web \| native
login_jetpack_setup_completed | The Jetpack install flow completes. | source: web \| native

This is similar to the tracking for iOS (https://github.com/woocommerce/woocommerce-ios/issues/7269). The difference is that `LOGIN_JETPACK_SETUP_FLOW` is not included. The current solution using Custom Tab does not allow checking currently opened URL, so finding the current setup flow is not possible.

### Testing
1. Create a self-hosted test site with WooCommerce but no Jetpack.
2. Start app, skip initial carousel,
3. On the login screen, select "Enter your store address",
4. Enter the site address created on step 1,
5. On the next screen, enter site username / password,
6. On the next screen, tap "Install Jetpack" button, notice in logcat: `🔵 Tracked: login_jetpack_setup_button_tapped`.
7. Close the Custom Tab that opened, then notice in logcat: `🔵 Tracked: login_jetpack_setup_dismissed` with `source: web`.
8.  Tap "Install Jetpack" button again,
9. Follow the steps in the screen, which will involve entering site credentials, installing Jetpack, activating Jetpack, logging in to WPCom account, and accepting connection,
10. Eventually the connection process will complete, in which case the screen will redirect automatically back to the app, opening the "Login with WPCom email" flow.  Notice in logcat: `🔵 Tracked: login_jetpack_setup_completed` with `source: web`