### PR TITLE
issue/7219-no-such-element-order-creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreateEditProductSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreateEditProductSelectionFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowProductVariations
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigator
 import com.woocommerce.android.ui.orders.creation.products.OrderCreateEditProductSelectionViewModel.AddProduct
+import com.woocommerce.android.ui.orders.creation.products.OrderCreateEditProductSelectionViewModel.ProductNotFound
 import com.woocommerce.android.ui.orders.creation.products.OrderCreateEditProductSelectionViewModel.ViewState
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.ui.products.ProductListAdapter
@@ -29,6 +30,7 @@ import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
+import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -76,6 +78,10 @@ class OrderCreateEditProductSelectionFragment :
                     findNavController().navigateUp()
                 }
                 is ShowProductVariations -> OrderCreateEditNavigator.navigate(this, event)
+                is ProductNotFound -> ToastUtils.showToast(
+                    requireActivity(),
+                    R.string.product_detail_fetch_product_invalid_id_error
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreateEditProductSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreateEditProductSelectionViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.map
 import com.woocommerce.android.AppConstants
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.differsFrom
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowProductVariations

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreateEditProductSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreateEditProductSelectionViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.map
 import com.woocommerce.android.AppConstants
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.differsFrom
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowProductVariations
@@ -80,11 +81,14 @@ class OrderCreateEditProductSelectionViewModel @Inject constructor(
     }
 
     fun onProductSelected(productId: Long) {
-        val product = productList.value!!.first { it.remoteId == productId }
-        if (product.numVariations == 0) {
-            triggerEvent(AddProduct(productId))
-        } else {
-            triggerEvent(ShowProductVariations(productId))
+        productList.value!!.firstOrNull { it.remoteId == productId }?.let { product ->
+            if (product.numVariations == 0) {
+                triggerEvent(AddProduct(productId))
+            } else {
+                triggerEvent(ShowProductVariations(productId))
+            }
+        } ?: run {
+            triggerEvent(ProductNotFound)
         }
     }
 
@@ -155,4 +159,6 @@ class OrderCreateEditProductSelectionViewModel @Inject constructor(
     ) : Parcelable
 
     data class AddProduct(val productId: Long) : MultiLiveEvent.Event()
+
+    object ProductNotFound : MultiLiveEvent.Event()
 }


### PR DESCRIPTION
Closes: #7219

This PR handles the situation where the user enters the product selection during order creation and selects a product that no longer exists. Looking at some of the logs it's clear this is happening after logging `FETCHED_PRODUCTS` or `SEARCHED_PRODUCTS`, so my assumption is the user tapped a product that's no longer in the list before the list could be updated. This should be a rare situation.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
