### PR TITLE
Activate: Simplify various wordings on the "No WPCom Account Found" screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
@@ -85,7 +85,7 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
         // Only show "Enter Store Address" button if not coming from the "Enter store address" login flow.
         if (showEnterStoreAddressButton) {
             with(btnBinding.buttonPrimary) {
-                text = getString(R.string.login_store_address)
+                text = getString(R.string.login_with_store_address)
                 setOnClickListener {
                     unifiedLoginTracker.trackClick(Click.LOGIN_WITH_SITE_ADDRESS)
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -248,7 +248,7 @@
     <string name="login_jetpack_not_found">Jetpack not found. Please try again</string>
     <string name="login_jetpack_install">Install Jetpack</string>
     <string name="login_sign_in">Sign in</string>
-    <string name="login_need_help_finding_email"><u>Need help finding the connected email?</u></string>
+    <string name="login_need_help_finding_email"><u>Need help finding the required email?</u></string>
     <string name="login_email_help_title">What email do I use to sign in?</string>
     <string name="login_email_help_desc">In your site admin you can find the email you used to connect to WordPress.com from the %1$sJetpack Dashboard%2$s under %3$sConnections &gt; Account connection%4$s</string>
     <string name="login_discovery_error_title">Connection error</string>
@@ -256,7 +256,7 @@
     <string name="login_with_wordpress">Sign in with WordPress.com</string>
     <string name="login_troubleshooting_tips">Read our troubleshooting tips</string>
     <string name="login_discovery_error_option_select">Select an option</string>
-    <string name="login_no_wpcom_account_found">It looks like %1$s isn\'t associated with a WordPress.com account.</string>
+    <string name="login_no_wpcom_account_found">The email %1$s isn\'t used with a WordPress.com account.</string>
     <string name="user_role_access_error_msg">This app supports only Administrator and Shop Manager user roles. Please contact your store owner to upgrade your role.</string>
     <string name="user_role_access_error_link">Learn more about roles and permissions</string>
     <string name="user_role_access_error_retry">You don\'t have the correct user role</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -196,6 +196,7 @@
     <string name="login_jetpack_required">This app requires Jetpack to connect to your store.</string>
     <string name="login_wpcom">Continue with WordPress.com</string>
     <string name="login_store_address">Enter your store address</string>
+    <string name="login_with_store_address">Log in with your store address</string>
     <string name="login_configure_link">Read the %sconfiguration instructions%s.</string>
 
     <string name="login_prologue_label_analytics">Track sales and high performing products</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7121
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Updated wordings:
1. Button "Enter your store address" -> **"Log in with your store address".** It's unclear why someone is asked to enter store address after entering an invalid email. The wording "Log in" makes it more clear what the next action is.
2. Button "Need help finding the connected email?" -> **"Need help finding the required email?"** It's not super obvious what a "connected email" is. "Required email" is easier to understand.
3. Message "It looks like [email] isn't associated with a WordPress.com account." -> **"The email [email] isn't used with a WordPress.com account."** The wording "It looks like" is too verbose and seems unsure (while in reality the email is definitely not used." The wording "associated" is replaced with the simpler "used" word that conveys the same meaning.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start app, then "Continue with WordPress.com".
2. Enter a gibberish email: `adasdadasd@adadada.com`,
3. Make sure the shown screen is similar to the screenshot below:

<img src="https://user-images.githubusercontent.com/266376/184101545-ce65ed26-772b-47a2-a150-5998db7ddd1a.png" width="42%" />

