### PR TITLE
Avoid tracking feature_card_shown event twice in the order listing screen for upsell card reader banner.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -515,12 +515,24 @@ class OrderListViewModel @Inject constructor(
         shouldShowUpsellCardReaderDismissDialog.value = false
     }
 
-    fun canShowCardReaderUpsellBanner(currentTimeInMillis: Long, source: String): Boolean {
-        return bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(currentTimeInMillis, source)
+    fun canShowCardReaderUpsellBanner(
+        currentTimeInMillis: Long,
+        source: String,
+        shouldTrackEvent: Boolean
+    ): Boolean {
+        return bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
+            currentTimeInMillis,
+            source,
+            shouldTrackEvent
+        )
     }
 
     fun shouldDisplaySimplePaymentsWIPCard(): Boolean {
-        return !canShowCardReaderUpsellBanner(System.currentTimeMillis(), AnalyticsTracker.KEY_BANNER_ORDER_LIST)
+        return !canShowCardReaderUpsellBanner(
+            System.currentTimeMillis(),
+            AnalyticsTracker.KEY_BANNER_ORDER_LIST,
+            false
+        )
     }
 
     private fun updateOrderDisplayedStatus(position: Int, status: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
@@ -312,7 +312,11 @@ class SelectPaymentMethodViewModel @Inject constructor(
     }
 
     private fun canShowCardReaderUpsellBanner(currentTimeInMillis: Long, source: String): Boolean {
-        return bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(currentTimeInMillis, source)
+        return bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
+            currentTimeInMillis,
+            source,
+            true
+        )
     }
 
     sealed class TakePaymentViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -72,7 +72,11 @@ fun OrderListScreenBanner(
 
     if (
         isEligibleForInPersonPayments &&
-        viewModel.canShowCardReaderUpsellBanner(System.currentTimeMillis(), AnalyticsTracker.KEY_BANNER_ORDER_LIST)
+        viewModel.canShowCardReaderUpsellBanner(
+            System.currentTimeMillis(),
+            AnalyticsTracker.KEY_BANNER_ORDER_LIST,
+            true
+        )
     ) {
         Banner(
             onCtaClick = viewModel::onCtaClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/BannerDisplayEligibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/BannerDisplayEligibilityChecker.kt
@@ -98,7 +98,11 @@ class BannerDisplayEligibilityChecker @Inject constructor(
         return getCardReaderUpsellBannerLastDismissed() != 0L
     }
 
-    fun canShowCardReaderUpsellBanner(currentTimeInMillis: Long, source: String): Boolean {
+    fun canShowCardReaderUpsellBanner(
+        currentTimeInMillis: Long,
+        source: String,
+        shouldTrackEvent: Boolean
+    ): Boolean {
         return (
             !isCardReaderUpsellBannerDismissedForever() &&
                 (
@@ -106,7 +110,7 @@ class BannerDisplayEligibilityChecker @Inject constructor(
                         isLastDialogDismissedMoreThan14DaysAgo(currentTimeInMillis)
                     )
             ).also { trackable ->
-            if (trackable) {
+            if (trackable && shouldTrackEvent) {
                 analyticsTrackerWrapper.track(
                     AnalyticsEvent.FEATURE_CARD_SHOWN,
                     mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -83,6 +83,10 @@ class MainSettingsPresenter @Inject constructor(
     }
 
     override fun canShowCardReaderUpsellBanner(currentTimeInMillis: Long, source: String): Boolean {
-        return bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(currentTimeInMillis, source)
+        return bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
+            currentTimeInMillis,
+            source,
+            true
+        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/banner/BannerDisplayEligibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/banner/BannerDisplayEligibilityCheckerTest.kt
@@ -169,7 +169,8 @@ class BannerDisplayEligibilityCheckerTest : BaseUnitTest() {
 
         val canShowBanner = bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
             0L,
-            KEY_BANNER_PAYMENTS
+            KEY_BANNER_PAYMENTS,
+            true
         )
 
         assertThat(canShowBanner).isTrue
@@ -187,7 +188,8 @@ class BannerDisplayEligibilityCheckerTest : BaseUnitTest() {
 
         val canShowBanner = bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
             0L,
-            KEY_BANNER_PAYMENTS
+            KEY_BANNER_PAYMENTS,
+            true
         )
 
         assertThat(canShowBanner).isFalse
@@ -215,7 +217,8 @@ class BannerDisplayEligibilityCheckerTest : BaseUnitTest() {
 
         val canShowBanner = bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
             currentTimeInMillis,
-            KEY_BANNER_PAYMENTS
+            KEY_BANNER_PAYMENTS,
+            true
         )
 
         assertThat(canShowBanner).isFalse
@@ -243,7 +246,8 @@ class BannerDisplayEligibilityCheckerTest : BaseUnitTest() {
 
         val canShowBanner = bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
             currentTimeInMillis,
-            KEY_BANNER_PAYMENTS
+            KEY_BANNER_PAYMENTS,
+            true
         )
 
         assertThat(canShowBanner).isTrue
@@ -369,7 +373,8 @@ class BannerDisplayEligibilityCheckerTest : BaseUnitTest() {
 
         bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
             0L,
-            KEY_BANNER_PAYMENTS
+            KEY_BANNER_PAYMENTS,
+            true
         )
 
         // Then
@@ -387,7 +392,8 @@ class BannerDisplayEligibilityCheckerTest : BaseUnitTest() {
         // WHEN
         bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
             0L,
-            KEY_BANNER_PAYMENTS
+            KEY_BANNER_PAYMENTS,
+            true
         )
 
         // Then
@@ -405,7 +411,8 @@ class BannerDisplayEligibilityCheckerTest : BaseUnitTest() {
         // WHEN
         bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
             0L,
-            KEY_BANNER_ORDER_LIST
+            KEY_BANNER_ORDER_LIST,
+            true
         )
 
         // Then
@@ -419,11 +426,31 @@ class BannerDisplayEligibilityCheckerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given upsell banner from order list, when shouldTrackEvent is false, then do not track event`() {
+        // WHEN
+        bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
+            0L,
+            KEY_BANNER_ORDER_LIST,
+            false
+        )
+
+        // Then
+        verify(analyticsTrackerWrapper, never()).track(
+            AnalyticsEvent.FEATURE_CARD_SHOWN,
+            mapOf(
+                AnalyticsTracker.KEY_BANNER_SOURCE to KEY_BANNER_ORDER_LIST,
+                AnalyticsTracker.KEY_BANNER_CAMPAIGN_NAME to AnalyticsTracker.KEY_BANNER_UPSELL_CARD_READERS
+            )
+        )
+    }
+
+    @Test
     fun `given upsell banner from settings, when banner is shown, then track proper event`() {
         // WHEN
         bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
             0L,
-            KEY_BANNER_SETTINGS
+            KEY_BANNER_SETTINGS,
+            true
         )
 
         // Then

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
@@ -558,7 +559,8 @@ class OrderListViewModelTest : BaseUnitTest() {
             whenever(
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
                     anyLong(),
-                    anyString()
+                    anyString(),
+                    anyBoolean()
                 )
             ).thenReturn(true)
 
@@ -574,7 +576,8 @@ class OrderListViewModelTest : BaseUnitTest() {
             whenever(
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
                     anyLong(),
-                    anyString()
+                    anyString(),
+                    anyBoolean()
                 )
             ).thenReturn(false)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
@@ -719,7 +720,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             whenever(
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
                     anyLong(),
-                    anyString()
+                    anyString(),
+                    anyBoolean()
                 )
             ).thenReturn(true)
             val orderId = 1L
@@ -744,7 +746,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             whenever(
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
                     anyLong(),
-                    anyString()
+                    anyString(),
+                    anyBoolean()
                 )
             ).thenReturn(true)
             val orderId = 1L
@@ -769,7 +772,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             whenever(
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(
                     anyLong(),
-                    anyString()
+                    anyString(),
+                    anyBoolean()
                 )
             ).thenReturn(false)
             val orderId = 1L


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Closes: #7258 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes tracking the `feature_card_shown` event twice in the order listing screen for upsell card reader banner.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to the order listing screen
2. Ensure you see the upsell card reader banner
3. Check logs and make sure you see the `feature_card_shown` event logged only once.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
