### PR TITLE
[Login] Site discovery post-login, part 1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -118,6 +118,8 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_PICKER_NOT_WOO_STORE_REFRESH_APP_LINK_TAPPED(siteless = true),
     SITE_PICKER_NOT_CONNECTED_JETPACK_REFRESH_APP_LINK_TAPPED(siteless = true),
     SITE_PICKER_NON_WOO_SITE_TAPPED(siteless = true),
+    SITE_PICKER_NEW_TO_WOO_TAPPED(siteless = true),
+    SITE_PICKER_ENTER_SITE_ADDRESS_TAPPED(siteless = true),
 
     // -- Dashboard
     DASHBOARD_PULLED_TO_REFRESH,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ProgressDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -37,8 +38,13 @@ fun ProgressDialog(
                         vertical = dimensionResource(id = R.dimen.major_150)
                     )
             ) {
-                Text(text = title, style = MaterialTheme.typography.h6)
-                Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_150))) {
+                if (title.isNotBlank()) {
+                    Text(text = title, style = MaterialTheme.typography.h6)
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_150)),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     CircularProgressIndicator()
                     Text(text = subtitle, style = MaterialTheme.typography.body2)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSitePickerBinding
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.ui.base.BaseFragment
@@ -246,7 +247,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
 
     private fun navigateToAddressScreen() {
         findNavController()
-            .navigate(SitePickerFragmentDirections.actionSitePickerFragmentToSitePickerSiteDiscoveryFragment())
+            .navigateSafely(SitePickerFragmentDirections.actionSitePickerFragmentToSitePickerSiteDiscoveryFragment())
     }
 
     private fun navigateToHelpScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -240,7 +240,8 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
     }
 
     private fun navigateToAddressScreen() {
-        TODO()
+        findNavController()
+            .navigate(SitePickerFragmentDirections.actionSitePickerFragmentToSitePickerSiteDiscoveryFragment())
     }
 
     private fun navigateToHelpScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSitePickerBinding
 import com.woocommerce.android.extensions.handleNotice
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.ui.base.BaseFragment
@@ -35,6 +36,7 @@ import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.StoreListState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.WooNotFoundState
+import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
@@ -164,6 +166,9 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
         }
         handleNotice(WPComWebViewFragment.WEBVIEW_DISMISSED) {
             AnalyticsTracker.track(AnalyticsEvent.LOGIN_WOOCOMMERCE_SETUP_DISMISSED)
+        }
+        handleResult<String>(SitePickerSiteDiscoveryFragment.SITE_PICKER_SITE_ADDRESS_RESULT) {
+            viewModel.onSiteAddressReceived(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -22,15 +22,14 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
-import com.woocommerce.android.ui.login.LoginWhatIsJetpackDialogFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToEmailHelpDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToMainActivityEvent
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToNewToWooEvent
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToSiteAddressEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToHelpFragmentEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToLearnMoreAboutJetpackEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToWhatIsJetpackFragmentEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.ShowWooUpgradeDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.AccountMismatchState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
@@ -52,7 +51,8 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
     private val binding get() = _binding!!
 
     private val viewModel: SitePickerViewModel by viewModels()
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private var skeletonView = SkeletonView()
     private var progressDialog: CustomProgressDialog? = null
@@ -145,8 +145,8 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 is NavigateToMainActivityEvent -> (activity as? MainActivity)?.handleSitePickerResult()
                 is ShowWooUpgradeDialogEvent -> showWooUpgradeDialog()
                 is NavigationToHelpFragmentEvent -> navigateToHelpScreen()
-                is NavigationToWhatIsJetpackFragmentEvent -> navigateToWhatIsJetpackScreen()
-                is NavigationToLearnMoreAboutJetpackEvent -> navigateToLearnMoreAboutJetpackScreen()
+                is NavigateToNewToWooEvent -> navigateToNewToWooScreen()
+                is NavigateToSiteAddressEvent -> navigateToAddressScreen()
                 is NavigateToEmailHelpDialogEvent -> navigateToNeedHelpFindingEmailScreen()
                 is NavigateToWPComWebView -> navigateToWPComWebView(event)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
@@ -175,10 +175,10 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
 
     private fun updateNoStoresView() {
         binding.loginEpilogueButtonBar.buttonPrimary.setOnClickListener {
-            viewModel.onLearnMoreAboutJetpackButtonClick()
+            viewModel.onEnterSiteAddressClick()
         }
         binding.noStoresView.clickSecondaryAction {
-            viewModel.onWhatIsJetpackButtonClick()
+            viewModel.onNewToWooClick()
         }
     }
 
@@ -235,12 +235,12 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
         }
     }
 
