### PR TITLE
issue/7196-remove-base-fragment-save-restore-title

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.base
 
-import android.os.Bundle
-import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
@@ -14,23 +12,7 @@ open class BaseFragment : Fragment, BaseFragmentView {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
-    companion object {
-        private const val KEY_TITLE = "title"
-    }
-
     open val activityAppBarStatus: AppBarStatus = AppBarStatus.Visible()
-
-    @CallSuper
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        savedInstanceState?.let {
-            activity?.title = it.getString(KEY_TITLE)
-        }
-    }
-
-    @CallSuper
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putString(KEY_TITLE, getFragmentTitle())
-    }
 
     @CallSuper
     override fun onHiddenChanged(hidden: Boolean) {


### PR DESCRIPTION
Closes: #7196

This PR removes the saving and restoring of the `BaseFragment` title. The title is restored already in `onResume` so that code isn't necessary.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.