### PR TITLE
Сonsider removing upsell ipp banner from the settings screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.list.OrderListViewModel
 import com.woocommerce.android.ui.payments.SelectPaymentMethodViewModel
 import com.woocommerce.android.ui.payments.SelectPaymentMethodViewModel.TakePaymentViewState.Success
-import com.woocommerce.android.ui.prefs.MainSettingsContract
 
 @Composable
 fun PaymentsScreenBanner(
@@ -82,29 +81,6 @@ fun OrderListScreenBanner(
             subtitle = subtitle,
             ctaLabel = ctaLabel,
             source = AnalyticsTracker.KEY_BANNER_ORDER_LIST
-        )
-    }
-}
-
-@Composable
-fun SettingsScreenBanner(
-    presenter: MainSettingsContract.Presenter,
-    title: String,
-    subtitle: String,
-    ctaLabel: String,
-) {
-    val isEligibleForInPersonPayments by presenter.isEligibleForInPersonPayments.observeAsState(false)
-    if (
-        isEligibleForInPersonPayments &&
-        presenter.canShowCardReaderUpsellBanner(System.currentTimeMillis(), AnalyticsTracker.KEY_BANNER_SETTINGS)
-    ) {
-        Banner(
-            onCtaClick = presenter::onCtaClicked,
-            onDismissClick = presenter::onDismissClicked,
-            title = title,
-            subtitle = subtitle,
-            ctaLabel = ctaLabel,
-            source = AnalyticsTracker.KEY_BANNER_SETTINGS
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/BannerDismissDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/BannerDismissDialog.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.orders.list.OrderListViewModel
 import com.woocommerce.android.ui.payments.SelectPaymentMethodViewModel
-import com.woocommerce.android.ui.prefs.MainSettingsContract
 
 @Composable
 fun PaymentsScreenBannerDismissDialog(viewModel: SelectPaymentMethodViewModel) {
@@ -44,18 +43,6 @@ fun OrderListBannerDismissDialog(viewModel: OrderListViewModel) {
         onDismissClick = viewModel::onBannerAlertDismiss,
         showDialog,
         AnalyticsTracker.KEY_BANNER_ORDER_LIST
-    )
-}
-
-@Composable
-fun SettingsBannerDismissDialog(presenter: MainSettingsContract.Presenter) {
-    val showDialog by presenter.shouldShowUpsellCardReaderDismissDialog.observeAsState(true)
-    BannerDismissDialog(
-        onRemindLaterClick = presenter::onRemindLaterClicked,
-        onDontShowAgainClick = presenter::onDontShowAgainClicked,
-        onDismissClick = presenter::onBannerAlertDismiss,
-        showDialog,
-        AnalyticsTracker.KEY_BANNER_SETTINGS
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -13,12 +13,7 @@ interface MainSettingsContract {
         fun setupAnnouncementOption()
         fun setupJetpackInstallOption()
         fun onCtaClicked(source: String)
-        fun onDismissClicked()
-        fun onRemindLaterClicked(currentTimeInMillis: Long, source: String)
-        fun onDontShowAgainClicked(source: String)
-        fun onBannerAlertDismiss()
         fun canShowCardReaderUpsellBanner(currentTimeInMillis: Long, source: String): Boolean
-        val shouldShowUpsellCardReaderDismissDialog: MutableLiveData<Boolean>
         val isEligibleForInPersonPayments: MutableLiveData<Boolean>
     }
 
@@ -26,10 +21,6 @@ interface MainSettingsContract {
         fun showDeviceAppNotificationSettings()
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
         fun handleJetpackInstallOption(isJetpackCPSite: Boolean)
-        fun dismissUpsellCardReaderBanner()
-        fun dismissUpsellCardReaderBannerViaBack()
-        fun dismissUpsellCardReaderBannerViaRemindLater()
-        fun dismissUpsellCardReaderBannerViaDontShowAgain()
         fun openPurchaseCardReaderLink(url: String)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -9,8 +9,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.res.stringResource
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -35,9 +33,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.payments.banner.SettingsBannerDismissDialog
-import com.woocommerce.android.ui.payments.banner.SettingsScreenBanner
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -80,7 +75,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         _binding = FragmentSettingsMainBinding.inflate(inflater, container, false)
 
         val view = binding.root
-        applyBannerComposeUI()
         return view
     }
 
@@ -246,24 +240,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
     }
 
-    override fun dismissUpsellCardReaderBanner() {
-        applyBannerDismissDialogComposeUI()
-    }
-
-    override fun dismissUpsellCardReaderBannerViaBack() {
-        binding.upsellCardReaderComposeView.upsellCardReaderDismissView.visibility = View.GONE
-    }
-
-    override fun dismissUpsellCardReaderBannerViaRemindLater() {
-        binding.upsellCardReaderComposeView.upsellCardReaderBannerView.visibility = View.GONE
-        binding.upsellCardReaderComposeView.upsellCardReaderDismissView.visibility = View.GONE
-    }
-
-    override fun dismissUpsellCardReaderBannerViaDontShowAgain() {
-        binding.upsellCardReaderComposeView.upsellCardReaderBannerView.visibility = View.GONE
-        binding.upsellCardReaderComposeView.upsellCardReaderDismissView.visibility = View.GONE
-    }
-
     override fun openPurchaseCardReaderLink(url: String) {
         ChromeCustomTabUtils.launchUrl(requireContext(), url)
     }
@@ -285,35 +261,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                         announcement
                     )
                 )
-        }
-    }
-
-    private fun applyBannerComposeUI() {
-        binding.upsellCardReaderComposeView.upsellCardReaderBannerView.apply {
-            // Dispose of the Composition when the view's LifecycleOwner is destroyed
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-            setContent {
-                WooThemeWithBackground {
-                    SettingsScreenBanner(
-                        presenter = presenter,
-                        title = stringResource(id = R.string.card_reader_upsell_card_reader_banner_title),
-                        subtitle = stringResource(id = R.string.card_reader_upsell_card_reader_banner_description),
-                        ctaLabel = stringResource(id = R.string.card_reader_upsell_card_reader_banner_cta)
-                    )
-                }
-            }
-        }
-    }
-
-    private fun applyBannerDismissDialogComposeUI() {
-        binding.upsellCardReaderComposeView.upsellCardReaderDismissView.apply {
-            // Dispose of the Composition when the view's LifecycleOwner is destroyed
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-            setContent {
-                WooThemeWithBackground {
-                    SettingsBannerDismissDialog(presenter)
-                }
-            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -26,7 +26,6 @@ class MainSettingsPresenter @Inject constructor(
 
     private var jetpackMonitoringJob: Job? = null
 
-    override val shouldShowUpsellCardReaderDismissDialog: MutableLiveData<Boolean> = MutableLiveData(false)
     override val isEligibleForInPersonPayments: MutableLiveData<Boolean> = MutableLiveData(false)
 
     override fun takeView(view: MainSettingsContract.View) {
@@ -81,28 +80,6 @@ class MainSettingsPresenter @Inject constructor(
                 bannerDisplayEligibilityChecker.getPurchaseCardReaderUrl(source)
             )
         }
-    }
-
-    override fun onDismissClicked() {
-        shouldShowUpsellCardReaderDismissDialog.value = true
-        appSettingsFragmentView?.dismissUpsellCardReaderBanner()
-    }
-
-    override fun onRemindLaterClicked(currentTimeInMillis: Long, source: String) {
-        shouldShowUpsellCardReaderDismissDialog.value = false
-        bannerDisplayEligibilityChecker.onRemindLaterClicked(currentTimeInMillis, source)
-        appSettingsFragmentView?.dismissUpsellCardReaderBannerViaRemindLater()
-    }
-
-    override fun onDontShowAgainClicked(source: String) {
-        shouldShowUpsellCardReaderDismissDialog.value = false
-        bannerDisplayEligibilityChecker.onDontShowAgainClicked(source)
-        appSettingsFragmentView?.dismissUpsellCardReaderBannerViaDontShowAgain()
-    }
-
-    override fun onBannerAlertDismiss() {
-        shouldShowUpsellCardReaderDismissDialog.value = false
-        appSettingsFragmentView?.dismissUpsellCardReaderBannerViaBack()
     }
 
     override fun canShowCardReaderUpsellBanner(currentTimeInMillis: Long, source: String): Boolean {

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -12,15 +12,6 @@
 
         <View style="@style/Woo.Divider" />
 
-        <include
-            android:id="@+id/upsellCardReaderComposeView"
-            layout="@layout/fragment_card_reader_upsell_banner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
-
-        <View style="@style/Woo.Divider"
-            android:background="@color/woo_black_90_alpha_020"/>
-
         <!--
             Help & support
         -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainPresenterTest.kt
@@ -61,59 +61,6 @@ class MainPresenterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given upsell banner, when banner is dismissed, then trigger DismissCardReaderUpsellBanner event`() {
-        // WHEN
-        mainSettingsPresenter.onDismissClicked()
-
-        // Then
-        verify(mainPresenterSettingsContractView).dismissUpsellCardReaderBanner()
-    }
-
-    @Test
-    fun `given upsell banner, when banner is dismissed via remind later, then trigger proper event`() {
-        // WHEN
-        mainSettingsPresenter.onRemindLaterClicked(0L, KEY_BANNER_PAYMENTS)
-
-        // Then
-        verify(mainPresenterSettingsContractView).dismissUpsellCardReaderBannerViaRemindLater()
-    }
-
-    @Test
-    fun `given upsell banner, when banner is dismissed via don't show gain, then trigger proper event`() {
-        // WHEN
-        mainSettingsPresenter.onDontShowAgainClicked(KEY_BANNER_PAYMENTS)
-
-        // Then
-        verify(mainPresenterSettingsContractView).dismissUpsellCardReaderBannerViaDontShowAgain()
-    }
-
-    @Test
-    fun `given card reader banner has dismissed, then update dialogShow state to true`() {
-        mainSettingsPresenter.onDismissClicked()
-
-        Assertions.assertThat(mainSettingsPresenter.shouldShowUpsellCardReaderDismissDialog.value).isTrue
-    }
-
-    @Test
-    fun `given card reader banner has dismissed via remind later, then update dialogShow state to false`() {
-        mainSettingsPresenter.onRemindLaterClicked(0L, KEY_BANNER_PAYMENTS)
-
-        Assertions.assertThat(mainSettingsPresenter.shouldShowUpsellCardReaderDismissDialog.value).isFalse
-    }
-
-    @Test
-    fun `given card reader banner has dismissed via don't show again, then update dialogShow state to false`() {
-        mainSettingsPresenter.onDontShowAgainClicked(KEY_BANNER_PAYMENTS)
-
-        Assertions.assertThat(mainSettingsPresenter.shouldShowUpsellCardReaderDismissDialog.value).isFalse
-    }
-
-    @Test
-    fun `given presenter init, then update dialogShow state to false`() {
-        Assertions.assertThat(mainSettingsPresenter.shouldShowUpsellCardReaderDismissDialog.value).isFalse
-    }
-
-    @Test
     fun `given store not eligible for IPP, then isEligibleForInPersonPayments is false`() {
         runTest {
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(false)
@@ -133,20 +80,6 @@ class MainPresenterTest : BaseUnitTest() {
 
             Assertions.assertThat(mainSettingsPresenter.isEligibleForInPersonPayments.value).isTrue
         }
-    }
-
-    @Test
-    fun `when alert dialog dismissed by pressing back, then shouldShowUpsellCardReaderDismissDialog set to false`() {
-        mainSettingsPresenter.onBannerAlertDismiss()
-
-        Assertions.assertThat(mainSettingsPresenter.shouldShowUpsellCardReaderDismissDialog.value).isFalse
-    }
-
-    @Test
-    fun `when alert dialog dismissed by pressing back, then dismissUpsellCardReaderBannerViaBack is called`() {
-        mainSettingsPresenter.onBannerAlertDismiss()
-
-        verify(mainPresenterSettingsContractView).dismissUpsellCardReaderBannerViaBack()
     }
     //endregion
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7026
<!-- Id number of the GitHub issue this PR addresses. -->

@AnirudhBhat if I got you right, you are ok with removing it from here?

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removes upsell IPP banner from the settings screen

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open settings screen and notice that upsell IPP banner is gone

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
