### PR TITLE
Improve order detail loading time

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -183,8 +183,6 @@ class OrderDetailViewModel @Inject constructor(
                 fetchSLCreationEligibilityAsync()
             )
 
-            orderDetailsTransactionLauncher.onOrderFetched()
-
             displayOrderDetails()
 
             viewState = viewState.copy(
@@ -553,6 +551,7 @@ class OrderDetailViewModel @Inject constructor(
 
     private fun fetchOrderAsync() = async {
         val fetchedOrder = orderDetailRepository.fetchOrderById(navArgs.orderId)
+        orderDetailsTransactionLauncher.onOrderFetched()
         if (fetchedOrder != null) {
             order = fetchedOrder
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -193,7 +193,6 @@ class OrderDetailViewModel @Inject constructor(
             )
         } else {
             triggerEvent(ShowSnackbar(string.offline_error))
-            viewState = viewState.copy(isOrderDetailSkeletonShown = false)
             viewState = viewState.copy(
                 isOrderDetailSkeletonShown = false,
                 isRefreshing = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -200,12 +200,10 @@ class OrderDetailViewModel @Inject constructor(
         }
     }
 
-    private fun checkOrderMetaData() {
-        launch {
-            viewState = viewState.copy(
-                isCustomFieldsButtonShown = orderDetailRepository.orderHasMetadata(navArgs.orderId)
-            )
-        }
+    private suspend fun checkOrderMetaData() {
+        viewState = viewState.copy(
+            isCustomFieldsButtonShown = orderDetailRepository.orderHasMetadata(navArgs.orderId)
+        )
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -563,7 +563,6 @@ class OrderDetailViewModel @Inject constructor(
         if (!orderDetailRepository.fetchOrderNotes(navArgs.orderId)) {
             triggerEvent(ShowSnackbar(string.order_error_fetch_notes_generic))
         }
-        // fetch order notes from the local db and hide the skeleton view
         orderDetailsTransactionLauncher.onNotesFetched()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -187,6 +187,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         doReturn(nonRefundedOrder).whenever(orderDetailRepository).getOrderById(any())
 
+        doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
+
         doReturn(testOrderNotes).whenever(orderDetailRepository).getOrderNotes(any())
 
         doReturn(testOrderShipmentTrackings).whenever(orderDetailRepository).getOrderShipmentTrackings(any())
@@ -358,7 +360,9 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             val order = order.copy(items = items)
             doReturn(order).whenever(orderDetailRepository).getOrderById(any())
-
+            doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
+            doReturn(ids.size).whenever(orderDetailRepository).getProductCountForOrder(any())
             viewModel.start()
 
             verify(orderDetailRepository, never()).fetchProductsByRemoteIds(ids)
@@ -629,6 +633,9 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Shows and hides order detail skeleton correctly`() =
         testBlocking {
+            doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
+            doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             doReturn(null).whenever(orderDetailRepository).getOrderById(any())
 
             val isSkeletonShown = ArrayList<Boolean>()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7168

### Description
This PR aims to reduce the fetching data time in the order details screen. In the current version, we trigger at least six requests for fetching order data, five of them waiting for the first one to finish. This approach produces a total waiting time of (the total time for the first call to complete) + (the longest time of the remaining five requests to complete). With the changes implemented in this PR, we will fetch all data in parallel, reducing fetching data time to only the longest time of the six requests (almost half of today's fetching data time).

### Testing instructions

1. Open order list
2. Select an order from the list
3. Check that all fetch data requests run in parallel

### Images/gif

| [Before](https://sentry.io/organizations/a8c/performance/woocommerce-android:9ae12466b19b44fb93d50362fcbc10ea/?breakdown=none&environment=debug&project=1459556&query=transaction.duration%3A%3C15m+user.display%3Aalejandro.torres.veiga%40automattic.com&showTransactions=p100&sort=transaction.duration&statsPeriod=1h&transaction=OrderDetails)   | [After](https://sentry.io/organizations/a8c/performance/woocommerce-android:1ca53a41ab234a5ea00d639e9e547eeb/?breakdown=none&environment=debug&project=1459556&query=transaction.duration%3A%3C15m+user.display%3Aalejandro.torres.veiga%40automattic.com&showTransactions=p100&sort=transaction.duration&statsPeriod=1h&transaction=OrderDetails) |
| ------------- | ------------- |
| <img width="1192" alt="Screen Shot 2022-08-11 at 15 24 33" src="https://user-images.githubusercontent.com/18119390/184213281-7a420c8f-e9e3-496c-9be8-116cddf031c6.png">  | <img width="1270" alt="Screen Shot 2022-08-11 at 15 27 16" src="https://user-images.githubusercontent.com/18119390/184213292-7efddfc5-5f73-43c5-88c6-7c55b93ca2cf.png">  |
| <img width="459" alt="Screen Shot 2022-08-11 at 15 28 34" src="https://user-images.githubusercontent.com/18119390/184213825-48704f6d-3321-4977-ac7b-e026ec3239de.png">  | <img width="462" alt="Screen Shot 2022-08-11 at 15 23 08" src="https://user-images.githubusercontent.com/18119390/184213814-296a778d-2e2b-40e8-a0dc-6638160e542d.png">  |

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
