### PR TITLE
Set correct LoginMode when opening LoginActivity from notifications

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -125,6 +125,7 @@ class LoginActivity :
                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or
                     Intent.FLAG_ACTIVITY_CLEAR_TASK
                 putExtra(KEY_LOGIN_HELP_NOTIFICATION, notificationType.toString())
+                LoginMode.WOO_LOGIN_MODE.putInto(this)
             }
             return intent
         }


### PR DESCRIPTION
### Description
While testing some scenarios for my experiment, I reused the `createIntent` function of `LoginActivity`, then I found out that the login flow doesn't behave similarly to what I expected, and after investigating I found out that it's because the `getLoginMode` returns `LoginMode.FULL` instead of the expected `LoginMode.WOO_LOGIN_MODE`, and this is because we don't supply the `LoginMode` to the `Intent`. This PR fixes this.

IMO this doesn't need a new beta right away, it can wait for the final build after code freeze, but I'll leave the final decision to you, and please ping the release manager as well, as I'm AFK the next two days.

### Testing instructions
I didn't have time to retest my code, but I expect it would work, otherwise feel free to fix it.
1. Repeat test steps to trigger a login error notification.
2. Open the app from the notification.
3. Debug the app and confirm `getLoginMode` returns the correct value now.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
