### PR TITLE
Fix the onBackPressed() deprecation warnings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -101,7 +101,7 @@ class HelpActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
@@ -19,7 +19,7 @@ class WooLogViewerActivity : AppCompatActivity() {
             WooThemeWithBackground {
                 WooLogViewerScreen(
                     WooLog.logEntries,
-                    onBackPress = ::onBackPressed,
+                    onBackPress = onBackPressedDispatcher::onBackPressed,
                     onCopyButtonClick = ::copyAppLogToClipboard,
                     onShareButtonClick = ::shareAppLog
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -41,7 +41,7 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment(R.layout.fragme
             clickableContent = contactUsText,
             clickAction = WooClickableSpan { activity?.startHelpActivity(FEEDBACK_SURVEY) }
         )
-        binding.btnBackToStore.setOnClickListener { activity?.onBackPressedDispatcher?.onBackPressed()}
+        binding.btnBackToStore.setOnClickListener { activity?.onBackPressedDispatcher?.onBackPressed() }
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -41,7 +41,7 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment(R.layout.fragme
             clickableContent = contactUsText,
             clickAction = WooClickableSpan { activity?.startHelpActivity(FEEDBACK_SURVEY) }
         )
-        binding.btnBackToStore.setOnClickListener { activity?.onBackPressed() }
+        binding.btnBackToStore.setOnClickListener { activity?.onBackPressedDispatcher?.onBackPressed()}
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -160,12 +160,14 @@ class LoginActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                handleBackPress()
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    handleBackPress()
+                }
             }
-        })
+        )
 
         dispatcher.register(this)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -160,6 +161,13 @@ class LoginActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                AnalyticsTracker.trackBackPressed(this)
+                super@LoginActivity
+            }
+        })
+
         dispatcher.register(this)
 
         binding = ActivityLoginBinding.inflate(layoutInflater)
@@ -302,7 +310,7 @@ class LoginActivity :
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -161,10 +161,9 @@ class LoginActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                AnalyticsTracker.trackBackPressed(this)
-                super@LoginActivity
+                handleBackPress()
             }
         })
 
@@ -193,6 +192,16 @@ class LoginActivity :
         savedInstanceState?.let { ss ->
             unifiedLoginTracker.setSource(ss.getString(KEY_UNIFIED_TRACKER_SOURCE, Source.DEFAULT.value))
             unifiedLoginTracker.setFlow(ss.getString(KEY_UNIFIED_TRACKER_FLOW))
+        }
+    }
+
+    private fun handleBackPress() {
+        AnalyticsTracker.trackBackPressed(this)
+
+        if (supportFragmentManager.backStackEntryCount == 1) {
+            finish()
+        } else {
+            supportFragmentManager.popBackStack()
         }
     }
 
@@ -315,16 +324,6 @@ class LoginActivity :
         }
 
         return false
-    }
-
-    override fun onBackPressed() {
-        AnalyticsTracker.trackBackPressed(this)
-
-        if (supportFragmentManager.backStackEntryCount == 1) {
-            finish()
-        } else {
-            super.onBackPressed()
-        }
     }
 
     override fun getLoginMode(): LoginMode {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginSiteCheckErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginSiteCheckErrorFragment.kt
@@ -71,7 +71,7 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.fragment_login_site_check_
             setOnClickListener {
                 unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_STORE)
 
-                requireActivity().onBackPressed()
+                requireActivity().onBackPressedDispatcher.onBackPressed()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -40,7 +40,7 @@ abstract class BaseProductFragment : BaseFragment, BackPressListener {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is Exit -> requireActivity().onBackPressed()
+                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
                 is ShowDialog -> WooDialog.showDialog(
                     requireActivity(),
                     event.positiveBtnAction,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -119,7 +119,7 @@ class AddProductCategoryFragment : BaseFragment(R.layout.fragment_add_product_ca
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is Exit -> requireActivity().onBackPressed()
+                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
                 is ShowDialog -> event.showDialog()
                 is ExitWithResult<*> -> navigateBackWithResult(ARG_ADDED_CATEGORY, event.data)
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -248,7 +248,7 @@ class VariationDetailFragment :
                 }
                 is ExitWithResult<*> -> navigateBackWithResult(KEY_VARIATION_DETAILS_RESULT, event.data)
                 is ShowDialog -> event.showDialog()
-                is Exit -> requireActivity().onBackPressed()
+                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -180,7 +180,7 @@ class VariationListFragment :
                 is ShowBulkUpdateAttrPicker -> openBulkUpdateView(event.variationsToUpdate)
                 is ShowBulkUpdateLimitExceededWarning -> showBulkUpdateLimitExceededWarning()
                 is ExitWithResult<*> -> navigateBackWithResult(KEY_VARIATION_LIST_RESULT, event.data)
-                is Exit -> activity?.onBackPressed()
+                is Exit -> activity?.onBackPressedDispatcher?.onBackPressed()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceFragment.kt
@@ -55,7 +55,7 @@ class VariationsBulkUpdatePriceFragment : BaseFragment(R.layout.fragment_variati
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is Exit -> requireActivity().onBackPressed()
+                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -358,7 +358,7 @@ class SitePickerViewModel @Inject constructor(
     fun onTryAnotherAccountButtonClick() {
         trackLoginEvent(clickEvent = UnifiedLoginTracker.Click.TRY_ANOTHER_ACCOUNT)
         launch {
-            repository.logout()?.let {
+            repository.logout().let {
                 if (!repository.isUserLoggedIn()) {
                     appPrefsWrapper.removeLoginSiteAddress()
                     triggerEvent(Logout)


### PR DESCRIPTION
Fixes #7211. This PR fixes the deprecation warnings for the usage of `onBackPressed()` overrides.

**To test:**
1. Start the app in a logged-out test
2. Tap on the Enter store address button and tap back
3. Verify the prologue screen is shown
4. Tap back and verify the app is dismissed
6. Now open the app again log in 
7. Go to the help screen in the settings and tap back
8. Verify the back button is behaving as expected
9. Go to products
10. Select a variable product
11. Go to variations
12. Select a variation
13. Now tap the back button until you get to the dashboard
14. Verify the back button is behaving as expected
15. Tap back again and verify the app gets closed