### PR TITLE
Create new milestones with 7 day duration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (5.2.0)
+    fastlane-plugin-wpmreleasetoolkit (5.3.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)
@@ -200,7 +200,7 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    oj (3.13.19)
+    oj (3.13.20)
     optimist (3.0.1)
     options (2.3.2)
     optparse (0.1.1)
@@ -273,7 +273,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 5.2)
+  fastlane-plugin-wpmreleasetoolkit (~> 5.3)
   nokogiri
   rmagick (~> 4.1)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -302,7 +302,7 @@ platform :android do
     # Wrap up
     removebranchprotection(repository:GHHELPER_REPO, branch: "release/#{version["name"]}")
     setfrozentag(repository:GHHELPER_REPO, milestone: version["name"], freeze: false)
-    create_new_milestone(repository:GHHELPER_REPO)
+    create_new_milestone(repository:GHHELPER_REPO, need_appstore_submission: true, milestone_duration:7, number_of_days_from_code_freeze_to_release: 10)
     close_milestone(repository:GHHELPER_REPO, milestone: version["name"])
 
     trigger_release_build(branch_to_build: "release/#{version["name"]}")

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,6 +6,6 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.2'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.3'
 #gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 #gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'add/s3-binary-upload'


### PR DESCRIPTION
~_Note that we need to merge https://github.com/wordpress-mobile/release-toolkit/pull/397 and publish a new version of `release-toolkit` before we can merge this PR._~

### Description
We are experimenting with weekly releases where we code freeze on Fridays (every 7 days) and release on Mondays. (in 10 days)

This PR updates the `create_new_milestone` action and utilizes the new `milestone_duration` & `number_of_days_from_code_freeze_to_release` that is being introduced in https://github.com/wordpress-mobile/release-toolkit/pull/397 to update our Github milestone creation.

It's worth noting that I manually adjusted the last milestone because the implementation in `release-toolkit` has some built-in assumptions to it.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**Test 1:**

Run the following lane to test that unless the optional parameters are used, the old behaviour hasn't changed and new milestones are created 14 days after the last milestone.

```
lane :test_create_new_milestone do | options |
  create_new_milestone(repository:GHHELPER_REPO)
end
```

**Test 2:**

Run the following lane to test that when the optional parameters are used, the new milestone is created 7 days after the last milestone and the release date is 10 days from its due date.

```
lane :test_create_new_milestone do | options |
  create_new_milestone(repository:GHHELPER_REPO, need_appstore_submission: true, milestone_duration:7, number_of_days_from_code_freeze_to_release: 10)
end

```

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
