### PR TITLE
Ignore notifications when site is not selected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.model.Notification
 import com.woocommerce.android.model.isOrderNotification
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.support.ZendeskHelper
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.util.NotificationsParser
 import com.woocommerce.android.util.WooLog.T.NOTIFS
@@ -44,7 +45,8 @@ class NotificationMessageHandler @Inject constructor(
     private val notificationBuilder: WooNotificationBuilder,
     private val analyticsTracker: NotificationAnalyticsTracker,
     private val zendeskHelper: ZendeskHelper,
-    private val notificationsParser: NotificationsParser
+    private val notificationsParser: NotificationsParser,
+    private val selectedSite: SelectedSite,
 ) {
     companion object {
         private const val KEY_PUSH_TYPE_ZENDESK = "zendesk"
@@ -81,6 +83,11 @@ class NotificationMessageHandler @Inject constructor(
     fun onNewMessageReceived(messageData: Map<String, String>, appContext: Context) {
         if (!accountStore.hasAccessToken()) {
             wooLogWrapper.e(NOTIFS, "User is not logged in!")
+            return
+        }
+
+        if (!selectedSite.exists()) {
+            wooLogWrapper.e(NOTIFS, "User has no site selected!")
             return
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7161
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes the crash
* Clear apps data
* Start new logging flow
* Pause it on the "Site Selection" screen
* Send push notification:
```
adb shell am broadcast -a com.google.android.c2dm.intent.RECEIVE -n com.woocommerce.android.dev/com.google.firebase.iid.FirebaseInstanceIdReceiver \
 --es "user" "193905569" \
 --es "note_full_data" "eNqVkstu2zAQRX+FGWQXPUjWlmz+Q9pNN0VVGLRMO0z4gkjGMQL9e4eKY6TLLiRS4L2Hd2b0Ds4nFUH8fgd9ANGted+znnasgnQJCgTE5Ce189NBTVBBdpOSKHTZmAqi0yGo9PlpVZIgCimWJeqEALblDKnrdQUfENFvV3MFRruXLzJ4SilEMbRDG/Le6LGWQTdntIRJxdiM3g4t7tLQvrKhLaY4tDc43Oj/CVpcSMJQMGOsmGTK8VZg3j+rMS39SeoNN/DLZ/IkXxWRxKkzWfx3ZMiHzbcR38fNFubqpv7+KSFHP5F71lBKvCOPF2K8O5FSBnHSKrI38usD8x+cgLaYU9qAIE45r+mmZvwnXQneC75+oFRQCkWXjLpe9uM6KD16908zYnMOH8WfQ42HSTlsgc11MPmkHbZg+RWGVlt5KmsOB5lUHeTForTmb01wJySj7Aof8nG16peoRsa0i0q5XQmNZ6zrKO+6vt8WS7b7Mhs2/wXcwswL" \
 --es "blog_id" "192152755" \
 --es "icon" "https://s.wp.com/wp-content/mu-plugins/notes/images/update-payment-2x.png" \
 --es "type" "store_order" \
 --es "category" "store_order" \
 --es "title" "WordPress.com" \
 --es "note_id" "6527717061"
```

Add the following in your AndroidManifest.xml:

```
        <receiver
            android:name="com.google.firebase.iid.FirebaseInstanceIdReceiver"
            android:exported="true"
            android:permission="@null"
            tools:replace="android:permission">
            <intent-filter>
                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
                <category android:name="com.picpay.debug" />
            </intent-filter>
        </receiver>
```

(you might need use your `blod_id` and and `user_id`)
* Click on the incoming notification
* Notice an app crash


### My fix ignores `ALL` notifications if a site is not selected. I am not sure if it's the right way to go though, do we have any notifications not site related? 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Clear apps data
* Start new logging flow
* Pause it on the "Site Selection" screen
* Send push notification:
```
adb shell am broadcast -a com.google.android.c2dm.intent.RECEIVE -n com.woocommerce.android.dev/com.google.firebase.iid.FirebaseInstanceIdReceiver \
 --es "user" "193905569" \
 --es "note_full_data" "eNqVkstu2zAQRX+FGWQXPUjWlmz+Q9pNN0VVGLRMO0z4gkjGMQL9e4eKY6TLLiRS4L2Hd2b0Ds4nFUH8fgd9ANGted+znnasgnQJCgTE5Ce189NBTVBBdpOSKHTZmAqi0yGo9PlpVZIgCimWJeqEALblDKnrdQUfENFvV3MFRruXLzJ4SilEMbRDG/Le6LGWQTdntIRJxdiM3g4t7tLQvrKhLaY4tDc43Oj/CVpcSMJQMGOsmGTK8VZg3j+rMS39SeoNN/DLZ/IkXxWRxKkzWfx3ZMiHzbcR38fNFubqpv7+KSFHP5F71lBKvCOPF2K8O5FSBnHSKrI38usD8x+cgLaYU9qAIE45r+mmZvwnXQneC75+oFRQCkWXjLpe9uM6KD16908zYnMOH8WfQ42HSTlsgc11MPmkHbZg+RWGVlt5KmsOB5lUHeTForTmb01wJySj7Aof8nG16peoRsa0i0q5XQmNZ6zrKO+6vt8WS7b7Mhs2/wXcwswL" \
 --es "blog_id" "192152755" \
 --es "icon" "https://s.wp.com/wp-content/mu-plugins/notes/images/update-payment-2x.png" \
 --es "type" "store_order" \
 --es "category" "store_order" \
 --es "title" "WordPress.com" \
 --es "note_id" "6527717061"
```
* Notice that notification was not shown at all


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/184288799-719f4367-d569-4e4a-8f19-50a5bbdd1c3e.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
