### PR TITLE
Immutable notification in fluxc

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailRepository.kt
@@ -3,9 +3,12 @@ package com.woocommerce.android.ui.reviews
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.getCommentId
-import com.woocommerce.android.model.*
+import com.woocommerce.android.model.ProductReview
+import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.model.RequestResult.ERROR
 import com.woocommerce.android.model.RequestResult.SUCCESS
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.model.toProductReviewProductModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.REVIEWS
@@ -60,9 +63,11 @@ class ReviewDetailRepository @Inject constructor(
 
     suspend fun markNotificationAsRead(notification: NotificationModel, remoteReviewId: Long) {
         if (!notification.read) {
-            notification.read = true
-            trackMarkNotificationAsReadStarted(notification, remoteReviewId)
-            val result = notificationStore.markNotificationsRead(MarkNotificationsReadPayload(listOf(notification)))
+            val updatedNotification = notification.copy(read = true)
+            trackMarkNotificationAsReadStarted(updatedNotification, remoteReviewId)
+            val result = notificationStore.markNotificationsRead(
+                payload = MarkNotificationsReadPayload(listOf(updatedNotification))
+            )
             trackMarkNotificationReadResult(result)
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.49.0'
+    fluxCVersion = 'trunk-87b03bffccc4b1573ae38f6fb881972a1802fe0d'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
### Description
This small PR updates the FluxC version used in Woo and refactors `markNotificationAsRead() ` function to use the new immutable Notification model.

### Testing instructions

TC1
1. On your test Woocommerce store create a new review for a product
2. Open the review notification in the phone
3. Check that the notification is marked as read (1) in the device database

TC2
1. Smoke-test the notifications and ensure everything is working as expected. 

### Images/gif
<img width="1689" alt="Screen Shot 2022-08-17 at 13 15 56" src="https://user-images.githubusercontent.com/18119390/185190925-b2428a8b-3235-4567-863a-c5872469fd6e.png">


