### PR TITLE
Add logic during on boarding to check if Cash on Delivery is enabled or not in the store.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResul
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.RESTRICTED
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.RESTRICTED_SOON
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.store.WCGatewayStore
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -69,6 +70,7 @@ class CardReaderOnboardingChecker @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val wooStore: WooCommerceStore,
     private val inPersonPaymentsStore: WCInPersonPaymentsStore,
+    private val wcGatewayStore: WCGatewayStore,
     private val dispatchers: CoroutineDispatchers,
     private val networkStatus: NetworkStatus,
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper,
@@ -196,6 +198,13 @@ class CardReaderOnboardingChecker @Inject constructor(
             preferredPlugin.info?.version,
             requireNotNull(countryCode)
         )
+    }
+
+    suspend fun isCashOnDeliveryEnabled(): Boolean {
+        val gateways = wcGatewayStore.fetchAllGateways(selectedSite.get()).model
+        return gateways?.firstOrNull { wcGatewayModel ->
+            wcGatewayModel.id.equals("cod", ignoreCase = true)
+        }?.isEnabled ?: false
     }
 
     private fun isUserComingFromChoosePaymentGatewayScreen(userSelectedPlugin: PluginType?): Boolean {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7140 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a method in the IPP onboarding class that checks whether the site has the "Cash on Delivery" payment option enabled or not. 

This PR does not do anything when the "Cash on Delivery" is disabled. In fact, the check won't even run during onboarding. Right now, only the tests are making use of the method.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Green CI should be enough since the logic isn't used anywhere apart from the tests.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
