### PR TITLE
Fix crash about Order Creation fragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -645,15 +645,13 @@ class MainActivity :
         }
         AnalyticsTracker.track(stat)
 
-        // if we're at the root scroll the active fragment to the top, otherwise clear the nav backstack
+        // if we're at the root scroll the active fragment to the top
         if (isAtNavigationRoot()) {
             // If the fragment's view is not yet created, do nothing
             if (getActiveTopLevelFragment()?.view != null) {
                 getActiveTopLevelFragment()?.scrollToTop()
                 expandToolbar(expand = true, animate = true)
             }
-        } else {
-            navController.navigate(binding.bottomNav.currentPosition.id)
         }
     }
     // endregion

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -646,6 +646,8 @@ class MainActivity :
         AnalyticsTracker.track(stat)
 
         // if we're at the root scroll the active fragment to the top
+        // TODO bring back clearing the backstack when the navgraphs are fixed to support multiple backstacks:
+        // https://github.com/woocommerce/woocommerce-android/issues/7183
         if (isAtNavigationRoot()) {
             // If the fragment's view is not yet created, do nothing
             if (getActiveTopLevelFragment()?.view != null) {


### PR DESCRIPTION
Closes: #7184 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The current navigation solution in the app went through multiple refactorings to support multiple backstacks, the last one was switching to the native support of multiple backstacks with navigation 2.4.0, but one leftover from the previous refactorings was causing this crash, as when reselecting a tab, we were using the wrong API for clearing the back stack, we are using `NavController#navigate` instead of `NavController#popBackStack`.

For now, we can't simply switch to `popBackStack` as our implementation is not fully compliant with navigation requirements (check #7183).
But a simple solution can be followed for now: delete the code 😅. This code is used for popping back stack when reselecting a tab, but for our app, we hide the bottom navigation when navigating to child fragments, so this code wasn't really useful, except when clicking fast enough when the bottom navigation is still animating, and as this is just an edge case, and the app self-corrects itself, it's OK to remove the code for now.

### Testing instructions
1. Open the app.
2. Click on Orders tab.
3. Click on Create Order, then click at the products tab while the bottom navigation is still animating.
4. Make a fast click to Orders tab then back to products tab.
5. Switch between tabs, and confirm the app doesn't crash.

Check the attached video for directions on how to follow the steps (the video leads to crash as it was recorded on `trunk`)

https://user-images.githubusercontent.com/1657201/184621580-745854d3-d430-4a07-b08a-5b540ad25159.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
