### PR TITLE
Fix null order in detail screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -179,7 +179,6 @@ class OrderDetailViewModel @Inject constructor(
                 fetchOrderShippingLabelsAsync(),
                 fetchShipmentTrackingAsync(),
                 fetchOrderRefundsAsync(),
-                fetchOrderProductsAsync(),
                 fetchSLCreationEligibilityAsync()
             )
 
@@ -554,6 +553,7 @@ class OrderDetailViewModel @Inject constructor(
         orderDetailsTransactionLauncher.onOrderFetched()
         if (fetchedOrder != null) {
             order = fetchedOrder
+            fetchOrderProducts()
         } else {
             triggerEvent(ShowSnackbar(string.order_error_fetch_generic))
         }
@@ -585,7 +585,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     // the database might be missing certain products, so we need to fetch the ones we don't have
-    private fun fetchOrderProductsAsync() = async {
+    private suspend fun fetchOrderProducts() {
         val productIds = order.getProductIds()
         val numLocalProducts = orderDetailRepository.getProductCountForOrder(productIds)
         if (numLocalProducts != order.items.size) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -595,13 +595,13 @@ class OrderDetailViewModel @Inject constructor(
 
     private fun fetchSLCreationEligibilityAsync() = async {
         if (shippingLabelOnboardingRepository.isShippingPluginReady) {
-            orderDetailRepository.fetchSLCreationEligibility(order.id)
+            orderDetailRepository.fetchSLCreationEligibility(navArgs.orderId)
         }
         orderDetailsTransactionLauncher.onPackageCreationEligibleFetched()
     }
 
     private fun loadShipmentTracking(shippingLabels: ListInfo<ShippingLabel>): ListInfo<OrderShipmentTracking> {
-        val trackingList = orderDetailRepository.getOrderShipmentTrackings(order.id)
+        val trackingList = orderDetailRepository.getOrderShipmentTrackings(navArgs.orderId)
         return if (!appPrefs.isTrackingExtensionAvailable() || shippingLabels.isVisible || hasVirtualProductsOnly()) {
             ListInfo(isVisible = false)
         } else {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -359,6 +359,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             val ids = items.map { it.productId }
 
             val order = order.copy(items = items)
+            doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
             doReturn(order).whenever(orderDetailRepository).getOrderById(any())
             doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())


### PR DESCRIPTION
Closes: #7195 

### Description
This PR fixes the `IllegalArgumentException` when the app tries to fetch the order data from an order that doesn't exist locally. With the changes introduced in this PR, the `fetchOrderProducts()` would be called only after we successfully fetched the order locally. Now, none of the async requests sent to fetch the order details will depend on the `fetchOrderProducts()` to complete.

Discussion: p1660662218321629-slack-CGPNUU63E

### Testing instructions

You can apply the following Patch to reproduce the error on `trunk` and test that the app doesn't crash with the fix. This patch adds a delay of 3 seconds to the `fetchOrderAsync` and forces the call to `fetchOrder(showSkeleton = true)` with the idea to test that non of the fetch sync requests depends on the `fetchOrderAsync` to complete.
<details>
  <summary>Patch</summary>

```
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
index 38b51c768b..2800463ccd 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -75,6 +75,7 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
@@ -152,11 +153,7 @@ class OrderDetailViewModel @Inject constructor(
 
     fun start() {
         launch {
-            orderDetailRepository.getOrderById(navArgs.orderId)?.let {
-                order = it
-                displayOrderDetails()
-                fetchOrder(showSkeleton = false)
-            } ?: fetchOrder(showSkeleton = true)
+             fetchOrder(showSkeleton = true)
         }
     }
 
@@ -549,6 +546,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchOrderAsync() = async {
+        delay(3_000)
         val fetchedOrder = orderDetailRepository.fetchOrderById(navArgs.orderId)
         orderDetailsTransactionLauncher.onOrderFetched()
         if (fetchedOrder != null) {

```
</details>


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->