### PR TITLE
Show red badge on the new payments icon

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MenuUiButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MenuUiButton.kt
@@ -1,12 +1,23 @@
 package com.woocommerce.android.ui.moremenu
 
+import androidx.annotation.ColorRes
+import androidx.annotation.DimenRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 
 data class MenuUiButton(
     @StringRes val text: Int,
     @DrawableRes val icon: Int,
-    val badgeCount: Int = 0,
+    val badgeState: BadgeState? = null,
     val isEnabled: Boolean = true,
     val onClick: () -> Unit = {},
 )
+
+data class BadgeState(
+    @DimenRes val badgeSize: Int,
+    @ColorRes val backgroundColor: Int,
+    @ColorRes val textColor: Int,
+    val textState: TextState,
+)
+
+data class TextState(val text: String, @DimenRes val fontSize: Int)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -106,7 +106,7 @@ private fun MoreMenuItems(state: MoreMenuViewState) {
             MoreMenuButton(
                 text = item.text,
                 iconDrawable = item.icon,
-                badgeCount = item.badgeCount,
+                badgeState = item.badgeState,
                 onClick = item.onClick
             )
         }
@@ -243,7 +243,7 @@ private fun MoreMenuUserAvatar(avatarUrl: String) {
 private fun MoreMenuButton(
     @StringRes text: Int,
     @DrawableRes iconDrawable: Int,
-    badgeCount: Int,
+    badgeState: BadgeState?,
     onClick: () -> Unit,
 ) {
     Button(
@@ -256,7 +256,7 @@ private fun MoreMenuButton(
         shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_75))
     ) {
         Box(Modifier.fillMaxSize()) {
-            MoreMenuBadge(badgeCount = badgeCount)
+            MoreMenuBadge(badgeState = badgeState)
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
@@ -289,22 +289,22 @@ private fun MoreMenuButton(
 }
 
 @Composable
-fun MoreMenuBadge(badgeCount: Int) {
-    if (badgeCount > 0) {
+fun MoreMenuBadge(badgeState: BadgeState?) {
+    if (badgeState != null) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.End
         ) {
             Box(
                 modifier = Modifier
-                    .size(dimensionResource(id = R.dimen.major_150))
+                    .size(dimensionResource(id = badgeState.badgeSize))
                     .clip(CircleShape)
-                    .background(MaterialTheme.colors.primary)
+                    .background(colorResource(id = badgeState.backgroundColor))
             ) {
                 Text(
-                    text = badgeCount.toString(),
-                    fontSize = 13.sp,
-                    color = colorResource(id = color.color_on_surface_inverted),
+                    text = badgeState.textState.text,
+                    fontSize = dimensionResource(id = badgeState.textState.fontSize).value.sp,
+                    color = colorResource(id = badgeState.textColor),
                     modifier = Modifier.align(Alignment.Center)
                 )
             }
@@ -322,11 +322,27 @@ fun MoreMenuBadge(badgeCount: Int) {
 private fun MoreMenuPreview() {
     val state = MoreMenuViewState(
         moreMenuItems = listOf(
-            MenuUiButton(string.more_menu_button_payments, drawable.ic_more_menu_payments),
+            MenuUiButton(
+                string.more_menu_button_payments, drawable.ic_more_menu_payments,
+                BadgeState(
+                    badgeSize = R.dimen.major_85,
+                    backgroundColor = color.color_secondary,
+                    textColor = color.color_on_surface_inverted,
+                    textState = TextState("", R.dimen.text_minor_80),
+                )
+            ),
             MenuUiButton(string.more_menu_button_wс_admin, drawable.ic_more_menu_wp_admin),
             MenuUiButton(string.more_menu_button_store, drawable.ic_more_menu_store),
             MenuUiButton(string.more_menu_button_coupons, drawable.ic_more_menu_coupons),
-            MenuUiButton(string.more_menu_button_reviews, drawable.ic_more_menu_reviews, 3)
+            MenuUiButton(
+                string.more_menu_button_reviews, drawable.ic_more_menu_reviews,
+                BadgeState(
+                    badgeSize = R.dimen.major_150,
+                    backgroundColor = color.color_primary,
+                    textColor = color.color_on_surface_inverted,
+                    textState = TextState("3", R.dimen.text_minor_80),
+                )
+            )
         ),
         siteName = "Example Site",
         siteUrl = "woocommerce.com",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -56,6 +56,12 @@ class MoreMenuViewModel @Inject constructor(
             MenuUiButton(
                 text = R.string.more_menu_button_payments,
                 icon = R.drawable.ic_more_menu_payments,
+                badgeState = BadgeState(
+                    badgeSize = R.dimen.major_85,
+                    backgroundColor = R.color.color_secondary,
+                    textColor = R.color.color_on_surface_inverted,
+                    textState = TextState("", R.dimen.text_minor_80),
+                ),
                 onClick = ::onPaymentsButtonClick
             ),
             MenuUiButton(
@@ -77,7 +83,7 @@ class MoreMenuViewModel @Inject constructor(
             MenuUiButton(
                 text = R.string.more_menu_button_reviews,
                 icon = R.drawable.ic_more_menu_reviews,
-                badgeCount = unseenReviewsCount,
+                badgeState = buildUnseenReviewsBadgeState(unseenReviewsCount),
                 onClick = ::onReviewsButtonClick
             ),
             MenuUiButton(
@@ -87,6 +93,14 @@ class MoreMenuViewModel @Inject constructor(
                 onClick = ::onInboxButtonClick
             )
         )
+
+    private fun buildUnseenReviewsBadgeState(unseenReviewsCount: Int) =
+        if (unseenReviewsCount > 0) BadgeState(
+            badgeSize = R.dimen.major_150,
+            backgroundColor = R.color.color_primary,
+            textColor = R.color.color_on_surface_inverted,
+            textState = TextState(unseenReviewsCount.toString(), R.dimen.text_minor_80),
+        ) else null
 
     private fun SiteModel.getSelectedSiteName(): String =
         if (!displayName.isNullOrBlank()) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7021
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds a red badge on the new payment icon. It's shown always and this will be changed in the next PR

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Go to the More screen
* Noticed red badge
* Make sure that there is no regression for the reviews badge, both in light/dark mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="273" alt="image" src="https://user-images.githubusercontent.com/4923871/181188802-835d0718-3dc1-43a2-9d9b-30a9b98170f9.png">
<img width="278" alt="image" src="https://user-images.githubusercontent.com/4923871/181188904-1861f31c-0494-4661-9b72-9bbb0dc0fe1f.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
