### PR TITLE
Implicitly add instructions when COD is enabled.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -61,6 +61,7 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestClient
+import org.wordpress.android.fluxc.store.Settings
 import org.wordpress.android.fluxc.store.WCGatewayStore
 import java.util.Date
 import java.util.Locale
@@ -310,6 +311,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 enabled = true,
                 title = "Pay in Person",
                 description = "Pay by card or another accepted payment method",
+                settings = Settings(instructions = "Pay by card or another accepted payment method"),
             )
             result.model?.let {
                 cardReaderTracker.trackCashOnDeliveryEnabledSuccess()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -57,6 +57,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestClient
+import org.wordpress.android.fluxc.store.Settings
 import org.wordpress.android.fluxc.store.WCGatewayStore
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -1217,7 +1218,10 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                     gatewayId = GatewayRestClient.GatewayId.CASH_ON_DELIVERY,
                     enabled = true,
                     title = "Pay in Person",
-                    description = "Pay by card or another accepted payment method"
+                    description = "Pay by card or another accepted payment method",
+                    settings = Settings(
+                        instructions = "Pay by card or another accepted payment method"
+                    )
                 )
             ).thenReturn(
                 WooResult(
@@ -1263,7 +1267,10 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                     gatewayId = GatewayRestClient.GatewayId.CASH_ON_DELIVERY,
                     enabled = true,
                     title = "Pay in Person",
-                    description = "Pay by card or another accepted payment method"
+                    description = "Pay by card or another accepted payment method",
+                    settings = Settings(
+                        instructions = "Pay by card or another accepted payment method"
+                    )
                 )
             ).thenReturn(
                 WooResult(
@@ -2090,7 +2097,10 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                     gatewayId = GatewayRestClient.GatewayId.CASH_ON_DELIVERY,
                     enabled = true,
                     title = "Pay in Person",
-                    description = "Pay by card or another accepted payment method"
+                    description = "Pay by card or another accepted payment method",
+                    settings = Settings(
+                        instructions = "Pay by card or another accepted payment method"
+                    )
                 )
             ).thenReturn(
                 WooResult(
@@ -2130,7 +2140,10 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                     gatewayId = GatewayRestClient.GatewayId.CASH_ON_DELIVERY,
                     enabled = true,
                     title = "Pay in Person",
-                    description = "Pay by card or another accepted payment method"
+                    description = "Pay by card or another accepted payment method",
+                    settings = Settings(
+                        instructions = "Pay by card or another accepted payment method"
+                    )
                 )
             ).thenReturn(
                 WooResult(

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2510-f079e124d7cf7c56d556da345b7b14ef1f1d1da1'
+    fluxCVersion = 'trunk-efc3333cb6612f863df964cf83b95d66d9ef6619'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.50.0'
+    fluxCVersion = '2510-f079e124d7cf7c56d556da345b7b14ef1f1d1da1'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### NOTE: Please make sure to review and merge the [fluxc PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2510) before merging this PR. Once the fluxc PR is merged, update the fluxcVersion hash in this PR and remove the `do not merge` label.

Closes: #7261 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR Implicitly adds instructions when COD is enabled. Instructions are displayed on the post-checkout Thank You screen and in the confirmation email

Instruction text: `Pay by card or another accepted payment method`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure COD is disabled on your store
2. Navigate to the IPP settings
3. Make sure you see COD disabled screen during onboarding
4. Tap on "Enable Pay in Person" CTA
5. Ensure the API call succeeds
6. Visit wp-admin -> Payments and make sure the instruction field is set correctly

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="1133" alt="Screenshot 2022-08-23 at 5 51 06 PM" src="https://user-images.githubusercontent.com/1331230/186156586-8cbd4dc1-1807-4ab5-9995-a60969d55fe1.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
