### PR TITLE
Fix WorkManager initialization in UI tests

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceTest.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import com.yarolegovich.wellsql.WellSql
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -14,11 +16,17 @@ import dagger.hilt.components.SingletonComponent
 @CustomTestApplication(BaseWooCommerce::class)
 interface WooCommerceTest
 
-open class BaseWooCommerce : Application(), HasAndroidInjector {
+open class BaseWooCommerce : Application(), HasAndroidInjector, Configuration.Provider {
     @EntryPoint
     @InstallIn(SingletonComponent::class)
     interface AndroidInjectorEntryPoint {
         fun injector(): DispatchingAndroidInjector<Any>
+    }
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface HiltWorkerFactoryEntryPoint {
+        fun workerFactory(): HiltWorkerFactory
     }
 
     override fun onCreate() {
@@ -32,5 +40,16 @@ open class BaseWooCommerce : Application(), HasAndroidInjector {
             applicationContext,
             AndroidInjectorEntryPoint::class.java
         ).injector()
+    }
+
+    override fun getWorkManagerConfiguration(): Configuration {
+        val hiltWorkerFactory = EntryPoints.get(
+            applicationContext,
+            HiltWorkerFactoryEntryPoint::class.java
+        ).workerFactory()
+
+        return Configuration.Builder()
+            .setWorkerFactory(hiltWorkerFactory)
+            .build()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/login/CarouselScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/login/CarouselScreen.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.screenshots.login
+
+import com.woocommerce.android.R
+import com.woocommerce.android.screenshots.util.Screen
+
+class CarouselScreen : Screen(SKIP_BUTTON) {
+    companion object {
+        val SKIP_BUTTON = R.id.button_skip
+    }
+
+    fun skip(): WelcomeScreen {
+        clickOn(SKIP_BUTTON)
+        return WelcomeScreen()
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/login/WelcomeScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/login/WelcomeScreen.kt
@@ -20,7 +20,11 @@ class WelcomeScreen : Screen {
 
             Thread.sleep(1000)
 
-            return WelcomeScreen()
+            return if (isElementDisplayed(CarouselScreen.SKIP_BUTTON)) {
+                CarouselScreen().skip()
+            } else {
+                WelcomeScreen()
+            }
         }
     }
 


### PR DESCRIPTION
### Description
WorkManager was added in https://github.com/woocommerce/woocommerce-android/pull/6990, and this broke UI tests, this PR fixes this.
This PR also fixes the login step in the UI tests: supports skipping the carousel in the prologue.

### Testing instructions
1. Comment/delete this [line](https://github.com/woocommerce/woocommerce-android/blob/c4448b040cbc206bbd4fbefd5488a8fa9dbec215/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt#L69)
2. Execute the `screenshots` test from the `ScreenshotTest` class.
3. Confirm the test runs successfully.

The `@Ignore` annotation has been added by platform9 because the test fails on CI, I'll try to investigate this more, and hopefully fix in a separate PR.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
