### PR TITLE
Fix compiler warnings in generated code

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
@@ -16,7 +16,7 @@ class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle
     }
 
     private val navArgs: SimpleTextEditorFragmentArgs by savedState.navArgs()
-    private val textLiveData = savedState.getLiveData<String>(TEXT_KEY, navArgs.currentText)
+    private val textLiveData = savedState.getLiveData(TEXT_KEY, navArgs.currentText)
     val viewState = textLiveData.map {
         ViewState(
             text = it,
@@ -43,13 +43,13 @@ class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle
     }
 
     data class ViewState(
-        val text: String,
+        val text: String?,
         val hint: String,
         val hasChanges: Boolean
     )
 
     data class SimpleTextEditorResult(
-        val text: String,
+        val text: String?,
         val requestCode: Int?
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
@@ -20,9 +20,6 @@ object DeviceInfo {
     val locale: String?
         get() {
             val locale = ConfigurationCompat.getLocales(Resources.getSystem().configuration)
-            if (locale.isEmpty.not()) {
-                return locale[0]!!.displayLanguage
-            }
-            return null
+            return locale[0]?.displayLanguage
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
@@ -2,12 +2,11 @@ package com.woocommerce.android.util
 
 import android.content.res.Resources
 import android.os.Build
-import android.os.Build.VERSION
 import androidx.core.os.ConfigurationCompat
 
 object DeviceInfo {
     val OS: String
-        get() = VERSION.RELEASE
+        get() = Build.VERSION.RELEASE
     val name: String
         get() {
             val manufacturer = Build.MANUFACTURER

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
@@ -2,11 +2,12 @@ package com.woocommerce.android.util
 
 import android.content.res.Resources
 import android.os.Build
+import android.os.Build.VERSION
 import androidx.core.os.ConfigurationCompat
 
 object DeviceInfo {
     val OS: String
-        get() = android.os.Build.VERSION.RELEASE
+        get() = VERSION.RELEASE
     val name: String
         get() {
             val manufacturer = Build.MANUFACTURER
@@ -21,7 +22,7 @@ object DeviceInfo {
         get() {
             val locale = ConfigurationCompat.getLocales(Resources.getSystem().configuration)
             if (locale.isEmpty.not()) {
-                return locale[0].displayLanguage
+                return locale[0]!!.displayLanguage
             }
             return null
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
     gradle.ext.daggerVersion = '2.42'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.6.10'
-    gradle.ext.navigationVersion = '2.4.1'
+    gradle.ext.navigationVersion = '2.5.1'
 
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7210
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR updates the navigation library to the latest version. It is needed because the current version generated code that contains deprecated methods

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Sanity check that nothing changed in the app's navigation
* Check that the flow that touches SimpleTextEditor is not affected by the changes
* Compile the code before and after the change. Notice that all warnings from the generated code are gone

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
