### PR TITLE
My Store performance transaction

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -112,6 +112,11 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     private val handler = Handler(Looper.getMainLooper())
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        lifecycle.addObserver(viewModel.performanceObserver)
+        super.onCreate(savedInstanceState)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTransactionLauncher.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.ui.mystore
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.automattic.android.tracks.crashlogging.performance.PerformanceTransactionRepository
+import com.automattic.android.tracks.crashlogging.performance.TransactionId
+import com.automattic.android.tracks.crashlogging.performance.TransactionOperation
+import com.automattic.android.tracks.crashlogging.performance.TransactionStatus
+import com.woocommerce.android.util.CoroutineDispatchers
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ViewModelScoped
+class MyStoreTransactionLauncher @Inject constructor(
+    private val performanceTransactionRepository: PerformanceTransactionRepository,
+    dispatchers: CoroutineDispatchers,
+) : LifecycleEventObserver {
+    private companion object {
+        const val TRANSACTION_NAME = "MyStore"
+    }
+
+    private var performanceTransactionId: TransactionId? = null
+    private val conditionsToSatisfy = MutableStateFlow(Conditions.values().toList())
+    private val validatorScope = CoroutineScope(dispatchers.main + Job())
+
+    init {
+        validatorScope.launch {
+            conditionsToSatisfy.collect { toSatisfy ->
+                if (toSatisfy.isEmpty()) {
+                    performanceTransactionId?.let {
+                        performanceTransactionRepository.finishTransaction(it, TransactionStatus.SUCCESSFUL)
+                    }
+                }
+            }
+        }
+    }
+
+    private enum class Conditions {
+        STORE_STATISTICS_FETCHED,
+        TOP_PERFORMERS_FETCHED
+    }
+
+    fun onStoreStatisticsFetched() = satisfyCondition(Conditions.STORE_STATISTICS_FETCHED)
+
+    fun onTopPerformersFetched() = satisfyCondition(Conditions.TOP_PERFORMERS_FETCHED)
+
+    fun clear() {
+        validatorScope.cancel()
+    }
+
+    private fun satisfyCondition(condition: Conditions) {
+        conditionsToSatisfy.value = (conditionsToSatisfy.value - condition)
+    }
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        when (event) {
+            Lifecycle.Event.ON_CREATE -> {
+                performanceTransactionId =
+                    performanceTransactionRepository.startTransaction(TRANSACTION_NAME, TransactionOperation.UI_LOAD)
+            }
+            Lifecycle.Event.ON_STOP -> {
+                performanceTransactionId?.let {
+                    performanceTransactionRepository.finishTransaction(it, TransactionStatus.ABORTED)
+                }
+                performanceTransactionId = null
+            }
+            else -> {
+                // no-op
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.mystore
 
 import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -68,12 +69,15 @@ class MyStoreViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val myStoreTransactionLauncher: MyStoreTransactionLauncher
 ) : ScopedViewModel(savedState) {
     private companion object {
         const val NUM_TOP_PERFORMERS = 5
         const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
         const val ACTIVE_STATS_GRANULARITY_KEY = "active_stats_granularity_key"
     }
+
+    val performanceObserver: LifecycleObserver = myStoreTransactionLauncher
 
     private var _revenueStatsState = MutableLiveData<RevenueStatsViewState>()
     val revenueStatsState: LiveData<RevenueStatsViewState> = _revenueStatsState
@@ -176,6 +180,7 @@ class MyStoreViewModel @Inject constructor(
                     IsJetPackCPEnabled -> onJetPackCpConnected()
                     is HasOrders -> _hasOrders.value = if (it.hasOrder) OrderState.AtLeastOne else OrderState.Empty
                 }
+                myStoreTransactionLauncher.onStoreStatisticsFetched()
             }
     }
 
@@ -256,6 +261,7 @@ class MyStoreViewModel @Inject constructor(
                     }
                     TopPerformersError -> _topPerformersState.value = TopPerformersViewState.Error
                 }
