### PR TITLE
Introduces CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+<!--
+Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
+-->
+
+## 9.9
+This release has a few improvements to your login experience, including the option to install WooCommerce from the app. We also have a new Payments section in the app. Head over to the More menu to start using Payments!


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
Introduces a `CHANGELOG.md` which we can use to track editorialized release notes per version. We currently request these release notes in a p2 post, however with the upcoming 1 week release cycle change, we'll need a faster turnaround for the release notes. Instead of `owl-team` having to ask for the editorialized release notes, we'll ask the Woo team to open a pull request every Friday that adds the relevant release notes for the upcoming code freeze. That way the release notes metadata can be updated during code freeze and can be sent for translation as soon as possible.

### Testing instructions
N/A

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
