### PR TITLE
Issue/7052 explat UI integration

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -129,7 +129,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         explat.getVariation(
             AB_TEST_LINKED_PRODUCTS_PROMO,
             true
-        ) is Variation.Treatment
+        )
 
         // Apply Theme
         AppThemeUtils.setAppTheme()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -51,7 +51,6 @@ import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.logging.FluxCCrashLogger
 import org.wordpress.android.fluxc.logging.FluxCCrashLoggerProvider
-import org.wordpress.android.fluxc.model.experiments.Variation
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
@@ -122,14 +121,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
 
         FeedbackPrefs.init(application)
 
-        explat.getVariation(
-            AA_TEST_202208,
-            true
-        )
-        explat.getVariation(
-            AB_TEST_LINKED_PRODUCTS_PROMO,
-            true
-        )
+        initExPlat()
 
         // Apply Theme
         AppThemeUtils.setAppTheme()
@@ -169,6 +161,17 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         appCoroutineScope.launch {
             siteObserver.observeAndUpdateSelectedSiteData()
         }
+    }
+
+    private fun initExPlat() {
+        explat.getVariation(
+            AA_TEST_202208,
+            true
+        )
+        explat.getVariation(
+            AB_TEST_LINKED_PRODUCTS_PROMO,
+            true
+        )
     }
 
     @Suppress("DEPRECATION")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -14,8 +14,6 @@ import com.google.android.gms.common.GoogleApiAvailability
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.di.AppCoroutineScope
-import com.woocommerce.android.di.ExperimentationModule.Companion.AA_TEST_202208
-import com.woocommerce.android.di.ExperimentationModule.Companion.AB_TEST_LINKED_PRODUCTS_PROMO
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.push.RegisterDevice
 import com.woocommerce.android.push.RegisterDevice.Mode.IF_NEEDED
@@ -121,8 +119,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
 
         FeedbackPrefs.init(application)
 
-        initExPlat()
-
         // Apply Theme
         AppThemeUtils.setAppTheme()
 
@@ -161,17 +157,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         appCoroutineScope.launch {
             siteObserver.observeAndUpdateSelectedSiteData()
         }
-    }
-
-    private fun initExPlat() {
-        explat.getVariation(
-            AA_TEST_202208,
-            true
-        )
-        explat.getVariation(
-            AB_TEST_LINKED_PRODUCTS_PROMO,
-            true
-        )
     }
 
     @Suppress("DEPRECATION")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -8,7 +8,6 @@ import android.net.ConnectivityManager
 import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.automattic.android.experimentation.ExPlat
-import com.automattic.android.experimentation.Experiment
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
@@ -66,7 +65,6 @@ import javax.inject.Singleton
 class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     companion object {
         private const val SECONDS_BETWEEN_SITE_UPDATE = 60 * 60 // 1 hour
-        var AB_TEST_LINKED_PRODUCTS_PROMO_ENABLED = false
     }
 
     @Inject lateinit var crashLogging: CrashLogging
@@ -128,10 +126,10 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
             AA_TEST_202208,
             true
         )
-        AB_TEST_LINKED_PRODUCTS_PROMO_ENABLED = explat.getVariation(
+        explat.getVariation(
             AB_TEST_LINKED_PRODUCTS_PROMO,
             true
-        ).name == "treatment"
+        ) is Variation.Treatment
 
         // Apply Theme
         AppThemeUtils.setAppTheme()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -15,6 +15,8 @@ import com.google.android.gms.common.GoogleApiAvailability
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.di.ExperimentationModule.Companion.AA_TEST_202208
+import com.woocommerce.android.di.ExperimentationModule.Companion.AB_TEST_LINKED_PRODUCTS_PROMO
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.push.RegisterDevice
 import com.woocommerce.android.push.RegisterDevice.Mode.IF_NEEDED
@@ -50,6 +52,7 @@ import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.logging.FluxCCrashLogger
 import org.wordpress.android.fluxc.logging.FluxCCrashLoggerProvider
+import org.wordpress.android.fluxc.model.experiments.Variation
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
@@ -63,6 +66,7 @@ import javax.inject.Singleton
 class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     companion object {
         private const val SECONDS_BETWEEN_SITE_UPDATE = 60 * 60 // 1 hour
+        var AB_TEST_LINKED_PRODUCTS_PROMO_ENABLED = false
     }
 
     @Inject lateinit var crashLogging: CrashLogging
@@ -121,11 +125,13 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         FeedbackPrefs.init(application)
 
         explat.getVariation(
-            object : Experiment {
-                override val identifier = "woocommerceandroid_explat_aa_test_202208"
-            },
+            AA_TEST_202208,
             true
         )
+        AB_TEST_LINKED_PRODUCTS_PROMO_ENABLED = explat.getVariation(
+            AB_TEST_LINKED_PRODUCTS_PROMO,
+            true
+        ).name == "treatment"
 
         // Apply Theme
         AppThemeUtils.setAppTheme()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ExperimentationModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ExperimentationModule.kt
