### PR TITLE
Issue/7012 hide upsell banner on empty orders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -57,6 +57,7 @@ import com.woocommerce.android.ui.payments.banner.OrderListBannerDismissDialog
 import com.woocommerce.android.ui.payments.banner.OrderListScreenBanner
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
@@ -153,20 +154,7 @@ class OrderListFragment :
         _binding = FragmentOrderListBinding.inflate(inflater, container, false)
 
         val view = binding.root
-        if (viewModel.shouldShowUpsellCardReaderDismissDialog.value == true) {
-            applyBannerDismissDialogComposeUI()
-        }
-        val isLandscape = DisplayUtils.isLandscape(view.context)
-        /**
-         * We are hiding the upsell card reader banner in the landscape mode since it becomes impossible for
-         * the merchants to scroll the order list. More info here: pdfdoF-12d-p2
-         */
-        if (!isLandscape) {
-            applyBannerComposeUI()
-        }
-        if (viewModel.shouldDisplaySimplePaymentsWIPCard() || isLandscape) {
-            displaySimplePaymentsWIPCard(true)
-        }
+        bannerDisplayLogic(view)
         return view
     }
 
@@ -217,6 +205,23 @@ class OrderListFragment :
         searchMenuItem = null
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun bannerDisplayLogic(view: ScrollChildSwipeRefreshLayout) {
+        if (viewModel.shouldShowUpsellCardReaderDismissDialog.value == true) {
+            applyBannerDismissDialogComposeUI()
+        }
+        val isLandscape = DisplayUtils.isLandscape(view.context)
+        /**
+         * We are hiding the upsell card reader banner in the landscape mode since it becomes impossible for
+         * the merchants to scroll the order list. More info here: pdfdoF-12d-p2
+         */
+        if (!isLandscape) {
+            applyBannerComposeUI()
+        }
+        if (viewModel.shouldDisplaySimplePaymentsWIPCard() || isLandscape) {
+            displaySimplePaymentsWIPCard(true)
+        }
     }
 
     private fun applyBannerComposeUI() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.list
 
+import android.content.Context
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -57,7 +58,6 @@ import com.woocommerce.android.ui.payments.banner.OrderListBannerDismissDialog
 import com.woocommerce.android.ui.payments.banner.OrderListScreenBanner
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
@@ -153,9 +153,7 @@ class OrderListFragment :
         setHasOptionsMenu(true)
         _binding = FragmentOrderListBinding.inflate(inflater, container, false)
 
-        val view = binding.root
-        bannerDisplayLogic(view)
-        return view
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -207,26 +205,31 @@ class OrderListFragment :
         _binding = null
     }
 
-    private fun bannerDisplayLogic(view: ScrollChildSwipeRefreshLayout) {
-        if (viewModel.shouldShowUpsellCardReaderDismissDialog.value == true) {
-            applyBannerDismissDialogComposeUI()
-        }
-        val isLandscape = DisplayUtils.isLandscape(view.context)
-        /**
-         * We are hiding the upsell card reader banner in the landscape mode since it becomes impossible for
-         * the merchants to scroll the order list. More info here: pdfdoF-12d-p2
-         */
-        if (!isLandscape) {
-            applyBannerComposeUI()
-        }
-        if (viewModel.shouldDisplaySimplePaymentsWIPCard() || isLandscape) {
-            displaySimplePaymentsWIPCard(true)
+    private fun bannerDisplayViewLogic(context: Context, ordersListSize: Int) {
+        if (ordersListSize <= 0) {
+            binding.upsellCardReaderComposeView.upsellCardReaderBannerView.visibility = View.GONE
+        } else {
+            if (viewModel.shouldShowUpsellCardReaderDismissDialog.value == true) {
+                applyBannerDismissDialogComposeUI()
+            }
+            val isLandscape = DisplayUtils.isLandscape(context)
+            /**
+             * We are hiding the upsell card reader banner in the landscape mode since it becomes impossible for
+             * the merchants to scroll the order list. More info here: pdfdoF-12d-p2
+             */
+            if (!isLandscape) {
+                applyBannerComposeUI()
+            }
+            if (viewModel.shouldDisplaySimplePaymentsWIPCard() || isLandscape) {
+                displaySimplePaymentsWIPCard(true)
+            }
         }
     }
 
     private fun applyBannerComposeUI() {
         binding.upsellCardReaderComposeView.upsellCardReaderBannerView.apply {
             // Dispose of the Composition when the view's LifecycleOwner is destroyed
+            visibility = View.VISIBLE
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 WooThemeWithBackground {
@@ -325,6 +328,7 @@ class OrderListFragment :
         }
 
         viewModel.pagedListData.observe(viewLifecycleOwner) {
+            bannerDisplayViewLogic(binding.root.context, it.size)
             updatePagedListData(it)
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7012 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR hides upsell card reader banner when there are no orders on the orders list screen. We want to hide the banner since there is no point in displaying the banner when the merchant hasn't even gotten his first order.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Have a store with 0 orders OR move all of the orders from your test store into the trash from wp-admin
2. Navigate to the orders list screen and ensure the banner is not displayed
3. Add an order into the store using wp-admin
4. Refresh orders list screen
5. Make sure the banner gets displayed as soon as the new order appears in the orders listing screen.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/1331230/181494248-4454578a-f490-483c-8f3e-17872ffa7dd9.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
