### PR TITLE
Issue/7190 prevent duplicate calls order details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -140,6 +140,8 @@ class OrderDetailViewModel @Inject constructor(
     private val _shippingLabels = MutableLiveData<List<ShippingLabel>>()
     val shippingLabels: LiveData<List<ShippingLabel>> = _shippingLabels
 
+    private var isFetchingData = false
+
     override fun onCleared() {
         super.onCleared()
         productImageMap.unsubscribeFromOnProductFetchedEvents(this)
@@ -168,11 +170,15 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private suspend fun fetchOrder(showSkeleton: Boolean) {
+        // Prevent re-fetch data when a fetching request is ongoing
+        if (isFetchingData) return
+
         if (networkStatus.isConnected()) {
             viewState = viewState.copy(
                 isOrderDetailSkeletonShown = showSkeleton
             )
 
+            isFetchingData = true
             awaitAll(
                 fetchOrderAsync(),
                 fetchOrderNotesAsync(),
@@ -182,9 +188,9 @@ class OrderDetailViewModel @Inject constructor(
                 fetchOrderProductsAsync(),
                 fetchSLCreationEligibilityAsync()
             )
+            isFetchingData = false
 
             displayOrderDetails()
-
             viewState = viewState.copy(
                 isOrderDetailSkeletonShown = false,
                 isRefreshing = false


### PR DESCRIPTION

Closes: #7190

### Description
This small PR prevents making multiple fetching requests in the Order Details screen. It does that by adding a flag to the OrderDetailViewModel preventing the app from sending a request if there is an ongoing request taking place.

### Testing instructions

TC1
1. Open orders list
2. Pull to refresh right away
3. Check that requests are not duplicated

TC2
Run OrderDetailViewModelTest


### Images/gif
[Untitled_ Aug 15, 2022 3_29 PM.webm](https://user-images.githubusercontent.com/18119390/184694233-ae4c83cb-a30e-4607-b7c3-ba5a3dd2323a.webm)



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