@@ -23,12 +23,22 @@ class ExperimentationModule {
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
     ) = ExPlat(
         platform = ExperimentStore.Platform.WOOCOMMERCE_ANDROID,
-        experiments = setOf(object : Experiment {
-            override val identifier: String = "woocommerceandroid_explat_aa_test_202208"
-        }),
+        experiments = setOf(
+            AA_TEST_202208,
+            AB_TEST_LINKED_PRODUCTS_PROMO
+        ),
         experimentStore = experimentStore,
         appLogWrapper = appLogWrapper,
         coroutineScope = appCoroutineScope,
         isDebug = BuildConfig.DEBUG
     )
+
+    companion object {
+        val AA_TEST_202208 = object : Experiment {
+            override val identifier: String = "woocommerceandroid_explat_aa_test_202208"
+        }
+        val AB_TEST_LINKED_PRODUCTS_PROMO = object : Experiment {
+            override val identifier: String = "woocommerceandroid_product_details_linked_products_banner"
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -7,11 +7,13 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.automattic.android.experimentation.ExPlat
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.di.ExperimentationModule
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
@@ -69,7 +71,8 @@ class MyStoreViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val myStoreTransactionLauncher: MyStoreTransactionLauncher
+    private val myStoreTransactionLauncher: MyStoreTransactionLauncher,
+    private val explat: ExPlat
 ) : ScopedViewModel(savedState) {
     private companion object {
         const val NUM_TOP_PERFORMERS = 5
@@ -104,6 +107,7 @@ class MyStoreViewModel @Inject constructor(
 
     init {
         ConnectionChangeReceiver.getEventBus().register(this)
+        initExPlat()
         viewModelScope.launch {
             combine(
                 _activeStatsGranularity,
@@ -319,6 +323,17 @@ class MyStoreViewModel @Inject constructor(
             totalSpend,
             wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: currency
         )
+
+    private fun initExPlat() {
+        explat.getVariation(
+            ExperimentationModule.AA_TEST_202208,
+            true
+        )
+        explat.getVariation(
+            ExperimentationModule.AB_TEST_LINKED_PRODUCTS_PROMO,
+            true
+        )
+    }
 
     private fun String.toImageUrl() =
         PhotonUtils.getPhotonImageUrl(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.automattic.android.experimentation.ExPlat
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -86,6 +85,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.experiments.Variation
+import org.wordpress.android.fluxc.store.ExperimentStore
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import java.math.BigDecimal
 import java.util.Collections
@@ -109,7 +109,7 @@ class ProductDetailViewModel @Inject constructor(
     private val mediaFileUploadHandler: MediaFileUploadHandler,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val addonRepository: AddonRepository,
-    private val explat: ExPlat
+    private val experimentStore: ExperimentStore
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
@@ -291,10 +291,12 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     fun start() {
-        abTestLinkProductsPromoIsTreatment = explat.getVariation(
-            ExperimentationModule.AB_TEST_LINKED_PRODUCTS_PROMO,
-            true
-        ) is Variation.Treatment
+        experimentStore.getCachedAssignments()
+            ?.variations
+            ?.get(ExperimentationModule.AB_TEST_LINKED_PRODUCTS_PROMO.identifier)
+            ?.let {
+                abTestLinkProductsPromoIsTreatment = it is Variation.Treatment
+            }
 
         val isRestoredFromSavedState = viewState.productDraft != null
         if (!isRestoredFromSavedState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -107,13 +107,12 @@ class ProductDetailViewModel @Inject constructor(
     private val mediaFileUploadHandler: MediaFileUploadHandler,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val addonRepository: AddonRepository,
+    private val explat: ExPlat
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
         const val DEFAULT_ADD_NEW_PRODUCT_ID: Long = 0L
     }
-
-    @Inject lateinit var explat: ExPlat
 
     private val navArgs: ProductDetailFragmentArgs by savedState.navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -88,7 +88,9 @@ import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.experiments.Variation
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import java.math.BigDecimal
-import java.util.*
+import java.util.Collections
+import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppInitializer
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -1631,7 +1632,7 @@ class ProductDetailViewModel @Inject constructor(
      * doesn't already have linked products
      */
     private fun checkLinkedProductPromo() {
-        if (FeatureFlag.LINKED_PRODUCTS_PROMO.isEnabled() &&
+        if (AppInitializer.AB_TEST_LINKED_PRODUCTS_PROMO_ENABLED &&
             appPrefsWrapper.isPromoBannerShown(PromoBannerType.LINKED_PRODUCTS).not() &&
             viewState.productDraft?.hasLinkedProducts() == false
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -15,8 +15,7 @@ enum class FeatureFlag {
     WC_SHIPPING_BANNER,
     UNIFIED_ORDER_EDITING,
     ORDER_CREATION_CUSTOMER_SEARCH,
-    PRE_LOGIN_NOTIFICATIONS,
-    LINKED_PRODUCTS_PROMO;
+    PRE_LOGIN_NOTIFICATIONS;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -31,8 +30,7 @@ enum class FeatureFlag {
             ANALYTICS_HUB,
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            PRE_LOGIN_NOTIFICATIONS,
-            LINKED_PRODUCTS_PROMO -> PackageUtils.isDebugBuild()
+            PRE_LOGIN_NOTIFICATIONS -> PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -428,7 +428,8 @@ class MyStoreViewModelTest : BaseUnitTest() {
             appPrefsWrapper,
             usageTracksEventEmitter,
             analyticsTrackerWrapper,
-            mock()
+            myStoreTransactionLauncher = mock(),
+            explat = mock()
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import androidx.lifecycle.SavedStateHandle
-import com.automattic.android.experimentation.ExPlat
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -111,7 +110,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     private val prefsWrapper: AppPrefsWrapper = mock()
     private val productUtils = ProductUtils()
-    private val explat: ExPlat = mock()
 
     private val product = ProductTestUtils.generateProduct(PRODUCT_REMOTE_ID)
     private val productWithTagsAndCategories = ProductTestUtils.generateProductWithTagsAndCategories(PRODUCT_REMOTE_ID)
@@ -242,7 +240,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 mediaFileUploadHandler,
                 prefsWrapper,
                 addonRepository,
-                explat
+                experimentStore = mock()
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import androidx.lifecycle.SavedStateHandle
+import com.automattic.android.experimentation.ExPlat
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -110,6 +111,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     private val prefsWrapper: AppPrefsWrapper = mock()
     private val productUtils = ProductUtils()
+    private val explat: ExPlat = mock()
 
     private val product = ProductTestUtils.generateProduct(PRODUCT_REMOTE_ID)
     private val productWithTagsAndCategories = ProductTestUtils.generateProductWithTagsAndCategories(PRODUCT_REMOTE_ID)
@@ -240,6 +242,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 mediaFileUploadHandler,
                 prefsWrapper,
                 addonRepository,
+                explat
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -76,7 +76,6 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         on { it.observeSuccessfulUploads(any()) } doReturn emptyFlow()
     }
 
-
     private var savedState: SavedStateHandle =
         ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID, isAddProduct = true).initSavedStateHandle()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import androidx.lifecycle.SavedStateHandle
+import com.automattic.android.experimentation.ExPlat
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.initSavedStateHandle
@@ -75,6 +76,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         on { it.observeCurrentUploads(any()) } doReturn flowOf(emptyList())
         on { it.observeSuccessfulUploads(any()) } doReturn emptyFlow()
     }
+
+    private val explat: ExPlat = mock()
 
     private var savedState: SavedStateHandle =
         ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID, isAddProduct = true).initSavedStateHandle()
@@ -174,6 +177,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 mediaFileUploadHandler,
                 prefs,
                 addonRepository,
+                explat
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import androidx.lifecycle.SavedStateHandle
-import com.automattic.android.experimentation.ExPlat
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.initSavedStateHandle
@@ -77,7 +76,6 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         on { it.observeSuccessfulUploads(any()) } doReturn emptyFlow()
     }
 
-    private val explat: ExPlat = mock()
 
     private var savedState: SavedStateHandle =
         ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID, isAddProduct = true).initSavedStateHandle()
@@ -177,7 +175,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 mediaFileUploadHandler,
                 prefs,
                 addonRepository,
-                explat
+                experimentStore = mock()
             )
         )
 


### PR DESCRIPTION
Closes: #7052

### Description
This PR adds the A/B test for the linked product promo banner, and removes the feature flag. The banner will only be visible to users in the A/B test treatment group, and only after the A/B test is started on the backend. The related iOS PR is [here](https://github.com/woocommerce/woocommerce-ios/pull/7462).

### Changes

- Adds the experiment `woocommerceandroid_product_details_linked_products_banner` to `ExperimentationModule`
- Removes the feature flag `LINKED_PRODUCTS_PROMO`
- Updates `ProductDetailViewModel` to check that the experiment variation is treatment and to remove the feature flag check

### Prerequisite (before launching the app)

- Open the experiment details in Abacus (ping me for the link)
- In the Audience section of the experiment setup, go to `Variations > Manual Assignment` and use the bookmarklet to assign yourself to the control group.

### Test the control behavior

- Build and run the app. Note: You must be logged in to the app with an a8c account to test the experiment assignment/behavior while the experiment is in staging. If you are logged in to a different account, log out and log in again with your a8c account.
- Open a product without any linked products.
- Update some property and tap "Save".
- Confirm no banner appears.

### Test the treatment behavior

- Close the app.
- Repeat the prerequisite steps, this time using the bookmarklet to assign yourself to the treatment group.
- Run the app.
- Open a product without any linked products.
- Update some property and tap "Save".
- Confirm promo banner appears.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.