### PR TITLE
Replace deprecated "readParcelable", "getParcelable", "getserializable" and "getParcelableArrayList" methods usage

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerUtil.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerUtil.kt
@@ -56,8 +56,10 @@ object MediaPickerUtil {
     }
 
     private fun handleMediaLibraryPickerResult(data: Bundle): List<Product.Image> {
-        return data.getParcelableArrayList<MediaItem.Identifier.RemoteMedia>(MediaPickerConstants.EXTRA_REMOTE_MEDIA)
-            ?.map { Product.Image(it.id, it.name, it.url, DateTimeUtils.dateFromIso8601(it.date)) }
+        return data.getParcelableArrayList(
+            MediaPickerConstants.EXTRA_REMOTE_MEDIA,
+            MediaItem.Identifier.RemoteMedia::class.java
+        )?.map { Product.Image(it.id, it.name, it.url, DateTimeUtils.dateFromIso8601(it.date)) }
             ?: emptyList()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -48,7 +48,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         var viewState = state
         if (state is Bundle) {
             isCustomerInfoViewExpanded = state.getBoolean(KEY_IS_CUSTOMER_INFO_VIEW_EXPANDED)
-            viewState = state.getParcelable(KEY_SUPER_STATE)
+            viewState = state.getParcelable(KEY_SUPER_STATE, Parcelable::class.java)
         }
         super.onRestoreInstanceState(viewState)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -165,7 +165,7 @@ class ProductDetailFragment :
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.getParcelable(LIST_STATE_KEY, Parcelable::class.java)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
         binding.cardsRecyclerView.layoutManager = layoutManager

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -141,7 +141,7 @@ class VariationDetailFragment :
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.getParcelable(LIST_STATE_KEY, Parcelable::class.java)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
         binding.cardsRecyclerView.layoutManager = layoutManager

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -109,7 +109,7 @@ class VariationListFragment :
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.getParcelable(LIST_STATE_KEY, Parcelable::class.java)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeFragment.kt
@@ -102,7 +102,7 @@ class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.getParcelable(LIST_STATE_KEY, Parcelable::class.java)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -255,7 +255,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         )
         assignedTermsAdapter = binding.assignedTermList.adapter as AttributeTermsListAdapter
         assignedTermsAdapter.setOnTermListener(assignedTermListener)
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY_ASSIGNED)?.let {
+        savedInstanceState?.getParcelable(LIST_STATE_KEY_ASSIGNED, Parcelable::class.java)?.let {
             layoutManagerAssigned!!.onRestoreInstanceState(it)
         }
 
@@ -266,7 +266,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         )
         globalTermsAdapter = binding.globalTermList.adapter as AttributeTermsListAdapter
         globalTermsAdapter.setOnTermListener(globalTermListener)
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY_GLOBAL)?.let {
+        savedInstanceState?.getParcelable(LIST_STATE_KEY_GLOBAL, Parcelable::class.java)?.let {
             layoutManagerGlobal!!.onRestoreInstanceState(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeListFragment.kt
@@ -91,7 +91,7 @@ class AttributeListFragment : BaseProductFragment(R.layout.fragment_attribute_li
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.getParcelable(LIST_STATE_KEY, Parcelable::class.java)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyAmountDialog.kt
@@ -46,9 +46,9 @@ open class CurrencyAmountDialog : DialogFragment(), DialogInterface.OnClickListe
         val args = arguments
         if (args != null) {
             headerText.text = args.getString(TITLE_KEY, "")
-            currentValue = args.getSerializable(CURRENT_VALUE_KEY) as? BigDecimal ?: BigDecimal.ZERO
-            maxValue = args.getSerializable(MAX_VALUE_KEY) as? BigDecimal ?: BigDecimal(Double.MAX_VALUE)
-            minValue = args.getSerializable(MIN_VALUE_KEY) as? BigDecimal ?: BigDecimal(Double.MIN_VALUE)
+            currentValue = args.getSerializable(CURRENT_VALUE_KEY, BigDecimal::class.java) ?: BigDecimal.ZERO
+            maxValue = args.getSerializable(MAX_VALUE_KEY, BigDecimal::class.java) ?: BigDecimal(Double.MAX_VALUE)
+            minValue = args.getSerializable(MIN_VALUE_KEY, BigDecimal::class.java) ?: BigDecimal(Double.MIN_VALUE)
             messageText.text = args.getString(MESSAGE_KEY, "")
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -166,7 +166,7 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.getParcelable(KEY_SUPER_STATE, WCSavedState::class.java)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -164,7 +164,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.getParcelable(KEY_SUPER_STATE, WCSavedState::class.java)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -93,7 +93,7 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.getParcelable(KEY_SUPER_STATE, WCSavedState::class.java)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCSavedState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCSavedState.kt
@@ -24,18 +24,18 @@ class WCSavedState : BaseSavedState {
      * the super(source, loader) method won't work on older APIs - thus the app will crash.
      */
     constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?) : super(superState) {
-        savedState = source.readParcelable(loader)
+        savedState = source.readParcelable(loader, Parcelable::class.java)
     }
 
     constructor(source: Parcel) : super(source) {
-        savedState = source.readParcelable(this::class.java.classLoader)
+        savedState = source.readParcelable(this::class.java.classLoader, Parcelable::class.java)
     }
 
     @RequiresApi(VERSION_CODES.N)
     constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
         savedState = loader?.let {
-            source.readParcelable<Parcelable>(it)
-        } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
+            source.readParcelable(it, Parcelable::class.java)
+        } ?: source.readParcelable(this::class.java.classLoader, Parcelable::class.java)
     }
 
     override fun writeToParcel(out: Parcel, flags: Int) {
@@ -51,7 +51,7 @@ class WCSavedState : BaseSavedState {
                 return if (VERSION.SDK_INT >= VERSION_CODES.N) {
                     WCSavedState(source, loader)
                 } else {
-                    WCSavedState(source, loader, source.readParcelable<Parcelable>(loader))
+                    WCSavedState(source, loader, source.readParcelable(loader, Parcelable::class.java))
                 }
             }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7208
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The PR replaces deprecated "readParcelable", "getParcelable", "getserializable" and "getParcelableArrayList" methods usage

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
It's a probably safe change, but running some changes with "don't keep activities" hiding/resuming the app would make sense

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
