### PR TITLE
Change the manifest to set the splash theme to the main activity

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Woo.Splash">
+        android:theme="@style/Theme.Woo.DayNight">
 
         <!-- TODO: we eventually want to drop support for Apache, but for now it's used by FluxC -->
         <uses-library
@@ -38,6 +38,7 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"
+            android:theme="@style/Theme.Woo.Splash"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
For #7089 I researched the new `SplashScreen` compat library, in the hopes it would enable us to stop using `Theme.Woo.Splash` as the `application` theme in the manifest. The reason for this is it has a side effect of defaulting to the splash theme whenever a layout is opened, which forces us to switch to `Theme.Woo.DayNight` every time we open a layout. This is something I usually have to do several times a day.

I was unable to get the `SplashScreen` to work in a backwards compatible way (probably my fault rather than the library, but I didn't want to spend much time on this). However, I did discover we can simply use `Theme.Woo.Splash` on the main activity rather than the application, which resolves the problem.

To test, simply run the app and verify the splash screen appears when the app is opened. I recommend trying this on a Lollipop emulator, as my API 21 emulator no longer works.

@AmandaRiu Pinging you to ask if there was a reason to assign the theme at the application level?

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.