### PR TITLE
Fix crash in ProductImageViewerFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -31,6 +32,8 @@ import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ImageViewerFragment.Companion.ImageViewerListener
 import com.woocommerce.android.util.WooAnimUtils
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -103,10 +106,11 @@ class ProductImageViewerFragment :
         // which would prevent the previous fragment's view from getting destroyed, this causes an issue where the
         // Toolbar doesn't get restored when navigating back.
         // This seems like a bug in the fragment library.
-        view.postDelayed({
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(500)
             @Suppress("DEPRECATION")
             requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-        }, 500)
+        }
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
Closes: #7075 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We use a `postDelayed` to make sure the change to full-screen is executed with a small delay, this causes a crash when the phone is rotated, as we might access the `Activity` after the fragment was detached.
The change of this PR fixes this by switching to a coroutine with `delay` instead, the cancellation behavior of the `delay` means we won't call the code after the view is destroyed, which prevents the crash.

### Testing instructions
To reproduce the crash:
1. Checkout `release/9.7`.
2. Open the app, then open a product, and open the image viewer.
3. Rotate your phone multiple times until the app crashes (just keep trying)

To confirm the fix:
1. Checkout this branch.
2. Repeat previous steps.
3. Confirm the app doesn't crash.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
