### PR TITLE
issue/7071-linked-product-promo-tweaks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -117,6 +117,7 @@ fun Banner(
     subtitle: String,
     ctaLabel: String,
     source: String,
+    chipLabel: String = stringResource(id = R.string.card_reader_upsell_card_reader_banner_new)
 ) {
     Card(
         modifier = Modifier.fillMaxWidth()
@@ -170,7 +171,7 @@ fun Banner(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = stringResource(id = R.string.card_reader_upsell_card_reader_banner_new),
+                        text = chipLabel,
                         color = colorResource(id = R.color.woo_purple_60),
                         style = MaterialTheme.typography.caption,
                         fontWeight = FontWeight.Bold,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -480,8 +480,7 @@ class ProductDetailFragment :
                             },
                             onDismissClick = {
                                 WooAnimUtils.scaleOut(binding.promoComposableContainer)
-                            },
-                            source = ""
+                            }
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/promobanner/PromoBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/promobanner/PromoBanner.kt
@@ -19,8 +19,9 @@ fun PromoBanner(
         onDismissClick = onDismissClick,
         title = stringResource(id = bannerType.titleRes),
         subtitle = stringResource(id = bannerType.messageRes),
-        ctaLabel = stringResource(R.string.try_it_now),
-        source = ""
+        ctaLabel = stringResource(R.string.set_up_now),
+        source = "",
+        chipLabel = stringResource(id = R.string.tip)
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/promobanner/PromoBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/promobanner/PromoBanner.kt
@@ -1,114 +1,27 @@
 package com.woocommerce.android.ui.promobanner
 
 import android.content.res.Configuration
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.payments.banner.Banner
 
 @Composable
 fun PromoBanner(
     bannerType: PromoBannerType,
     onCtaClick: (String) -> Unit,
-    onDismissClick: () -> Unit,
-    source: String
+    onDismissClick: () -> Unit
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = dimensionResource(id = R.dimen.major_100)),
-            horizontalArrangement = Arrangement.End
-        ) {
-            IconButton(
-                onClick = onDismissClick
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_close),
-                    contentDescription = stringResource(id = R.string.card_reader_upsell_card_reader_banner_dismiss),
-                    tint = colorResource(id = R.color.color_on_surface)
-                )
-            }
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = dimensionResource(id = R.dimen.major_100),
-                    top = dimensionResource(id = R.dimen.major_100)
-                ),
-            verticalAlignment = Alignment.Bottom,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                Text(
-                    text = stringResource(id = bannerType.titleRes),
-                    style = MaterialTheme.typography.subtitle1,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(
-                        bottom = dimensionResource(id = R.dimen.minor_100)
-                    )
-                )
-                Text(
-                    text = stringResource(id = bannerType.messageRes),
-                    style = MaterialTheme.typography.subtitle1,
-                    modifier = Modifier.padding(
-                        bottom = dimensionResource(id = R.dimen.minor_100)
-                    )
-                )
-                TextButton(
-                    modifier = Modifier
-                        .padding(
-                            top = dimensionResource(id = R.dimen.minor_100),
-                            bottom = dimensionResource(id = R.dimen.minor_100),
-                        ),
-                    contentPadding = PaddingValues(start = dimensionResource(id = R.dimen.minor_00)),
-                    onClick = {
-                        onCtaClick(source)
-                    }
-                ) {
-                    Text(
-                        text = stringResource(id = R.string.try_it_now),
-                        color = colorResource(id = R.color.color_secondary),
-                        style = MaterialTheme.typography.subtitle1,
-                        fontWeight = FontWeight.Bold,
-                    )
-                }
-            }
-            Column {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_banner_upsell_card_reader_illustration),
-                    contentDescription = null,
-                    contentScale = ContentScale.Inside
-                )
-            }
-        }
-    }
+    Banner(
+        onCtaClick = onCtaClick,
+        onDismissClick = onDismissClick,
+        title = stringResource(id = bannerType.titleRes),
+        subtitle = stringResource(id = bannerType.messageRes),
+        ctaLabel = stringResource(R.string.try_it_now),
+        source = ""
+    )
 }
 
 @Preview(name = "Light mode")
@@ -116,6 +29,6 @@ fun PromoBanner(
 @Composable
 private fun PromoBannerPreview() {
     WooThemeWithBackground {
-        PromoBanner(PromoBannerType.LINKED_PRODUCTS, {}, {}, "")
+        PromoBanner(PromoBannerType.LINKED_PRODUCTS, {}, {})
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="keep_changes">Keep changes</string>
     <string name="learn_more">Learn more</string>
     <string name="try_it_now">Try it now</string>
+    <string name="set_up_now">Set up now</string>
     <string name="offline_message">Offline \u2014 using cached data</string>
     <string name="offline_error">Your network is unavailable. Check your data or wifi connection.</string>
     <string name="product">Product</string>
@@ -144,6 +145,7 @@
     <string name="copy" tools:override="true">Copy</string>
     <string name="variations_bulk_update_sale_price">Update Sale Price</string>
     <string name="variations_bulk_update_regular_price">Update Regular Price</string>
+    <string name="tip">Tip</string>
 
     <!--
         Date/Time Labels


### PR DESCRIPTION
Partially Closes: #7071 - this PR changes the "linked product promo banner" to reuse the existing card reader upsell banner. As with #7059, I recommended changing [isPromoBannerShown](https://github.com/woocommerce/woocommerce-android/blob/400d7f5c180caa0ff0acdeda45a846e2404c8c98/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt#L364) to always return `false` so the banner isn't limited to being shown one time.

@ThomazFB I hope you don't mind, but I've asked for your review since you reviewed the previous PR and understand the context.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
