### PR TITLE
Show red budge on the more button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivityMainBinding
 import com.woocommerce.android.extensions.active
 import com.woocommerce.android.extensions.collapse
+import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
@@ -58,6 +59,9 @@ import com.woocommerce.android.ui.main.BottomNavigationPosition.MORE
 import com.woocommerce.android.ui.main.BottomNavigationPosition.MY_STORE
 import com.woocommerce.android.ui.main.BottomNavigationPosition.ORDERS
 import com.woocommerce.android.ui.main.BottomNavigationPosition.PRODUCTS
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
 import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForNotification
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShowFeatureAnnouncement
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
@@ -616,10 +620,6 @@ class MainActivity :
         binding.bottomNav.setOrderBadgeCount(0)
     }
 
-    private fun showMoreMenuBadge(count: Int) {
-        binding.bottomNav.showMoreMenuBadge(count)
-    }
-
     override fun onNavItemSelected(navPos: BottomNavigationPosition) {
         val stat = when (navPos) {
             MY_STORE -> AnalyticsEvent.MAIN_TAB_DASHBOARD_SELECTED
@@ -716,8 +716,12 @@ class MainActivity :
             }
         }
 
-        viewModel.unseenReviewsCount.observe(this) { count ->
-            showMoreMenuBadge(count)
+        viewModel.moreMenuBadgeState.observe(this) { moreMenuBadgeState ->
+            when (moreMenuBadgeState) {
+                is UnseenReviews -> binding.bottomNav.showMoreMenuUnseenReviewsBadge(moreMenuBadgeState.count)
+                NewFeature -> binding.bottomNav.showMoreMenuNewFeatureBadge()
+                Hidden -> binding.bottomNav.hideMoreMenuBadge()
+            }.exhaustive
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -13,6 +13,10 @@ import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureProvider
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.WooLog
@@ -20,6 +24,7 @@ import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
@@ -34,7 +39,8 @@ class MainActivityViewModel @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper,
     private val prefs: AppPrefs,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    unseenReviewsCountHandler: UnseenReviewsCountHandler
+    private val moreMenuNewFeatureProvider: MoreMenuNewFeatureProvider,
+    unseenReviewsCountHandler: UnseenReviewsCountHandler,
 ) : ScopedViewModel(savedState) {
     init {
         launch {
@@ -44,7 +50,10 @@ class MainActivityViewModel @Inject constructor(
 
     val startDestination = if (selectedSite.exists()) R.id.dashboard else R.id.sitePickerFragment
 
-    val unseenReviewsCount = unseenReviewsCountHandler.observeUnseenCount().asLiveData()
+    val moreMenuBadgeState = unseenReviewsCountHandler
+        .observeUnseenCount()
+        .map { determineMenuBadgeState(it) }
+        .asLiveData()
 
     fun removeOrderNotifications() {
         notificationHandler.removeNotificationsOfTypeFromSystemsBar(
@@ -110,6 +119,10 @@ class MainActivityViewModel @Inject constructor(
         }
     }
 
+    private fun determineMenuBadgeState(count: Int) =
+        if (moreMenuNewFeatureProvider.provideNewFeatures().isNotEmpty()) NewFeature
+        else if (count > 0) UnseenReviews(count) else Hidden
+
     fun showFeatureAnnouncementIfNeeded() {
         launch {
             val cachedAnnouncement = featureAnnouncementRepository.getLatestFeatureAnnouncement(fromCache = true)
@@ -143,4 +156,10 @@ class MainActivityViewModel @Inject constructor(
     data class ShowFeatureAnnouncement(val announcement: FeatureAnnouncement) : Event()
     data class ViewReviewDetail(val uniqueId: Long) : Event()
     data class ViewOrderDetail(val uniqueId: Long, val remoteNoteId: Long) : Event()
+
+    sealed class MoreMenuBadgeState {
+        data class UnseenReviews(val count: Int) : MoreMenuBadgeState()
+        object NewFeature : MoreMenuBadgeState()
+        object Hidden : MoreMenuBadgeState()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -81,7 +81,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
         moreMenuBadge = getOrCreateBadge(R.id.moreMenu)
         moreMenuBadge.isVisible = false
-        moreMenuBadge.backgroundColor = ContextCompat.getColor(context, R.color.color_primary)
     }
 
     /**
@@ -111,20 +110,27 @@ class MainBottomNavigationView @JvmOverloads constructor(
         assignNavigationListeners(true)
     }
 
-    fun showMoreMenuBadge(count: Int) {
-        showBadge(moreMenuBadge, count)
+    fun showMoreMenuUnseenReviewsBadge(count: Int) {
+        moreMenuBadge.backgroundColor = ContextCompat.getColor(context, R.color.color_primary)
+        moreMenuBadge.number = count
+        moreMenuBadge.isVisible = true
+    }
+
+    fun showMoreMenuNewFeatureBadge() {
+        moreMenuBadge.backgroundColor = ContextCompat.getColor(context, R.color.color_secondary)
+        moreMenuBadge.isVisible = true
+    }
+
+    fun hideMoreMenuBadge() {
+        moreMenuBadge.isVisible = false
     }
 
     fun setOrderBadgeCount(count: Int) {
-        showBadge(ordersBadge, count)
-    }
-
-    private fun showBadge(badgeDrawable: BadgeDrawable, count: Int) {
         if (count > 0) {
-            badgeDrawable.number = count
-            badgeDrawable.isVisible = true
+            ordersBadge.number = count
+            ordersBadge.isVisible = true
         } else {
-            badgeDrawable.isVisible = false
+            ordersBadge.isVisible = false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureAvailableProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureAvailableProvider.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.moremenu
+
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature.Payments
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class MoreMenuNewFeatureProvider @Inject constructor() {
+    fun provideNewFeatures() = listOf(Payments)
+}
+
+enum class MoreMenuNewFeature {
+    Payments
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -366,7 +366,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given zero unseen reviews and new features, when listening badge state, then hidden returned`() =
+    fun `given zero unseen reviews and no new features, when listening badge state, then hidden returned`() =
         testBlocking {
             // GIVEN
             whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(0))
@@ -400,6 +400,21 @@ class MainActivityViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(1))
+            whenever(moreMenuNewFeatureProvider.provideNewFeatures()).thenReturn(listOf(Payments))
+            createViewModel()
+
+            // WHEN
+            viewModel.moreMenuBadgeState.observeForever { }
+
+            // THEN
+            assertThat(viewModel.moreMenuBadgeState.value).isEqualTo(NewFeature)
+        }
+
+    @Test
+    fun `given zero unseen reviews and new features, when listening badge state, then new feature returned`() =
+        testBlocking {
+            // GIVEN
+            whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(0))
             whenever(moreMenuNewFeatureProvider.provideNewFeatures()).thenReturn(listOf(Payments))
             createViewModel()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -13,6 +13,9 @@ import com.woocommerce.android.push.NotificationTestUtils
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.push.WooNotificationType
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
 import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForNotification
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShowFeatureAnnouncement
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
@@ -21,11 +24,14 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewDetail
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature.Payments
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureProvider
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -99,8 +105,9 @@ class MainActivityViewModelTest : BaseUnitTest() {
     private val featureAnnouncementRepository: FeatureAnnouncementRepository = mock()
     private val buildConfigWrapper: BuildConfigWrapper = mock()
     private val prefs: AppPrefs = mock()
+    private val moreMenuNewFeatureProvider: MoreMenuNewFeatureProvider = mock()
     private val unseenReviewsCountHandler: UnseenReviewsCountHandler = mock {
-        on { observeUnseenCount() } doReturn MutableStateFlow(0)
+        on { observeUnseenCount() } doReturn MutableStateFlow(1)
     }
 
     private val testAnnouncement = FeatureAnnouncement(
@@ -135,19 +142,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        viewModel = spy(
-            MainActivityViewModel(
-                savedStateHandle,
-                siteStore,
-                selectedSite,
-                notificationMessageHandler,
-                featureAnnouncementRepository,
-                buildConfigWrapper,
-                prefs,
-                analyticsTrackerWrapper,
-                unseenReviewsCountHandler
-            )
-        )
+        createViewModel()
 
         clearInvocations(
             viewModel,
@@ -369,4 +364,66 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 )
             )
         }
+
+    @Test
+    fun `given zero unseen reviews and new features, when listening badge state, then hidden returned`() =
+        testBlocking {
+            // GIVEN
+            whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(0))
+            whenever(moreMenuNewFeatureProvider.provideNewFeatures()).thenReturn(emptyList())
+            createViewModel()
+
+            // WHEN
+            viewModel.moreMenuBadgeState.observeForever { }
+
+            // THEN
+            assertThat(viewModel.moreMenuBadgeState.value).isEqualTo(Hidden)
+        }
+
+    @Test
+    fun `given unseen reviews and no new features, when listening badge state, then unseen reviews returned`() =
+        testBlocking {
+            // GIVEN
+            whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(1))
+            whenever(moreMenuNewFeatureProvider.provideNewFeatures()).thenReturn(emptyList())
+            createViewModel()
+
+            // WHEN
+            viewModel.moreMenuBadgeState.observeForever {}
+
+            // THEN
+            assertThat(viewModel.moreMenuBadgeState.value).isEqualTo(UnseenReviews(1))
+        }
+
+    @Test
+    fun `given unseen reviews and new features, when listening badge state, then new feature returned`() =
+        testBlocking {
+            // GIVEN
+            whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(1))
+            whenever(moreMenuNewFeatureProvider.provideNewFeatures()).thenReturn(listOf(Payments))
+            createViewModel()
+
+            // WHEN
+            viewModel.moreMenuBadgeState.observeForever { }
+
+            // THEN
+            assertThat(viewModel.moreMenuBadgeState.value).isEqualTo(NewFeature)
+        }
+
+    private fun createViewModel() {
+        viewModel = spy(
+            MainActivityViewModel(
+                savedStateHandle,
+                siteStore,
+                selectedSite,
+                notificationMessageHandler,
+                featureAnnouncementRepository,
+                buildConfigWrapper,
+                prefs,
+                analyticsTrackerWrapper,
+                moreMenuNewFeatureProvider,
+                unseenReviewsCountHandler,
+            )
+        )
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7018
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a red badge that indicates that there is a new feature in the "more"  screen. We show it in priority to the unseen reviews badge. Currently we show it all the time, in the next issue I'll add hidden that after a user visited the "more" screen

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open the app and notice a red dot on the right
2. Have unseen reviews and change the code of `MoreMenuNewFeatureProvider` to return empty list notice unseen reviews badge
3. Have all the reviews seen and notice that there is no badge anymore

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="107" alt="image" src="https://user-images.githubusercontent.com/4923871/180925165-47f45402-2280-4ce0-8e8b-567e337796f3.png">
<img width="100" alt="image" src="https://user-images.githubusercontent.com/4923871/180925211-646b57ec-3620-42cc-b833-fcbfa26d349b.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