-    private fun navigateToWhatIsJetpackScreen() {
-        LoginWhatIsJetpackDialogFragment().show(parentFragmentManager, LoginWhatIsJetpackDialogFragment.TAG)
+    private fun navigateToNewToWooScreen() {
+        ChromeCustomTabUtils.launchUrl(requireContext(), AppUrls.NEW_TO_WOO_DOC)
     }
 
-    private fun navigateToLearnMoreAboutJetpackScreen() {
-        ChromeCustomTabUtils.launchUrl(requireContext(), AppUrls.JETPACK_INSTRUCTIONS)
+    private fun navigateToAddressScreen() {
+        TODO()
     }
 
     private fun navigateToHelpScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -348,12 +348,12 @@ class SitePickerViewModel @Inject constructor(
     }
 
     fun onNewToWooClick() {
-        // TODO track event
+        analyticsTrackerWrapper.track(AnalyticsEvent.SITE_PICKER_NEW_TO_WOO_TAPPED)
         triggerEvent(SitePickerEvent.NavigateToNewToWooEvent)
     }
 
     fun onEnterSiteAddressClick() {
-        // TODO track event
+        analyticsTrackerWrapper.track(AnalyticsEvent.SITE_PICKER_ENTER_SITE_ADDRESS_TAPPED)
         triggerEvent(SitePickerEvent.NavigateToSiteAddressEvent)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -242,9 +242,9 @@ class SitePickerViewModel @Inject constructor(
         sitePickerViewState = sitePickerViewState.copy(
             isNoStoresViewVisible = true,
             isPrimaryBtnVisible = true,
-            primaryBtnText = resourceProvider.getString(string.login_jetpack_view_instructions_alt),
+            primaryBtnText = resourceProvider.getString(string.login_site_picker_enter_site_address),
             noStoresLabelText = resourceProvider.getString(string.login_no_stores),
-            noStoresBtnText = resourceProvider.getString(string.login_jetpack_what_is),
+            noStoresBtnText = resourceProvider.getString(string.login_site_picker_new_to_woo),
             currentSitePickerState = SitePickerState.NoStoreState
         )
     }
@@ -347,14 +347,14 @@ class SitePickerViewModel @Inject constructor(
         launch { fetchSitesFromApi(showSkeleton = false) }
     }
 
-    fun onWhatIsJetpackButtonClick() {
-        analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
-        triggerEvent(SitePickerEvent.NavigationToWhatIsJetpackFragmentEvent)
+    fun onNewToWooClick() {
+        // TODO track event
+        triggerEvent(SitePickerEvent.NavigateToNewToWooEvent)
     }
 
-    fun onLearnMoreAboutJetpackButtonClick() {
-        analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_REQUIRED_VIEW_INSTRUCTIONS_BUTTON_TAPPED)
-        triggerEvent(SitePickerEvent.NavigationToLearnMoreAboutJetpackEvent)
+    fun onEnterSiteAddressClick() {
+        // TODO track event
+        triggerEvent(SitePickerEvent.NavigateToSiteAddressEvent)
     }
 
     fun onTryAnotherAccountButtonClick() {
@@ -563,8 +563,8 @@ class SitePickerViewModel @Inject constructor(
         object NavigateToMainActivityEvent : SitePickerEvent()
         object NavigateToEmailHelpDialogEvent : SitePickerEvent()
         object NavigationToHelpFragmentEvent : SitePickerEvent()
-        object NavigationToWhatIsJetpackFragmentEvent : SitePickerEvent()
-        object NavigationToLearnMoreAboutJetpackEvent : SitePickerEvent()
+        object NavigateToNewToWooEvent : SitePickerEvent()
+        object NavigateToSiteAddressEvent : SitePickerEvent()
         data class NavigateToWPComWebView(val url: String, val validationUrl: String) : SitePickerEvent()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -504,6 +504,11 @@ class SitePickerViewModel @Inject constructor(
         }
     }
 
+    fun onSiteAddressReceived(siteAddress: String) {
+        loginSiteAddress = siteAddress
+        launch { fetchSitesFromApi(showSkeleton = true) }
+    }
+
     private fun trackLoginEvent(
         currentFlow: UnifiedLoginTracker.Flow? = null,
         currentStep: UnifiedLoginTracker.Step? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/FetchSiteInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/FetchSiteInfo.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.ui.sitepicker.sitediscovery
+
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
+import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.API
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+class FetchSiteInfo @Inject constructor(private val dispatcher: Dispatcher) {
+    suspend operator fun invoke(siteAddress: String) =
+        suspendCancellableCoroutine<Result<ConnectSiteInfoPayload>> { continuation ->
+            val listener = ConnectSiteInfoListener(continuation)
+            dispatcher.register(listener)
+            dispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(siteAddress))
+
+            continuation.invokeOnCancellation {
+                dispatcher.unregister(listener)
+            }
+        }
+
+    private inner class ConnectSiteInfoListener(
+        private val continuation: CancellableContinuation<Result<ConnectSiteInfoPayload>>
+    ) {
+        @Subscribe(threadMode = MAIN)
+        fun onFetchedConnectSiteInfo(event: OnConnectSiteInfoChecked) {
+            dispatcher.unregister(this@ConnectSiteInfoListener)
+
+            if (!continuation.isActive) return
+            if (event.isError) {
+                AppLog.e(API, "onFetchedConnectSiteInfo has error: " + event.error.message)
+                continuation.resume(Result.failure(FetchSiteInfoException(event.error.type, event.error.message)))
+            } else {
+                continuation.resume(Result.success(event.info))
+            }
+        }
+    }
+
+    class FetchSiteInfoException(val type: SiteErrorType, message: String?) : Exception(message)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/FetchSiteInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/FetchSiteInfo.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.sitepicker.sitediscovery
 
-import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -17,7 +16,22 @@ import kotlin.coroutines.resume
 class FetchSiteInfo @Inject constructor(private val dispatcher: Dispatcher) {
     suspend operator fun invoke(siteAddress: String) =
         suspendCancellableCoroutine<Result<ConnectSiteInfoPayload>> { continuation ->
-            val listener = ConnectSiteInfoListener(continuation)
+            val listener = object : Any() {
+                @Subscribe(threadMode = MAIN)
+                fun onFetchedConnectSiteInfo(event: OnConnectSiteInfoChecked) {
+                    dispatcher.unregister(this)
+                    if (!continuation.isActive) return
+
+                    if (event.isError) {
+                        AppLog.e(API, "onFetchedConnectSiteInfo has error: " + event.error.message)
+                        continuation.resume(
+                            Result.failure(FetchSiteInfoException(event.error.type, event.error.message))
+                        )
+                    } else {
+                        continuation.resume(Result.success(event.info))
+                    }
+                }
+            }
             dispatcher.register(listener)
             dispatcher.dispatch(SiteActionBuilder.newFetchConnectSiteInfoAction(siteAddress))
 
@@ -25,23 +39,6 @@ class FetchSiteInfo @Inject constructor(private val dispatcher: Dispatcher) {
                 dispatcher.unregister(listener)
             }
         }
-
-    private inner class ConnectSiteInfoListener(
-        private val continuation: CancellableContinuation<Result<ConnectSiteInfoPayload>>
-    ) {
-        @Subscribe(threadMode = MAIN)
-        fun onFetchedConnectSiteInfo(event: OnConnectSiteInfoChecked) {
-            dispatcher.unregister(this@ConnectSiteInfoListener)
-
-            if (!continuation.isActive) return
-            if (event.isError) {
-                AppLog.e(API, "onFetchedConnectSiteInfo has error: " + event.error.message)
-                continuation.resume(Result.failure(FetchSiteInfoException(event.error.type, event.error.message)))
-            } else {
-                continuation.resume(Result.success(event.info))
-            }
-        }
-    }
 
     class FetchSiteInfoException(val type: SiteErrorType, message: String?) : Exception(message)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/RunSiteDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/RunSiteDiscovery.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.sitepicker.sitediscovery
+
+import javax.inject.Inject
+
+class RunSiteDiscovery @Inject constructor() {
+    suspend operator fun invoke(siteAddress: String) {
+
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/RunSiteDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/RunSiteDiscovery.kt
@@ -1,9 +1,0 @@
-package com.woocommerce.android.ui.sitepicker.sitediscovery
-
-import javax.inject.Inject
-
-class RunSiteDiscovery @Inject constructor() {
-    suspend operator fun invoke(siteAddress: String) {
-
-    }
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -7,13 +7,17 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.CreateZendeskTicket
+import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.NavigateToHelpScreen
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -55,7 +59,11 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
                 CreateZendeskTicket -> {
                     zendeskHelper.createNewTicket(requireActivity(), Origin.LOGIN_SITE_ADDRESS, null)
                 }
+                is NavigateToHelpScreen -> {
+                    startActivity(HelpActivity.createIntent(requireContext(), Origin.LOGIN_SITE_ADDRESS, null))
+                }
                 is ExitWithResult<*> -> navigateBackWithResult(SITE_PICKER_SITE_ADDRESS_RESULT, event.data)
+                is Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -7,17 +7,23 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.CreateZendeskTicket
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class SitePickerSiteDiscoveryFragment : BaseFragment() {
+    companion object {
+        const val SITE_PICKER_SITE_ADDRESS_RESULT = "site-url"
+    }
+
     private val viewModel: SitePickerSiteDiscoveryViewModel by viewModels()
 
     @Inject
@@ -49,6 +55,7 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
                 CreateZendeskTicket -> {
                     zendeskHelper.createNewTicket(requireActivity(), Origin.LOGIN_SITE_ADDRESS, null)
                 }
+                is ExitWithResult<*> -> navigateBackWithResult(SITE_PICKER_SITE_ADDRESS_RESULT, event.data)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -6,16 +6,22 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import com.woocommerce.android.support.HelpActivity.Origin
+import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.CreateZendeskTicket
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SitePickerSiteDiscoveryFragment : BaseFragment() {
     private val viewModel: SitePickerSiteDiscoveryViewModel by viewModels()
+
+    @Inject
+    lateinit var zendeskHelper: ZendeskHelper
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -26,6 +32,22 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
             setContent {
                 WooThemeWithBackground {
                     SitePickerSiteDiscoveryScreen(viewModel)
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                CreateZendeskTicket -> {
+                    zendeskHelper.createNewTicket(requireActivity(), Origin.LOGIN_SITE_ADDRESS, null)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.sitepicker.sitediscovery
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SitePickerSiteDiscoveryFragment : BaseFragment() {
+    private val viewModel: SitePickerSiteDiscoveryViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireActivity()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WooThemeWithBackground {
+                    SitePickerSiteDiscoveryScreen(viewModel)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryScreen.kt
@@ -66,13 +66,18 @@ private fun AddressInputView(
             onValueChange = onAddressChanged,
             label = stringResource(id = R.string.login_site_address),
             isError = state.inlineErrorMessage != 0,
-            helperText = state.inlineErrorMessage.takeIf { it != 0 }?.let { stringResource(id = it) }
+            helperText = state.inlineErrorMessage.takeIf { it != 0 }?.let { stringResource(id = it) },
+            maxLines = 1
         )
         WCTextButton(onClick = { /*TODO*/ }) {
             Text(text = stringResource(id = R.string.login_find_your_site_adress))
         }
         Spacer(modifier = Modifier.weight(1f))
-        WCColoredButton(onClick = { /*TODO*/ }, modifier = Modifier.fillMaxWidth()) {
+        WCColoredButton(
+            onClick = { /*TODO*/ },
+            enabled = state.isAddressValid,
+            modifier = Modifier.fillMaxWidth()
+        ) {
             Text(text = stringResource(id = R.string.continue_button))
         }
     }
@@ -108,7 +113,7 @@ private fun Toolbar() {
 private fun AddressInputViewPreview() {
     WooThemeWithBackground {
         AddressInputView(
-            state = AddressInputState("", false),
+            state = AddressInputState("", isAddressValid = true, isLoading = false),
             onAddressChanged = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryScreen.kt
@@ -1,0 +1,115 @@
+package com.woocommerce.android.ui.sitepicker.sitediscovery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.ViewState.AddressInputState
+import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.ViewState.ErrorState
+
+@Composable
+fun SitePickerSiteDiscoveryScreen(viewModel: SitePickerSiteDiscoveryViewModel) {
+    viewModel.viewState.observeAsState().value?.let { viewState ->
+        Scaffold(topBar = { Toolbar() }) { paddingValues ->
+            when (viewState) {
+                is AddressInputState -> AddressInputView(
+                    viewState,
+                    viewModel::onAddressChanged,
+                    Modifier.padding(paddingValues)
+                )
+                is ErrorState -> TODO()
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddressInputView(
+    state: AddressInputState,
+    onAddressChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .background(color = MaterialTheme.colors.surface)
+            .padding(dimensionResource(id = R.dimen.major_100)),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Text(text = stringResource(id = R.string.enter_site_address))
+        WCOutlinedTextField(
+            value = state.siteAddress,
+            onValueChange = onAddressChanged,
+            label = stringResource(id = R.string.login_site_address),
+            isError = state.inlineErrorMessage != 0,
+            helperText = state.inlineErrorMessage.takeIf { it != 0 }?.let { stringResource(id = it) }
+        )
+        WCTextButton(onClick = { /*TODO*/ }) {
+            Text(text = stringResource(id = R.string.login_find_your_site_adress))
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        WCColoredButton(onClick = { /*TODO*/ }, modifier = Modifier.fillMaxWidth()) {
+            Text(text = stringResource(id = R.string.continue_button))
+        }
+    }
+}
+
+@Composable
+private fun Toolbar() {
+    TopAppBar(
+        backgroundColor = MaterialTheme.colors.surface,
+        title = { Text(stringResource(id = R.string.login_site_picker_enter_site_address)) },
+        navigationIcon = {
+            IconButton(onClick = { /*TODO*/ }) {
+                Icon(
+                    Icons.Filled.ArrowBack,
+                    contentDescription = stringResource(id = R.string.back)
+                )
+            }
+        },
+        actions = {
+            IconButton(onClick = { /*TODO*/ }) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_help_24dp),
+                    contentDescription = stringResource(id = R.string.help)
+                )
+            }
+        },
+        elevation = 0.dp
+    )
+}
+
+@Composable
+@Preview
+private fun AddressInputViewPreview() {
+    WooThemeWithBackground {
+        AddressInputView(
+            state = AddressInputState("", false),
+            onAddressChanged = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryScreen.kt
@@ -39,7 +39,12 @@ import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscove
 @Composable
 fun SitePickerSiteDiscoveryScreen(viewModel: SitePickerSiteDiscoveryViewModel) {
     viewModel.viewState.observeAsState().value?.let { viewState ->
-        Scaffold(topBar = { Toolbar() }) { paddingValues ->
+        Scaffold(topBar = {
+            Toolbar(
+                onHelpButtonClick = viewModel::onHelpButtonClick,
+                onBackButtonClick = viewModel::onBackButtonClick
+            )
+        }) { paddingValues ->
             when (viewState) {
                 is AddressInputState -> AddressInputView(
                     viewState,
@@ -132,12 +137,16 @@ fun SiteAddressHelpDialog(
 }
 
 @Composable
-private fun Toolbar() {
+private fun Toolbar(
+    onHelpButtonClick: () -> Unit,
+    onBackButtonClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     TopAppBar(
         backgroundColor = MaterialTheme.colors.surface,
         title = { Text(stringResource(id = R.string.login_site_picker_enter_site_address)) },
         navigationIcon = {
-            IconButton(onClick = { /*TODO*/ }) {
+            IconButton(onClick = onBackButtonClick) {
                 Icon(
                     Icons.Filled.ArrowBack,
                     contentDescription = stringResource(id = R.string.back)
@@ -145,14 +154,15 @@ private fun Toolbar() {
             }
         },
         actions = {
-            IconButton(onClick = { /*TODO*/ }) {
+            IconButton(onClick = onHelpButtonClick) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_help_24dp),
                     contentDescription = stringResource(id = R.string.help)
                 )
             }
         },
-        elevation = 0.dp
+        elevation = 0.dp,
+        modifier = modifier
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -1,0 +1,74 @@
+package com.woocommerce.android.ui.sitepicker.sitediscovery
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.transformLatest
+import javax.inject.Inject
+
+@HiltViewModel
+class SitePickerSiteDiscoveryViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+    private val siteAddressFlow = savedStateHandle.getStateFlow(viewModelScope, "")
+    private val stepFlow = savedStateHandle.getStateFlow(viewModelScope, Step.AddressInput)
+
+    private val isLoadingFlow = MutableStateFlow(false)
+    private val inlineErrorFlow = savedStateHandle.getStateFlow(viewModelScope, 0)
+
+    val viewState = combine(siteAddressFlow, stepFlow) { address, step ->
+        Pair(address, step)
+    }.transformLatest<Pair<String, Step>, ViewState> { (address, step) ->
+        when (step) {
+            Step.AddressInput -> emitAll(prepareAddressViewState(address))
+            Step.JetpackUnavailable -> TODO()
+            Step.NotWordpress -> TODO()
+        }
+    }.asLiveData()
+
+    private fun prepareAddressViewState(address: String): Flow<ViewState.AddressInputState> {
+        return combine(isLoadingFlow, inlineErrorFlow) { isLoading, error ->
+            ViewState.AddressInputState(
+                siteAddress = address,
+                isLoading = isLoading,
+                inlineErrorMessage = error
+            )
+        }
+    }
+
+    fun onAddressChanged(address: String) {
+        inlineErrorFlow.value = 0
+        siteAddressFlow.value = address
+    }
+
+    private enum class Step {
+        AddressInput, JetpackUnavailable, NotWordpress
+    }
+
+    sealed class ViewState {
+        abstract val siteAddress: String
+
+        data class AddressInputState(
+            override val siteAddress: String,
+            val isLoading: Boolean,
+            @StringRes val inlineErrorMessage: Int = 0
+        ) : ViewState()
+
+        data class ErrorState(
+            override val siteAddress: String,
+            val message: String,
+            val primaryButtonText: String,
+            val primaryButtonAction: () -> Unit,
+            val secondaryButtonText: String,
+            val secondaryButtonAction: () -> Unit
+        ) : ViewState()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -95,7 +95,8 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
                 when {
                     !it.exists -> inlineErrorFlow.value = R.string.invalid_site_url_message
                     !it.isWordPress -> stepFlow.value = Step.NotWordpress
-                    !it.hasJetpack || !it.isJetpackConnected -> stepFlow.value = Step.JetpackUnavailable
+                    !it.isWPCom && (!it.hasJetpack || !it.isJetpackConnected) ->
+                        stepFlow.value = Step.JetpackUnavailable
                     else -> navigateBackToSitePicker()
                 }
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -106,6 +107,14 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
         )
     }
 
+    fun onBackButtonClick() {
+        triggerEvent(Exit)
+    }
+
+    fun onHelpButtonClick() {
+        triggerEvent(NavigateToHelpScreen)
+    }
+
     private fun navigateBackToSitePicker() {
         fetchedSiteUrl.let { url ->
             requireNotNull(url)
@@ -144,4 +153,5 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
     }
 
     object CreateZendeskTicket : MultiLiveEvent.Event()
+    object NavigateToHelpScreen : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.sitepicker.sitediscovery
 
+import android.util.Patterns
 import androidx.annotation.StringRes
+import androidx.core.util.PatternsCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -38,6 +40,7 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
         return combine(isLoadingFlow, inlineErrorFlow) { isLoading, error ->
             ViewState.AddressInputState(
                 siteAddress = address,
+                isAddressValid = PatternsCompat.WEB_URL.matcher(address).matches(),
                 isLoading = isLoading,
                 inlineErrorMessage = error
             )
@@ -58,6 +61,7 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
 
         data class AddressInputState(
             override val siteAddress: String,
+            val isAddressValid: Boolean,
             val isLoading: Boolean,
             @StringRes val inlineErrorMessage: Int = 0
         ) : ViewState()

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -2,7 +2,8 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/nav_graph_main">
+    android:id="@+id/nav_graph_main"
+    app:startDestination="@id/sitePickerSiteDiscoveryFragment">
 
     <include app:graph="@navigation/nav_graph_orders" />
     <include app:graph="@navigation/nav_graph_order_filters" />
@@ -388,6 +389,9 @@
             android:name="openedFromLogin"
             android:defaultValue="true"
             app:argType="boolean" />
+        <action
+            android:id="@+id/action_sitePickerFragment_to_sitePickerSiteDiscoveryFragment"
+            app:destination="@id/sitePickerSiteDiscoveryFragment" />
     </fragment>
     <fragment
         android:id="@+id/simpleTextEditorFragment"
@@ -411,4 +415,8 @@
     <action
         android:id="@+id/action_global_simpleTextEditorFragment"
         app:destination="@id/simpleTextEditorFragment" />
+    <fragment
+        android:id="@+id/sitePickerSiteDiscoveryFragment"
+        android:name="com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryFragment"
+        android:label="SitePickerSiteDiscoveryFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -226,7 +226,7 @@
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>
     <string name="login_with_a_different_account">Login with a different account</string>
-    <string name="login_no_stores">We didn\'t find WooCommerce stores connected to this account. You\'ll need to install and connect the free Jetpack plugin on your WooCommerce stores to use this app.</string>
+    <string name="login_no_stores">We didn\'t find WooCommerce stores connected to this account.</string>
     <string name="login_not_connected_to_account">It looks like %1$s is connected to a different WordPress.com account.</string>
     <string name="login_try_another_account">Log in with another account</string>
     <string name="login_try_another_store">Try another store</string>
@@ -263,6 +263,9 @@
     <string name="user_role_access_error_link">Learn more about roles and permissions</string>
     <string name="user_role_access_error_retry">You don\'t have the correct user role</string>
     <string name="user_access_verifying">Verifying role…</string>
+    <string name="login_site_picker_enter_site_address">Enter a site address</string>
+    <string name="site_discovery_postlogin_failure">A failure occurred, please contact support</string>
+    <string name="login_site_picker_new_to_woo">New to WooCommerce</string>
     <!--
         My Store View
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerTestUtils.kt
@@ -57,9 +57,9 @@ object SitePickerTestUtils {
     ) = defaultViewState.copy(
         isNoStoresViewVisible = true,
         isPrimaryBtnVisible = true,
-        primaryBtnText = resourceProvider.getString(R.string.login_jetpack_view_instructions_alt),
+        primaryBtnText = resourceProvider.getString(R.string.login_site_picker_enter_site_address),
         noStoresLabelText = resourceProvider.getString(R.string.login_no_stores),
-        noStoresBtnText = resourceProvider.getString(R.string.login_jetpack_what_is)
+        noStoresBtnText = resourceProvider.getString(R.string.login_site_picker_new_to_woo)
     )
 
     fun generateStores(totalCount: Int = 5): List<SiteModel> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -15,9 +15,9 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToEmailHelpDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToMainActivityEvent
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToNewToWooEvent
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToSiteAddressEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToHelpFragmentEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToLearnMoreAboutJetpackEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigationToWhatIsJetpackFragmentEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.ShowWooUpgradeDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.AccountMismatchState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
@@ -500,22 +500,23 @@ class SitePickerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given user is logging in, when learn more about Jetpack is clicked, learn more is displayed`() = testBlocking {
-        givenTheScreenIsFromLogin(true)
-        whenViewModelIsCreated()
+    fun `given there are no sites, when enter site address is tapped, then navigate to site discovery screen`() =
+        testBlocking {
+            givenTheScreenIsFromLogin(true)
+            whenViewModelIsCreated()
 
-        var view: NavigationToLearnMoreAboutJetpackEvent? = null
-        viewModel.event.observeForever {
-            if (it is NavigationToLearnMoreAboutJetpackEvent) view = it
+            var view: NavigateToSiteAddressEvent? = null
+            viewModel.event.observeForever {
+                if (it is NavigateToSiteAddressEvent) view = it
+            }
+
+            viewModel.onEnterSiteAddressClick()
+
+            verify(analyticsTrackerWrapper, times(1)).track(
+                AnalyticsEvent.SITE_PICKER_ENTER_SITE_ADDRESS_TAPPED
+            )
+            assertThat(view).isEqualTo(NavigateToSiteAddressEvent)
         }
-
-        viewModel.onLearnMoreAboutJetpackButtonClick()
-
-        verify(analyticsTrackerWrapper, times(1)).track(
-            AnalyticsEvent.LOGIN_JETPACK_REQUIRED_VIEW_INSTRUCTIONS_BUTTON_TAPPED
-        )
-        assertThat(view).isEqualTo(NavigationToLearnMoreAboutJetpackEvent)
-    }
 
     @Test
     fun `given user is logging in, when refresh button is clicked, refresh the screen`() =
@@ -539,21 +540,21 @@ class SitePickerViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given user is logging in, when what is Jetpack is clicked, Jetpack screen is displayed`() = testBlocking {
+    fun `given user is logging in, when new to woo clicked, then open browser with the docs`() = testBlocking {
         givenTheScreenIsFromLogin(true)
         whenViewModelIsCreated()
 
-        var view: NavigationToWhatIsJetpackFragmentEvent? = null
+        var view: NavigateToNewToWooEvent? = null
         viewModel.event.observeForever {
-            if (it is NavigationToWhatIsJetpackFragmentEvent) view = it
+            if (it is NavigateToNewToWooEvent) view = it
         }
 
-        viewModel.onWhatIsJetpackButtonClick()
+        viewModel.onNewToWooClick()
 
         verify(analyticsTrackerWrapper, times(1)).track(
-            AnalyticsEvent.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED
+            AnalyticsEvent.SITE_PICKER_NEW_TO_WOO_TAPPED
         )
-        assertThat(view).isEqualTo(NavigationToWhatIsJetpackFragmentEvent)
+        assertThat(view).isEqualTo(NavigateToNewToWooEvent)
     }
 
     @Test


### PR DESCRIPTION
Part of: #7215 

Please don't merge until the second part #7225 is approved.

### Description
This PR is the first part for implementing the site discovery post-login, it implements the following things:
1. New Fragment for the site discovery.
2. The UI part for the site input.
3. Handling the "Find your site address" click.
4. API call to fetch site info.
5. Post-API handling for Jetpack and WPCom sites, it basically just returns to the site picker.
6. Inline errors for fetch failures.

Remaining tasks:
1. Error state for non-wordpress sites.
2. Error state for non-Jetpack sites + Jetpack installation.

The work done here was first implemented in the PR #7216, but I wasn't satisfied with the quality of the code because of depending on `LoginListener`, then I decided to rewrite everything from scratch.

### Testing instructions
1. Open the app, then sign in with a WordPress.com account that's not connected to any site.
2. In the no-stores error screen, click on "New to woo" button and confirm it works as expected.
4. Check the logs for the tracking of: `site_picker_new_to_woo_tapped`
5. Go back to the app.
6. Click on "Enter a site address"
7. Check the logs for the tracking of: `site_picker_enter_site_address_tapped`.
8. Click on "Find your site address"
9. Confirm the dialog works as expected.
10. Click on "Help" button, and confirm it opens the help screen.
11. Edit the content of the site address.
12. Confirm the Continue button is disabled when the address is not a valid URL.
13. Enter an address for a non-working site.
14. Click on Continue.
15. Confirm an inline error is shown.
16. Enter an address for Jetpack connected site that's connected to another account.
17. Click on Continue.
18. Confirm the account mismatch error is shown.

(Repeat 15-17 for WordPress.com sites, atomic and non-atomic)

### Images/gif
https://user-images.githubusercontent.com/1657201/185418880-9493c48f-543c-4d20-9362-088e6ddcf34a.mov


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
