### PR TITLE
Implement navigation on click on the error text on the hub screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubAdapter.kt
@@ -4,7 +4,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 
 class CardReaderHubAdapter : RecyclerView.Adapter<CardReaderHubViewHolder>() {
-    private val items = ArrayList<CardReaderHubViewModel.CardReaderHubListItemViewState>()
+    private val items = ArrayList<CardReaderHubViewModel.CardReaderHubViewState.ListItem>()
 
     override fun getItemCount() = items.size
 
@@ -16,7 +16,7 @@ class CardReaderHubAdapter : RecyclerView.Adapter<CardReaderHubViewHolder>() {
         holder.onBind(items[position])
     }
 
-    fun setItems(rows: List<CardReaderHubViewModel.CardReaderHubListItemViewState>) {
+    fun setItems(rows: List<CardReaderHubViewModel.CardReaderHubViewState.ListItem>) {
         items.clear()
         items.addAll(rows)
         notifyDataSetChanged()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
@@ -90,10 +90,12 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
             binding.cardReaderHubLoading.isInvisible = !state.isLoading
             with(binding.cardReaderHubOnboardingFailedTv) {
                 movementMethod = LinkMovementMethod.getInstance()
-                if (state.errorText != null) {
+                val onboardingErrorAction = state.onboardingErrorAction
+                if (onboardingErrorAction != null) {
                     animateErrorAppearance()
+                    setOnClickListener { onboardingErrorAction.onClick() }
                 }
-                UiHelpers.setTextOrHide(this, state.errorText)
+                UiHelpers.setTextOrHide(this, onboardingErrorAction?.text)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewHolder.kt
@@ -12,16 +12,16 @@ private const val DISABLED_BUTTON_ALPHA = 0.5f
 
 sealed class CardReaderHubViewHolder(val parent: ViewGroup, @LayoutRes layout: Int) :
     RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
-    abstract fun onBind(uiState: CardReaderHubViewModel.CardReaderHubListItemViewState)
+    abstract fun onBind(uiState: CardReaderHubViewModel.CardReaderHubViewState.ListItem)
 
     class RowViewHolder(parent: ViewGroup) : CardReaderHubViewHolder(parent, R.layout.card_reader_hub_list_item) {
         var binding: CardReaderHubListItemBinding = CardReaderHubListItemBinding.bind(itemView)
-        override fun onBind(uiState: CardReaderHubViewModel.CardReaderHubListItemViewState) {
+        override fun onBind(uiState: CardReaderHubViewModel.CardReaderHubViewState.ListItem) {
             binding.cardReaderHubListItemLabelTv.text = UiHelpers.getTextOfUiString(itemView.context, uiState.label)
             binding.cardReaderMenuIcon.setImageResource(uiState.icon)
 
             if (uiState.isEnabled) {
-                binding.root.setOnClickListener { uiState.onItemClicked.invoke() }
+                binding.root.setOnClickListener { uiState.onClick.invoke() }
                 binding.cardReaderMenuIcon.alpha = 1.0f
                 binding.cardReaderHubListItemLabelTv.alpha = 1.0f
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.InPersonPaymentsCanadaFeatureFlag
+import com.woocommerce.android.ui.payments.cardreader.hub.CardReaderHubViewModel.CardReaderHubViewState.ListItem
+import com.woocommerce.android.ui.payments.cardreader.hub.CardReaderHubViewModel.CardReaderHubViewState.OnboardingErrorAction
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentGatewayProvider
@@ -45,7 +47,7 @@ class CardReaderHubViewModel @Inject constructor(
         CardReaderHubViewState(
             rows = createHubListWhenSinglePluginInstalled(isOnboardingComplete = false),
             isLoading = true,
-            errorText = null
+            onboardingErrorAction = null
         )
     )
 
@@ -80,34 +82,34 @@ class CardReaderHubViewModel @Inject constructor(
 
     private fun createHubListWhenSinglePluginInstalled(isOnboardingComplete: Boolean) =
         listOf(
-            CardReaderHubListItemViewState(
+            ListItem(
                 icon = R.drawable.ic_gridicons_money_on_surface,
                 label = UiStringRes(R.string.card_reader_collect_payment),
-                onItemClicked = ::onCollectPaymentClicked
+                onClick = ::onCollectPaymentClicked
             ),
-            CardReaderHubListItemViewState(
+            ListItem(
                 icon = R.drawable.ic_shopping_cart,
                 label = UiStringRes(R.string.card_reader_purchase_card_reader),
-                onItemClicked = ::onPurchaseCardReaderClicked
+                onClick = ::onPurchaseCardReaderClicked
             ),
-            CardReaderHubListItemViewState(
+            ListItem(
                 icon = R.drawable.ic_card_reader_manual,
                 label = UiStringRes(R.string.settings_card_reader_manuals),
-                onItemClicked = ::onCardReaderManualsClicked
+                onClick = ::onCardReaderManualsClicked
             ),
-            CardReaderHubListItemViewState(
+            ListItem(
                 icon = R.drawable.ic_manage_card_reader,
                 label = UiStringRes(R.string.card_reader_manage_card_reader),
                 isEnabled = isOnboardingComplete,
-                onItemClicked = ::onManageCardReaderClicked
+                onClick = ::onManageCardReaderClicked
             ),
         )
 
     private fun createAdditionalItemWhenMultiplePluginsInstalled() =
-        CardReaderHubListItemViewState(
+        ListItem(
             icon = R.drawable.ic_payment_provider,
             label = UiStringRes(R.string.card_reader_manage_payment_provider),
-            onItemClicked = ::onCardReaderPaymentProviderClicked
+            onClick = ::onCardReaderPaymentProviderClicked
         )
 
     private fun createOnboardingCompleteState(showMultiplePluginsChoice: Boolean) = CardReaderHubViewState(
@@ -118,13 +120,16 @@ class CardReaderHubViewModel @Inject constructor(
             createHubListWhenSinglePluginInstalled(isOnboardingComplete = true)
         },
         isLoading = false,
-        errorText = null,
+        onboardingErrorAction = null,
     )
 
     private fun createOnboardingFailedState() = CardReaderHubViewState(
         rows = createHubListWhenSinglePluginInstalled(isOnboardingComplete = false),
         isLoading = false,
-        errorText = UiStringRes(R.string.card_reader_onboarding_not_finished, containsHtml = true)
+        onboardingErrorAction = OnboardingErrorAction(
+            text = UiStringRes(R.string.card_reader_onboarding_not_finished, containsHtml = true),
+            onClick = ::onOnboardingErrorClicked
+        )
     )
 
     val viewStateData: LiveData<CardReaderHubViewState> = viewState
@@ -148,6 +153,10 @@ class CardReaderHubViewModel @Inject constructor(
     private fun onCardReaderPaymentProviderClicked() {
         trackPaymentProviderClickedEvent()
         clearPluginExplicitlySelectedFlag()
+        triggerEvent(CardReaderHubEvents.NavigateToCardReaderOnboardingScreen)
+    }
+
+    private fun onOnboardingErrorClicked() {
         triggerEvent(CardReaderHubEvents.NavigateToCardReaderOnboardingScreen)
     }
 
@@ -181,15 +190,20 @@ class CardReaderHubViewModel @Inject constructor(
     }
 
     data class CardReaderHubViewState(
-        val rows: List<CardReaderHubListItemViewState>,
+        val rows: List<ListItem>,
         val isLoading: Boolean,
-        val errorText: UiString?,
-    )
+        val onboardingErrorAction: OnboardingErrorAction?,
+    ) {
+        data class ListItem(
+            @DrawableRes val icon: Int,
+            val label: UiString,
+            val isEnabled: Boolean = true,
+            val onClick: () -> Unit
+        )
 
-    data class CardReaderHubListItemViewState(
-        @DrawableRes val icon: Int,
-        val label: UiString,
-        val isEnabled: Boolean = true,
-        val onItemClicked: () -> Unit
-    )
+        data class OnboardingErrorAction(
+            val text: UiString?,
+            val onClick: () -> Unit,
+        )
+    }
 }

--- a/WooCommerce/src/main/res/layout/card_reader_learn_more_section.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_learn_more_section.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!-- android:textColorHighlight="#00FFFFFF": Workaround for a bug https://stackoverflow.com/a/70394538/632516 -->
 <com.google.android.material.textview.MaterialTextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/learnMore"
@@ -7,6 +9,7 @@
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
     android:drawableStart="@drawable/ic_info_outline_20dp"
+    android:textColorHighlight="#00FFFFFF"
     android:drawablePadding="@dimen/major_100"
     android:padding="@dimen/major_100"
     android:layout_marginStart="0dp"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_hub.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_hub.xml
@@ -26,6 +26,7 @@
         android:layout_height="0dp"
         android:layout_weight="1" />
 
+    <!-- android:textColorHighlight="#00FFFFFF": Workaround for a bug https://stackoverflow.com/a/70394538/632516 -->
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/cardReaderHubOnboardingFailedTv"
         style="@style/Woo.TextView.Caption"
@@ -42,7 +43,8 @@
         android:foreground="?attr/selectableItemBackground"
         android:outlineProvider="bounds"
         android:padding="@dimen/major_100"
-        android:textColor="@color/color_on_surface"
+        android:textColor="@color/color_on_surface_high"
+        android:textColorHighlight="#00FFFFFF"
         app:drawableTint="@color/color_on_surface"
         tools:text="@string/card_reader_onboarding_not_finished" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -78,7 +78,8 @@
         <action
             android:id="@+id/action_cardReaderOnboardingFragment_to_cardReaderHubFragment"
             app:destination="@id/cardReaderHubFragment"
-            app:popUpTo="@+id/mainSettingsFragment"
+            app:launchSingleTop="true"
+            app:popUpTo="@+id/cardReaderHubFragment"
             app:popUpToInclusive="false" />
         <action
             android:id="@+id/action_cardReaderOnboardingFragment_to_cardReaderConnectDialogFragment"
@@ -102,9 +103,7 @@
             app:destination="@id/cardReaderManualsFragment" />
         <action
             android:id="@+id/action_cardReaderHubFragment_to_cardReaderOnboardingFragment"
-            app:destination="@id/cardReaderOnboardingFragment"
-            app:popUpTo="@+id/cardReaderHubFragment"
-            app:popUpToInclusive="true"/>
+            app:destination="@id/cardReaderOnboardingFragment" />
         <action
             android:id="@+id/action_cardReaderHubFragment_to_simplePayments"
             app:destination="@id/simplePaymentsDialog"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -211,6 +211,22 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given onboarding check error, when user clicks on text, then onboarding shown`() = testBlocking {
+        whenever(cardReaderChecker.getOnboardingState()).thenReturn(
+            mock<CardReaderOnboardingState.GenericError>()
+        )
+
+        initViewModel()
+
+        viewModel.viewStateData.value?.onboardingErrorAction!!.onClick.invoke()
+
+        assertThat(viewModel.event.value)
+            .isEqualTo(
+                CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderOnboardingScreen
+            )
+    }
+
+    @Test
     fun ` when screen shown, then manuals row is displayed`() {
         assertThat((viewModel.viewStateData.value)?.rows)
             .anyMatch {
@@ -376,7 +392,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
             initViewModel()
 
-            assertThat(viewModel.viewStateData.value?.onboardingErrorAction).isEqualTo(
+            assertThat(viewModel.viewStateData.value?.onboardingErrorAction?.text).isEqualTo(
                 UiString.UiStringRes(R.string.card_reader_onboarding_not_finished, containsHtml = true)
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -116,7 +116,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `when user clicks on collect payment, then app navigates to card reader detail screen`() {
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_collect_payment)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(viewModel.event.value)
             .isEqualTo(
@@ -128,7 +128,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `when user clicks on manage card reader, then app navigates to card reader detail screen`() {
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_manage_card_reader)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(viewModel.event.value)
             .isEqualTo(
@@ -144,7 +144,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_purchase_card_reader)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(viewModel.event.value)
             .isEqualTo(
@@ -161,7 +161,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_purchase_card_reader)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(viewModel.event.value)
             .isEqualTo(
@@ -175,7 +175,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `when user clicks on purchase card reader, then app opens external webview with in-person-payments link`() {
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_purchase_card_reader)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(
             (viewModel.event.value as CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow).url
@@ -189,7 +189,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_purchase_card_reader)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(
             (viewModel.event.value as CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow).url
@@ -203,7 +203,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_purchase_card_reader)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(
             (viewModel.event.value as CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow).url
@@ -223,7 +223,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `when user clicks on manuals row, then app navigates to manuals screen`() {
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.settings_card_reader_manuals)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(viewModel.event.value)
             .isEqualTo(
@@ -283,7 +283,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         initViewModel()
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_manage_payment_provider)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         assertThat(viewModel.event.value).isEqualTo(
             CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderOnboardingScreen
@@ -304,7 +304,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         initViewModel()
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_manage_payment_provider)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         verify(appPrefsWrapper).setIsCardReaderPluginExplicitlySelectedFlag(
             anyInt(),
@@ -328,7 +328,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         initViewModel()
         (viewModel.viewStateData.value)?.rows?.find {
             it.label == UiString.UiStringRes(R.string.card_reader_manage_payment_provider)
-        }!!.onItemClicked.invoke()
+        }!!.onClick.invoke()
 
         verify(analyticsTrackerWrapper).track(AnalyticsEvent.SETTINGS_CARD_PRESENT_SELECT_PAYMENT_GATEWAY_TAPPED)
     }
@@ -376,7 +376,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
             initViewModel()
 
-            assertThat(viewModel.viewStateData.value?.errorText).isEqualTo(
+            assertThat(viewModel.viewStateData.value?.onboardingErrorAction).isEqualTo(
                 UiString.UiStringRes(R.string.card_reader_onboarding_not_finished, containsHtml = true)
             )
         }
@@ -390,7 +390,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
             initViewModel()
 
-            assertThat(viewModel.viewStateData.value?.errorText).isNull()
+            assertThat(viewModel.viewStateData.value?.onboardingErrorAction).isNull()
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7096
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Opens onboarding when user clicks on the error text in 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open payment hub with a site that doesn't have IPP setup
* Notice error at the bottom
* Click on it
* Notice onboarding flow starts

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/4923871/182815525-79f0ec08-2ca9-4bec-b7b6-e75318860c7d.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
