### PR TITLE
Avoid disabling androidX startup completely

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -161,8 +161,14 @@
 
         <provider
             android:name="androidx.startup.InitializationProvider"
-            tools:node="remove"
-            android:authorities="${applicationId}.androidx-startup" />
+            tools:node="merge"
+            android:exported="false"
+            android:authorities="${applicationId}.androidx-startup">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

When adding WorkManager [here](https://github.com/woocommerce/woocommerce-android/pull/6990#discussion_r924985665) in order to be able to inject depencies to Worker classes using Hilt I ended up disabling `androidX startup`. More context in this [discussion](https://github.com/woocommerce/woocommerce-android/pull/6990#discussion_r924985665)

Disabling `androidX startup` breaks Sentry initialization: pdnsEh-qs-p2
TLDR

> The issue was caused by our upgrade of androidx.lifecycle to 2.4.1 in WP/JP Android 20.1, which introduced a regression due to the fact that we were removing the whole androidx.startup.InitializationProvider in our manifest to use our own WorkManagerInitializer, preventing Sentry and lifecycle-process from being hooked properly

This PR applies an already tested and merged  (in `trunk`) fix  that we want to release in v9.8