+                myStoreTransactionLauncher.onTopPerformersFetched()
             }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncher.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 @ViewModelScoped
 class OrderDetailsTransactionLauncher @Inject constructor(
     private val performanceTransactionRepository: PerformanceTransactionRepository,
-    private val dispatchers: CoroutineDispatchers,
+    dispatchers: CoroutineDispatchers,
 ) : LifecycleEventObserver {
     private companion object {
         const val TRANSACTION_NAME = "OrderDetails"
@@ -80,6 +80,7 @@ class OrderDetailsTransactionLauncher @Inject constructor(
                 performanceTransactionId?.let {
                     performanceTransactionRepository.finishTransaction(it, TransactionStatus.ABORTED)
                 }
+                performanceTransactionId = null
             }
             else -> {
                 // no-op

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListTransactionLauncher.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 @ViewModelScoped
 class OrderListTransactionLauncher @Inject constructor(
     private val performanceTransactionRepository: PerformanceTransactionRepository,
-    private val dispatchers: CoroutineDispatchers,
+    dispatchers: CoroutineDispatchers,
 ) : LifecycleEventObserver {
     private companion object {
         const val TRANSACTION_NAME = "OrderList"
@@ -66,6 +66,7 @@ class OrderListTransactionLauncher @Inject constructor(
                 performanceTransactionId?.let {
                     performanceTransactionRepository.finishTransaction(it, TransactionStatus.ABORTED)
                 }
+                performanceTransactionId = null
             }
             else -> {
                 // no-op

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreTransactionLauncherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreTransactionLauncherTest.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.ui.mystore
+
+import androidx.lifecycle.Lifecycle
+import com.automattic.android.tracks.crashlogging.performance.PerformanceTransactionRepository
+import com.automattic.android.tracks.crashlogging.performance.TransactionId
+import com.automattic.android.tracks.crashlogging.performance.TransactionOperation
+import com.automattic.android.tracks.crashlogging.performance.TransactionStatus
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyStoreTransactionLauncherTest : BaseUnitTest() {
+    val transactionId = TransactionId("testTransactionId")
+    val performanceTransactionRepository: PerformanceTransactionRepository = mock {
+        on { startTransaction(any(), any()) } doReturn transactionId
+    }
+
+    private val sut = MyStoreTransactionLauncher(
+        performanceTransactionRepository,
+        coroutinesTestRule.testDispatchers
+    )
+
+    @Test
+    fun `should start transaction on create`() {
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_CREATE)
+
+        verify(performanceTransactionRepository).startTransaction("MyStore", TransactionOperation.UI_LOAD)
+    }
+
+    @Test
+    fun `should abort transaction if on destroy`() {
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_CREATE)
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_STOP)
+
+        verify(performanceTransactionRepository).finishTransaction(transactionId, TransactionStatus.ABORTED)
+    }
+
+    @Test
+    fun `should successfully finish transaction if list fetch condition is met`() {
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_CREATE)
+
+        sut.onStoreStatisticsFetched()
+        sut.onTopPerformersFetched()
+
+        verify(performanceTransactionRepository).finishTransaction(transactionId, TransactionStatus.SUCCESSFUL)
+    }
+
+    @Test
+    fun `should not finish transaction if not all conditions are met`() {
+        sut.onStoreStatisticsFetched()
+
+        verifyNoInteractions(performanceTransactionRepository)
+    }
+
+    @Test
+    fun `should not allow to successfully finish transaction after abort`() {
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_CREATE)
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_STOP)
+
+        sut.onStoreStatisticsFetched()
+        sut.onTopPerformersFetched()
+
+        verify(performanceTransactionRepository, never()).finishTransaction(transactionId, TransactionStatus.SUCCESSFUL)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -428,6 +428,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
             appPrefsWrapper,
             usageTracksEventEmitter,
             analyticsTrackerWrapper,
+            mock()
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncherTest.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 
@@ -61,5 +62,20 @@ class OrderDetailsTransactionLauncherTest : BaseUnitTest() {
         sut.onPackageCreationEligibleFetched()
 
         verify(performanceTransactionRepository).finishTransaction(transactionId, TransactionStatus.SUCCESSFUL)
+    }
+
+    @Test
+    fun `should not allow to successfully finish transaction after abort`() {
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_CREATE)
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_DESTROY)
+
+        sut.onOrderFetched()
+        sut.onShippingLabelFetched()
+        sut.onNotesFetched()
+        sut.onRefundsFetched()
+        sut.onShipmentTrackingFetched()
+        sut.onPackageCreationEligibleFetched()
+
+        verify(performanceTransactionRepository, never()).finishTransaction(transactionId, TransactionStatus.SUCCESSFUL)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/OrderListTransactionLauncherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/OrderListTransactionLauncherTest.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -47,5 +48,15 @@ class OrderListTransactionLauncherTest : BaseUnitTest() {
         sut.onListFetched()
 
         verify(performanceTransactionRepository).finishTransaction(transactionId, TransactionStatus.SUCCESSFUL)
+    }
+
+    @Test
+    fun `should not allow to successfully finish transaction after abort`() {
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_CREATE)
+        sut.onStateChanged(mock(), Lifecycle.Event.ON_STOP)
+
+        sut.onListFetched()
+
+        verify(performanceTransactionRepository, never()).finishTransaction(transactionId, TransactionStatus.SUCCESSFUL)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7112 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a performance measurement transaction for displaying `MyStore` view

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open the app
2. Open Sentry Performance to see if there's a new `MyStore` transaction

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/5845095/182904219-11726e6f-3822-487d-a748-b4de37c7184f.png">



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
