### PR TITLE
Set name using fragment tag to add transactions into back stack

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -248,7 +248,7 @@ class LoginActivity :
         )
         fragmentTransaction.replace(R.id.fragment_container, fragment, tag)
         if (shouldAddToBackStack) {
-            fragmentTransaction.addToBackStack(null)
+            fragmentTransaction.addToBackStack(tag)
         }
         fragmentTransaction.commitAllowingStateLoss()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes [this navigation bug](https://github.com/wordpress-mobile/WordPress-Android/issues/16960#issue-1319353527)

### Description 

After [adding the new prologue carousel ](https://github.com/woocommerce/woocommerce-android/commit/4e8ac6bdb4f0686d1f13cb507e2573ef2d60ac38) navigation was altered, surfacing an issue we have with the `slideInFragment()` function. Fragment transactions were not given a name so when trying to navigate back using `popBackStack`, like we do in `startOver()` function won't do anything as there's no transaction with the expected name.

This is not a major issue imo, so I'm targeting `trunk` but please let me know if I should add this to `release/9.7` too @pachlava. 

### Expected behavior
Tapping `Log in with another account` button should result in redirect to prologue screen.

### Actual behavior
Tapping this button does nothing, both in cases of getting to the screen via `WPCOM login` or via `store address login`.
Never mind that video is shot for debug variant with emulator, it's the same for release beta 9.7-rc-1 on a real device.

https://user-images.githubusercontent.com/73365754/181225830-35d3d5ca-785c-4bb3-83a9-15dbba730af3.mov

### Steps to reproduce the behavior

Way 1:
1. Make sure you're logged out
2. Tap `Enter your store address`
3. Enter `google.com` and tap `Continue`
4. In the next screen, tap `Log in with another account` ~> nothing happens

Way 2:
1. Make sure you're logged out
2. Tap `Log in with WordPress.com`
3. Enter some valid email address, which is not associated with a WPCOM account, and tap `Continue`
4. In the next screen, tap `Log in with another account` ~> nothing happens


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
