### PR TITLE
Pass onboarding error to avoid another onboarding check

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
@@ -70,7 +70,10 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderOnboardingScreen -> {
                     findNavController().navigate(
                         CardReaderHubFragmentDirections.actionCardReaderHubFragmentToCardReaderOnboardingFragment(
-                            CardReaderOnboardingParams.Check(CardReaderFlowParam.CardReadersHub)
+                            CardReaderOnboardingParams.Failed(
+                                cardReaderFlowParam = CardReaderFlowParam.CardReadersHub,
+                                onboardingState = event.onboardingState
+                            )
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -156,9 +156,11 @@ class CardReaderHubViewModel @Inject constructor(
     private fun onCardReaderPaymentProviderClicked() {
         trackEvent(AnalyticsEvent.SETTINGS_CARD_PRESENT_SELECT_PAYMENT_GATEWAY_TAPPED)
         clearPluginExplicitlySelectedFlag()
-        triggerEvent(CardReaderHubEvents.NavigateToCardReaderOnboardingScreen(
-            CardReaderOnboardingState.ChoosePaymentGatewayProvider
-        ))
+        triggerEvent(
+            CardReaderHubEvents.NavigateToCardReaderOnboardingScreen(
+                CardReaderOnboardingState.ChoosePaymentGatewayProvider
+            )
+        )
     }
 
     private fun onOnboardingErrorClicked(state: CardReaderOnboardingState) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -241,8 +241,9 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given onboarding check error, when user clicks on text, then onboarding shown`() = testBlocking {
+        val genericError = mock<CardReaderOnboardingState.GenericError>()
         whenever(cardReaderChecker.getOnboardingState()).thenReturn(
-            mock<CardReaderOnboardingState.GenericError>()
+            genericError
         )
 
         initViewModel()
@@ -251,7 +252,9 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.event.value)
             .isEqualTo(
-                CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderOnboardingScreen
+                CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderOnboardingScreen(
+                    genericError
+                )
             )
     }
 
@@ -353,7 +356,9 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         }!!.onClick.invoke()
 
         assertThat(viewModel.event.value).isEqualTo(
-            CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderOnboardingScreen
+            CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderOnboardingScreen(
+                CardReaderOnboardingState.ChoosePaymentGatewayProvider
+            )
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7158
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is improves performance by passing known onboarding error to the onboarding screen, both from "choose payment provider" and error which shown as pop up from the bottom

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open payment hub with a site with not finished IPP onboarding
* Click on the Error at the bottom
* Notice that onboarding check is not performed anymore and error is displayed right away
* Perform the same actions on the site with 2 active plugins
* Click on the "choose payment provider" button 
* Notice that onboarding check is not performed anymore and error is displayed right away

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/184069616-1b79931f-78c8-434c-923d-fbafe5f3346e.mp4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
