### PR TITLE
Nullability fix when updating core-ktx from 1.7.0 to 1.8.0 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
@@ -21,7 +21,7 @@ object DeviceInfo {
         get() {
             val locale = ConfigurationCompat.getLocales(Resources.getSystem().configuration)
             if (locale.isEmpty.not()) {
-                return locale[0].displayLanguage
+                return locale[0]?.displayLanguage
             }
             return null
         }


### PR DESCRIPTION
Closes: #7088
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

This PR adds nullability check as required by core-ktx 1.8.0. For more details, please check issue #7088

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Switch to branch `dependabot/gradle/androidx.core-core-ktx-1.8.0`, build app, and see build error: `woocoomerce-android/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt: (24, 33): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Locale?`
2. Switch to this PR's branch, build app, ensure app now builds properly.
