### PR TITLE
Disable Edit menu until order exists

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -169,6 +169,13 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         menuEditOrder.isVisible = FeatureFlag.UNIFIED_ORDER_EDITING.isEnabled()
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+        menu.findItem(R.id.menu_edit_order)?.let {
+            it.isEnabled = viewModel.hasOrder()
+        }
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_edit_order -> {
@@ -195,6 +202,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.orderInfo?.takeIfNotEqualTo(old?.orderInfo) {
                 showOrderDetail(it.order!!, it.isPaymentCollectableWithCardReader, it.isReceiptButtonsVisible)
+                requireActivity().invalidateOptionsMenu()
             }
             new.orderStatus?.takeIfNotEqualTo(old?.orderStatus) { showOrderStatus(it) }
             new.isMarkOrderCompleteButtonVisible?.takeIfNotEqualTo(old?.isMarkOrderCompleteButtonVisible) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -160,6 +160,8 @@ class OrderDetailViewModel @Inject constructor(
         }
     }
 
+    fun hasOrder() = viewState.orderInfo?.order != null
+
     private suspend fun displayOrderDetails() {
         updateOrderState()
         loadOrderNotes()


### PR DESCRIPTION
Closes: #7197

This PR fixes a crash that occurs when the user taps Edit in order detail before the order has been loaded. This most likely occurs when going to order detail from a notification.

To test:

* Add `delay(2000)` above [this line](https://github.com/woocommerce/woocommerce-android/blob/d64f9a72012109e0ca3374626c08a4e471777a8a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt#L155) to delay loading the order
* Go to the order list and tap an order
* Notice that the order detail Edit button is disabled until the order is loaded

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.