### PR TITLE
Un-ignore `screenshots` test and exclude it properly instead.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 5.3)
+  fastlane-plugin-wpmreleasetoolkit (~> 5.4)
   nokogiri
   rmagick (~> 4.1)
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/ScreenshotTest.kt
@@ -20,7 +20,6 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import tools.fastlane.screengrab.Screengrab
@@ -66,7 +65,6 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
         CleanStatusBar.disable()
     }
 
-    @Ignore("Disabled because it fails in CI")
     @Test
     fun screenshots() {
         val testedTheme: String? = InstrumentationRegistry.getArguments().getString("theme")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -745,6 +745,7 @@ platform :android do
       version: 23,
       test_apk_path: File.join(apk_dir, 'androidTest', 'vanilla', 'debug', 'WooCommerce-vanilla-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'vanilla', 'debug', 'WooCommerce-vanilla-debug.apk'),
+      test_targets: 'notPackage com.woocommerce.android.screenshots',
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
      )
   end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,6 +6,6 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.3'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.4'
 #gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 #gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'add/s3-binary-upload'


### PR DESCRIPTION
### Why?

_TLDR_: The `screenshots` test is now disabled on CI via `@Ignore`:

<img width="304" alt="Screenshot 2022-08-26 at 14 48 41" src="https://user-images.githubusercontent.com/73365754/186899093-5594a8c6-6993-404b-b764-12f3fe24fd53.png">

This makes it hard to run this test locally (this is where this test is usually executed). The ideal case would be excluding it from FTL execution using [--test-targets](https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run#--test-targets) option, but this possibility was lost during the migration to Buildkite. 

Since then, [wordpress-mobile/release-toolkit/pull/403](https://github.com/wordpress-mobile/release-toolkit/pull/403) was implemented, so using `--test-targets` is now possible.

### How
See extended description in the WPAndroid counterpart: wordpress-mobile/WordPress-Android/pull/17063.
I'm just stealing the implementation by @AliSoftware 🙇 

### To Test
- Ensure the Connected Tests still pass and go green.
- Verify that they didn't run the `screenshots` instrumented test as part of the [test suite run in Firebase Test Lab](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.edfd947f2636efe3/matrices/5022609154472190778/details?stepId=bs.eb80086c10d4f525&testCaseId=39):

<img width="305" alt="Screenshot 2022-08-26 at 15 13 18" src="https://user-images.githubusercontent.com/73365754/186901061-d2c5ea84-06b1-4e00-8f26-7ddf75f65fcb.png">
