### PR TITLE
Issue/7186 custom fields dark mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -147,7 +147,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             scrollUpChild = binding.scrollView
             setOnRefreshListener { viewModel.onRefreshRequested() }
         }
-        binding.customFieldsButton.setOnClickListener {
+        binding.customFieldsCard.customFieldsButton.setOnClickListener {
             viewModel.onCustomFieldsButtonClicked()
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomFieldsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomFieldsCard.kt
@@ -14,4 +14,7 @@ class OrderDetailCustomFieldsCard @JvmOverloads constructor(
     init {
         View.inflate(context, R.layout.order_detail_custom_fields_card, this)
     }
+
+    val customFieldsButton: View
+        get() = findViewById(R.id.customFieldsButton)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomFieldsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomFieldsCard.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.orders.details.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.R
+
+class OrderDetailCustomFieldsCard @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    init {
+        View.inflate(context, R.layout.order_detail_custom_fields_card, this)
+    }
+}

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -60,27 +60,13 @@
                     tools:visibility="visible" />
 
                 <!-- Custom fields button -->
-                <FrameLayout
-                    style="@style/Woo.Card"
-                    android:background="@color/color_on_primary"
+                <com.woocommerce.android.ui.orders.details.views.OrderDetailCustomFieldsCard
                     android:id="@+id/customFieldsCard"
+                    style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:visibility="gone"
-                    tools:visibility="visible">
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/customFieldsButton"
-                        style="@style/Woo.Button.Outlined"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="end|center_vertical"
-                        android:layout_marginStart="@dimen/major_100"
-                        android:layout_marginTop="@dimen/minor_100"
-                        android:layout_marginEnd="@dimen/major_100"
-                        android:layout_marginBottom="@dimen/minor_100"
-                        android:text="@string/orderdetail_view_custom_fields" />
-                </FrameLayout>
+                    tools:visibility="visible" />
 
                 <!-- Refunds Info -->
                 <com.woocommerce.android.ui.orders.details.views.OrderDetailRefundsView

--- a/WooCommerce/src/main/res/layout/order_detail_custom_fields_card.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_custom_fields_card.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/customFieldsButton"
+        style="@style/Woo.Button.Outlined"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|center_vertical"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/minor_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/minor_100"
+        android:text="@string/orderdetail_view_custom_fields" />
+</merge>


### PR DESCRIPTION
Closes: #7186 - this PR fixes the background color of the "View custom fields" button in dark mode by moving it to a separate `MaterialCardView`.

**BEFORE**
![before](https://user-images.githubusercontent.com/3903757/184671204-8b63f630-43f5-486a-84b8-d53ef949aa52.png)

**AFTER**
![after](https://user-images.githubusercontent.com/3903757/184671246-ef9f9ddc-a860-430b-a57f-1082f9309f19.png)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
