### PR TITLE
Fix missing/wrongly named tracks events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -205,7 +205,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDER_EDIT_BUTTON_TAPPED,
 
     // -- Order Creation
-    ORDER_ADD_NEW,
+    ORDERS_ADD_NEW,
     ORDER_PRODUCT_ADD,
     ORDER_CUSTOMER_ADD,
     ORDER_FEE_ADD,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -566,6 +566,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     REVIEWS_LIST_SHARE_YOUR_STORE_BUTTON_TAPPED,
 
     // -- Product Review Detail
+    REVIEW_OPEN,
     REVIEW_LOADED,
     REVIEW_LOAD_FAILED,
     REVIEW_PRODUCT_LOADED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -464,7 +464,7 @@ class OrderListFragment :
     }
 
     private fun openOrderCreationFragment() {
-        AnalyticsTracker.track(AnalyticsEvent.ORDER_ADD_NEW)
+        AnalyticsTracker.track(AnalyticsEvent.ORDERS_ADD_NEW)
         findNavController().navigateSafely(
             OrderListFragmentDirections.actionOrderListFragmentToOrderCreationFragment(
                 OrderCreateEditViewModel.Mode.Creation

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -157,6 +157,7 @@ class ProductReviewsFragment :
     }
 
     override fun onReviewClick(review: ProductReview, sharedView: View?) {
+        AnalyticsTracker.track(AnalyticsEvent.REVIEW_OPEN)
         (activity as? MainNavigationRouter)?.showReviewDetail(
             review.remoteId,
             launchedFromNotification = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -245,6 +245,7 @@ class ReviewListFragment :
     override fun getItemTypeAtPosition(position: Int) = reviewsAdapter.getItemTypeAtRecyclerPosition(position)
 
     override fun onReviewClick(review: ProductReview, sharedView: View?) {
+        AnalyticsTracker.track(AnalyticsEvent.REVIEW_OPEN)
         (activity as? MainNavigationRouter)?.let { router ->
             if (sharedView == null) {
                 router.showReviewDetail(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7253
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Renames `ORDER_ADD_NEW` -> `ORDERS_ADD_NEW` (to much iOS naming)
* Adds `REVIEW_OPEN` to the click on a review in the products details and in the review lists

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Use logcat filtered by `TRACK` keyword (Make sure logging is enabled in the app -> Settings -> Privacy -> Collect information)
* Go to `orders` -> `create order`. Notice track:
```
Tracked: orders_add_new, Properties: {"blog_id":192152755,"is_wpcom_store":true,"is_debug":true}
```
* Go to `reviews` -> `review`. Notice track:
```
Tracked: review_open, Properties: {"blog_id":192152755,"is_wpcom_store":true,"is_debug":true}
```
* Go to `Products` -> `Product's details` -> `Reviews` -> `Review`. Notice track:
```
Tracked: review_open, Properties: {"blog_id":192152755,"is_wpcom_store":true,"is_debug":true}
```

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
