### PR TITLE
Activate: Hide "Enter your store address" button in "No WPCom Account Found" screen if from "Enter Site Address" flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -371,6 +371,9 @@ class LoginActivity :
     }
 
     private fun startLoginViaWPCom() {
+        // Clean previously saved site address, e.g: if merchants return from a store address flow.
+        AppPrefs.removeLoginSiteAddress()
+
         unifiedLoginTracker.setFlow(Flow.WORDPRESS_COM.value)
         showEmailLoginScreen()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
@@ -67,8 +67,7 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
 
         if (!appPrefsWrapper.getLoginSiteAddress().isNullOrBlank()) {
             btnBinding.buttonPrimary.hide()
-        }
-        else {
+        } else {
             with(btnBinding.buttonPrimary) {
                 text = getString(R.string.login_store_address)
                 setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
@@ -9,8 +9,10 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentLoginNoWpcomAccountFoundBinding
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.zendesk.util.StringUtils
@@ -36,6 +38,7 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
     private var loginListener: LoginListener? = null
     private var emailAddress: String? = null
 
+    @Inject internal lateinit var appPrefsWrapper: AppPrefsWrapper
     @Inject internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -62,12 +65,17 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
 
         binding.noWpAccountMsg.text = getString(R.string.login_no_wpcom_account_found, emailAddress)
 
-        with(btnBinding.buttonPrimary) {
-            text = getString(R.string.login_store_address)
-            setOnClickListener {
-                unifiedLoginTracker.trackClick(Click.LOGIN_WITH_SITE_ADDRESS)
+        if (!appPrefsWrapper.getLoginSiteAddress().isNullOrBlank()) {
+            btnBinding.buttonPrimary.hide()
+        }
+        else {
+            with(btnBinding.buttonPrimary) {
+                text = getString(R.string.login_store_address)
+                setOnClickListener {
+                    unifiedLoginTracker.trackClick(Click.LOGIN_WITH_SITE_ADDRESS)
 
-                loginListener?.loginViaSiteAddress()
+                    loginListener?.loginViaSiteAddress()
+                }
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentLoginNoWpcomAccountFoundBinding
+import com.woocommerce.android.databinding.ViewLoginEpilogueButtonBarBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
@@ -65,9 +66,16 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
 
         binding.noWpAccountMsg.text = getString(R.string.login_no_wpcom_account_found, emailAddress)
 
-        if (!appPrefsWrapper.getLoginSiteAddress().isNullOrBlank()) {
-            btnBinding.buttonPrimary.hide()
-        } else {
+        setupButtons(btnBinding, appPrefsWrapper.getLoginSiteAddress().isNullOrBlank())
+
+        binding.btnFindConnectedEmail.setOnClickListener {
+            loginListener?.showHelpFindingConnectedEmail()
+        }
+    }
+
+    private fun setupButtons(btnBinding: ViewLoginEpilogueButtonBarBinding, showEnterStoreAddressButton: Boolean) {
+        // Only show "Enter Store Address" button if not coming from the "Enter store address" login flow.
+        if (showEnterStoreAddressButton) {
             with(btnBinding.buttonPrimary) {
                 text = getString(R.string.login_store_address)
                 setOnClickListener {
@@ -76,20 +84,26 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
                     loginListener?.loginViaSiteAddress()
                 }
             }
-        }
 
-        with(btnBinding.buttonSecondary) {
-            visibility = View.VISIBLE
-            text = getString(R.string.login_try_another_account)
-            setOnClickListener {
-                unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_ACCOUNT)
+            with(btnBinding.buttonSecondary) {
+                visibility = View.VISIBLE
+                text = getString(R.string.login_try_another_account)
+                setOnClickListener {
+                    unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_ACCOUNT)
 
-                loginListener?.startOver()
+                    loginListener?.startOver()
+                }
             }
-        }
+        } else {
+            with(btnBinding.buttonPrimary) {
+                text = getString(R.string.login_try_another_account)
+                setOnClickListener {
+                    unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_ACCOUNT)
 
-        binding.btnFindConnectedEmail.setOnClickListener {
-            loginListener?.showHelpFindingConnectedEmail()
+                    loginListener?.startOver()
+                }
+            }
+            btnBinding.buttonSecondary.hide()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7121
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This hides "Enter your store address" button on "No WPCom account found" screen, if user is already coming from the "Enter your store address" login flow.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start app, log in through the "Enter your store address" option,
2. Enter a valid wpcom WooCommerce site that's already connected to Jetpack,
3. The "Email Log In" screen will be shown.
4. Enter an invalid, random email address, then tap "Continue",
5. The "No WPcom account found" screen is shown, ensure that the "Enter Your Store Address" button is not shown.
6. Tap the "Log in with another account" button,
7. Tap "Continue with WordPress.com" button,
8. Enter an invalid, random email address, then tap "Continue",
9. The "No WPcom account found" screen is shown, ensure that the "Enter Your Store Address" button and "Log in with another account" button are shown.
