### PR TITLE
issue/7053-product-detail-loaded-event 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -148,6 +148,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_ORDER_ID = "order_id"
         const val KEY_PRODUCT_ID = "product_id"
         const val KEY_PRODUCT_COUNT = "product_count"
+        const val KEY_HAS_LINKED_PRODUCTS = "has_linked_products"
         const val KEY_IS_LOADING_MORE = "is_loading_more"
         const val KEY_IS_WPCOM_STORE = "is_wpcom_store"
         const val KEY_NAME = "name"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.AppConstants
-import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_LOADED
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_UPDATE_ERROR
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_UPDATE_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -84,8 +83,6 @@ class ProductDetailRepository @Inject constructor(
 
         if (result.isError) {
             lastFetchProductErrorType = result.error.type
-        } else {
-            AnalyticsTracker.track(PRODUCT_DETAIL_LOADED)
         }
 
         return getProduct(remoteProductId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_LINKED_PRODUCTS
 import com.woocommerce.android.extensions.addNewItem
 import com.woocommerce.android.extensions.clearList
 import com.woocommerce.android.extensions.containsItem
@@ -289,7 +290,11 @@ class ProductDetailViewModel @Inject constructor(
             initializeStoredProductAfterRestoration()
         }
         observeImageUploadEvents()
-        AnalyticsTracker.track(AnalyticsEvent.PRODUCT_DETAIL_LOADED)
+
+        val properties = viewState.productDraft?.let {
+            mapOf(KEY_HAS_LINKED_PRODUCTS to it.hasLinkedProducts())
+        } ?: emptyMap()
+        AnalyticsTracker.track(AnalyticsEvent.PRODUCT_DETAIL_LOADED, properties)
     }
 
     private fun initializeViewState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -289,6 +289,7 @@ class ProductDetailViewModel @Inject constructor(
             initializeStoredProductAfterRestoration()
         }
         observeImageUploadEvents()
+        AnalyticsTracker.track(AnalyticsEvent.PRODUCT_DETAIL_LOADED)
     }
 
     private fun initializeViewState() {


### PR DESCRIPTION
Partially closes: #7053 - This PR changes the `PRODUCT_DETAIL_LOADED` event to only be tracked when the product detail view model is started (ie: when the product detail is first loaded). Previously we tracked this whenever the product was fetched, which happens at startup and when the product is updated.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.