### PR TITLE
Login: Use WooLoginEmailFragment in the "Enter Site Address" Login Flow.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -268,7 +268,7 @@ class LoginActivity :
         } else {
             supportFragmentManager.findFragmentByTag(LoginEmailFragment.TAG)
         }
-        return if (fragment == null) null else fragment as LoginEmailFragment
+        return if (fragment == null) null else fragment as WooLoginEmailFragment
     }
 
     private fun getLoginViaSiteAddressFragment(): LoginSiteAddressFragment? =
@@ -736,7 +736,7 @@ class LoginActivity :
             // Show the layout that includes the option to login with site credentials.
             val loginEmailFragment = getLoginEmailFragment(
                 siteCredsLayout = true
-            ) ?: LoginEmailFragment.newInstance(siteAddress, true)
+            ) ?: WooLoginEmailFragment.newInstance(siteAddress, true)
             slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG_SITE_CREDS_LAYOUT)
         } else {
             val loginEmailFragment = getLoginEmailFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -46,11 +46,6 @@ class WooLoginEmailFragment : LoginEmailFragment() {
         rootView.findViewById<Button>(R.id.login_what_is_wordpress).setOnClickListener {
             whatIsWordPressLinkClickListener.onWhatIsWordPressLinkClicked()
         }
-
-        // Follow LoginEmailFragment's behavior to only show this button if not on "Site Credentials" layout.
-        if (optionalSiteCredsLayout) {
-            rootView.findViewById<Button>(R.id.continue_tos).hide()
-        }
     }
 
     override fun onAttach(context: Context) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.login.overrides
 
 import android.content.Context
+import android.os.Bundle
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.LayoutRes
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.hide
 import org.wordpress.android.login.LoginEmailFragment
 
 class WooLoginEmailFragment : LoginEmailFragment() {
@@ -12,15 +14,42 @@ class WooLoginEmailFragment : LoginEmailFragment() {
         fun onWhatIsWordPressLinkClicked()
     }
 
+    companion object {
+        fun newInstance(siteAddress: String, optionalSiteCredsLayout: Boolean): WooLoginEmailFragment {
+            val fragment = WooLoginEmailFragment()
+            val args = Bundle()
+            args.putString(ARG_LOGIN_SITE_URL, siteAddress)
+            args.putBoolean(ARG_OPTIONAL_SITE_CREDS_LAYOUT, optionalSiteCredsLayout)
+            fragment.arguments = args
+            return fragment
+        }
+
+        const val ARG_LOGIN_SITE_URL = "ARG_LOGIN_SITE_URL"
+        const val ARG_OPTIONAL_SITE_CREDS_LAYOUT = "ARG_OPTIONAL_SITE_CREDS_LAYOUT"
+    }
+
     private lateinit var whatIsWordPressLinkClickListener: Listener
+    private var optionalSiteCredsLayout = false
+    private var loginSiteUrl = ""
 
     @LayoutRes
-    override fun getContentLayout(): Int = R.layout.fragment_login_email_screen
+    override fun getContentLayout(): Int {
+        return if (optionalSiteCredsLayout) {
+            R.layout.fragment_login_email_optional_site_creds_screen
+        } else {
+            R.layout.fragment_login_email_screen
+        }
+    }
 
     override fun setupContent(rootView: ViewGroup) {
         super.setupContent(rootView)
         rootView.findViewById<Button>(R.id.login_what_is_wordpress).setOnClickListener {
             whatIsWordPressLinkClickListener.onWhatIsWordPressLinkClicked()
+        }
+
+        // Follow LoginEmailFragment's behavior to only show this button if not on "Site Credentials" layout.
+        if (optionalSiteCredsLayout) {
+            rootView.findViewById<Button>(R.id.continue_tos).hide()
         }
     }
 
@@ -28,6 +57,15 @@ class WooLoginEmailFragment : LoginEmailFragment() {
         super.onAttach(context)
         if (activity is Listener) {
             whatIsWordPressLinkClickListener = activity as Listener
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        arguments?.let {
+            optionalSiteCredsLayout = it.getBoolean(ARG_OPTIONAL_SITE_CREDS_LAYOUT, false)
+            loginSiteUrl = it.getString(ARG_LOGIN_SITE_URL, "")
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.LayoutRes
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.hide
 import org.wordpress.android.login.LoginEmailFragment
 
 class WooLoginEmailFragment : LoginEmailFragment() {

--- a/WooCommerce/src/main/res/layout/fragment_login_email_optional_site_creds_screen.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_email_optional_site_creds_screen.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/label"
+            style="@style/Widget.LoginFlow.TextView.Label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@string/enter_email_wordpress_com" />
+
+        <!-- Even though this field only accepts email addresses, we also include "username" as an
+        autofill hint value to ensure that the default autofill service works well with it -->
+        <org.wordpress.android.login.widgets.WPLoginInputRow
+            android:id="@+id/login_email_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:autofillHints="emailAddress,username"
+            android:hint="@string/email_address"
+            android:imeOptions="actionNext"
+            android:importantForAutofill="yes"
+            android:inputType="textEmailAddress"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/label"
+            tools:ignore="UnusedAttribute" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/login_find_connected_email"
+            style="@style/Widget.LoginFlow.Button.Tertiary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingEnd="@dimen/margin_none"
+            android:paddingStart="@dimen/margin_none"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:text="@string/login_find_your_connected_email"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/login_email_row"
+            app:layout_constraintHorizontal_bias="0.0"/>
+
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/continue_tos"
+            style="@style/Widget.LoginFlow.Button.Tertiary.Small"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:text="@string/continue_terms_of_service_text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/login_find_connected_email"
+            tools:visibility="gone" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/login_continue_button"
+            style="@style/Widget.LoginFlow.Button.Primary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:text="@string/login_continue"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/continue_tos"
+            app:layout_goneMarginTop="@dimen/margin_extra_large" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/login_what_is_wordpress"
+            style="@style/Widget.LoginFlow.Button.Tertiary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:text="@string/what_is_wordpress_link"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/login_continue_button" />
+
+        <Space
+            android:id="@+id/spacer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/login_what_is_wordpress" />
+
+        <include
+            android:id="@+id/orLayout"
+            layout="@layout/login_or_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toTopOf="@+id/login_site_creds"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/spacer"
+            app:layout_constraintVertical_bias="1.0" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/login_site_creds"
+            style="@style/Widget.LoginFlow.Button.Secondary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/continue_site_credentials"
+            app:icon="@drawable/ic_globe_grey_24dp"
+            app:iconGravity="textStart"
+            app:iconPadding="@dimen/margin_small_medium"
+            app:iconSize="14dp"
+            app:iconTint="@color/login_secondary_button_icon_tint_color"
+            app:iconTintMode="src_in"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_login_email_optional_site_creds_screen.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_email_optional_site_creds_screen.xml
@@ -55,20 +55,6 @@
             app:layout_constraintTop_toBottomOf="@+id/login_email_row"
             app:layout_constraintHorizontal_bias="0.0"/>
 
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/continue_tos"
-            style="@style/Widget.LoginFlow.Button.Tertiary.Small"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_extra_large"
-            android:layout_marginEnd="@dimen/margin_extra_large"
-            android:text="@string/continue_terms_of_service_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/login_find_connected_email"
-            tools:visibility="gone" />
-
         <com.google.android.material.button.MaterialButton
             android:id="@+id/login_continue_button"
             style="@style/Widget.LoginFlow.Button.Primary"
@@ -79,7 +65,7 @@
             android:text="@string/login_continue"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/continue_tos"
+            app:layout_constraintTop_toBottomOf="@+id/login_find_connected_email"
             app:layout_goneMarginTop="@dimen/margin_extra_large" />
 
         <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6989 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is related to the following login flow:
1. Start app, choose "Enter your store address" button.
2. Site address input form is shown,
3. a WooCommerce site with Jetpack already connected is entered,
4. The "Log In with WordPress.com email" screen is shown.

Previously, the screen on step 4 uses `LoginEmailFragment` provided by the WordPress Login Library.

With this PR, the screen on step 4 uses `WooLoginEmailFragment` instead. `WooLoginEmailFragment` is a subclass of `LoginEmailFragment` with Woo-specific layout and changes such as the addition of the "What is WordPress.com" button.

This PR also updates `WooLoginEmailFragment` to be able to show the alternative login layout that has a "Continue with store credentials" button in it.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
