### PR TITLE
Create artificial orderStatus when status not present in db

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
@@ -33,6 +33,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -237,7 +238,9 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private suspend fun updateOrderStatus(statusKey: String) {
         val statusModel = withContext(dispatchers.io) {
             orderStore.getOrderStatusForSiteAndKey(selectedSite.get(), statusKey)
-                ?: error("Couldn't find a status with key $statusKey")
+                ?: WCOrderStatusModel(statusKey = statusKey).apply {
+                    label = statusKey
+                }
         }
 
         orderStore.updateOrderStatus(


### PR DESCRIPTION
Closes: #7098 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a crash when the app attempts to update order status but the new status is not found in the database. Instead of crashing, the app creates an artificial order status instead. It shouldn't have any side-effects and this approach is used in several other places where we are attempting to load a status from the db.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Start Simple Payment flow
2. Enter an amount
3. Confirm the details
4. Tap on "Cash"
5. Open for example Flipper - `wp-fluxc` WCOrderStatusModel table -> remove/rename `completed` status.
6. Tap on the confirmation dialog in the app
7. Notice the app doesn't crash

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
