### PR TITLE
Replace deprecated "readParcelable", "getParcelable", "getserializable" and "getParcelableArrayList" methods usage

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BundleExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BundleExt.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.extensions
+
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.TIRAMISU
+import android.os.Parcel
+
+inline fun <reified T> Parcel.parcelable(loader: ClassLoader?): T? = when {
+    SDK_INT >= TIRAMISU -> readParcelable(loader, T::class.java)
+    else -> @Suppress("DEPRECATION") readParcelable(loader) as? T
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BundleExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BundleExt.kt
@@ -2,9 +2,15 @@ package com.woocommerce.android.extensions
 
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.TIRAMISU
+import android.os.Bundle
 import android.os.Parcel
 
 inline fun <reified T> Parcel.parcelable(loader: ClassLoader?): T? = when {
     SDK_INT >= TIRAMISU -> readParcelable(loader, T::class.java)
     else -> @Suppress("DEPRECATION") readParcelable(loader) as? T
+}
+
+inline fun <reified T> Bundle.parcelable(key: String): T? = when {
+    SDK_INT >= TIRAMISU -> getParcelable(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelable(key) as? T
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DataContainerExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DataContainerExt.kt
@@ -4,6 +4,7 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Bundle
 import android.os.Parcel
+import java.io.Serializable
 
 inline fun <reified T> Parcel.parcelable(loader: ClassLoader?): T? = when {
     SDK_INT >= TIRAMISU -> readParcelable(loader, T::class.java)
@@ -13,4 +14,9 @@ inline fun <reified T> Parcel.parcelable(loader: ClassLoader?): T? = when {
 inline fun <reified T> Bundle.parcelable(key: String): T? = when {
     SDK_INT >= TIRAMISU -> getParcelable(key, T::class.java)
     else -> @Suppress("DEPRECATION") getParcelable(key) as? T
+}
+
+inline fun <reified T : Serializable> Bundle.serializable(key: String): T? = when {
+    SDK_INT >= TIRAMISU -> getSerializable(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getSerializable(key) as? T
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DataContainerExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DataContainerExt.kt
@@ -4,16 +4,22 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Bundle
 import android.os.Parcel
+import android.os.Parcelable
 import java.io.Serializable
 
 inline fun <reified T> Parcel.parcelable(loader: ClassLoader?): T? = when {
     SDK_INT >= TIRAMISU -> readParcelable(loader, T::class.java)
-    else -> @Suppress("DEPRECATION") readParcelable(loader) as? T
+    else -> @Suppress("DEPRECATION") readParcelable(loader)
 }
 
 inline fun <reified T> Bundle.parcelable(key: String): T? = when {
     SDK_INT >= TIRAMISU -> getParcelable(key, T::class.java)
-    else -> @Suppress("DEPRECATION") getParcelable(key) as? T
+    else -> @Suppress("DEPRECATION") getParcelable(key)
+}
+
+inline fun <reified T : Parcelable> Bundle.parcelableArrayList(key: String): ArrayList<T>? = when {
+    SDK_INT >= TIRAMISU -> getParcelableArrayList(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelableArrayList(key)
 }
 
 inline fun <reified T : Serializable> Bundle.serializable(key: String): T? = when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerUtil.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerUtil.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.ActivityResult
 import androidx.appcompat.app.AppCompatActivity
+import com.woocommerce.android.extensions.parcelableArrayList
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.mediapicker.MediaPickerConstants
@@ -56,7 +57,7 @@ object MediaPickerUtil {
     }
 
     private fun handleMediaLibraryPickerResult(data: Bundle): List<Product.Image> {
-        return data.getParcelableArrayList<MediaItem.Identifier.RemoteMedia>(MediaPickerConstants.EXTRA_REMOTE_MEDIA)
+        return data.parcelableArrayList<MediaItem.Identifier.RemoteMedia>(MediaPickerConstants.EXTRA_REMOTE_MEDIA)
             ?.map { Product.Image(it.id, it.name, it.url, DateTimeUtils.dateFromIso8601(it.date)) }
             ?: emptyList()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderCustomerHelper
@@ -48,7 +49,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         var viewState = state
         if (state is Bundle) {
             isCustomerInfoViewExpanded = state.getBoolean(KEY_IS_CUSTOMER_INFO_VIEW_EXPANDED)
-            viewState = state.getParcelable(KEY_SUPER_STATE)
+            viewState = state.parcelable(KEY_SUPER_STATE)
         }
         super.onRestoreInstanceState(viewState)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
@@ -165,7 +166,7 @@ class ProductDetailFragment :
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.parcelable<Parcelable>(LIST_STATE_KEY)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
         binding.cardsRecyclerView.layoutManager = layoutManager

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.databinding.FragmentVariationDetailBinding
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product.Image
@@ -141,7 +142,7 @@ class VariationDetailFragment :
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.parcelable<Parcelable>(LIST_STATE_KEY)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
         binding.cardsRecyclerView.layoutManager = layoutManager

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
@@ -109,7 +110,7 @@ class VariationListFragment :
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.parcelable<Parcelable>(LIST_STATE_KEY)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentAddAttributeBinding
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.model.ProductGlobalAttribute
@@ -102,7 +103,7 @@ class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.parcelable<Parcelable>(LIST_STATE_KEY)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentAddAttributeTermsBinding
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductAttributeTerm
 import com.woocommerce.android.ui.dialog.WooDialog
@@ -255,7 +256,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         )
         assignedTermsAdapter = binding.assignedTermList.adapter as AttributeTermsListAdapter
         assignedTermsAdapter.setOnTermListener(assignedTermListener)
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY_ASSIGNED)?.let {
+        savedInstanceState?.parcelable<Parcelable>(LIST_STATE_KEY_ASSIGNED)?.let {
             layoutManagerAssigned!!.onRestoreInstanceState(it)
         }
 
@@ -266,7 +267,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         )
         globalTermsAdapter = binding.globalTermList.adapter as AttributeTermsListAdapter
         globalTermsAdapter.setOnTermListener(globalTermListener)
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY_GLOBAL)?.let {
+        savedInstanceState?.parcelable<Parcelable>(LIST_STATE_KEY_GLOBAL)?.let {
             layoutManagerGlobal!!.onRestoreInstanceState(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeListFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentAttributeListBinding
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.ui.products.BaseProductFragment
@@ -91,7 +92,7 @@ class AttributeListFragment : BaseProductFragment(R.layout.fragment_attribute_li
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 
-        savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
+        savedInstanceState?.parcelable<Parcelable>(LIST_STATE_KEY)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyAmountDialog.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.filterNotNull
+import com.woocommerce.android.extensions.serializable
 import org.wordpress.android.util.ActivityUtils
 import java.math.BigDecimal
 
@@ -46,9 +47,9 @@ open class CurrencyAmountDialog : DialogFragment(), DialogInterface.OnClickListe
         val args = arguments
         if (args != null) {
             headerText.text = args.getString(TITLE_KEY, "")
-            currentValue = args.getSerializable(CURRENT_VALUE_KEY) as? BigDecimal ?: BigDecimal.ZERO
-            maxValue = args.getSerializable(MAX_VALUE_KEY) as? BigDecimal ?: BigDecimal(Double.MAX_VALUE)
-            minValue = args.getSerializable(MIN_VALUE_KEY) as? BigDecimal ?: BigDecimal(Double.MIN_VALUE)
+            currentValue = args.serializable(CURRENT_VALUE_KEY) ?: BigDecimal.ZERO
+            maxValue = args.serializable(MAX_VALUE_KEY) ?: BigDecimal(Double.MAX_VALUE)
+            minValue = args.serializable(MIN_VALUE_KEY) ?: BigDecimal(Double.MIN_VALUE)
             messageText.text = args.getString(MESSAGE_KEY, "")
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -21,6 +21,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.isNotEqualTo
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.CurrencyFormattingParameters
 import com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView.EditTextLayoutMode.FILL
@@ -166,7 +167,7 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.parcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -15,6 +15,7 @@ import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ViewMaterialOutlinedEdittextBinding
+import com.woocommerce.android.extensions.parcelable
 import org.wordpress.android.util.ActivityUtils
 
 /**
@@ -164,7 +165,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.parcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -15,6 +15,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.R.style
 import com.woocommerce.android.databinding.ViewMaterialOutlinedSpinnerBinding
+import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.setHtmlText
 
 /**
@@ -84,7 +85,7 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
         }
     }
 
-    override fun onSaveInstanceState(): Parcelable? {
+    override fun onSaveInstanceState(): Parcelable {
         val bundle = Bundle()
         binding.spinnerEditText.onSaveInstanceState()?.let {
             bundle.putParcelable(KEY_SUPER_STATE, WCSavedState(super.onSaveInstanceState(), it))
@@ -93,7 +94,7 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.parcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCSavedState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCSavedState.kt
@@ -6,6 +6,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.view.View.BaseSavedState
 import androidx.annotation.RequiresApi
+import com.woocommerce.android.extensions.parcelable
 
 /**
  * Wrapper for custom view state which can be used to save the parent's (super.onSaveInstanceState) state
@@ -24,18 +25,18 @@ class WCSavedState : BaseSavedState {
      * the super(source, loader) method won't work on older APIs - thus the app will crash.
      */
     constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?) : super(superState) {
-        savedState = source.readParcelable(loader)
+        savedState = source.parcelable(loader)
     }
 
     constructor(source: Parcel) : super(source) {
-        savedState = source.readParcelable(this::class.java.classLoader)
+        savedState = source.parcelable(this::class.java.classLoader)
     }
 
     @RequiresApi(VERSION_CODES.N)
     constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
         savedState = loader?.let {
-            source.readParcelable<Parcelable>(it)
-        } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
+            source.parcelable(it)
+        } ?: source.parcelable(this::class.java.classLoader)
     }
 
     override fun writeToParcel(out: Parcel, flags: Int) {
@@ -51,7 +52,7 @@ class WCSavedState : BaseSavedState {
                 return if (VERSION.SDK_INT >= VERSION_CODES.N) {
                     WCSavedState(source, loader)
                 } else {
-                    WCSavedState(source, loader, source.readParcelable<Parcelable>(loader))
+                    WCSavedState(source, loader, source.parcelable(loader))
                 }
             }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7208
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The PR replaces deprecated "readParcelable", "getParcelable", "getserializable" and "getParcelableArrayList" methods usage

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
It's probably a safe change, but running some tests with "don't keep activities" hiding/resuming the app would help

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
