### PR TITLE
Upsell card reader banner gets preference over feedback banner in the order list screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -164,6 +164,9 @@ class OrderListFragment :
         if (!isLandscape) {
             applyBannerComposeUI()
         }
+        if (viewModel.shouldDisplaySimplePaymentsWIPCard() || isLandscape) {
+            displaySimplePaymentsWIPCard(true)
+        }
         return view
     }
 
@@ -193,11 +196,6 @@ class OrderListFragment :
         }
         binding.orderFiltersCard.setClickListener { viewModel.onFiltersButtonTapped() }
         initCreateOrderFAB(binding.createOrderButton)
-    }
-
-    override fun onViewStateRestored(savedInstanceState: Bundle?) {
-        super.onViewStateRestored(savedInstanceState)
-        displaySimplePaymentsWIPCard(true)
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -16,6 +16,7 @@ import androidx.paging.PagedList
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_BANNER_ORDER_LIST
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CUSTOM_FIELDS_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CUSTOM_FIELDS_SIZE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ID
@@ -486,6 +487,10 @@ class OrderListViewModel @Inject constructor(
 
     fun canShowCardReaderUpsellBanner(currentTimeInMillis: Long, source: String): Boolean {
         return bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(currentTimeInMillis, source)
+    }
+
+    fun shouldDisplaySimplePaymentsWIPCard(): Boolean {
+        return !canShowCardReaderUpsellBanner(System.currentTimeMillis(), KEY_BANNER_ORDER_LIST)
     }
 
     sealed class OrderListEvent : Event() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -39,6 +39,8 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
@@ -542,6 +544,38 @@ class OrderListViewModelTest : BaseUnitTest() {
         viewModel.onBannerAlertDismiss()
 
         assertThat(viewModel.shouldShowUpsellCardReaderDismissDialog.value).isFalse
+    }
+
+    @Test
+    fun `when upsell card reader banner is displayed, then don't display feedback banner`() {
+        runTest {
+            whenever(
+                bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
+                    anyLong(),
+                    anyString()
+                )
+            ).thenReturn(true)
+
+            val shouldDisplaySimplePaymentsWIPCard = viewModel.shouldDisplaySimplePaymentsWIPCard()
+
+            assertFalse(shouldDisplaySimplePaymentsWIPCard)
+        }
+    }
+
+    @Test
+    fun `when upsell card reader banner is not displayed, then display feedback banner`() {
+        runTest {
+            whenever(
+                bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
+                    anyLong(),
+                    anyString()
+                )
+            ).thenReturn(false)
+
+            val shouldDisplaySimplePaymentsWIPCard = viewModel.shouldDisplaySimplePaymentsWIPCard()
+
+            assertTrue(shouldDisplaySimplePaymentsWIPCard)
+        }
     }
     //endregion
 


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #7048 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR has the following changes:
1. The upsell card reader banner has a preference over the feedback banner.
2. If the upsell card reader banner is not shown, the feedback banner can be shown.
3. Both banners should not appear simultaneously.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to the orders list screen
2. If you see the upsell card reader banner, make sure the simple payments feedback banner is not displayed
3. Dismiss the upsell card reader banner either via Remind me later or Don't show me again CTA
4. Navigate to some other tab and come back to the orders list screen and notice the feedback banner is being shown now.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
NOTE: I'm using `Flipper` to clear the shared preference of `Don't show again` value .

https://user-images.githubusercontent.com/1331230/181496655-7eda3915-f2ff-47ae-96bc-ab57d59f2139.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
