### PR TITLE
Login Local Notification: Show help notification if merchants entered incorrect WordPress.com email during login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 9.8
 -----
-
+- [**] Users will now receive notifications with help info and actions 24h after running into some issue during login [https://github.com/woocommerce/woocommerce-android/pull/7072]
 
 9.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -87,6 +87,7 @@ object AppPrefs {
         PRODUCT_SORTING_PREFIX,
         PRE_LOGIN_NOTIFICATION_WORK_REQUEST,
         PRE_LOGIN_NOTIFICATION_DISPLAYED,
+        PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE,
         CARD_READER_UPSELL_BANNER_DIALOG_DISMISSED_FOREVER,
         CARD_READER_UPSELL_BANNER_DIALOG_DISMISSED_REMIND_ME_LATER,
     }
@@ -779,6 +780,12 @@ object AppPrefs {
 
     fun setLocalNotificationWorkRequestId(workRequestId: String) {
         setString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_WORK_REQUEST, workRequestId)
+    }
+
+    fun getPreLoginNotificationDisplayedType() = getString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE)
+
+    fun setPreLoginNotificationDisplayedType(notificationType: String) {
+        setString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE, notificationType)
     }
 
     fun setPreLoginNotificationDisplayed(displayed: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -159,6 +159,11 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun hasPreLoginNotificationBeenDisplayed() = AppPrefs.isPreLoginNotificationBeenDisplayed()
 
+    fun setPreLoginNotificationDisplayedType(notificationType: String) =
+        AppPrefs.setPreLoginNotificationDisplayedType(notificationType)
+
+    fun getPreLoginNotificationDisplayedType() = AppPrefs.getPreLoginNotificationDisplayedType()
+
     fun setPreLoginNotificationDisplayed(displayed: Boolean) =
         AppPrefs.setPreLoginNotificationDisplayed(displayed)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -642,6 +642,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     LOGIN_ONBOARDING_SKIP_BUTTON_TAPPED,
 
     // Login help scheduled notifications
+    LOGIN_LOCAL_NOTIFICATION_SCHEDULED(siteless = true),
     LOGIN_LOCAL_NOTIFICATION_DISPLAYED(siteless = true),
     LOGIN_LOCAL_NOTIFICATION_TAPPED(siteless = true),
     LOGIN_LOCAL_NOTIFICATION_DISMISSED(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.os.Build
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.LOGIN_LOCAL_NOTIFICATION_DISMISSED
 import com.woocommerce.android.analytics.AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED
 import com.woocommerce.android.analytics.AnalyticsEvent.PUSH_NOTIFICATION_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -65,8 +65,16 @@ class NotificationMessageHandler @Inject constructor(
     fun onNotificationDismissed(localPushId: Int) {
         removeNotificationByPushIdFromSystemsBar(localPushId)
         if (localPushId == LOGIN_HELP_NOTIFICATION_ID) {
-            AnalyticsTracker.track(AnalyticsEvent.LOGIN_LOCAL_NOTIFICATION_DISMISSED)
+            onLocalNotificationDismissed()
         }
+    }
+
+    private fun onLocalNotificationDismissed() {
+        val notificationTypeName = appPrefsWrapper.getPreLoginNotificationDisplayedType()
+        AnalyticsTracker.track(
+            stat = LOGIN_LOCAL_NOTIFICATION_DISMISSED,
+            properties = mapOf(AnalyticsTracker.KEY_TYPE to notificationTypeName)
+        )
     }
 
     @Suppress("ReturnCount", "ComplexMethod")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_TAG
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
@@ -81,7 +80,7 @@ class HelpActivity : AppCompatActivity() {
         }
 
         if (originFromExtras == Origin.LOGIN_HELP_NOTIFICATION) {
-            handleOpenedFromLoginHelpNotification()
+            handleOpenedFromLoginHelpNotification(extraTagsFromExtras?.first())
         }
     }
 
@@ -186,11 +185,11 @@ class HelpActivity : AppCompatActivity() {
         startActivity(Intent(this, SSRActivity::class.java))
     }
 
-    private fun handleOpenedFromLoginHelpNotification() {
+    private fun handleOpenedFromLoginHelpNotification(notificationTypeName: String?) {
         NotificationManagerCompat.from(this).cancel(LOGIN_HELP_NOTIFICATION_TAG, LOGIN_HELP_NOTIFICATION_ID)
         AnalyticsTracker.track(
             AnalyticsEvent.LOGIN_LOCAL_NOTIFICATION_TAPPED,
-            mapOf(AnalyticsTracker.KEY_TYPE to LOGIN_SITE_ADDRESS_ERROR.name)
+            mapOf(AnalyticsTracker.KEY_TYPE to notificationTypeName)
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -39,6 +39,8 @@ import com.woocommerce.android.ui.login.localnotifications.LoginNotificationSche
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_TAG
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_INCORRECT_WPCOM_EMAIL
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
 import com.woocommerce.android.ui.main.MainActivity
@@ -162,7 +164,10 @@ class LoginActivity :
     }
 
     private fun processLoginHelpNotification(loginHelpNotification: String) {
-        startLoginViaWPCom()
+        when(loginHelpNotification) {
+            LOGIN_SITE_ADDRESS_ERROR.toString() -> startLoginViaWPCom()
+            LOGIN_INCORRECT_WPCOM_EMAIL.toString() -> loginViaSiteCredentials(inputSiteAddress = null)
+        }
         NotificationManagerCompat.from(this).cancel(
             LOGIN_HELP_NOTIFICATION_TAG,
             LOGIN_HELP_NOTIFICATION_ID
@@ -767,7 +772,7 @@ class LoginActivity :
     }
 
     override fun gotUnregisteredEmail(email: String?) {
-        loginNotificationScheduler.scheduleNotification(LoginHelpNotificationType.LOGIN_INCORRECT_WPCOM_EMAIL)
+        loginNotificationScheduler.scheduleNotification(LOGIN_INCORRECT_WPCOM_EMAIL)
 
         // Show the 'No WordPress.com account found' screen
         val fragment = LoginNoWPcomAccountFoundFragment.newInstance(email)
@@ -826,7 +831,7 @@ class LoginActivity :
                 shouldAddToBackStack = true,
                 tag = LoginSiteCheckErrorFragment.TAG
             )
-            loginNotificationScheduler.scheduleNotification(LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR)
+            loginNotificationScheduler.scheduleNotification(LOGIN_SITE_ADDRESS_ERROR)
         } else {
             // Just in case we use this method for a different scenario in the future
             TODO("Handle a new error scenario")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -767,6 +767,8 @@ class LoginActivity :
     }
 
     override fun gotUnregisteredEmail(email: String?) {
+        loginNotificationScheduler.scheduleNotification(LoginHelpNotificationType.LOGIN_INCORRECT_WPCOM_EMAIL)
+
         // Show the 'No WordPress.com account found' screen
         val fragment = LoginNoWPcomAccountFoundFragment.newInstance(email)
         slideInFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -56,9 +56,9 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.MemorizingTrustManager
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme.WOOCOMMERCE
 import org.wordpress.android.fluxc.store.AccountStore.AuthOptionsErrorType.UNKNOWN_USER
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthOptionsFetched
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked
@@ -869,7 +869,7 @@ class LoginActivity :
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = MAIN)
-    fun onAuthOptionsFetched(event: AccountStore.OnAuthOptionsFetched) {
+    fun onAuthOptionsFetched(event: OnAuthOptionsFetched) {
         if (event.error?.type == UNKNOWN_USER) {
             loginNotificationScheduler.scheduleNotification(LOGIN_INCORRECT_WPCOM_EMAIL)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -99,16 +99,21 @@ class LoginActivity :
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
         private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
         private const val KEY_LOGIN_HELP_NOTIFICATION = "KEY_LOGIN_HELP_NOTIFICATION"
+        private const val KEY_LOGIN_HELP_NOTIFICATION_SITE_ADDRESS = "KEY_LOGIN_HELP_NOTIFICATION_SITE_ADDRESS"
 
         fun createIntent(
             context: Context,
-            notificationType: LoginHelpNotificationType
+            notificationType: LoginHelpNotificationType,
+            siteAddress: String? = null
         ): Intent {
             val intent = Intent(context, LoginActivity::class.java)
             intent.apply {
                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or
                     Intent.FLAG_ACTIVITY_CLEAR_TASK
                 putExtra(KEY_LOGIN_HELP_NOTIFICATION, notificationType.toString())
+                siteAddress?.let {
+                    putExtra(KEY_LOGIN_HELP_NOTIFICATION_SITE_ADDRESS, siteAddress)
+                }
             }
             return intent
         }
@@ -140,6 +145,7 @@ class LoginActivity :
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
         val loginHelpNotification = getLoginHelpNotification()
+        val siteAddress = getLoginHelpNotificationSiteAddress()
 
         if (hasJetpackConnectedIntent()) {
             AnalyticsTracker.track(
@@ -150,7 +156,7 @@ class LoginActivity :
         } else if (hasMagicLinkLoginIntent()) {
             getAuthTokenFromIntent()?.let { showMagicLinkInterceptFragment(it) }
         } else if (!loginHelpNotification.isNullOrBlank()) {
-            processLoginHelpNotification(loginHelpNotification)
+            processLoginHelpNotification(loginHelpNotification, siteAddress)
         } else if (savedInstanceState == null) {
             loginAnalyticsListener.trackLoginAccessed()
 
@@ -163,10 +169,10 @@ class LoginActivity :
         }
     }
 
-    private fun processLoginHelpNotification(loginHelpNotification: String) {
+    private fun processLoginHelpNotification(loginHelpNotification: String, siteAddress: String?) {
         when (loginHelpNotification) {
             LOGIN_SITE_ADDRESS_ERROR.toString() -> startLoginViaWPCom()
-            LOGIN_INCORRECT_WPCOM_EMAIL.toString() -> loginViaSiteCredentials(inputSiteAddress = null)
+            LOGIN_INCORRECT_WPCOM_EMAIL.toString() -> loginViaSiteCredentials(siteAddress)
         }
         NotificationManagerCompat.from(this).cancel(
             LOGIN_HELP_NOTIFICATION_TAG,
@@ -845,6 +851,9 @@ class LoginActivity :
 
     private fun getLoginHelpNotification(): String? =
         intent.extras?.getString(KEY_LOGIN_HELP_NOTIFICATION)
+
+    private fun getLoginHelpNotificationSiteAddress(): String? =
+        intent.extras?.getString(KEY_LOGIN_HELP_NOTIFICATION_SITE_ADDRESS)
 
     override fun onCarouselFinished() {
         showPrologueFragment()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -39,8 +39,9 @@ import com.woocommerce.android.ui.login.localnotifications.LoginNotificationSche
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_TAG
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_INCORRECT_WPCOM_EMAIL
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_EMAIL_ERROR
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_WPCOM_EMAIL_ERROR
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
 import com.woocommerce.android.ui.main.MainActivity
@@ -174,7 +175,7 @@ class LoginActivity :
     private fun processLoginHelpNotification(loginHelpNotification: String, siteAddress: String?) {
         when (loginHelpNotification) {
             LOGIN_SITE_ADDRESS_ERROR.toString() -> startLoginViaWPCom()
-            LOGIN_INCORRECT_WPCOM_EMAIL.toString() -> loginViaSiteCredentials(siteAddress)
+            LOGIN_SITE_ADDRESS_EMAIL_ERROR.toString() -> loginViaSiteCredentials(siteAddress)
         }
         NotificationManagerCompat.from(this).cancel(
             LOGIN_HELP_NOTIFICATION_TAG,
@@ -780,7 +781,7 @@ class LoginActivity :
     }
 
     override fun gotUnregisteredEmail(email: String?) {
-        loginNotificationScheduler.scheduleNotification(LOGIN_INCORRECT_WPCOM_EMAIL)
+        loginNotificationScheduler.scheduleNotification(LOGIN_WPCOM_EMAIL_ERROR)
 
         // Show the 'No WordPress.com account found' screen
         val fragment = LoginNoWPcomAccountFoundFragment.newInstance(email)
@@ -871,7 +872,7 @@ class LoginActivity :
     @Subscribe(threadMode = MAIN)
     fun onAuthOptionsFetched(event: OnAuthOptionsFetched) {
         if (event.error?.type == UNKNOWN_USER) {
-            loginNotificationScheduler.scheduleNotification(LOGIN_INCORRECT_WPCOM_EMAIL)
+            loginNotificationScheduler.scheduleNotification(LOGIN_SITE_ADDRESS_EMAIL_ERROR)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -102,21 +102,16 @@ class LoginActivity :
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
         private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
         private const val KEY_LOGIN_HELP_NOTIFICATION = "KEY_LOGIN_HELP_NOTIFICATION"
-        private const val KEY_LOGIN_HELP_NOTIFICATION_SITE_ADDRESS = "KEY_LOGIN_HELP_NOTIFICATION_SITE_ADDRESS"
 
         fun createIntent(
             context: Context,
             notificationType: LoginHelpNotificationType,
-            siteAddress: String? = null
         ): Intent {
             val intent = Intent(context, LoginActivity::class.java)
             intent.apply {
                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or
                     Intent.FLAG_ACTIVITY_CLEAR_TASK
                 putExtra(KEY_LOGIN_HELP_NOTIFICATION, notificationType.toString())
-                siteAddress?.let {
-                    putExtra(KEY_LOGIN_HELP_NOTIFICATION_SITE_ADDRESS, siteAddress)
-                }
             }
             return intent
         }
@@ -148,7 +143,6 @@ class LoginActivity :
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
         val loginHelpNotification = getLoginHelpNotification()
-        val siteAddress = getLoginHelpNotificationSiteAddress()
 
         if (hasJetpackConnectedIntent()) {
             AnalyticsTracker.track(
@@ -159,7 +153,7 @@ class LoginActivity :
         } else if (hasMagicLinkLoginIntent()) {
             getAuthTokenFromIntent()?.let { showMagicLinkInterceptFragment(it) }
         } else if (!loginHelpNotification.isNullOrBlank()) {
-            processLoginHelpNotification(loginHelpNotification, siteAddress)
+            processLoginHelpNotification(loginHelpNotification)
         } else if (savedInstanceState == null) {
             loginAnalyticsListener.trackLoginAccessed()
 
@@ -172,11 +166,8 @@ class LoginActivity :
         }
     }
 
-    private fun processLoginHelpNotification(loginHelpNotification: String, siteAddress: String?) {
-        when (loginHelpNotification) {
-            LOGIN_SITE_ADDRESS_ERROR.toString() -> startLoginViaWPCom()
-            LOGIN_SITE_ADDRESS_EMAIL_ERROR.toString() -> loginViaSiteCredentials(siteAddress)
-        }
+    private fun processLoginHelpNotification(loginHelpNotification: String) {
+        startLoginViaWPCom()
         NotificationManagerCompat.from(this).cancel(
             LOGIN_HELP_NOTIFICATION_TAG,
             LOGIN_HELP_NOTIFICATION_ID
@@ -852,9 +843,6 @@ class LoginActivity :
 
     private fun getLoginHelpNotification(): String? =
         intent.extras?.getString(KEY_LOGIN_HELP_NOTIFICATION)
-
-    private fun getLoginHelpNotificationSiteAddress(): String? =
-        intent.extras?.getString(KEY_LOGIN_HELP_NOTIFICATION_SITE_ADDRESS)
 
     override fun onCarouselFinished() {
         showPrologueFragment()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -164,7 +164,7 @@ class LoginActivity :
     }
 
     private fun processLoginHelpNotification(loginHelpNotification: String) {
-        when(loginHelpNotification) {
+        when (loginHelpNotification) {
             LOGIN_SITE_ADDRESS_ERROR.toString() -> startLoginViaWPCom()
             LOGIN_INCORRECT_WPCOM_EMAIL.toString() -> loginViaSiteCredentials(inputSiteAddress = null)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -781,8 +781,6 @@ class LoginActivity :
     }
 
     override fun gotUnregisteredEmail(email: String?) {
-        loginNotificationScheduler.scheduleNotification(LOGIN_WPCOM_EMAIL_ERROR)
-
         // Show the 'No WordPress.com account found' screen
         val fragment = LoginNoWPcomAccountFoundFragment.newInstance(email)
         slideInFragment(
@@ -872,7 +870,11 @@ class LoginActivity :
     @Subscribe(threadMode = MAIN)
     fun onAuthOptionsFetched(event: OnAuthOptionsFetched) {
         if (event.error?.type == UNKNOWN_USER) {
-            loginNotificationScheduler.scheduleNotification(LOGIN_SITE_ADDRESS_EMAIL_ERROR)
+            val notificationType = when {
+                !appPrefsWrapper.getLoginSiteAddress().isNullOrBlank() -> LOGIN_SITE_ADDRESS_EMAIL_ERROR
+                else -> LOGIN_WPCOM_EMAIL_ERROR
+            }
+            loginNotificationScheduler.scheduleNotification(notificationType)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -56,7 +56,9 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.MemorizingTrustManager
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme.WOOCOMMERCE
+import org.wordpress.android.fluxc.store.AccountStore.AuthOptionsErrorType.UNKNOWN_USER
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked
@@ -863,5 +865,13 @@ class LoginActivity :
     @Subscribe(threadMode = MAIN)
     fun onFetchedConnectSiteInfo(event: OnConnectSiteInfoChecked) {
         isSiteOnWPcom = event.info.isWPCom
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = MAIN)
+    fun onAuthOptionsFetched(event: AccountStore.OnAuthOptionsFetched) {
+        if (event.error?.type == UNKNOWN_USER) {
+            loginNotificationScheduler.scheduleNotification(LOGIN_INCORRECT_WPCOM_EMAIL)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -22,8 +22,6 @@ import com.woocommerce.android.ui.login.localnotifications.LoginNotificationSche
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.DEFAULT_HELP
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_INCORRECT_WPCOM_EMAIL
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
-import com.woocommerce.android.util.WooLog.T.NOTIFS
-import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -34,8 +32,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val wooNotificationBuilder: WooNotificationBuilder,
     private val resourceProvider: ResourceProvider,
-    private val prefsWrapper: AppPrefsWrapper,
-    private val wooLogWrapper: WooLogWrapper
+    private val prefsWrapper: AppPrefsWrapper
 ) : Worker(appContext, workerParams) {
     override fun doWork(): Result {
         val notificationType = LoginHelpNotificationType.fromString(
@@ -91,10 +88,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
                 notificationTappedIntent = buildOpenLoginWithSiteCredentialsIntent(siteAddress),
                 actions = getActionsForIncorrectWPComEmailNotification(siteAddress)
             )
-        } ?: wooLogWrapper.e(
-            NOTIFS,
-            "Can't create local notification for incorrect WPCom email: site address is missing"
-        )
+        } ?: defaultLoginSupportNotification()
     }
 
     private fun buildLoginNotification(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.login.localnotifications.LoginNotificationSche
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.DEFAULT_HELP
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_INCORRECT_WPCOM_EMAIL
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -40,6 +41,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         when (notificationType) {
             DEFAULT_HELP -> defaultLoginSupportNotification()
             LOGIN_SITE_ADDRESS_ERROR -> siteAddressErrorNotification()
+            LOGIN_INCORRECT_WPCOM_EMAIL -> incorrectWPComEmailNotification()
         }
         AnalyticsTracker.track(
             LOGIN_LOCAL_NOTIFICATION_DISPLAYED,
@@ -47,6 +49,10 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         )
         prefsWrapper.setPreLoginNotificationDisplayed(displayed = true)
         return Result.success()
+    }
+
+    private fun incorrectWPComEmailNotification() {
+        TODO("Not yet implemented")
     }
 
     private fun defaultLoginSupportNotification() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -91,7 +91,10 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
                 notificationTappedIntent = buildOpenLoginWithSiteCredentialsIntent(siteAddress),
                 actions = getActionsForIncorrectWPComEmailNotification(siteAddress)
             )
-        } ?: wooLogWrapper.e(NOTIFS, "Can't create local notification for incorrect WPCom email: site address is missing")
+        } ?: wooLogWrapper.e(
+            NOTIFS,
+            "Can't create local notification for incorrect WPCom email: site address is missing"
+        )
     }
 
     private fun buildLoginNotification(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -51,10 +51,6 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         return Result.success()
     }
 
-    private fun incorrectWPComEmailNotification() {
-        TODO("Not yet implemented")
-    }
-
     private fun defaultLoginSupportNotification() {
         wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
             notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
@@ -80,6 +76,19 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         )
     }
 
+    private fun incorrectWPComEmailNotification() {
+        wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
+            notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
+            appContext.getString(R.string.notification_channel_pre_login_id),
+            notification = buildLoginNotification(
+                title = R.string.login_help_notification_default_title,
+                description = R.string.login_help_notification_incorrect_wpcom_email_description
+            ),
+            notificationTappedIntent = buildOpenLoginWithSiteCredentialsIntent(),
+            actions = getActionsForSiteAddressErrorNotification()
+        )
+    }
+
     private fun buildLoginNotification(
         @StringRes title: Int,
         @StringRes description: Int
@@ -100,6 +109,9 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
 
     private fun buildOpenLoginWithEmailScreenIntent(): Intent =
         LoginActivity.createIntent(appContext, LOGIN_SITE_ADDRESS_ERROR)
+
+    private fun buildOpenLoginWithSiteCredentialsIntent(): Intent =
+        LoginActivity.createIntent(appContext, LOGIN_INCORRECT_WPCOM_EMAIL)
 
     private fun getActionsForSiteAddressErrorNotification(): List<Pair<String, Intent>> =
         listOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -20,8 +20,9 @@ import com.woocommerce.android.ui.login.localnotifications.LoginNotificationSche
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_NOTIFICATION_TYPE_KEY
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.DEFAULT_HELP
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_INCORRECT_WPCOM_EMAIL
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_EMAIL_ERROR
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_WPCOM_EMAIL_ERROR
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -41,7 +42,8 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         when (notificationType) {
             DEFAULT_HELP -> defaultLoginSupportNotification()
             LOGIN_SITE_ADDRESS_ERROR -> siteAddressErrorNotification()
-            LOGIN_INCORRECT_WPCOM_EMAIL -> incorrectWPComEmailNotification(prefsWrapper.getLoginSiteAddress())
+            LOGIN_SITE_ADDRESS_EMAIL_ERROR,
+            LOGIN_WPCOM_EMAIL_ERROR -> incorrectWPComEmailNotification(prefsWrapper.getLoginSiteAddress())
         }
         AnalyticsTracker.track(
             LOGIN_LOCAL_NOTIFICATION_DISPLAYED,
@@ -113,7 +115,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         LoginActivity.createIntent(appContext, LOGIN_SITE_ADDRESS_ERROR)
 
     private fun buildOpenLoginWithSiteCredentialsIntent(siteAddress: String): Intent =
-        LoginActivity.createIntent(appContext, LOGIN_INCORRECT_WPCOM_EMAIL, siteAddress)
+        LoginActivity.createIntent(appContext, LOGIN_SITE_ADDRESS_EMAIL_ERROR, siteAddress)
 
     private fun getActionsForSiteAddressErrorNotification(): List<Pair<String, Intent>> =
         listOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -131,9 +131,9 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
 
     private fun getActionsForIncorrectWPComEmailNotification(siteAddress: String): List<Pair<String, Intent>> =
         listOf(
-            resourceProvider.getString(R.string.login_help_notification_wordpress_login_button)
-                to buildOpenLoginWithSiteCredentialsIntent(siteAddress),
             resourceProvider.getString(R.string.login_help_notification_site_credentials_login_button)
+                to buildOpenLoginWithSiteCredentialsIntent(siteAddress),
+            resourceProvider.getString(R.string.login_help_notification_contact_support_button)
                 to buildOpenSupportScreenIntent(),
         )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -53,7 +53,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         return Result.success()
     }
 
-    private fun defaultLoginSupportNotification() {
+    private fun defaultLoginSupportNotification(notificationType: LoginHelpNotificationType = DEFAULT_HELP) {
         wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
             notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
             appContext.getString(R.string.notification_channel_pre_login_id),
@@ -61,7 +61,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
                 title = R.string.login_help_notification_default_title,
                 description = R.string.login_help_notification_no_interaction_default_description
             ),
-            notificationTappedIntent = buildOpenSupportScreenIntent()
+            notificationTappedIntent = buildOpenSupportScreenIntent(notificationType)
         )
     }
 
@@ -87,10 +87,16 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
                     title = R.string.login_help_notification_default_title,
                     description = R.string.login_help_notification_incorrect_wpcom_email_description
                 ),
-                notificationTappedIntent = buildOpenLoginWithSiteCredentialsIntent(siteAddress),
-                actions = getActionsForIncorrectWPComEmailNotification(siteAddress)
+                notificationTappedIntent = buildOpenLoginWithSiteCredentialsIntent(
+                    siteAddress,
+                    LOGIN_SITE_ADDRESS_EMAIL_ERROR
+                ),
+                actions = getActionsForIncorrectWPComEmailNotification(
+                    siteAddress,
+                    LOGIN_SITE_ADDRESS_EMAIL_ERROR
+                )
             )
-        } ?: defaultLoginSupportNotification()
+        } ?: defaultLoginSupportNotification(LOGIN_WPCOM_EMAIL_ERROR)
     }
 
     private fun buildLoginNotification(
@@ -108,28 +114,37 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         channelType = NotificationChannelType.PRE_LOGIN
     )
 
-    private fun buildOpenSupportScreenIntent(): Intent =
-        HelpActivity.createIntent(appContext, HelpActivity.Origin.LOGIN_HELP_NOTIFICATION, null)
+    private fun buildOpenSupportScreenIntent(notificationType: LoginHelpNotificationType): Intent =
+        HelpActivity.createIntent(
+            appContext,
+            HelpActivity.Origin.LOGIN_HELP_NOTIFICATION,
+            arrayListOf(notificationType.toString())
+        )
 
     private fun buildOpenLoginWithEmailScreenIntent(): Intent =
         LoginActivity.createIntent(appContext, LOGIN_SITE_ADDRESS_ERROR)
 
-    private fun buildOpenLoginWithSiteCredentialsIntent(siteAddress: String): Intent =
-        LoginActivity.createIntent(appContext, LOGIN_SITE_ADDRESS_EMAIL_ERROR, siteAddress)
+    private fun buildOpenLoginWithSiteCredentialsIntent(
+        siteAddress: String,
+        notificationType: LoginHelpNotificationType
+    ): Intent = LoginActivity.createIntent(appContext, notificationType, siteAddress)
 
     private fun getActionsForSiteAddressErrorNotification(): List<Pair<String, Intent>> =
         listOf(
             resourceProvider.getString(R.string.login_help_notification_wordpress_login_button)
                 to buildOpenLoginWithEmailScreenIntent(),
             resourceProvider.getString(R.string.login_help_notification_contact_support_button)
-                to buildOpenSupportScreenIntent(),
+                to buildOpenSupportScreenIntent(LOGIN_SITE_ADDRESS_EMAIL_ERROR),
         )
 
-    private fun getActionsForIncorrectWPComEmailNotification(siteAddress: String): List<Pair<String, Intent>> =
+    private fun getActionsForIncorrectWPComEmailNotification(
+        siteAddress: String,
+        notificationType: LoginHelpNotificationType
+    ): List<Pair<String, Intent>> =
         listOf(
             resourceProvider.getString(R.string.login_help_notification_site_credentials_login_button)
-                to buildOpenLoginWithSiteCredentialsIntent(siteAddress),
+                to buildOpenLoginWithSiteCredentialsIntent(siteAddress, LOGIN_SITE_ADDRESS_EMAIL_ERROR),
             resourceProvider.getString(R.string.login_help_notification_contact_support_button)
-                to buildOpenSupportScreenIntent(),
+                to buildOpenSupportScreenIntent(notificationType),
         )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -50,6 +50,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
             mapOf(AnalyticsTracker.KEY_TYPE to notificationType.toString())
         )
         prefsWrapper.setPreLoginNotificationDisplayed(displayed = true)
+        prefsWrapper.setPreLoginNotificationDisplayedType(notificationType.toString())
         return Result.success()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -20,8 +20,8 @@ import com.woocommerce.android.ui.login.localnotifications.LoginNotificationSche
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_NOTIFICATION_TYPE_KEY
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.DEFAULT_HELP
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_INCORRECT_WPCOM_EMAIL
+import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -85,7 +85,7 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
                 description = R.string.login_help_notification_incorrect_wpcom_email_description
             ),
             notificationTappedIntent = buildOpenLoginWithSiteCredentialsIntent(),
-            actions = getActionsForSiteAddressErrorNotification()
+            actions = getActionsForIncorrectWPComEmailNotification()
         )
     }
 
@@ -118,6 +118,14 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
             resourceProvider.getString(R.string.login_help_notification_wordpress_login_button)
                 to buildOpenLoginWithEmailScreenIntent(),
             resourceProvider.getString(R.string.login_help_notification_contact_support_button)
+                to buildOpenSupportScreenIntent(),
+        )
+
+    private fun getActionsForIncorrectWPComEmailNotification(): List<Pair<String, Intent>> =
+        listOf(
+            resourceProvider.getString(R.string.login_help_notification_wordpress_login_button)
+                to buildOpenLoginWithSiteCredentialsIntent(),
+            resourceProvider.getString(R.string.login_help_notification_site_credentials_login_button)
                 to buildOpenSupportScreenIntent(),
         )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -60,6 +60,7 @@ class LoginNotificationScheduler @Inject constructor(
 
     enum class LoginHelpNotificationType(private val typeName: String) {
         LOGIN_SITE_ADDRESS_ERROR("site_address_error"),
+        LOGIN_INCORRECT_WPCOM_EMAIL("incorrect_wpcom_email"),
         DEFAULT_HELP("default_support");
 
         override fun toString(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -42,7 +42,7 @@ class LoginNotificationScheduler @Inject constructor(
             val workRequest: WorkRequest =
                 OneTimeWorkRequestBuilder<LoginHelpNotificationWorker>()
                     .setInputData(notificationData)
-                    .setInitialDelay(NOTIFICATION_TEST_DELAY_IN_HOURS, TimeUnit.HOURS)
+                    .setInitialDelay(5, TimeUnit.SECONDS)
                     .build()
 
             prefsWrapper.setPreLoginNotificationWorkRequestId(workRequest.id.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -7,6 +7,8 @@ import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import androidx.work.workDataOf
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -46,6 +48,10 @@ class LoginNotificationScheduler @Inject constructor(
                     .build()
 
             prefsWrapper.setPreLoginNotificationWorkRequestId(workRequest.id.toString())
+            AnalyticsTracker.track(
+                AnalyticsEvent.LOGIN_LOCAL_NOTIFICATION_SCHEDULED,
+                mapOf(AnalyticsTracker.KEY_TYPE to notificationType.toString())
+            )
             workManager.enqueue(workRequest)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -36,7 +36,7 @@ class LoginNotificationScheduler @Inject constructor(
     }
 
     fun scheduleNotification(notificationType: LoginHelpNotificationType) {
-        if (!prefsWrapper.hasPreLoginNotificationBeenDisplayed()) {
+//        if (!prefsWrapper.hasPreLoginNotificationBeenDisplayed()) {
             cancelCurrentNotificationWorkRequest()
             val notificationData = workDataOf(
                 LOGIN_NOTIFICATION_TYPE_KEY to notificationType.toString()
@@ -53,7 +53,7 @@ class LoginNotificationScheduler @Inject constructor(
                 mapOf(AnalyticsTracker.KEY_TYPE to notificationType.toString())
             )
             workManager.enqueue(workRequest)
-        }
+//        }
     }
 
     private fun cancelCurrentNotificationWorkRequest() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -20,7 +20,7 @@ class LoginNotificationScheduler @Inject constructor(
 ) {
     companion object {
         const val LOGIN_NOTIFICATION_TYPE_KEY = "Notification-type"
-        const val NOTIFICATION_TEST_DELAY_IN_HOURS = 5L
+        const val NOTIFICATION_TEST_DELAY_IN_HOURS = 24L
         const val LOGIN_HELP_NOTIFICATION_ID = 987612345
         const val LOGIN_HELP_NOTIFICATION_TAG = "login-help-notification"
     }
@@ -44,7 +44,7 @@ class LoginNotificationScheduler @Inject constructor(
             val workRequest: WorkRequest =
                 OneTimeWorkRequestBuilder<LoginHelpNotificationWorker>()
                     .setInputData(notificationData)
-                    .setInitialDelay(NOTIFICATION_TEST_DELAY_IN_HOURS, TimeUnit.SECONDS)
+                    .setInitialDelay(NOTIFICATION_TEST_DELAY_IN_HOURS, TimeUnit.HOURS)
                     .build()
 
             prefsWrapper.setPreLoginNotificationWorkRequestId(workRequest.id.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -72,6 +72,7 @@ class LoginNotificationScheduler @Inject constructor(
                 when (string) {
                     LOGIN_SITE_ADDRESS_ERROR.typeName -> LOGIN_SITE_ADDRESS_ERROR
                     DEFAULT_HELP.typeName -> DEFAULT_HELP
+                    LOGIN_INCORRECT_WPCOM_EMAIL.typeName -> LOGIN_INCORRECT_WPCOM_EMAIL
                     else -> DEFAULT_HELP
                 }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -60,7 +60,8 @@ class LoginNotificationScheduler @Inject constructor(
 
     enum class LoginHelpNotificationType(private val typeName: String) {
         LOGIN_SITE_ADDRESS_ERROR("site_address_error"),
-        LOGIN_INCORRECT_WPCOM_EMAIL("incorrect_wpcom_email"),
+        LOGIN_WPCOM_EMAIL_ERROR("wpcom_email_error"),
+        LOGIN_SITE_ADDRESS_EMAIL_ERROR("site_address_email_error"),
         DEFAULT_HELP("default_support");
 
         override fun toString(): String {
@@ -72,7 +73,8 @@ class LoginNotificationScheduler @Inject constructor(
                 when (string) {
                     LOGIN_SITE_ADDRESS_ERROR.typeName -> LOGIN_SITE_ADDRESS_ERROR
                     DEFAULT_HELP.typeName -> DEFAULT_HELP
-                    LOGIN_INCORRECT_WPCOM_EMAIL.typeName -> LOGIN_INCORRECT_WPCOM_EMAIL
+                    LOGIN_SITE_ADDRESS_EMAIL_ERROR.typeName -> LOGIN_SITE_ADDRESS_EMAIL_ERROR
+                    LOGIN_WPCOM_EMAIL_ERROR.typeName -> LOGIN_WPCOM_EMAIL_ERROR
                     else -> DEFAULT_HELP
                 }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -18,7 +18,7 @@ class LoginNotificationScheduler @Inject constructor(
 ) {
     companion object {
         const val LOGIN_NOTIFICATION_TYPE_KEY = "Notification-type"
-        const val NOTIFICATION_TEST_DELAY_IN_HOURS = 24L
+        const val NOTIFICATION_TEST_DELAY_IN_HOURS = 5L
         const val LOGIN_HELP_NOTIFICATION_ID = 987612345
         const val LOGIN_HELP_NOTIFICATION_TAG = "login-help-notification"
     }
@@ -42,7 +42,7 @@ class LoginNotificationScheduler @Inject constructor(
             val workRequest: WorkRequest =
                 OneTimeWorkRequestBuilder<LoginHelpNotificationWorker>()
                     .setInputData(notificationData)
-                    .setInitialDelay(5, TimeUnit.SECONDS)
+                    .setInitialDelay(NOTIFICATION_TEST_DELAY_IN_HOURS, TimeUnit.SECONDS)
                     .build()
 
             prefsWrapper.setPreLoginNotificationWorkRequestId(workRequest.id.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginNotificationScheduler.kt
@@ -36,7 +36,7 @@ class LoginNotificationScheduler @Inject constructor(
     }
 
     fun scheduleNotification(notificationType: LoginHelpNotificationType) {
-//        if (!prefsWrapper.hasPreLoginNotificationBeenDisplayed()) {
+        if (!prefsWrapper.hasPreLoginNotificationBeenDisplayed()) {
             cancelCurrentNotificationWorkRequest()
             val notificationData = workDataOf(
                 LOGIN_NOTIFICATION_TYPE_KEY to notificationType.toString()
@@ -53,7 +53,7 @@ class LoginNotificationScheduler @Inject constructor(
                 mapOf(AnalyticsTracker.KEY_TYPE to notificationType.toString())
             )
             workManager.enqueue(workRequest)
-//        }
+        }
     }
 
     private fun cancelCurrentNotificationWorkRequest() {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2130,6 +2130,7 @@
     <string name="login_help_notification_incorrect_wpcom_email_description">Log in with your site credentials</string>
     <string name="login_help_notification_contact_support_button">Contact support</string>
     <string name="login_help_notification_wordpress_login_button">Log in with WordPress.com</string>
+    <string name="login_help_notification_site_credentials_login_button">Log in with Site Credentials</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2126,9 +2126,10 @@
     <!-- Login local notifications -->
     <string name="login_help_notification_default_title">Problems with logging in?</string>
     <string name="login_help_notification_no_interaction_default_description">Get some help!</string>
-    <string name="login_help_notification_site_error_description">Try login with your WordPress.com account</string>
+    <string name="login_help_notification_site_error_description">Log in with your WordPress.com account</string>
+    <string name="login_help_notification_incorrect_wpcom_email_description">Log in with your site credentials</string>
     <string name="login_help_notification_contact_support_button">Contact support</string>
-    <string name="login_help_notification_wordpress_login_button">Login with WordPress.com</string>
+    <string name="login_help_notification_wordpress_login_button">Log in with WordPress.com</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2130,7 +2130,6 @@
     <string name="login_help_notification_incorrect_wpcom_email_description">Log in with your site credentials</string>
     <string name="login_help_notification_contact_support_button">Contact support</string>
     <string name="login_help_notification_wordpress_login_button">Log in with WordPress.com</string>
-    <string name="login_help_notification_site_credentials_login_button">Log in with Site Credentials</string>
 
     <!-- Other -->
     <string name="error_loading_image">Unable to load image</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6989
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR handles local notifications for the following scenarios from the Local notifications experiment pe5sF9-h9-p2

- Scenario 3: Entered a site address -> incorrect email
- Scenario 5: Entered incorrect WordPress.com email 

Originally Scenario 3 notification would include an additional CTA in the notification to directly open "Login with site credentials screen". After this discussion: p1659600559140319-slack-C03L1NF1EA3
we decided that it doesn't make sense as with **Experiment  8** self hosted site addresses will be redirected to site credential screens directly and WordPress.com site addressed don't have login with site credentials available. 

### Scenario 3

**Demo**

https://user-images.githubusercontent.com/2663464/182834678-9f6d71f9-4e1a-424e-b8c8-5d046595bb28.mp4

- Open the app and click on "Enter your store address" 
- Enter a WP.com site address. You can use `jorgemucientes.wpcomstaging.com` for convenience
- Enter a random email like `alfsjhgbjdkafsd@gmail.com`
- See the notification appears after 5 seconds. Notification UI should match the UI from the demo video
- Click on login with site credentials
- Check the following events were tracked in the logcat: 
```
Tracked: login_local_notification_scheduled, Properties: {"type":"site_address_email_error","is_debug":true}
Tracked: login_local_notification_displayed, Properties: {"type":"site_address_email_error","is_debug":true}
Tracked: login_local_notification_tapped, Properties: {"type":"site_address_email_error","is_debug":true}
```

### Scenario 5

**Demo**

https://user-images.githubusercontent.com/2663464/182834663-97170d06-a665-442d-8402-93bc610ece05.mp4

- Clear app data in order to see the notification again
- Open the app and select "Continue with WordPress" 
- Enter a random email like "sfdgfhgsdzsfb@gmail.com"
- Wait for the notification to appear and check the UI matches the one from the demo video
- Click on the notification
- Verify the following is tracked 
```
Tracked: login_local_notification_scheduled, Properties: {"type":"wpcom_email_error","is_debug":true}
Tracked: login_local_notification_displayed, Properties: {"type":"wpcom_email_error","is_debug":true}
Tracked: login_local_notification_tapped, Properties: {"type":"wpcom_email_error","is_debug":true}
```

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->