### PR TITLE
 Fix for broken hub layout in landscape

### DIFF
--- a/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="?attr/selectableItemBackground">
+    android:background="@color/color_surface"
+    android:foreground="?attr/selectableItemBackground">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/cardReaderMenuIcon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:srcCompat="@drawable/ic_manage_card_reader"
         android:layout_marginTop="0.5dp"
-        android:padding="@dimen/major_85"/>
+        android:padding="@dimen/major_85"
+        app:srcCompat="@drawable/ic_manage_card_reader" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/cardReaderHubListItemLabelTv"
         style="@style/Widget.Woo.Settings.OptionValue"
-        android:textColor="@color/color_on_surface"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingStart="@dimen/major_100"
         android:paddingEnd="@dimen/major_100"
+        android:textColor="@color/color_on_surface"
         tools:text="Manage card reader" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_hub.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_hub.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -11,20 +11,23 @@
         android:id="@+id/cardReaderHubLoading"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:indeterminate="true" />
+        android:indeterminate="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/cardReaderHubRv"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/color_surface"
+        android:layout_height="0dp"
+        android:layout_marginBottom="@dimen/minor_100"
+        app:layout_constraintBottom_toTopOf="@id/cardReaderHubOnboardingFailedTv"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cardReaderHubLoading"
+        app:layout_constraintVertical_chainStyle="spread_inside"
         tools:itemCount="5"
         tools:listitem="@layout/card_reader_hub_list_item" />
-
-    <Space
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
 
     <!-- android:textColorHighlight="#00FFFFFF": Workaround for a bug https://stackoverflow.com/a/70394538/632516 -->
     <com.google.android.material.textview.MaterialTextView
@@ -33,7 +36,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="0dp"
-        android:layout_marginTop="@dimen/major_100"
         android:layout_marginEnd="0dp"
         android:layout_marginBottom="@dimen/minor_100"
         android:background="@color/color_surface"
@@ -46,5 +48,10 @@
         android:textColor="@color/color_on_surface_high"
         android:textColorHighlight="#00FFFFFF"
         app:drawableTint="@color/color_on_surface"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cardReaderHubRv"
+        app:layout_constraintVertical_chainStyle="spread_inside"
         tools:text="@string/card_reader_onboarding_not_finished" />
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7151
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fix for:
<img width="902" alt="image" src="https://user-images.githubusercontent.com/4923871/183877001-b3fa18b2-526d-4bfb-a5a4-8fe3ac06653e.png">


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Use small device
* Open payment hub with not finished onboarding
* Check how it looks in landscape mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->




https://user-images.githubusercontent.com/4923871/183877308-c762468b-fd4e-453f-a047-bacbbd512eb2.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
