### PR TITLE
Fix tap event in UOE

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,7 +74,7 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "9.9-rc-1"
+            versionName "9.9-rc-2"
         }
         versionCode 319
 

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,7 +74,7 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "9.9-rc-2"
+            versionName "9.9-rc-1"
         }
         versionCode 319
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -411,7 +411,7 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     private fun trackCreateOrderButtonClick() {
-        AnalyticsTracker.track(
+        tracker.track(
             ORDER_CREATE_BUTTON_TAPPED,
             mapOf(
                 KEY_STATUS to _orderDraft.value.status,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -317,9 +317,9 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onCreateOrderClicked(order: Order) {
-        trackCreateOrderButtonClick()
         when (mode) {
             Mode.Creation -> viewModelScope.launch {
+                trackCreateOrderButtonClick()
                 viewState = viewState.copy(isProgressDialogShown = true)
                 orderCreateEditRepository.placeOrder(order).fold(
                     onSuccess = {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.orders.creation
 
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_CREATION
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
@@ -835,5 +837,24 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
             lastReceivedState = it
         }
         assertThat(lastReceivedState?.isEditable).isEqualTo(true)
+    }
+
+    @Test
+    fun `when create button tapped, send track event`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        createSut()
+
+        sut.onCreateOrderClicked(defaultOrderValue)
+
+        verify(tracker).track(
+            AnalyticsEvent.ORDER_CREATE_BUTTON_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_STATUS to defaultOrderValue.status,
+                AnalyticsTracker.KEY_PRODUCT_COUNT to sut.products.value?.count(),
+                AnalyticsTracker.KEY_HAS_CUSTOMER_DETAILS to defaultOrderValue.billingAddress.hasInfo(),
+                AnalyticsTracker.KEY_HAS_FEES to defaultOrderValue.feesLines.isNotEmpty(),
+                AnalyticsTracker.KEY_HAS_SHIPPING_METHOD to defaultOrderValue.shippingLines.isNotEmpty()
+            )
+        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.orders.creation
 
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_EDITING
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Succeeded
@@ -16,7 +18,9 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
 
 @ExperimentalCoroutinesApi
 // Remove Silent runner when feature is completed
@@ -114,5 +118,24 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             lastReceivedState = it
         }
         assertThat(lastReceivedState?.isEditable).isEqualTo(false)
+    }
+
+    @Test
+    fun `when done button tapped, don't send the track event`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        createSut()
+
+        sut.onCreateOrderClicked(defaultOrderValue)
+
+        verify(tracker, never()).track(
+            AnalyticsEvent.ORDER_CREATE_BUTTON_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_STATUS to defaultOrderValue.status,
+                AnalyticsTracker.KEY_PRODUCT_COUNT to sut.products.value?.count(),
+                AnalyticsTracker.KEY_HAS_CUSTOMER_DETAILS to defaultOrderValue.billingAddress.hasInfo(),
+                AnalyticsTracker.KEY_HAS_FEES to defaultOrderValue.feesLines.isNotEmpty(),
+                AnalyticsTracker.KEY_HAS_SHIPPING_METHOD to defaultOrderValue.shippingLines.isNotEmpty()
+            )
+        )
     }
 }


### PR DESCRIPTION
Closes: #7198 
Original PR #7202

### Description
This PR matches iOS on sending the `order_create_button_tapped` only on the Order Creation flow. 

### Testing instructions
TC1
1. Open the orders list
2. Tap the (+) button -> Create order
3. Tap the Create button
4. Check that `order_create_button_tapped` is sent

TC2
1. Open the orders list
2. Tap the Edit button 
3. Tap the Done button
4. Check that `order_create_button_tapped` is NOT sent

### Images/gif
The `order_create_button_tapped` looks like this on Logcat:

``` 
🔵 Tracked: order_create_button_tapped, Properties: {"status":null,"product_count":0,"has_customer_details":false,"has_fees":false,"has_shipping_method":false,"blog_id":202934350,"is_wpcom_store":true,"is_debug":true}
```

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->