### PR TITLE
Fix build issues with release 10

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -95,6 +95,10 @@
             app:argType="string"
             app:nullable="true"
             android:defaultValue="@null"/>
+        <argument
+            android:name="urlComparisonMode"
+            android:defaultValue="PARTIAL"
+            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment$UrlComparisonMode" />
     </fragment>
     <action android:id="@+id/action_global_WPComWebViewFragment" app:destination="@id/WPComWebViewFragment"/>
     <include app:graph="@navigation/nav_graph_jetpack_install" />


### PR DESCRIPTION
### Description
This PR fixes the build issues discussed in p1660924101131709-slack-C6H8C3G23

The cause is that the `WPComWebViewFragment` destination is both duplicated and marked as global destination, and when we added a new argument to the `nav_graph_main`, it made the build unpredictable, as `safe-args` will use the arguments from one of the destinations, and not merge both.

For this fix, I opted to add the argument to the declaration in `nav_graph_settings` to avoid having to re-test multiple scenarios, ~~but the optimal solution we need to implement in a later PR is removing the second declaration.~~ we can't remove it for now, as it's part of a separate Activity, which means we are stuck with this, and we need to make sure both destinations have the same list of arguments.

### Testing instructions
Just check that CI is green.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->