### PR TITLE
issue/search-sku-release-notes 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 9.7
 -----
+- [***] The product list now enables searching by SKU
 - [*] Login: Improved login flow when a WordPress site exists but has no Jetpack plugin installed. [https://github.com/woocommerce/woocommerce-android/pull/6910/]
 - [***] In-Person Payments: Display Upsell Card reader banner in the Payment, Order List, and Settings screen for the stores set up in the US and Canada [https://github.com/woocommerce/woocommerce-android/pull/6984]
 - [***] Order detail now enables viewing custom fields (metadata) for the order [https://github.com/woocommerce/woocommerce-android/pull/6993]


### PR DESCRIPTION
This tiny PR simply updates the release notes to mention searching the product list by SKU (added in 9.7)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
