### PR TITLE
Fix crash in order creation form

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -113,8 +113,8 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
         }
     }
 
-    override fun onStop() {
-        super.onStop()
+    override fun onPause() {
+        super.onPause()
         progressDialog?.dismiss()
         orderUpdateFailureSnackBar?.dismiss()
     }


### PR DESCRIPTION
Closes: #7077

### Description
This fixes a crash that occurs in the order creation form when the progress dialog is dismissed in `onStop`.

### Testing instructions
To reproduce the crash:

1. Checkout release/9.7.
2. Open the app, then open the order creation form.
3. Click on "Create" button.
4. When the progress dialog is shown, rotate your phone.
5. Notice the crash

To confirm the fix:

1. Checkout this branch.
2. Repeat previous steps.
3. Confirm the app doesn't crash.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
