### PR TITLE
Do not show cod disabled state when it is skipped previously

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -589,4 +589,18 @@ class AppPrefsTest {
             )
         ).isEqualTo(lastDismissedDialogTimeInMillis)
     }
+
+    @Test
+    fun givenCashOnDeliveryDisabledStateSkippedThenReturnSkippedAsTrue() {
+        AppPrefs.setCashOnDeliveryDisabledStateSkipped(true)
+
+        assertThat(AppPrefs.isCashOnDeliveryDisabledStateSkipped()).isTrue
+    }
+
+    @Test
+    fun givenCashOnDeliveryDisabledStateNotSkippedThenReturnSkippedAsFalse() {
+        AppPrefs.setCashOnDeliveryDisabledStateSkipped(false)
+
+        assertThat(AppPrefs.isCashOnDeliveryDisabledStateSkipped()).isFalse
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -91,6 +91,7 @@ object AppPrefs {
         LOGIN_EMAIL,
         CARD_READER_UPSELL_BANNER_DIALOG_DISMISSED_FOREVER,
         CARD_READER_UPSELL_BANNER_DIALOG_DISMISSED_REMIND_ME_LATER,
+        CARD_READER_DO_NOT_SHOW_CASH_ON_DELIVERY_DISABLED_ONBOARDING_STATE,
     }
 
     /**
@@ -551,6 +552,20 @@ object AppPrefs {
 
     fun setUnifiedLoginLastFlow(flow: String) {
         setString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW, flow)
+    }
+
+    fun isCashOnDeliveryDisabledStateSkipped(): Boolean {
+        return getBoolean(
+            DeletablePrefKey.CARD_READER_DO_NOT_SHOW_CASH_ON_DELIVERY_DISABLED_ONBOARDING_STATE,
+            false
+        )
+    }
+
+    fun setCashOnDeliveryDisabledStateSkipped(isSkipped: Boolean) {
+        setBoolean(
+            DeletablePrefKey.CARD_READER_DO_NOT_SHOW_CASH_ON_DELIVERY_DISABLED_ONBOARDING_STATE,
+            isSkipped
+        )
     }
 
     fun getCardReaderOnboardingStatus(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -90,6 +90,12 @@ class AppPrefsWrapper @Inject constructor() {
         selfHostedSiteId: Long
     ) = AppPrefs.getCardReaderStatementDescriptor(localSiteId, remoteSiteId, selfHostedSiteId)
 
+    fun isCashOnDeliveryDisabledStateSkipped() = AppPrefs.isCashOnDeliveryDisabledStateSkipped()
+
+    fun setCashOnDeliveryDisabledStateSkipped(isSkipped: Boolean) = AppPrefs.setCashOnDeliveryDisabledStateSkipped(
+        isSkipped
+    )
+
     fun setLastConnectedCardReaderId(readerId: String) = AppPrefs.setLastConnectedCardReaderId(readerId)
 
     fun getLastConnectedCardReaderId() = AppPrefs.getLastConnectedCardReaderId()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -195,7 +195,10 @@ class CardReaderOnboardingChecker @Inject constructor(
         if (isStripeAccountRejected(paymentAccount)) return StripeAccountRejected(preferredPlugin.type)
         if (isInUndefinedState(paymentAccount)) return GenericError
 
-        if (!isCashOnDeliveryEnabled()) return CashOnDeliveryDisabled(
+        if (
+            !appPrefsWrapper.isCashOnDeliveryDisabledStateSkipped() &&
+            !isCashOnDeliveryEnabled()
+        ) return CashOnDeliveryDisabled(
             requireNotNull(countryCode),
             preferredPlugin.type,
             preferredPlugin.info?.version

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -231,6 +231,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
     }
 
     private fun onSkipCashOnDeliveryClicked(countryCode: String) {
+        appPrefsWrapper.setCashOnDeliveryDisabledStateSkipped(true)
         continueFlow(countryCode)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1465,6 +1465,60 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         assertThat(result).isInstanceOf(CardReaderOnboardingState.CashOnDeliveryDisabled::class.java)
     }
 
+    @Test
+    fun `given cod disabled state, when cod disabled skipped, then don't show CashOnDeliveryDisabled`() = testBlocking {
+        whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+            .thenReturn(null)
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+            .thenReturn(buildWCPayPluginInfo(isActive = true))
+        whenever(appPrefsWrapper.isCashOnDeliveryDisabledStateSkipped()).thenReturn(true)
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isNotInstanceOf(CardReaderOnboardingState.CashOnDeliveryDisabled::class.java)
+    }
+
+    @Test
+    fun `given cod disabled state, when cod disabled not skipped, then show CashOnDeliveryDisabled`() = testBlocking {
+        whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_STRIPE_GATEWAY))
+            .thenReturn(null)
+        whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
+            .thenReturn(buildWCPayPluginInfo(isActive = true))
+        whenever(appPrefsWrapper.isCashOnDeliveryDisabledStateSkipped()).thenReturn(false)
+        whenever(wcGatewayStore.fetchAllGateways(selectedSite.get())).thenReturn(
+            WooResult(
+                model = listOf(
+                    WCGatewayModel(
+                        id = "cheque",
+                        title = "",
+                        description = "",
+                        order = 0,
+                        isEnabled = false,
+                        methodTitle = "",
+                        methodDescription = "",
+                        features = listOf()
+                    ),
+                    WCGatewayModel(
+                        id = "bacs",
+                        title = "",
+                        description = "",
+                        order = 0,
+                        isEnabled = false,
+                        methodTitle = "",
+                        methodDescription = "",
+                        features = listOf()
+                    )
+                )
+            )
+        )
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isInstanceOf(CardReaderOnboardingState.CashOnDeliveryDisabled::class.java)
+    }
+
     private fun buildPaymentAccountResult(
         status: WCPaymentAccountResult.WCPaymentAccountStatus = WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE,
         hasPendingRequirements: Boolean = false,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -1060,6 +1060,24 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given cash on delivery disabled screen, when skip button clicked, then store decision in app prefs`() =
+        testBlocking {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(
+                    CashOnDeliveryDisabled(
+                        countryCode = countryCode,
+                        preferredPlugin = WOOCOMMERCE_PAYMENTS,
+                        version = pluginVersion
+                    )
+                )
+            val viewModel = createVM()
+
+            (viewModel.viewStateData.value as CashOnDeliveryDisabledState).onSkipCashOnDeliveryClicked.invoke()
+
+            verify(appPrefsWrapper).setCashOnDeliveryDisabledStateSkipped(true)
+        }
+
+    @Test
     fun `given cash on delivery enabled clicked, then show progress`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7206 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR does not show the COD disabled state during onboarding if It was skipped previously. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### COD skipped
1. Make sure COD is disabled in your store
2. Navigate to the IPP settings
3. Ensure you see COD disabled state
4. Click on the skip button
5. Visit the IPP settings again
6. Ensure you don't see the COD disabled state anymore
7. Clear the app data or log out.
8. Login again and repeat steps 1 and 2
9. Ensure you see the COD disabled state now.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/1331230/185081491-2d5c6a1b-c08a-4475-b49a-3942ddf24bf0.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
