### PR TITLE
[Login] Fix button "need more help" in the email help dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -724,7 +724,8 @@ class LoginActivity :
         AnalyticsTracker.track(AnalyticsEvent.LOGIN_BY_EMAIL_HELP_FINDING_CONNECTED_EMAIL_LINK_TAPPED)
         unifiedLoginTracker.trackClick(Click.HELP_FINDING_CONNECTED_EMAIL)
 
-        LoginEmailHelpDialogFragment().show(supportFragmentManager, LoginEmailHelpDialogFragment.TAG)
+        LoginEmailHelpDialogFragment.newInstance(this)
+            .show(supportFragmentManager, LoginEmailHelpDialogFragment.TAG)
     }
 
     override fun onEmailNeedMoreHelpClicked() {


### PR DESCRIPTION
Closes: #7068 

### Description
This is a small PR that makes sure we assign the correct listener to the `LoginEmailHelpDialogFragment` to fix the behavior of the button "Need more help".

### Testing instructions
1. Open the app.
2. Click on login with site address.
3. Type the address of your store.
4. On the next screen, click on "Find your connected email"
5. Click on "need more help" and confirm it opens the support screen.

If at step 4 you end up on site credentials screen instead of the WPCom email, then update the code here https://github.com/woocommerce/woocommerce-android/blob/d0f7de55c22ad1f2c2a175b0968595d6948bfc7f/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SiteLoginExperiment.kt#L33-L36 to call `loginViaEmail` always.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
