### PR TITLE
Remove ipp settings from the main settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.payments.banner.SettingsBannerDismissDialog
 import com.woocommerce.android.ui.payments.banner.SettingsScreenBanner
-import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -131,12 +130,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
 
         updateStoreSettings()
-        binding.optionCardReaderPayments.setOnClickListener {
-            val action = MainSettingsFragmentDirections.actionMainSettingsFragmentToCardReaderFlow(
-                CardReaderFlowParam.CardReadersHub
-            )
-            findNavController().navigateSafely(action)
-        }
 
         binding.optionHelpAndSupport.setOnClickListener {
             AnalyticsTracker.track(AnalyticsEvent.MAIN_MENU_CONTACT_SUPPORT_TAPPED)
@@ -240,6 +233,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
     override fun handleJetpackInstallOption(isJetpackCPSite: Boolean) {
         if (isJetpackCPSite) {
+            binding.storeSettingsContainer.visibility = View.VISIBLE
             binding.optionInstallJetpack.visibility = View.VISIBLE
             binding.optionInstallJetpack.setOnClickListener {
                 findNavController().navigateSafely(
@@ -247,7 +241,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                 )
             }
         } else {
-            binding.optionInstallJetpack.visibility = View.GONE
+            // Hide the whole container because jetpack is the only option there
+            binding.storeSettingsContainer.visibility = View.GONE
         }
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -44,14 +44,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/settings_store" />
-            <!--
-                Card Reader
-            -->
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/option_card_reader_payments"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/settings_card_reader_payments" />
 
             <!--
                 Install Jetpack

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -10,14 +10,6 @@
         android:name="com.woocommerce.android.ui.prefs.MainSettingsFragment"
         android:label="MainSettingsFragment">
         <action
-            android:id="@+id/action_mainSettingsFragment_to_cardReaderFlow"
-            app:destination="@id/paymentFlow" >
-            <argument
-                android:name="cardReaderFlowParam"
-                app:argType="com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam"
-                app:nullable="false" />
-        </action>
-        <action
             android:id="@+id/action_mainSettingsFragment_to_privacySettingsFragment"
             app:destination="@id/privacySettingsFragment" />
         <action
@@ -106,5 +98,4 @@
     </fragment>
     <action android:id="@+id/action_global_WPComWebViewFragment" app:destination="@id/WPComWebViewFragment"/>
     <include app:graph="@navigation/nav_graph_jetpack_install" />
-    <include app:graph="@navigation/nav_graph_payment_flow" />
 </navigation>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7025
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR removes IPP option from the settings

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open settings with JP connection package available - notice that JP option is there but IPP is not
* Open settings with JP connection package is not available - notice that the whole "store settings" section is missin

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="224" alt="image" src="https://user-images.githubusercontent.com/4923871/182822611-418c608b-a571-4be5-a75a-c2ae143e5ac5.png">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
