### PR TITLE
Add mark to complete swipe action

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderListHeaderBinding
 import com.woocommerce.android.databinding.OrderListItemBinding
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.model.toOrderStatus
 import com.woocommerce.android.ui.orders.OrderStatusTag
@@ -128,7 +129,9 @@ class OrderListAdapter(
     }
 
     private inner class OrderItemUIViewHolder(val viewBinding: OrderListItemBinding) :
-        RecyclerView.ViewHolder(viewBinding.root) {
+        RecyclerView.ViewHolder(viewBinding.root), SwipeToComplete.SwipeAbleViewHolder {
+        private var isNotCompleted = true
+        private var orderId = -1L
         fun onBind(orderItemUI: OrderListItemUI) {
             // Grab the current context from the underlying view
             val ctx = this.itemView.context
@@ -153,6 +156,10 @@ class OrderListAdapter(
                     orderItemUI.orderId
                 )
             )
+
+            val status = Order.Status.fromValue(orderItemUI.status)
+            orderId = orderItemUI.orderId
+            isNotCompleted = status != Order.Status.Completed
 
             this.itemView.setOnClickListener {
                 listener.openOrderDetail(
@@ -182,6 +189,9 @@ class OrderListAdapter(
                 label = status
             }
         }
+
+        override fun isSwipeAble(): Boolean = isNotCompleted
+        override fun getSwipedItemId(): Long = orderId
     }
 
     private class LoadingViewHolder(view: View) : RecyclerView.ViewHolder(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -131,7 +131,7 @@ class OrderListAdapter(
     private inner class OrderItemUIViewHolder(val viewBinding: OrderListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root), SwipeToComplete.SwipeAbleViewHolder {
         private var isNotCompleted = true
-        private var orderId = -1L
+        private var orderId = SwipeToComplete.SwipeAbleViewHolder.EMPTY_SWIPED_ID
         fun onBind(orderItemUI: OrderListItemUI) {
             // Grab the current context from the underlying view
             val ctx = this.itemView.context

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -20,6 +20,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.paging.PagedList
+import androidx.recyclerview.widget.ItemTouchHelper
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.transition.MaterialFadeThrough
 import com.woocommerce.android.AppConstants
@@ -194,6 +195,13 @@ class OrderListFragment :
         }
         binding.orderFiltersCard.setClickListener { viewModel.onFiltersButtonTapped() }
         initCreateOrderFAB(binding.createOrderButton)
+        initSwipeBehaviour()
+    }
+
+    private fun initSwipeBehaviour() {
+        val swipeToComplete = SwipeToComplete(requireContext(), this)
+        val swipeHelper = ItemTouchHelper(swipeToComplete)
+        swipeHelper.attachToRecyclerView(binding.orderListView.ordersList)
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -68,7 +68,8 @@ class OrderListFragment :
     TopLevelFragment(R.layout.fragment_order_list),
     OnQueryTextListener,
     OnActionExpandListener,
-    OrderListListener {
+    OrderListListener,
+    SwipeToComplete.OnSwipeListener {
     companion object {
         const val TAG: String = "OrderListFragment"
         const val STATE_KEY_SEARCH_QUERY = "search-query"
@@ -640,5 +641,9 @@ class OrderListFragment :
             SIMPLE_PAYMENTS_AND_ORDER_CREATION,
             state
         ).registerItself()
+    }
+
+    override fun onSwiped(itemId: Long) {
+        uiMessageResolver.showSnack("Order $itemId Swiped")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
@@ -188,6 +188,10 @@ class SwipeToComplete(
     }
 
     interface SwipeAbleViewHolder {
+        companion object {
+            const val EMPTY_SWIPED_ID = -1L
+        }
+
         fun isSwipeAble(): Boolean
         fun getSwipedItemId(): Long
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
@@ -21,7 +21,7 @@ class SwipeToComplete(
     private val listener: OnSwipeListener
 ) : ItemTouchHelper.SimpleCallback(
     0,
-    ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
+    ItemTouchHelper.LEFT
 ) {
     companion object {
         private const val NO_SWIPE_ABLE_SCREEN_PERCENT = 0.10

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
@@ -1,0 +1,205 @@
+package com.woocommerce.android.ui.orders.list
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.os.Build
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.util.TypedValue
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import kotlin.math.roundToInt
+
+class SwipeToComplete(
+    private val context: Context,
+    private val listener: OnSwipeListener
+) : ItemTouchHelper.SimpleCallback(
+    0,
+    ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
+) {
+    companion object {
+        private const val NO_SWIPE_ABLE_SCREEN_PERCENT = 0.10
+    }
+
+    private val displayMetrics = context.resources.displayMetrics
+    private val swipeAbleColor = ContextCompat.getColor(context, R.color.color_primary)
+    private val noSwipeAbleColor = ContextCompat.getColor(context, R.color.color_on_surface_disabled)
+    private val width = (displayMetrics.widthPixels / displayMetrics.density).toInt().dp
+    private val completeIcon = ContextCompat.getDrawable(context, R.drawable.ic_checkmark_white_24dp)?.apply {
+        setTint(Color.WHITE)
+    }
+    private val messageSize = context.resources.getDimension(R.dimen.text_minor_125)
+    private val message = context.resources.getString(R.string.orderlist_mark_completed)
+    private val messagePaint: TextPaint = TextPaint().apply {
+        style = Paint.Style.FILL
+        isAntiAlias = true
+        color = Color.WHITE
+        textSize = messageSize
+    }
+    private val margin = context.resources.getDimension(R.dimen.major_100).toInt()
+
+    override fun onMove(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        target: RecyclerView.ViewHolder
+    ): Boolean {
+        return false
+    }
+
+    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+        val pos = viewHolder.absoluteAdapterPosition
+        viewHolder.bindingAdapter?.notifyItemChanged(pos)
+        val isSwipeAble = (viewHolder as SwipeAbleViewHolder).isSwipeAble()
+        if (isSwipeAble) {
+            val id = viewHolder.getSwipedItemId()
+            listener.onSwiped(id)
+        }
+    }
+
+    override fun getMovementFlags(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder): Int {
+        return if (viewHolder is SwipeAbleViewHolder) {
+            super.getMovementFlags(recyclerView, viewHolder)
+        } else {
+            makeMovementFlags(0, 0)
+        }
+    }
+
+    override fun onChildDraw(
+        canvas: Canvas,
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        dX: Float,
+        dY: Float,
+        actionState: Int,
+        isCurrentlyActive: Boolean
+    ) {
+        val isSwipeAble = (viewHolder as SwipeAbleViewHolder).isSwipeAble()
+        if (isSwipeAble) {
+            swipeAbleChildrenDraw(canvas, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive)
+        } else {
+            noSwipeAbleChildrenDraw(canvas, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive)
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun noSwipeAbleChildrenDraw(
+        canvas: Canvas,
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        dX: Float,
+        dY: Float,
+        actionState: Int,
+        isCurrentlyActive: Boolean
+    ) {
+        val maxDX = (width * NO_SWIPE_ABLE_SCREEN_PERCENT).toFloat()
+        val shrinkDX = if (dX > 0) dX.coerceAtMost(maxDX) else dX.coerceAtLeast(-maxDX)
+        canvas.drawColor(noSwipeAbleColor)
+        super.onChildDraw(canvas, recyclerView, viewHolder, shrinkDX, dY, actionState, isCurrentlyActive)
+    }
+
+    @Suppress("LongParameterList")
+    private fun swipeAbleChildrenDraw(
+        canvas: Canvas,
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        dX: Float,
+        dY: Float,
+        actionState: Int,
+        isCurrentlyActive: Boolean
+    ) {
+        // Draw background
+        canvas.drawColor(swipeAbleColor)
+        val isSwipingRight = dX > 0
+
+        // Select the longest line to measure the text width
+        val longLine = message.split("\n").maxOfWith(compareBy { it.length }) { it }
+
+        // Measure text width to place icon aligned to message center
+        val messageWidth = messagePaint.measureText(longLine).toInt()
+        var iconBottom = 0
+
+        // Draw icon
+        completeIcon?.let { icon ->
+            val xCenteredInMessage = (messageWidth / 2f) - (completeIcon.intrinsicWidth / 2f)
+
+            // Small adjustment for checkmark icon center alignment
+            val iconAdjustment = 3.dp
+
+            val iconRect = if (isSwipingRight) {
+                Rect(
+                    (xCenteredInMessage + margin + iconAdjustment).toInt(),
+                    viewHolder.itemView.top + margin,
+                    (completeIcon.intrinsicWidth + xCenteredInMessage + margin + iconAdjustment).toInt(),
+                    viewHolder.itemView.top + completeIcon.intrinsicHeight + margin
+                )
+            } else {
+                Rect(
+                    (width - completeIcon.intrinsicWidth - xCenteredInMessage - margin + iconAdjustment).toInt(),
+                    viewHolder.itemView.top + margin,
+                    (width - xCenteredInMessage - margin + iconAdjustment).toInt(),
+                    viewHolder.itemView.top + completeIcon.intrinsicHeight + margin
+                )
+            }
+            iconBottom = iconRect.height()
+            icon.run {
+                bounds = iconRect
+                draw(canvas)
+            }
+        }
+
+        val textLayout = getTextStaticLayout(messageWidth)
+
+        canvas.save()
+
+        val textX = if (isSwipingRight) margin.toFloat() else (width - messageWidth - margin).toFloat()
+        val textY = (viewHolder.itemView.top + margin + iconBottom + 4.dp).toFloat()
+
+        canvas.translate(textX, textY)
+        textLayout.draw(canvas)
+
+        canvas.restore()
+
+        super.onChildDraw(canvas, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive)
+    }
+
+    @Suppress("deprecation")
+    private fun getTextStaticLayout(width: Int): StaticLayout {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            StaticLayout.Builder.obtain(message, 0, message.length, messagePaint, width)
+                .setAlignment(Layout.Alignment.ALIGN_CENTER)
+                .build()
+        } else {
+            StaticLayout(
+                message,
+                messagePaint,
+                width,
+                Layout.Alignment.ALIGN_CENTER,
+                1f,
+                0f,
+                false
+            )
+        }
+    }
+
+    interface SwipeAbleViewHolder {
+        fun isSwipeAble(): Boolean
+        fun getSwipedItemId(): Long
+    }
+
+    interface OnSwipeListener {
+        fun onSwiped(itemId: Long)
+    }
+
+    private val Int.dp
+        get() = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            toFloat(),
+            context.resources.displayMetrics
+        ).roundToInt()
+}

--- a/WooCommerce/src/main/res/layout/order_list_header.xml
+++ b/WooCommerce/src/main/res/layout/order_list_header.xml
@@ -4,7 +4,8 @@
     android:id="@+id/heading_container"
     android:focusable="true"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="@color/default_window_background">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/orderListHeader"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -319,6 +319,7 @@
     <string name="orderlist_simple_payments_menu">Simple payment</string>
     <string name="order_card_transition_name">order_card_%1$s</string>
     <string name="order_card_detail_transition_name">order_card_detail</string>
+    <string name="orderlist_mark_completed">Mark\ncompleted</string>
     <!--
          Simple Payments
     -->


### PR DESCRIPTION
Closes: #7034 

### Description
This PR adds the swipe-to-complete gesture to non-completed orders in the order list. The action can be triggered by swiping the row > 50% of the screen width.
To implement the swipe to complete action, this PR adds a new class that wraps ItemTouchHelper.SimpleCallback functionality to draw the item list background while swiping. This class also exposes Two interfaces. SwipeAbleViewHolder is an interface to be implemented by ViewHolders that can be swiped. When a `SwipeAbleViewHolder.isSwipeAble()` returns true, the view would be fully swipe-able, while when this function returns false, only 10% of the screen (to indicate it as no action). The other interface is OnSwipeListener, implemented by the OrderListFragment, to observe for swipe gestures.

### Testing instructions
1. Open the app and go to the orders list
2. Try to swipe a completed order and check that it is only swiped 10% of the screen with a disabled background and no snack bar displays that the order has been swiped
3. Try to swipe a non-completed order and see that the "Mark Completed" message is displayed, and once the order is fully swiped, the app shows a snack bar indicating the order has been swiped.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/181335573-277c74f7-208c-4198-a47c-387114f61a28.mp4



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
