### PR TITLE
[Login] Allow entering a site address manually when encountring the no-stores erro

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 10.0
 -----
-
+- [**] Login: Add ability to enter site address manually after signing in if the account is not connected to any stores [https://github.com/woocommerce/woocommerce-android/pull/7216]
 
 9.9
 -----

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -65,7 +65,8 @@
 
         <activity
             android:name=".ui.sitediscovery.PostLoginSiteDiscoveryActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -64,7 +64,7 @@
         </activity>
 
         <activity
-            android:name=".PostLoginSiteDiscoveryActivity"
+            android:name=".ui.sitediscovery.PostLoginSiteDiscoveryActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -64,6 +64,21 @@
         </activity>
 
         <activity
+            android:name=".PostLoginSiteDiscoveryActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="jetpack-connected-post-login"
+                    android:scheme="woocommerce" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".ui.login.MagicLinkInterceptActivity"
             android:exported="true">
             <intent-filter>

--- a/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
@@ -273,7 +273,14 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         userAvatarUrl: String?,
         checkJetpackAvailability: Boolean?
     ) {
-        TODO("Not yet implemented")
+        siteAddress?.let {
+            val jetpackReqFragment = LoginJetpackRequiredFragment.newInstance(siteAddress)
+            changeFragment(
+                fragment = jetpackReqFragment as Fragment,
+                shouldAddToBackStack = true,
+                tag = LoginJetpackRequiredFragment.TAG
+            )
+        }
     }
 
     override fun helpHandleDiscoveryError(

--- a/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
@@ -1,0 +1,389 @@
+package com.woocommerce.android
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.woocommerce.android.databinding.ActivityLoginBinding
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragmentArgs
+import com.woocommerce.android.ui.login.LoginActivity
+import com.woocommerce.android.ui.login.LoginJetpackRequiredFragment
+import com.woocommerce.android.ui.login.LoginNoJetpackListener
+import com.woocommerce.android.ui.login.LoginWhatIsJetpackDialogFragment
+import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
+import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.fluxc.network.MemorizingTrustManager
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
+import org.wordpress.android.login.AuthOptions
+import org.wordpress.android.login.LoginListener
+import org.wordpress.android.login.LoginListener.SelfSignedSSLCallback
+import org.wordpress.android.login.LoginMode
+import org.wordpress.android.login.LoginSiteAddressFragment
+import kotlin.text.RegexOption.IGNORE_CASE
+
+@AndroidEntryPoint
+class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, LoginNoJetpackListener {
+    companion object {
+        private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect"
+        private const val JETPACK_CONNECTED_REDIRECT_URL = "woocommerce://jetpack-connected-post-login"
+        private const val JETPACK_CONNECTED_REDIRECT_URL_QUERY = "url"
+    }
+
+    private val binding by lazy {
+        ActivityLoginBinding.inflate(layoutInflater)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        if (hasJetpackConnectedIntent()) {
+            val siteAddress = intent.data!!.getQueryParameter(JETPACK_CONNECTED_REDIRECT_URL_QUERY)!!
+            // Save the site address to be able to continue login from the MainActivity
+            AppPrefs.setLoginSiteAddress(siteAddress)
+            showMainActivityAndFinish()
+        } else {
+            loginViaSiteAddress()
+        }
+    }
+
+    private fun hasJetpackConnectedIntent(): Boolean {
+        val action = intent.action
+        val uri = intent.data
+
+        return Intent.ACTION_VIEW == action && uri.toString().startsWith(JETPACK_CONNECTED_REDIRECT_URL)
+    }
+
+    private fun showMainActivityAndFinish() {
+        val intent = Intent(this, MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
+    }
+
+    override fun getLoginMode(): LoginMode = LoginMode.WOO_LOGIN_MODE
+
+    override fun startOver() {
+        // Clear logged in url from AppPrefs
+        AppPrefs.removeLoginSiteAddress()
+
+        val intent = Intent(this, LoginActivity::class.java)
+            .apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+                LoginMode.WOO_LOGIN_MODE.putInto(this)
+            }
+        startActivity(intent)
+    }
+
+    override fun gotWpcomEmail(email: String?, verifyEmail: Boolean, authOptions: AuthOptions?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun gotUnregisteredEmail(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun gotUnregisteredSocialAccount(
+        email: String?,
+        displayName: String?,
+        idToken: String?,
+        photoUrl: String?,
+        service: String?
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun loginViaSiteAddress() {
+        val loginSiteAddressFragment = supportFragmentManager.findFragmentByTag(LoginSiteAddressFragment.TAG)
+            as? WooLoginSiteAddressFragment
+            ?: WooLoginSiteAddressFragment()
+        changeFragment(loginSiteAddressFragment, true, LoginSiteAddressFragment.TAG)
+    }
+
+    override fun loginViaSocialAccount(
+        email: String?,
+        idToken: String?,
+        service: String?,
+        isPasswordRequired: Boolean
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun loggedInViaSocialAccount(oldSiteIds: ArrayList<Int>?, doLoginUpdate: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun loginViaWpcomUsernameInstead() {
+        TODO("Not yet implemented")
+    }
+
+    override fun loginViaSiteCredentials(inputSiteAddress: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpEmailScreen(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpSocialEmailScreen(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun addGoogleLoginFragment(isSignupFromLoginEnabled: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun showHelpFindingConnectedEmail() {
+        TODO("Not yet implemented")
+    }
+
+    override fun onTermsOfServiceClicked() {
+        TODO("Not yet implemented")
+    }
+
+    override fun showMagicLinkSentScreen(email: String?, allowPassword: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun usePasswordInstead(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpMagicLinkRequest(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun openEmailClient(isLogin: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpMagicLinkSent(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun forgotPassword(url: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun useMagicLinkInstead(email: String?, verifyEmail: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun needs2fa(email: String?, password: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun needs2faSocial(
+        email: String?,
+        userId: String?,
+        nonceAuthenticator: String?,
+        nonceBackup: String?,
+        nonceSms: String?
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun needs2faSocialConnect(email: String?, password: String?, idToken: String?, service: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun loggedInViaPassword(oldSitesIds: ArrayList<Int>?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpEmailPasswordScreen(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun alreadyLoggedInWpcom(oldSitesIds: ArrayList<Int>?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun gotWpcomSiteInfo(siteAddress: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun gotConnectedSiteInfo(siteAddress: String, redirectUrl: String?, hasJetpack: Boolean) {
+        val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
+        val siteAddressClean = siteAddress.replaceFirst(protocolRegex, "")
+
+        if (hasJetpack) {
+            // Save site address to continue login in MainActivity
+            AppPrefs.setLoginSiteAddress(siteAddressClean)
+            showMainActivityAndFinish()
+        } else {
+            val jetpackReqFragment = LoginJetpackRequiredFragment.newInstance(siteAddress)
+            changeFragment(
+                fragment = jetpackReqFragment as Fragment,
+                shouldAddToBackStack = true,
+                tag = LoginJetpackRequiredFragment.TAG
+            )
+        }
+    }
+
+    override fun gotXmlRpcEndpoint(inputSiteAddress: String?, endpointAddress: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun handleSslCertificateError(
+        memorizingTrustManager: MemorizingTrustManager?,
+        callback: SelfSignedSSLCallback?
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpSiteAddress(url: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun handleSiteAddressError(siteInfo: ConnectSiteInfoPayload?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun saveCredentialsInSmartLock(
+        username: String?,
+        password: String?,
+        displayName: String,
+        profilePicture: Uri?
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun loggedInViaUsernamePassword(oldSitesIds: ArrayList<Int>?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpUsernamePassword(url: String?, username: String?, isWpcom: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpNoJetpackScreen(
+        siteAddress: String?,
+        endpointAddress: String?,
+        username: String?,
+        password: String?,
+        userAvatarUrl: String?,
+        checkJetpackAvailability: Boolean?
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpHandleDiscoveryError(
+        siteAddress: String?,
+        endpointAddress: String?,
+        username: String?,
+        password: String?,
+        userAvatarUrl: String?,
+        errorMessage: Int
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun help2FaScreen(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun startPostLoginServices() {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpSignupEmailScreen(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpSignupMagicLinkScreen(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun helpSignupConfirmationScreen(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun showSignupMagicLink(email: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun showSignupSocial(
+        email: String?,
+        displayName: String?,
+        idToken: String?,
+        photoUrl: String?,
+        service: String?
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun showSignupToLoginMessage() {
+        TODO("Not yet implemented")
+    }
+
+    override fun showJetpackInstructions() {
+        ChromeCustomTabUtils.launchUrl(this, AppUrls.JETPACK_INSTRUCTIONS)
+    }
+
+    override fun showJetpackTroubleshootingTips() {
+        ChromeCustomTabUtils.launchUrl(this, AppUrls.JETPACK_TROUBLESHOOTING)
+    }
+
+    override fun showWhatIsJetpackDialog() {
+        LoginWhatIsJetpackDialogFragment().show(supportFragmentManager, LoginWhatIsJetpackDialogFragment.TAG)
+    }
+
+    override fun showEmailLoginScreen(siteAddress: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun showUsernamePasswordScreen(
+        siteAddress: String?,
+        endpointAddress: String?,
+        inputUsername: String?,
+        inputPassword: String?
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun startJetpackInstall(siteAddress: String?) {
+        siteAddress?.let { address ->
+            // Pass the site address in the redirect URL to retrieve it after installation
+            val redirectUrl = "$JETPACK_CONNECTED_REDIRECT_URL?$JETPACK_CONNECTED_REDIRECT_URL_QUERY=$siteAddress"
+            val url = "$JETPACK_CONNECT_URL?" +
+                "url=$address" +
+                "&mobile_redirect=$redirectUrl" +
+                "&from=mobile"
+
+            val wpComWebViewFragment = WPComWebViewFragment().apply {
+                arguments = WPComWebViewFragmentArgs(url).toBundle()
+            }
+            changeFragment(wpComWebViewFragment, true, tag = "Tag")
+        }
+    }
+
+    private fun changeFragment(
+        fragment: Fragment,
+        shouldAddToBackStack: Boolean,
+        tag: String,
+        animate: Boolean = true
+    ) {
+        val fragmentTransaction = supportFragmentManager.beginTransaction()
+        if (animate) {
+            fragmentTransaction.setCustomAnimations(
+                R.anim.default_enter_anim,
+                R.anim.default_exit_anim,
+                R.anim.default_pop_enter_anim,
+                R.anim.default_pop_exit_anim
+            )
+        }
+        fragmentTransaction.replace(binding.fragmentContainer.id, fragment, tag)
+        if (shouldAddToBackStack) {
+            fragmentTransaction.addToBackStack(tag)
+        }
+        fragmentTransaction.commitAllowingStateLoss()
+    }
+}

--- a/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragmentArgs
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginJetpackRequiredFragment
 import com.woocommerce.android.ui.login.LoginNoJetpackListener
+import com.woocommerce.android.ui.login.LoginSiteCheckErrorFragment
 import com.woocommerce.android.ui.login.LoginWhatIsJetpackDialogFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
 import com.woocommerce.android.ui.main.MainActivity
@@ -244,8 +245,24 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         TODO("Not yet implemented")
     }
 
-    override fun handleSiteAddressError(siteInfo: ConnectSiteInfoPayload?) {
-        TODO("Not yet implemented")
+    override fun handleSiteAddressError(siteInfo: ConnectSiteInfoPayload) {
+        if (!siteInfo.isWordPress) {
+            // The url entered is not a WordPress site.
+            val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
+            val siteAddressClean = siteInfo.url.replaceFirst(protocolRegex, "")
+            val errorMessage = getString(R.string.login_not_wordpress_site_v2)
+
+            // hide the keyboard
+            org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
+
+            // show the "not WordPress error" screen
+            val genericErrorFragment = LoginSiteCheckErrorFragment.newInstance(siteAddressClean, errorMessage)
+            changeFragment(
+                fragment = genericErrorFragment,
+                shouldAddToBackStack = true,
+                tag = LoginSiteCheckErrorFragment.TAG
+            )
+        }
     }
 
     override fun saveCredentialsInSmartLock(

--- a/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
@@ -3,8 +3,10 @@ package com.woocommerce.android
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivityLoginBinding
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragmentArgs
@@ -77,6 +79,27 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
                 LoginMode.WOO_LOGIN_MODE.putInto(this)
             }
         startActivity(intent)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+
+        return false
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onBackPressed() {
+        AnalyticsTracker.trackBackPressed(this)
+
+        if (supportFragmentManager.backStackEntryCount == 1) {
+            finish()
+        } else {
+            super.onBackPressed()
+        }
     }
 
     override fun gotWpcomEmail(email: String?, verifyEmail: Boolean, authOptions: AuthOptions?) {

--- a/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/java/com/woocommerce/android/PostLoginSiteDiscoveryActivity.kt
@@ -43,7 +43,7 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         setContentView(binding.root)
         if (hasJetpackConnectedIntent()) {
             val siteAddress = intent.data!!.getQueryParameter(JETPACK_CONNECTED_REDIRECT_URL_QUERY)!!
-            // Save the site address to be able to continue login from the MainActivity
+            // Save the site address to be able to continue login from the Site Picker
             AppPrefs.setLoginSiteAddress(siteAddress)
             showMainActivityAndFinish()
         } else {
@@ -211,7 +211,8 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         val siteAddressClean = siteAddress.replaceFirst(protocolRegex, "")
 
         if (hasJetpack) {
-            // Save site address to continue login in MainActivity
+            // This most probably means an account mismatch
+            // Save the address to allow the site picker to continue the flow
             AppPrefs.setLoginSiteAddress(siteAddressClean)
             showMainActivityAndFinish()
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.common.wpcomwebview
 
 import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebChromeClient
@@ -40,9 +42,11 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview), UrlI
     private val webViewClient by lazy { WPComWebViewClient(this) }
     private val navArgs: WPComWebViewFragmentArgs by navArgs()
 
-    @Inject lateinit var accountStore: AccountStore
+    @Inject
+    lateinit var accountStore: AccountStore
 
-    @Inject lateinit var userAgent: UserAgent
+    @Inject
+    lateinit var userAgent: UserAgent
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -75,9 +79,18 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview), UrlI
     }
 
     override fun onLoadUrl(url: String) {
-        navArgs.urlToTriggerExit?.let {
-            if (isAdded && url.contains(it)) {
+        if (!isAdded) return
+        if (navArgs.urlToTriggerExit != null) {
+            if (url.contains(navArgs.urlToTriggerExit!!)) {
                 navigateBackWithNotice(WEBVIEW_RESULT)
+            }
+        } else {
+            if (url.startsWith("woocommerce://")) {
+                Intent(Intent.ACTION_VIEW).apply {
+                    data = Uri.parse(url)
+                }.let {
+                    startActivity(it)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
@@ -62,10 +62,10 @@ class LoginJetpackRequiredFragment : Fragment(R.layout.fragment_login_jetpack_re
         binding.jetpackRequiredMsg.text = getString(R.string.login_jetpack_required_text, siteAddress.orEmpty())
 
         with(btnBinding.buttonPrimary) {
-            text = getString(R.string.login_jetpack_view_instructions)
+            text = getString(R.string.login_jetpack_install)
             setOnClickListener {
-                AnalyticsTracker.track(AnalyticsEvent.LOGIN_JETPACK_REQUIRED_VIEW_INSTRUCTIONS_BUTTON_TAPPED)
-                jetpackLoginListener?.showJetpackInstructions()
+                AnalyticsTracker.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_BUTTON_TAPPED)
+                jetpackLoginListener?.startJetpackInstall(siteAddress)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSiteDiscoveryActivity.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.ui.login.LoginJetpackRequiredFragment
 import com.woocommerce.android.ui.login.LoginNoJetpackListener
 import com.woocommerce.android.ui.login.LoginSiteCheckErrorFragment
 import com.woocommerce.android.ui.login.LoginWhatIsJetpackDialogFragment
-import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.WooLog
@@ -112,8 +111,8 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
 
     override fun loginViaSiteAddress() {
         val loginSiteAddressFragment = supportFragmentManager.findFragmentByTag(LoginSiteAddressFragment.TAG)
-            as? WooLoginSiteAddressFragment
-            ?: WooLoginSiteAddressFragment()
+            as? PostLoginSitedAddressFragment
+            ?: PostLoginSitedAddressFragment()
         changeFragment(loginSiteAddressFragment, true, LoginSiteAddressFragment.TAG)
     }
 
@@ -171,6 +170,17 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
                 shouldAddToBackStack = true,
                 tag = LoginJetpackRequiredFragment.TAG
             )
+        }
+    }
+
+    /**
+     * This is called when we get a WPCom site without Jetpack (a non-atomic site)
+     * We will save the site address then forward to the site picker to show the account mismatch error
+     */
+    override fun gotWpcomSiteInfo(siteAddress: String?) {
+        siteAddress?.let {
+            AppPrefs.setLoginSiteAddress(it)
+            showMainActivityAndFinish()
         }
     }
 
@@ -350,10 +360,6 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
     }
 
     override fun helpEmailPasswordScreen(email: String?) {
-        TODO("Not yet implemented")
-    }
-
-    override fun gotWpcomSiteInfo(siteAddress: String?) {
         TODO("Not yet implemented")
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSiteDiscoveryActivity.kt
@@ -59,6 +59,10 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        if (savedInstanceState != null) {
+            // The FragmentManager will restore the last fragment
+            return
+        }
         if (hasJetpackConnectedIntent()) {
             val siteAddress = intent.data!!.getQueryParameter(JETPACK_CONNECTED_REDIRECT_URL_QUERY)!!
             // Save the site address to be able to continue login from the Site Picker

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSiteDiscoveryActivity.kt
@@ -38,6 +38,10 @@ import org.wordpress.android.login.LoginSiteAddressFragment
 import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
 
+/**
+ * The goal of this Activity is to reuse the site discovery from the Login library, but since the login is tied
+ * to the [LoginListener], we need to implement all functions even though we need just a small subset of them.
+ */
 @AndroidEntryPoint
 class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, LoginNoJetpackListener {
     companion object {
@@ -231,6 +235,7 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
                 "&mobile_redirect=$redirectUrl" +
                 "&from=mobile"
 
+            // Use the WPComWebView to reduce chances of account mismatch after signing in
             val wpComWebViewFragment = WPComWebViewFragment().apply {
                 arguments = WPComWebViewFragmentArgs(url).toBundle()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSiteDiscoveryActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSiteDiscoveryActivity.kt
@@ -4,12 +4,13 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
-import com.woocommerce.android.R.anim
-import com.woocommerce.android.R.string
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivityLoginBinding
 import com.woocommerce.android.support.HelpActivity
@@ -34,6 +35,7 @@ import org.wordpress.android.login.LoginListener
 import org.wordpress.android.login.LoginListener.SelfSignedSSLCallback
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.login.LoginSiteAddressFragment
+import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
 
 @AndroidEntryPoint
@@ -47,6 +49,8 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
     private val binding by lazy {
         ActivityLoginBinding.inflate(layoutInflater)
     }
+
+    @Inject lateinit var crashLogging: CrashLogging
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -140,7 +144,7 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
             // The url entered is not a WordPress site.
             val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
             val siteAddressClean = siteInfo.url.replaceFirst(protocolRegex, "")
-            val errorMessage = getString(string.login_not_wordpress_site_v2)
+            val errorMessage = getString(R.string.login_not_wordpress_site_v2)
 
             // hide the keyboard
             org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
@@ -193,10 +197,10 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         val fragmentTransaction = supportFragmentManager.beginTransaction()
         if (animate) {
             fragmentTransaction.setCustomAnimations(
-                anim.default_enter_anim,
-                anim.default_exit_anim,
-                anim.default_pop_enter_anim,
-                anim.default_pop_exit_anim
+                R.anim.default_enter_anim,
+                R.anim.default_exit_anim,
+                R.anim.default_pop_enter_anim,
+                R.anim.default_pop_exit_anim
             )
         }
         fragmentTransaction.replace(binding.fragmentContainer.id, fragment, tag)
@@ -253,19 +257,23 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         photoUrl: String?,
         service: String?
     ) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun alreadyLoggedInWpcom(oldSitesIds: java.util.ArrayList<Int>?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun gotWpcomEmail(email: String?, verifyEmail: Boolean, authOptions: AuthOptions?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun gotUnregisteredEmail(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun loginViaSocialAccount(
@@ -274,71 +282,88 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         service: String?,
         isPasswordRequired: Boolean
     ) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun loggedInViaSocialAccount(oldSiteIds: ArrayList<Int>?, doLoginUpdate: Boolean) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun loginViaWpcomUsernameInstead() {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun loginViaSiteCredentials(inputSiteAddress: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpEmailScreen(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpSocialEmailScreen(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun addGoogleLoginFragment(isSignupFromLoginEnabled: Boolean) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun showHelpFindingConnectedEmail() {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun onTermsOfServiceClicked() {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun showMagicLinkSentScreen(email: String?, allowPassword: Boolean) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun usePasswordInstead(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpMagicLinkRequest(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun openEmailClient(isLogin: Boolean) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpMagicLinkSent(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun forgotPassword(url: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun useMagicLinkInstead(email: String?, verifyEmail: Boolean) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun needs2fa(email: String?, password: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun needs2faSocial(
@@ -348,27 +373,33 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         nonceBackup: String?,
         nonceSms: String?
     ) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun needs2faSocialConnect(email: String?, password: String?, idToken: String?, service: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun loggedInViaPassword(oldSitesIds: ArrayList<Int>?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpEmailPasswordScreen(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun gotXmlRpcEndpoint(inputSiteAddress: String?, endpointAddress: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun saveCredentialsInSmartLock(
@@ -377,15 +408,18 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         displayName: String,
         profilePicture: Uri?
     ) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun loggedInViaUsernamePassword(oldSitesIds: ArrayList<Int>?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpUsernamePassword(url: String?, username: String?, isWpcom: Boolean) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpHandleDiscoveryError(
@@ -396,31 +430,38 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         userAvatarUrl: String?,
         errorMessage: Int
     ) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun help2FaScreen(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun startPostLoginServices() {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpSignupEmailScreen(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpSignupMagicLinkScreen(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun helpSignupConfirmationScreen(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun showSignupMagicLink(email: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun showSignupSocial(
@@ -430,15 +471,18 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         photoUrl: String?,
         service: String?
     ) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun showSignupToLoginMessage() {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun showEmailLoginScreen(siteAddress: String?) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 
     override fun showUsernamePasswordScreen(
@@ -447,6 +491,7 @@ class PostLoginSiteDiscoveryActivity : AppCompatActivity(), LoginListener, Login
         inputUsername: String?,
         inputPassword: String?
     ) {
-        TODO("Not yet implemented")
+        crashLogging.recordException(IllegalStateException("Unhandled state in PostLoginSiteDiscoveryActivity"))
+        Toast.makeText(this, R.string.site_discovery_postlogin_failure, Toast.LENGTH_LONG).show()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSitedAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/PostLoginSitedAddressFragment.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.sitediscovery
+
+import org.wordpress.android.login.LoginSiteAddressFragment
+
+class PostLoginSitedAddressFragment : LoginSiteAddressFragment() {
+    override fun handleWpComDiscoveryError(failedEndpoint: String?) {
+        // Discovery fails for a WPCom site happens for non-atomic cases
+        mLoginListener.gotWpcomSiteInfo(failedEndpoint)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/SiteDiscoveryModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitediscovery/SiteDiscoveryModule.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.sitediscovery
+
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@InstallIn(SingletonComponent::class)
+@Module
+interface SiteDiscoveryModule {
+    @ContributesAndroidInjector
+    fun providePostLoginSitedAddressFragment(): PostLoginSitedAddressFragment
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -10,7 +10,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.NavGraphMainDirections
-import com.woocommerce.android.PostLoginSiteDiscoveryActivity
+import com.woocommerce.android.ui.sitediscovery.PostLoginSiteDiscoveryActivity
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.PostLoginSiteDiscoveryActivity
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -52,7 +53,8 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
     private val binding get() = _binding!!
 
     private val viewModel: SitePickerViewModel by viewModels()
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private var skeletonView = SkeletonView()
     private var progressDialog: CustomProgressDialog? = null
@@ -175,7 +177,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
 
     private fun updateNoStoresView() {
         binding.loginEpilogueButtonBar.buttonPrimary.setOnClickListener {
-            viewModel.onLearnMoreAboutJetpackButtonClick()
+            startActivity(Intent(requireActivity(), PostLoginSiteDiscoveryActivity::class.java))
         }
         binding.noStoresView.clickSecondaryAction {
             viewModel.onWhatIsJetpackButtonClick()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -22,16 +22,15 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
-import com.woocommerce.android.ui.login.LoginWhatIsJetpackDialogFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.sitediscovery.PostLoginSiteDiscoveryActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToEmailHelpDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToMainActivityEvent
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToNewToWooEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToHelpFragmentEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToLearnMoreAboutJetpackEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToWhatIsJetpackFragmentEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.ShowWooUpgradeDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.AccountMismatchState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
@@ -147,7 +146,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 is NavigateToMainActivityEvent -> (activity as? MainActivity)?.handleSitePickerResult()
                 is ShowWooUpgradeDialogEvent -> showWooUpgradeDialog()
                 is NavigationToHelpFragmentEvent -> navigateToHelpScreen()
-                is NavigationToWhatIsJetpackFragmentEvent -> navigateToWhatIsJetpackScreen()
+                is NavigateToNewToWooEvent -> navigateToNewToWooScreen()
                 is NavigationToLearnMoreAboutJetpackEvent -> navigateToLearnMoreAboutJetpackScreen()
                 is NavigateToEmailHelpDialogEvent -> navigateToNeedHelpFindingEmailScreen()
                 is NavigateToWPComWebView -> navigateToWPComWebView(event)
@@ -180,7 +179,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
             startActivity(Intent(requireActivity(), PostLoginSiteDiscoveryActivity::class.java))
         }
         binding.noStoresView.clickSecondaryAction {
-            viewModel.onWhatIsJetpackButtonClick()
+            viewModel.onNewToWooClick()
         }
     }
 
@@ -237,8 +236,8 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
         }
     }
 
-    private fun navigateToWhatIsJetpackScreen() {
-        LoginWhatIsJetpackDialogFragment().show(parentFragmentManager, LoginWhatIsJetpackDialogFragment.TAG)
+    private fun navigateToNewToWooScreen() {
+        ChromeCustomTabUtils.launchUrl(requireContext(), AppUrls.NEW_TO_WOO_DOC)
     }
 
     private fun navigateToLearnMoreAboutJetpackScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -10,7 +10,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.NavGraphMainDirections
-import com.woocommerce.android.ui.sitediscovery.PostLoginSiteDiscoveryActivity
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -26,6 +25,7 @@ import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import com.woocommerce.android.ui.login.LoginWhatIsJetpackDialogFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.sitediscovery.PostLoginSiteDiscoveryActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToEmailHelpDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToMainActivityEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -244,7 +244,7 @@ class SitePickerViewModel @Inject constructor(
             isPrimaryBtnVisible = true,
             primaryBtnText = resourceProvider.getString(string.login_site_picker_enter_site_address),
             noStoresLabelText = resourceProvider.getString(string.login_no_stores),
-            noStoresBtnText = resourceProvider.getString(string.login_jetpack_what_is),
+            noStoresBtnText = resourceProvider.getString(string.login_site_picker_new_to_woo),
             currentSitePickerState = SitePickerState.NoStoreState
         )
     }
@@ -347,9 +347,9 @@ class SitePickerViewModel @Inject constructor(
         launch { fetchSitesFromApi(showSkeleton = false) }
     }
 
-    fun onWhatIsJetpackButtonClick() {
-        analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
-        triggerEvent(SitePickerEvent.NavigationToWhatIsJetpackFragmentEvent)
+    fun onNewToWooClick() {
+        analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_NEW_TO_WOO_BUTTON_TAPPED)
+        triggerEvent(SitePickerEvent.NavigateToNewToWooEvent)
     }
 
     fun onLearnMoreAboutJetpackButtonClick() {
@@ -563,7 +563,7 @@ class SitePickerViewModel @Inject constructor(
         object NavigateToMainActivityEvent : SitePickerEvent()
         object NavigateToEmailHelpDialogEvent : SitePickerEvent()
         object NavigationToHelpFragmentEvent : SitePickerEvent()
-        object NavigationToWhatIsJetpackFragmentEvent : SitePickerEvent()
+        object NavigateToNewToWooEvent : SitePickerEvent()
         object NavigationToLearnMoreAboutJetpackEvent : SitePickerEvent()
         data class NavigateToWPComWebView(val url: String, val validationUrl: String) : SitePickerEvent()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -242,7 +242,7 @@ class SitePickerViewModel @Inject constructor(
         sitePickerViewState = sitePickerViewState.copy(
             isNoStoresViewVisible = true,
             isPrimaryBtnVisible = true,
-            primaryBtnText = resourceProvider.getString(string.login_jetpack_view_instructions_alt),
+            primaryBtnText = resourceProvider.getString(string.login_site_picker_enter_site_address),
             noStoresLabelText = resourceProvider.getString(string.login_no_stores),
             noStoresBtnText = resourceProvider.getString(string.login_jetpack_what_is),
             currentSitePickerState = SitePickerState.NoStoreState

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -263,6 +263,7 @@
     <string name="user_role_access_error_link">Learn more about roles and permissions</string>
     <string name="user_role_access_error_retry">You don\'t have the correct user role</string>
     <string name="user_access_verifying">Verifying role…</string>
+    <string name="login_site_picker_enter_site_address">Enter a site address</string>
     <!--
         My Store View
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -226,7 +226,7 @@
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>
     <string name="login_with_a_different_account">Login with a different account</string>
-    <string name="login_no_stores">We didn\'t find WooCommerce stores connected to this account. You\'ll need to install and connect the free Jetpack plugin on your WooCommerce stores to use this app.</string>
+    <string name="login_no_stores">We didn\'t find WooCommerce stores connected to this account.</string>
     <string name="login_not_connected_to_account">It looks like %1$s is connected to a different WordPress.com account.</string>
     <string name="login_try_another_account">Log in with another account</string>
     <string name="login_try_another_store">Try another store</string>
@@ -265,6 +265,7 @@
     <string name="user_access_verifying">Verifying role…</string>
     <string name="login_site_picker_enter_site_address">Enter a site address</string>
     <string name="site_discovery_postlogin_failure">A failure occurred, please contact support</string>
+    <string name="login_site_picker_new_to_woo">New to WooCommerce</string>
     <!--
         My Store View
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@
     <string name="user_role_access_error_retry">You don\'t have the correct user role</string>
     <string name="user_access_verifying">Verifying role…</string>
     <string name="login_site_picker_enter_site_address">Enter a site address</string>
+    <string name="site_discovery_postlogin_failure">A failure occurred, please contact support</string>
     <!--
         My Store View
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerTestUtils.kt
@@ -57,7 +57,7 @@ object SitePickerTestUtils {
     ) = defaultViewState.copy(
         isNoStoresViewVisible = true,
         isPrimaryBtnVisible = true,
-        primaryBtnText = resourceProvider.getString(R.string.login_jetpack_view_instructions_alt),
+        primaryBtnText = resourceProvider.getString(R.string.login_site_picker_enter_site_address),
         noStoresLabelText = resourceProvider.getString(R.string.login_no_stores),
         noStoresBtnText = resourceProvider.getString(R.string.login_jetpack_what_is)
     )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToMainActivityEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToHelpFragmentEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToLearnMoreAboutJetpackEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToWhatIsJetpackFragmentEvent
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToNewToWooEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.ShowWooUpgradeDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.AccountMismatchState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
@@ -543,17 +543,17 @@ class SitePickerViewModelTest : BaseUnitTest() {
         givenTheScreenIsFromLogin(true)
         whenViewModelIsCreated()
 
-        var view: NavigationToWhatIsJetpackFragmentEvent? = null
+        var view: NavigateToNewToWooEvent? = null
         viewModel.event.observeForever {
-            if (it is NavigationToWhatIsJetpackFragmentEvent) view = it
+            if (it is NavigateToNewToWooEvent) view = it
         }
 
-        viewModel.onWhatIsJetpackButtonClick()
+        viewModel.onNewToWooClick()
 
         verify(analyticsTrackerWrapper, times(1)).track(
             AnalyticsEvent.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED
         )
-        assertThat(view).isEqualTo(NavigationToWhatIsJetpackFragmentEvent)
+        assertThat(view).isEqualTo(NavigateToNewToWooEvent)
     }
 
     @Test


### PR DESCRIPTION
Closes: #7215 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds ability to enter a site address manually when the user encounters the no-stores error, after entering the site address, we will run a site discovery that reuses the same logic from the Login library, in order to do so, I opted for creating a separate Activity that implements `LoginListener`, this allows us to reuse the Login fragments, but gives us more flexibility in adapting the flow to our usecase.

### Testing instructions
For all the scenarios below, please start with a WordPress.com account that's not connected to any site, then when the no-stores error is shown, click on "Enter a site address"

##### Site without Jetpack
1. Enter the address of a site that doesn't have Jetpack.
2. Confirm that a screen that explains the issue is shown, with a CTA to install Jetpack.
3. Try installing Jetpack then connecting it to your WordPress.com account.
4. Confirm that in the WebView you are automatically signed in to your WordPress.com account.
5. Confirm that after installation, you can continue login.

##### Jetpack sites and WPCom sites
For all of these cases, you should land on the "account mismatch" error.

##### Non-wordpress site
Confirm that the app shows the appropriate error.

### Screenshots
<img src="https://user-images.githubusercontent.com/1657201/185133347-a242ba12-0287-4702-94e6-a9e24080dc6a.png" width=360/>



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
