### PR TITLE
Site credentials A/B test

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -645,4 +645,6 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     LOGIN_LOCAL_NOTIFICATION_DISPLAYED(siteless = true),
     LOGIN_LOCAL_NOTIFICATION_TAPPED(siteless = true),
     LOGIN_LOCAL_NOTIFICATION_DISMISSED(siteless = true),
+
+    LOGIN_SITE_CREDENTIALS_EXPERIMENT
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -370,6 +370,9 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_BANNER_UPSELL_CARD_READERS = "upsell_card_readers"
         const val KEY_BANNER_REMIND_LATER = "remind_later"
 
+        // -- Experiments
+        const val KEY_SITE_CREDENTIALS_EXPERIMENT_VARIANT = "site_credentials_experiment_variant"
+
         var sendUsageStats: Boolean = true
             set(value) {
                 if (value != field) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
@@ -5,6 +5,7 @@ import com.google.firebase.analytics.ktx.ParametersBuilder
 interface ExperimentTracker {
     companion object {
         const val PROLOGUE_CAROUSEL_DISPLAYED_EVENT = "prologue_carousel_displayed"
+        const val SITE_CREDENTIALS_EXPERIMENT_ELIGIBLE_EVENT = "site_credentials_experiment_eligible"
         const val LOGIN_SUCCESSFUL_EVENT = "login_successful"
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/DataStoreRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/DataStoreRemoteConfigRepository.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.config
 
-import androidx.compose.ui.text.toUpperCase
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/DataStoreRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/DataStoreRemoteConfigRepository.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.config
 
+import androidx.compose.ui.text.toUpperCase
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
@@ -7,6 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.experiment.PrologueVariant
+import com.woocommerce.android.experiment.SiteLoginExperiment.SiteLoginVariant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -16,6 +18,7 @@ class DataStoreRemoteConfigRepository @Inject constructor(
 ) : RemoteConfigRepository {
     companion object {
         const val PROLOGUE_VARIANT_KEY = "prologue_variant_key"
+        const val SITE_CREDENTIALS_EXPERIMENT_VARIANT_KEY = "site_credentials_experiment_variant_key"
     }
 
     override fun observePrologueVariant(): Flow<PrologueVariant> {
@@ -28,7 +31,22 @@ class DataStoreRemoteConfigRepository @Inject constructor(
 
     override suspend fun updatePrologueVariantValue(variantValue: String) {
         dataStore.edit { trackerPreferences ->
-            trackerPreferences[stringPreferencesKey(PROLOGUE_VARIANT_KEY)] = variantValue
+            trackerPreferences[stringPreferencesKey(PROLOGUE_VARIANT_KEY)] = variantValue.uppercase()
+        }
+    }
+
+    override fun observeSiteLoginVariant(): Flow<SiteLoginVariant> {
+        return dataStore.data.map { preferences ->
+            SiteLoginVariant.valueOf(
+                preferences[stringPreferencesKey(SITE_CREDENTIALS_EXPERIMENT_VARIANT_KEY)]
+                    ?: SiteLoginVariant.EMAIL_LOGIN.toString()
+            )
+        }
+    }
+
+    override suspend fun updateSiteLoginVariantValue(variantValue: String) {
+        dataStore.edit { trackerPreferences ->
+            trackerPreferences[stringPreferencesKey(SITE_CREDENTIALS_EXPERIMENT_VARIANT_KEY)] = variantValue.uppercase()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigManager.kt
@@ -42,10 +42,12 @@ class RemoteConfigManager @Inject constructor(
     fun getRemoteConfigValues() {
         remoteConfig.fetchAndActivate()
             .addOnSuccessListener {
-                val variant = remoteConfig.getString("prologue_variant")
+                val prologueVariant = remoteConfig.getString("prologue_variant")
+                val siteLoginVariant = remoteConfig.getString("site_credentials_emphasis")
 
                 scope.launch {
-                    repository.updatePrologueVariantValue(variant)
+                    repository.updatePrologueVariantValue(prologueVariant)
+                    repository.updateSiteLoginVariantValue(siteLoginVariant)
                 }
             }
             .addOnFailureListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -1,9 +1,13 @@
 package com.woocommerce.android.config
 
 import com.woocommerce.android.experiment.PrologueVariant
+import com.woocommerce.android.experiment.SiteLoginExperiment.SiteLoginVariant
 import kotlinx.coroutines.flow.Flow
 
 interface RemoteConfigRepository {
     fun observePrologueVariant(): Flow<PrologueVariant>
     suspend fun updatePrologueVariantValue(variantValue: String)
+
+    fun observeSiteLoginVariant(): Flow<SiteLoginVariant>
+    suspend fun updateSiteLoginVariantValue(variantValue: String)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SiteLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SiteLoginExperiment.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.experiment
+
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.analytics.ExperimentTracker
+import com.woocommerce.android.config.RemoteConfigRepository
+import com.woocommerce.android.experiment.SiteLoginExperiment.SiteLoginVariant.EMAIL_LOGIN
+import com.woocommerce.android.experiment.SiteLoginExperiment.SiteLoginVariant.SITE_CREDENTIALS_LOGIN
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class SiteLoginExperiment @Inject constructor(
+    private val experimentTracker: ExperimentTracker,
+    private val remoteConfigRepository: RemoteConfigRepository,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+) {
+    suspend fun run(
+        siteAddress: String?,
+        loginViaEmail: (String?) -> Unit,
+        loginViaSiteCredentials: (String?) -> Unit
+    ) {
+        experimentTracker.log(ExperimentTracker.SITE_CREDENTIALS_EXPERIMENT_ELIGIBLE_EVENT)
+
+        val loginVariant = remoteConfigRepository.observeSiteLoginVariant().first()
+
+        // track the variant used
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.LOGIN_SITE_CREDENTIALS_EXPERIMENT,
+            mapOf(Pair(AnalyticsTracker.KEY_SITE_CREDENTIALS_EXPERIMENT_VARIANT, loginVariant))
+        )
+
+        when (loginVariant) {
+            EMAIL_LOGIN -> loginViaEmail(siteAddress)
+            SITE_CREDENTIALS_LOGIN -> loginViaSiteCredentials(siteAddress)
+        }
+    }
+
+    fun trackSuccess() {
+        experimentTracker.log(ExperimentTracker.LOGIN_SUCCESSFUL_EVENT)
+    }
+
+    enum class SiteLoginVariant {
+        EMAIL_LOGIN,
+        SITE_CREDENTIALS_LOGIN
+    }
+}

--- a/WooCommerce/src/main/res/xml/remote_config_values.xml
+++ b/WooCommerce/src/main/res/xml/remote_config_values.xml
@@ -4,4 +4,8 @@
         <key>prologue_variant</key>
         <value>control</value>
     </entry>
+    <entry>
+        <key>site_credentials_emphasis</key>
+        <value>site_credentials_login</value>
+    </entry>
 </defaultsMap>


### PR DESCRIPTION
This PR changes the  site credentials emphasis experiment from showing credentials login for self-hosted site by default to using an A/B test.

**To test:**
Not much should change here for testing. The default value is still the site credentials login for self-hosted sites, but once the new version is released, this will be split 50/50 by an A/B test.

1. Start the app and tap on the "Enter your store address" button
2. Enter the address of a WP.com site
3. **After the site check, notice the login with email screen is shown**
4. Now go back to the site address screen
5. Enter the address of a non-WP.com site
6. **After the site check, notice the credentials login screen is shown**