### PR TITLE
Payments icon to more screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MenuUiButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MenuUiButton.kt
@@ -13,6 +13,7 @@ data class MenuUiButton(
 )
 
 enum class MenuButtonType {
+    VIEW_PAYMENTS,
     VIEW_ADMIN,
     VIEW_STORE,
     COUPONS,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MenuUiButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MenuUiButton.kt
@@ -4,19 +4,9 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 
 data class MenuUiButton(
-    val type: MenuButtonType,
     @StringRes val text: Int,
     @DrawableRes val icon: Int,
     val badgeCount: Int = 0,
     val isEnabled: Boolean = true,
     val onClick: () -> Unit = {},
 )
-
-enum class MenuButtonType {
-    VIEW_PAYMENTS,
-    VIEW_ADMIN,
-    VIEW_STORE,
-    COUPONS,
-    PRODUCT_REVIEWS,
-    INBOX
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.Start
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewAdminEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewCouponsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewInboxEvent
+import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewPayments
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewReviewsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewStoreEvent
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -83,8 +84,12 @@ class MoreMenuFragment : TopLevelFragment() {
                 is ViewReviewsEvent -> navigateToReviews()
                 is ViewInboxEvent -> navigateToInbox()
                 is ViewCouponsEvent -> navigateToCoupons()
+                is ViewPayments -> navigateToPayments()
             }
         }
+    }
+
+    private fun navigateToPayments() {
     }
 
     private fun navigateToSettings() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewI
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewPayments
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewReviewsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewStoreEvent
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -90,6 +91,9 @@ class MoreMenuFragment : TopLevelFragment() {
     }
 
     private fun navigateToPayments() {
+        findNavController().navigateSafely(
+            MoreMenuFragmentDirections.actionMoreMenuToPaymentFlow(CardReaderFlowParam.CardReadersHub)
+        )
     }
 
     private fun navigateToSettings() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.moremenu
 
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
@@ -49,6 +51,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.bumptech.glide.Glide
@@ -89,7 +92,7 @@ fun MoreMenuScreen(
 @Composable
 private fun MoreMenuItems(state: MoreMenuViewState) {
     LazyVerticalGrid(
-        cells = Fixed(2),
+        cells = Fixed(3),
         contentPadding = PaddingValues(
             horizontal = dimensionResource(id = R.dimen.major_100),
             vertical = dimensionResource(id = R.dimen.major_100)
@@ -270,7 +273,7 @@ private fun MoreMenuButton(
                         painter = painterResource(id = iconDrawable),
                         contentDescription = stringResource(id = text),
                         modifier = Modifier
-                            .size(dimensionResource(id = R.dimen.major_200))
+                            .size(dimensionResource(id = R.dimen.major_150))
                             .align(Alignment.Center)
                     )
                 }
@@ -310,12 +313,17 @@ fun MoreMenuBadge(badgeCount: Int) {
 }
 
 @ExperimentalFoundationApi
-@Preview
+@Preview(name = "dark", uiMode = UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = UI_MODE_NIGHT_NO)
+@Preview(name = "small screen", device = Devices.PIXEL)
+@Preview(name = "mid screen", device = Devices.PIXEL_4)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
 @Composable
 private fun MoreMenuPreview() {
     val state = MoreMenuViewState(
         moreMenuItems = listOf(
-            MenuUiButton(string.more_menu_button_woo_admin, drawable.ic_more_menu_wp_admin),
+            MenuUiButton(string.more_menu_button_payments, drawable.ic_more_menu_payments),
+            MenuUiButton(string.more_menu_button_wс_admin, drawable.ic_more_menu_wp_admin),
             MenuUiButton(string.more_menu_button_store, drawable.ic_more_menu_store),
             MenuUiButton(string.more_menu_button_coupons, drawable.ic_more_menu_coupons),
             MenuUiButton(string.more_menu_button_reviews, drawable.ic_more_menu_reviews, 3)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -58,10 +58,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ui.moremenu.MenuButtonType.COUPONS
-import com.woocommerce.android.ui.moremenu.MenuButtonType.PRODUCT_REVIEWS
-import com.woocommerce.android.ui.moremenu.MenuButtonType.VIEW_ADMIN
-import com.woocommerce.android.ui.moremenu.MenuButtonType.VIEW_STORE
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuViewState
 
 @ExperimentalFoundationApi
@@ -319,10 +315,10 @@ fun MoreMenuBadge(badgeCount: Int) {
 private fun MoreMenuPreview() {
     val state = MoreMenuViewState(
         moreMenuItems = listOf(
-            MenuUiButton(VIEW_ADMIN, string.more_menu_button_woo_admin, drawable.ic_more_menu_wp_admin),
-            MenuUiButton(VIEW_STORE, string.more_menu_button_store, drawable.ic_more_menu_store),
-            MenuUiButton(COUPONS, string.more_menu_button_coupons, drawable.ic_more_menu_coupons),
-            MenuUiButton(PRODUCT_REVIEWS, string.more_menu_button_reviews, drawable.ic_more_menu_reviews, 3)
+            MenuUiButton(string.more_menu_button_woo_admin, drawable.ic_more_menu_wp_admin),
+            MenuUiButton(string.more_menu_button_store, drawable.ic_more_menu_store),
+            MenuUiButton(string.more_menu_button_coupons, drawable.ic_more_menu_coupons),
+            MenuUiButton(string.more_menu_button_reviews, drawable.ic_more_menu_reviews, 3)
         ),
         siteName = "Example Site",
         siteUrl = "woocommerce.com",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -59,7 +59,7 @@ class MoreMenuViewModel @Inject constructor(
                 onClick = ::onPaymentsButtonClick
             ),
             MenuUiButton(
-                text = R.string.more_menu_button_woo_admin,
+                text = R.string.more_menu_button_wс_admin,
                 icon = R.drawable.ic_more_menu_wp_admin,
                 onClick = ::onViewAdminButtonClick
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.moremenu.MenuButtonType.COUPONS
 import com.woocommerce.android.ui.moremenu.MenuButtonType.INBOX
 import com.woocommerce.android.ui.moremenu.MenuButtonType.PRODUCT_REVIEWS
 import com.woocommerce.android.ui.moremenu.MenuButtonType.VIEW_ADMIN
+import com.woocommerce.android.ui.moremenu.MenuButtonType.VIEW_PAYMENTS
 import com.woocommerce.android.ui.moremenu.MenuButtonType.VIEW_STORE
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -58,6 +59,12 @@ class MoreMenuViewModel @Inject constructor(
 
     private suspend fun generateMenuButtons(unseenReviewsCount: Int, isCouponsEnabled: Boolean): List<MenuUiButton> =
         listOf(
+            MenuUiButton(
+                type = VIEW_PAYMENTS,
+                text = R.string.more_menu_button_payments,
+                icon = R.drawable.ic_more_menu_payments,
+                onClick = ::onPaymentsButtonClick
+            ),
             MenuUiButton(
                 type = VIEW_ADMIN,
                 text = R.string.more_menu_button_woo_admin,
@@ -116,6 +123,10 @@ class MoreMenuViewModel @Inject constructor(
         triggerEvent(MoreMenuEvent.StartSitePickerEvent)
     }
 
+    private fun onPaymentsButtonClick() {
+        triggerEvent(MoreMenuEvent.ViewPayments)
+    }
+
     private fun onViewAdminButtonClick() {
         trackMoreMenuOptionSelected(VALUE_MORE_MENU_ADMIN_MENU)
         triggerEvent(MoreMenuEvent.ViewAdminEvent(selectedSite.get().adminUrl))
@@ -158,6 +169,7 @@ class MoreMenuViewModel @Inject constructor(
     sealed class MoreMenuEvent : MultiLiveEvent.Event() {
         object NavigateToSettingsEvent : MoreMenuEvent()
         object StartSitePickerEvent : MoreMenuEvent()
+        object ViewPayments : MoreMenuEvent()
         data class ViewAdminEvent(val url: String) : MoreMenuEvent()
         data class ViewStoreEvent(val url: String) : MoreMenuEvent()
         object ViewReviewsEvent : MoreMenuEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -13,12 +13,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_M
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_VIEW_STORE
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.moremenu.MenuButtonType.COUPONS
-import com.woocommerce.android.ui.moremenu.MenuButtonType.INBOX
-import com.woocommerce.android.ui.moremenu.MenuButtonType.PRODUCT_REVIEWS
-import com.woocommerce.android.ui.moremenu.MenuButtonType.VIEW_ADMIN
-import com.woocommerce.android.ui.moremenu.MenuButtonType.VIEW_PAYMENTS
-import com.woocommerce.android.ui.moremenu.MenuButtonType.VIEW_STORE
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -57,42 +51,36 @@ class MoreMenuViewModel @Inject constructor(
         moreMenuNewFeatureHandler.markNewFeatureAsSeen()
     }
 
-    private suspend fun generateMenuButtons(unseenReviewsCount: Int, isCouponsEnabled: Boolean): List<MenuUiButton> =
+    private suspend fun generateMenuButtons(unseenReviewsCount: Int, isCouponsEnabled: Boolean) =
         listOf(
             MenuUiButton(
-                type = VIEW_PAYMENTS,
                 text = R.string.more_menu_button_payments,
                 icon = R.drawable.ic_more_menu_payments,
                 onClick = ::onPaymentsButtonClick
             ),
             MenuUiButton(
-                type = VIEW_ADMIN,
                 text = R.string.more_menu_button_woo_admin,
                 icon = R.drawable.ic_more_menu_wp_admin,
                 onClick = ::onViewAdminButtonClick
             ),
             MenuUiButton(
-                type = VIEW_STORE,
                 text = R.string.more_menu_button_store,
                 icon = R.drawable.ic_more_menu_store,
                 onClick = ::onViewStoreButtonClick
             ),
             MenuUiButton(
-                type = COUPONS,
                 text = R.string.more_menu_button_coupons,
                 icon = R.drawable.ic_more_menu_coupons,
                 isEnabled = isCouponsEnabled,
                 onClick = ::onCouponsButtonClick
             ),
             MenuUiButton(
-                type = PRODUCT_REVIEWS,
                 text = R.string.more_menu_button_reviews,
                 icon = R.drawable.ic_more_menu_reviews,
                 badgeCount = unseenReviewsCount,
                 onClick = ::onReviewsButtonClick
             ),
             MenuUiButton(
-                type = INBOX,
                 text = R.string.more_menu_button_inbox,
                 icon = R.drawable.ic_more_menu_inbox,
                 isEnabled = moreMenuRepository.isInboxEnabled(),

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -177,6 +177,14 @@
         <action
             android:id="@+id/action_moreMenu_to_couponListFragment"
             app:destination="@id/nav_graph_coupons" />
+        <action
+            android:id="@+id/action_moreMenu_to_paymentFlow"
+            app:destination="@id/paymentFlow" >
+            <argument
+                android:name="cardReaderFlowParam"
+                app:argType="com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam"
+                app:nullable="false" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/feedbackSurveyFragment"
@@ -394,4 +402,5 @@
     <action
         android:id="@+id/action_global_simpleTextEditorFragment"
         app:destination="@id/simpleTextEditorFragment" />
+    <include app:graph="@navigation/nav_graph_payment_flow" />
 </navigation>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -128,6 +128,6 @@ so that's the baseline as defined in `major_100`.
     <dimen name="card_reader_manuals_divider">105dp</dimen>
 
     <!-- More Menu dimens -->
-    <dimen name="more_menu_button_height">190dp</dimen>
+    <dimen name="more_menu_button_height">124dp</dimen>
 
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="review_notifications">Reviews</string>
     <string name="more_menu">Menu</string>
     <string name="more_menu_button_woo_admin">WooCommerce Admin</string>
+    <string name="more_menu_button_wс_admin">WC Admin</string>
     <string name="more_menu_button_payments">Payments</string>
     <string name="more_menu_button_analytics">Analytics</string>
     <string name="more_menu_button_inbox">Inbox</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7020
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds a new payment icon to the "more" screen. Also, it changes the grid to a smaller one. Payment button open the payment hub. Ignore for now the present of the Onboarding check - it will be gone latter

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open the "more" screen
* Notice the new payment icon. Check how it looks in both dark and light mode. Check different screen sizes
* Click on that and notice that it opens the payments hub screen

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/181154213-109141cb-7798-48bc-9da5-a3d317a60a74.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
