### PR TITLE
Add tracking for linked product promo

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -377,6 +377,9 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_BANNER_CAMPAIGN_NAME = "campaign_name"
         const val KEY_BANNER_UPSELL_CARD_READERS = "upsell_card_readers"
         const val KEY_BANNER_REMIND_LATER = "remind_later"
+        const val KEY_BANNER_LINKED_PRODUCTS_PROMO = "linked_products_promo"
+
+        const val SOURCE_PRODUCT_DETAIL = "product_detail"
 
         // -- Experiments
         const val KEY_EXPERIMENT_VARIANT = "experiment_variant"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -480,6 +480,7 @@ class ProductDetailFragment :
                             },
                             onDismissClick = {
                                 WooAnimUtils.scaleOut(binding.promoComposableContainer)
+                                viewModel.onLinkedProductPromoDismissed()
                             }
                         )
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_LINKED_PRODUCTS
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.SOURCE_PRODUCT_DETAIL
 import com.woocommerce.android.extensions.addNewItem
 import com.woocommerce.android.extensions.clearList
 import com.woocommerce.android.extensions.containsItem
@@ -1640,7 +1639,7 @@ class ProductDetailViewModel @Inject constructor(
             AnalyticsTracker.track(
                 AnalyticsEvent.FEATURE_CARD_SHOWN,
                 mapOf(
-                    AnalyticsTracker.KEY_BANNER_SOURCE to SOURCE_PRODUCT_DETAIL,
+                    AnalyticsTracker.KEY_BANNER_SOURCE to AnalyticsTracker.SOURCE_PRODUCT_DETAIL,
                     AnalyticsTracker.KEY_BANNER_CAMPAIGN_NAME to AnalyticsTracker.KEY_BANNER_LINKED_PRODUCTS_PROMO
                 )
             )
@@ -1652,7 +1651,7 @@ class ProductDetailViewModel @Inject constructor(
         AnalyticsTracker.track(
             AnalyticsEvent.FEATURE_CARD_CTA_TAPPED,
             mapOf(
-                AnalyticsTracker.KEY_BANNER_SOURCE to SOURCE_PRODUCT_DETAIL,
+                AnalyticsTracker.KEY_BANNER_SOURCE to AnalyticsTracker.SOURCE_PRODUCT_DETAIL,
                 AnalyticsTracker.KEY_BANNER_CAMPAIGN_NAME to AnalyticsTracker.KEY_BANNER_LINKED_PRODUCTS_PROMO
             )
         )
@@ -1663,8 +1662,9 @@ class ProductDetailViewModel @Inject constructor(
         AnalyticsTracker.track(
             AnalyticsEvent.FEATURE_CARD_DISMISSED,
             mapOf(
-                AnalyticsTracker.KEY_BANNER_SOURCE to SOURCE_PRODUCT_DETAIL,
-                AnalyticsTracker.KEY_BANNER_CAMPAIGN_NAME to AnalyticsTracker.KEY_BANNER_LINKED_PRODUCTS_PROMO
+                AnalyticsTracker.KEY_BANNER_SOURCE to AnalyticsTracker.SOURCE_PRODUCT_DETAIL,
+                AnalyticsTracker.KEY_BANNER_CAMPAIGN_NAME to AnalyticsTracker.KEY_BANNER_LINKED_PRODUCTS_PROMO,
+                AnalyticsTracker.KEY_BANNER_REMIND_LATER to false
             )
         )
         triggerEvent(ProductNavigationTarget.ViewLinkedProducts(getRemoteProductId()))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_LINKED_PRODUCTS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.SOURCE_PRODUCT_DETAIL
 import com.woocommerce.android.extensions.addNewItem
 import com.woocommerce.android.extensions.clearList
 import com.woocommerce.android.extensions.containsItem
@@ -1636,12 +1637,36 @@ class ProductDetailViewModel @Inject constructor(
             viewState.productDraft?.hasLinkedProducts() == false
         ) {
             appPrefsWrapper.setPromoBannerShown(PromoBannerType.LINKED_PRODUCTS, true)
+            AnalyticsTracker.track(
+                AnalyticsEvent.FEATURE_CARD_SHOWN,
+                mapOf(
+                    AnalyticsTracker.KEY_BANNER_SOURCE to SOURCE_PRODUCT_DETAIL,
+                    AnalyticsTracker.KEY_BANNER_CAMPAIGN_NAME to AnalyticsTracker.KEY_BANNER_LINKED_PRODUCTS_PROMO
+                )
+            )
             triggerEvent(ShowLinkedProductPromoBanner)
         }
     }
 
     fun onLinkedProductPromoClicked() {
-        // TODO analytics
+        AnalyticsTracker.track(
+            AnalyticsEvent.FEATURE_CARD_CTA_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_BANNER_SOURCE to SOURCE_PRODUCT_DETAIL,
+                AnalyticsTracker.KEY_BANNER_CAMPAIGN_NAME to AnalyticsTracker.KEY_BANNER_LINKED_PRODUCTS_PROMO
+            )
+        )
+        triggerEvent(ProductNavigationTarget.ViewLinkedProducts(getRemoteProductId()))
+    }
+
+    fun onLinkedProductPromoDismissed() {
+        AnalyticsTracker.track(
+            AnalyticsEvent.FEATURE_CARD_DISMISSED,
+            mapOf(
+                AnalyticsTracker.KEY_BANNER_SOURCE to SOURCE_PRODUCT_DETAIL,
+                AnalyticsTracker.KEY_BANNER_CAMPAIGN_NAME to AnalyticsTracker.KEY_BANNER_LINKED_PRODUCTS_PROMO
+            )
+        )
         triggerEvent(ProductNavigationTarget.ViewLinkedProducts(getRemoteProductId()))
     }
 


### PR DESCRIPTION
Closes: #7054 

This PR adds tracking for the linked products promo. To test:

* Change [this line](https://github.com/woocommerce/woocommerce-android/blob/400d7f5c180caa0ff0acdeda45a846e2404c8c98/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt#L364) to always return false so the promo banner won't be shown just once
* Open product detail for a product without linked products
* Make a change and save it
* When the "promo banner" appears ensure the event is tracked
* Dismiss the banner and ensure the event is tracked
* Force the banner to appear again, click "Set up now," and ensure the event is tracked

@rachelmcr I've added you as a reviewer to make sure WCAndroid is tracking the same as WCiOS. I'll assign an Android dev to do the actual code review.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.