### PR TITLE
REVIEW_OPEN event tracking on push notification click

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.REVIEW_OPEN
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.FeatureAnnouncement
@@ -111,6 +112,7 @@ class MainActivityViewModel @Inject constructor(
         notificationHandler.markNotificationTapped(notification.remoteNoteId)
         notificationHandler.removeNotificationByPushIdFromSystemsBar(localPushId)
         if (notification.channelType == NotificationChannelType.REVIEW) {
+            analyticsTrackerWrapper.track(REVIEW_OPEN)
             triggerEvent(ViewReviewDetail(notification.uniqueId))
         } else if (notification.channelType == NotificationChannelType.NEW_ORDER) {
             if (siteStore.getSiteBySiteId(notification.remoteSiteId) != null) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.main
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.REVIEW_OPEN
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.FeatureAnnouncement
@@ -221,10 +222,19 @@ class MainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when a new review notification is clicked, then review open even tracked`() {
+        val localPushId = 1001
+
+        viewModel.handleIncomingNotification(localPushId, testReviewNotification)
+
+        verify(analyticsTrackerWrapper).track(REVIEW_OPEN)
+    }
+
+    @Test
     fun `when a new zendesk notification is clicked, then the my tickets screen of zendesk is opened`() {
-        var event1: ViewZendeskTickets? = null
+        var event: ViewZendeskTickets? = null
         viewModel.event.observeForever {
-            if (it is ViewZendeskTickets) event1 = it
+            if (it is ViewZendeskTickets) event = it
         }
 
         viewModel.handleIncomingNotification(TEST_ZENDESK_PUSH_NOTIFICATION_ID, testZendeskNotification)
@@ -235,7 +245,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         verify(notificationMessageHandler, atLeastOnce()).removeNotificationByPushIdFromSystemsBar(
             eq(TEST_ZENDESK_PUSH_NOTIFICATION_ID)
         )
-        assertThat(event1).isEqualTo(ViewZendeskTickets)
+        assertThat(event).isEqualTo(ViewZendeskTickets)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7294
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds REVIEW_OPEN event tracking on push notification click

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Add a review to any products on your store
* Notice a push notification
* Click on the push notification
* In the logcat notice event being tracked:
```
Added REVIEW_OPEN event tracking on push notification click
```

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
