### PR TITLE
[UI Tests ] Read values from mock file for orders test assertions

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
@@ -6,7 +6,6 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withSubstring
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.util.OrderData

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
@@ -35,12 +35,13 @@ class SingleOrderScreen : Screen {
 
     fun assertSingleOrderScreenWithProduct(order: OrderData): SingleOrderScreen {
         Espresso.onView(withId(R.id.toolbar))
-            .check(ViewAssertions.matches(hasDescendant(withSubstring("#" + order.id))))
+            .check(ViewAssertions.matches(hasDescendant(withText("Order #" + order.id))))
             .check(ViewAssertions.matches(isDisplayed()))
 
-        Espresso.onView(withText(order.productName)).check(ViewAssertions.matches(isDisplayed()))
-        this.assertIdAndTextDisplayed(R.id.orderStatus_orderTags, order.status)
-        this.assertIdAndTextDisplayed(R.id.paymentInfo_total, order.total)
+        Espresso.onView(withText(order.productName))
+            .check(ViewAssertions.matches(isDisplayed()))
+        assertIdAndTextDisplayed(R.id.orderStatus_orderTags, order.status)
+        assertIdAndTextDisplayed(R.id.paymentInfo_total, order.total)
 
         return this
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
@@ -3,7 +3,11 @@ package com.woocommerce.android.screenshots.orders
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withSubstring
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.woocommerce.android.R
 import com.woocommerce.android.screenshots.util.OrderData
 import com.woocommerce.android.screenshots.util.Screen

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
@@ -2,9 +2,12 @@ package com.woocommerce.android.screenshots.orders
 
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import com.woocommerce.android.R
+import com.woocommerce.android.screenshots.util.OrderData
 import com.woocommerce.android.screenshots.util.Screen
+import org.hamcrest.Matchers
 
 class SingleOrderScreen : Screen {
     companion object {
@@ -18,20 +21,24 @@ class SingleOrderScreen : Screen {
         return OrderListScreen()
     }
 
-    fun assertSingleOrderScreen(): SingleOrderScreen {
-        Espresso.onView(withId(R.id.toolbar))
-            .check(ViewAssertions.matches(hasDescendant(withSubstring("#"))))
-            .check(ViewAssertions.matches(isDisplayed()))
-        Espresso.onView(withId(ORDER_NUMBER_LABEL))
-            .check(ViewAssertions.matches(isDisplayed()))
-        Espresso.onView(withId(R.id.paymentInfo_total))
-            .check(ViewAssertions.matches(isDisplayed()))
-        return this
+    private fun assertIdAndTextDisplayed(id: Int, text: String?) {
+        Espresso.onView(
+            Matchers.allOf(
+                ViewMatchers.withId(id), ViewMatchers.withText(text)
+            )
+        ).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 
-    fun assertSingleOrderScreenWithProduct(productName: String): SingleOrderScreen {
-        Espresso.onView(withText(productName)).check(ViewAssertions.matches(isDisplayed()))
-        return assertSingleOrderScreen()
+    fun assertSingleOrderScreenWithProduct(order: OrderData): SingleOrderScreen {
+        Espresso.onView(withId(R.id.toolbar))
+            .check(ViewAssertions.matches(hasDescendant(withSubstring("#" + order.id))))
+            .check(ViewAssertions.matches(isDisplayed()))
+
+        Espresso.onView(withText(order.productName)).check(ViewAssertions.matches(isDisplayed()))
+        this.assertIdAndTextDisplayed(R.id.orderStatus_orderTags, order.status)
+        this.assertIdAndTextDisplayed(R.id.paymentInfo_total, order.total)
+
+        return this
     }
 
     fun tapOnCollectPayment(): PaymentSelectionScreen {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/DataClasses.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/DataClasses.kt
@@ -25,6 +25,10 @@ val productTypesMap = mapOf(
     "simple" to "Physical product"
 )
 
+val orderStatusMap = mapOf(
+    "pending" to "Pending payment"
+)
+
 data class ReviewData(
     val productID: Int,
     val status: String,
@@ -66,4 +70,14 @@ data class ProductData(
 
         return price
     }
+}
+
+data class OrderData(
+    val id: Int,
+    val productName: String,
+    val statusRaw: String,
+    val totalRaw: String
+) {
+    val status = orderStatusMap[statusRaw]
+    val total = "\$$totalRaw"
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/MocksReader.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/MocksReader.kt
@@ -5,27 +5,29 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 class MocksReader {
-    fun readAllReviewsToArray(): JSONArray {
-        val reviewsWireMockFileName = "mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json"
-        val reviewsWireMockString = this.readAssetsFile(reviewsWireMockFileName)
-        val reviewsWireMockJSON = JSONObject(reviewsWireMockString)
-        return reviewsWireMockJSON
-            .getJSONObject("response")
-            .getJSONObject("jsonBody")
-            .getJSONArray("data")
-    }
-
-    fun readAllProductsToArray(): JSONArray {
-        val productsWireMockString = this.readAssetsFile("mocks/mappings/jetpack-blogs/wc/products/products.json")
-        val productsWireMockJSON = JSONObject(productsWireMockString)
-        return productsWireMockJSON
-            .getJSONObject("response")
-            .getJSONObject("jsonBody")
-            .getJSONArray("data")
-    }
-
     private fun readAssetsFile(fileName: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().context
         return appContext.assets.open(fileName).bufferedReader().use { it.readText() }
+    }
+
+    private fun readFileToArray(fileName: String): JSONArray {
+        val fileWireMockString = this.readAssetsFile(fileName)
+        val fileWireMockJSON = JSONObject(fileWireMockString)
+        return fileWireMockJSON
+            .getJSONObject("response")
+            .getJSONObject("jsonBody")
+            .getJSONArray("data")
+    }
+
+    fun readAllReviewsToArray(): JSONArray {
+        return readFileToArray("mocks/mappings/jetpack-blogs/wc/reviews/products_reviews_all.json")
+    }
+
+    fun readAllProductsToArray(): JSONArray {
+        return readFileToArray("mocks/mappings/jetpack-blogs/wc/products/products.json")
+    }
+
+    fun readOrderToArray(): JSONArray {
+        return readFileToArray("mocks/mappings/jetpack-blogs/wc/orders/2201/2201_detailed.json")
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
@@ -63,6 +63,7 @@ class OrdersUITest : TestBase() {
                 .assertNewOrderScreenWithProduct(orderData.productName)
                 .createOrder()
                 .assertSingleOrderScreenWithProduct(orderData)
+                .goBackToOrdersScreen()
         }
     }
 


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/7278

### Description
This PR updates the current assertions for the Orders test. Currently, the value to assert is hard coded in the test. To be more consistent with other UI tests, the test is updated to read the values from the mock file and ensure that those values are displayed on screen. 

### Testing instructions
Test that test works locally and in CI

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
