### PR TITLE
change background color of the card reader upsell banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -119,7 +119,8 @@ fun Banner(
     source: String,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
+        backgroundColor = colorResource(id = R.color.color_surface_elevated)
     ) {
         Row(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -120,7 +120,6 @@ fun Banner(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        backgroundColor = colorResource(id = R.color.color_surface_elevated)
     ) {
         Row(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/BannerDismissDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/BannerDismissDialog.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments.banner
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -75,18 +76,20 @@ fun BannerDismissDialog(
 ) {
     if (showDialog) {
         AlertDialog(
+            backgroundColor = colorResource(id = R.color.color_surface_elevated),
             onDismissRequest = onDismissClick,
             title = {
                 Text(
                     text = title,
                     style = MaterialTheme.typography.h6,
+                    color = colorResource(id = R.color.color_on_surface)
                 )
             },
             text = {
                 Text(
                     text = description,
                     style = MaterialTheme.typography.subtitle1,
-                    color = colorResource(id = R.color.woo_black_90)
+                    color = colorResource(id = R.color.color_on_surface)
                 )
             },
             buttons = {
@@ -108,7 +111,7 @@ fun BannerDismissDialog(
                     ) {
                         Text(
                             text = stringResource(id = R.string.card_reader_upsell_card_reader_banner_remind_me_later),
-                            color = colorResource(id = R.color.woo_purple_60),
+                            color = colorResource(id = R.color.color_secondary),
                             style = MaterialTheme.typography.subtitle2,
                             fontWeight = FontWeight.Bold,
                         )
@@ -126,7 +129,7 @@ fun BannerDismissDialog(
                     ) {
                         Text(
                             text = stringResource(id = R.string.card_reader_upsell_card_reader_banner_dont_show_again),
-                            color = colorResource(id = R.color.woo_purple_60),
+                            color = colorResource(id = R.color.color_secondary),
                             style = MaterialTheme.typography.subtitle2,
                             fontWeight = FontWeight.Bold,
                         )
@@ -137,7 +140,8 @@ fun BannerDismissDialog(
     }
 }
 
-@Preview
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun BannerDismissDialogPreview() {
     BannerDismissDialog(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7135 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There were some design issues observed in the banner card in dark mode

1. Banner and Banner dismiss dialog must be grey in color in dark mode. Right now, it's black.
2. Banner dismiss dialog CTAs are purple in color. It should be pink in color to match other CTAs throughout the screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Ensure the banner and banner dismiss dialog appears grey in dark mode
2. Ensure the banner dismiss dialog CTAs appear pink in color.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src=https://user-images.githubusercontent.com/1331230/183608366-bf6c2d0e-0137-4442-afae-7dad506af1d4.png width=300px height=650px/>

<img src=https://user-images.githubusercontent.com/1331230/183608635-879a7bac-4691-4be2-bd7a-09b2d99f7703.png width=300px height=650px/>

<img src=https://user-images.githubusercontent.com/1331230/183608745-cb61fa58-4701-445c-96ac-11f64af8e0d8.png width=350px height=650px/>

<img src=https://user-images.githubusercontent.com/1331230/183608887-ac370809-be66-4044-ab2d-2f1212a19cbb.png width=300px height=650px/>



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
