### PR TITLE
Feature/6617 save last selected granularity

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 10.2
 -----
 - [*] SitePicker: Reduces Jetpack timeout loading times and shows new error dialog  [https://github.com/woocommerce/woocommerce-android/pull/7271
+- [*] My store stats: Save selected stats granularity in My store tab between app session and site switching [https://github.com/woocommerce/woocommerce-android/pull/7304
 
 10.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -10,6 +10,7 @@ import androidx.preference.PreferenceManager
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.valueOf
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.ACTIVE_STATS_GRANULARITY
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_DO_NOT_SHOW_CASH_ON_DELIVERY_DISABLED_ONBOARDING_STATE
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_IS_PLUGIN_EXPLICITLY_SELECTED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_ONBOARDING_COMPLETED_STATUS_V2
@@ -21,11 +22,33 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_UPSELL_BANN
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.DATABASE_DOWNGRADED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_COUPONS_ENABLED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_PRODUCTS_FEATURE_ENABLED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_USER_ELIGIBLE
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_USING_V4_API
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.LOGIN_EMAIL
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.LOGIN_SITE_ADDRESS
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.LOGIN_USER_BYPASSED_JETPACK_REQUIRED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_END
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_START
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRE_LOGIN_NOTIFICATION_WORK_REQUEST
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_APP_THEME
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_PRODUCT_IS_VIRTUAL
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_PRODUCT_TYPE
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.SUPPORT_EMAIL
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.SUPPORT_NAME
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_SOURCE
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.USER_EMAIL
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.values
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.ONBOARDING_CAROUSEL_DISPLAYED
 import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.tools.SelectedSite
@@ -94,6 +117,7 @@ object AppPrefs {
         CARD_READER_UPSELL_BANNER_DIALOG_DISMISSED_FOREVER,
         CARD_READER_UPSELL_BANNER_DIALOG_DISMISSED_REMIND_ME_LATER,
         CARD_READER_DO_NOT_SHOW_CASH_ON_DELIVERY_DISABLED_ONBOARDING_STATE,
+        ACTIVE_STATS_GRANULARITY
     }
 
     /**
@@ -198,8 +222,8 @@ object AppPrefs {
             .let { setString(UndeletablePrefKey.APP_INSTALATION_DATE, it) }
 
     var isProductAddonsEnabled: Boolean
-        get() = getBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, false)
-        set(value) = setBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, value)
+        get() = getBoolean(IS_PRODUCT_ADDONS_ENABLED, false)
+        set(value) = setBoolean(IS_PRODUCT_ADDONS_ENABLED, value)
 
     var isCouponsEnabled: Boolean
         get() = getBoolean(IS_COUPONS_ENABLED, false)
@@ -238,28 +262,28 @@ object AppPrefs {
 
     fun setSupportEmail(email: String?) {
         if (!email.isNullOrEmpty()) {
-            setString(DeletablePrefKey.SUPPORT_EMAIL, email)
+            setString(SUPPORT_EMAIL, email)
         } else {
-            remove(DeletablePrefKey.SUPPORT_EMAIL)
+            remove(SUPPORT_EMAIL)
         }
     }
 
-    fun getSupportEmail() = getString(DeletablePrefKey.SUPPORT_EMAIL)
+    fun getSupportEmail() = getString(SUPPORT_EMAIL)
 
     fun hasSupportEmail() = getSupportEmail().isNotEmpty()
 
     fun removeSupportEmail() {
-        remove(DeletablePrefKey.SUPPORT_EMAIL)
+        remove(SUPPORT_EMAIL)
     }
 
     fun setSupportName(name: String) {
-        setString(DeletablePrefKey.SUPPORT_NAME, name)
+        setString(SUPPORT_NAME, name)
     }
 
-    fun getSupportName() = getString(DeletablePrefKey.SUPPORT_NAME)
+    fun getSupportName() = getString(SUPPORT_NAME)
 
     fun removeSupportName() {
-        remove(DeletablePrefKey.SUPPORT_NAME)
+        remove(SUPPORT_NAME)
     }
 
     /**
@@ -342,17 +366,17 @@ object AppPrefs {
      * Method to check if the v4 stats UI is supported.
      */
 
-    fun isV4StatsSupported() = getBoolean(DeletablePrefKey.IS_USING_V4_API, false)
+    fun isV4StatsSupported() = getBoolean(IS_USING_V4_API, false)
 
-    fun setV4StatsSupported(isUsingV4Api: Boolean) = setBoolean(DeletablePrefKey.IS_USING_V4_API, isUsingV4Api)
+    fun setV4StatsSupported(isUsingV4Api: Boolean) = setBoolean(IS_USING_V4_API, isUsingV4Api)
 
-    fun isUserEligible() = getBoolean(DeletablePrefKey.IS_USER_ELIGIBLE, true)
+    fun isUserEligible() = getBoolean(IS_USER_ELIGIBLE, true)
 
-    fun setIsUserEligible(isUserEligible: Boolean) = setBoolean(DeletablePrefKey.IS_USER_ELIGIBLE, isUserEligible)
+    fun setIsUserEligible(isUserEligible: Boolean) = setBoolean(IS_USER_ELIGIBLE, isUserEligible)
 
-    fun getUserEmail() = getString(DeletablePrefKey.USER_EMAIL)
+    fun getUserEmail() = getString(USER_EMAIL)
 
-    fun setUserEmail(email: String) = setString(DeletablePrefKey.USER_EMAIL, email)
+    fun setUserEmail(email: String) = setString(USER_EMAIL, email)
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
         getString(getReceiptKey(localSiteId, remoteSiteId, selfHostedSiteId, orderId))
@@ -401,10 +425,10 @@ object AppPrefs {
     /**
      * Flag to check products features are enabled
      */
-    fun isProductsFeatureEnabled() = getBoolean(DeletablePrefKey.IS_PRODUCTS_FEATURE_ENABLED, false)
+    fun isProductsFeatureEnabled() = getBoolean(IS_PRODUCTS_FEATURE_ENABLED, false)
 
     fun setIsProductsFeatureEnabled(isProductsFeatureEnabled: Boolean) =
-        setBoolean(DeletablePrefKey.IS_PRODUCTS_FEATURE_ENABLED, isProductsFeatureEnabled)
+        setBoolean(IS_PRODUCTS_FEATURE_ENABLED, isProductsFeatureEnabled)
 
     fun isCrashReportingEnabled(): Boolean {
         // default to False for debug builds
@@ -443,38 +467,38 @@ object AppPrefs {
     }
 
     fun getSelectedShipmentTrackingProviderName(): String =
-        getString(DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME)
+        getString(SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME)
 
     fun setSelectedShipmentTrackingProviderName(providerName: String) {
-        setString(DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME, providerName)
+        setString(SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME, providerName)
     }
 
     fun getIsSelectedShipmentTrackingProviderCustom(): Boolean =
-        getBoolean(DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM, false)
+        getBoolean(SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM, false)
 
     fun setIsSelectedShipmentTrackingProviderNameCustom(isCustomProvider: Boolean) {
-        setBoolean(DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM, isCustomProvider)
+        setBoolean(SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM, isCustomProvider)
     }
 
     fun setLoginSiteAddress(loginSiteAddress: String) {
-        setString(DeletablePrefKey.LOGIN_SITE_ADDRESS, loginSiteAddress)
+        setString(LOGIN_SITE_ADDRESS, loginSiteAddress)
     }
 
-    fun getLoginSiteAddress() = getString(DeletablePrefKey.LOGIN_SITE_ADDRESS)
+    fun getLoginSiteAddress() = getString(LOGIN_SITE_ADDRESS)
 
     fun removeLoginSiteAddress() {
-        remove(DeletablePrefKey.LOGIN_SITE_ADDRESS)
+        remove(LOGIN_SITE_ADDRESS)
     }
 
     fun setLoginUserBypassedJetpackRequired(bypassedLogin: Boolean = true) {
-        setBoolean(DeletablePrefKey.LOGIN_USER_BYPASSED_JETPACK_REQUIRED, bypassedLogin)
+        setBoolean(LOGIN_USER_BYPASSED_JETPACK_REQUIRED, bypassedLogin)
     }
 
     fun getLoginUserBypassedJetpackRequired() =
-        getBoolean(DeletablePrefKey.LOGIN_USER_BYPASSED_JETPACK_REQUIRED, false)
+        getBoolean(LOGIN_USER_BYPASSED_JETPACK_REQUIRED, false)
 
     fun removeLoginUserBypassedJetpackRequired() {
-        remove(DeletablePrefKey.LOGIN_USER_BYPASSED_JETPACK_REQUIRED)
+        remove(LOGIN_USER_BYPASSED_JETPACK_REQUIRED)
     }
 
     fun getDatabaseDowngraded() = getBoolean(DATABASE_DOWNGRADED, false)
@@ -484,20 +508,20 @@ object AppPrefs {
     }
 
     fun setSelectedOrderListTab(selectedOrderListTabPosition: Int) {
-        setInt(DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION, selectedOrderListTabPosition)
+        setInt(SELECTED_ORDER_LIST_TAB_POSITION, selectedOrderListTabPosition)
     }
 
     fun getSelectedOrderListTabPosition() =
-        getInt(DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION, -1)
+        getInt(SELECTED_ORDER_LIST_TAB_POSITION, -1)
 
-    fun setSelectedProductType(type: ProductType) = setString(DeletablePrefKey.SELECTED_PRODUCT_TYPE, type.value)
+    fun setSelectedProductType(type: ProductType) = setString(SELECTED_PRODUCT_TYPE, type.value)
 
-    fun getSelectedProductType(): String = getString(DeletablePrefKey.SELECTED_PRODUCT_TYPE, "")
+    fun getSelectedProductType(): String = getString(SELECTED_PRODUCT_TYPE, "")
 
     fun setSelectedProductIsVirtual(isVirtual: Boolean) =
-        setBoolean(DeletablePrefKey.SELECTED_PRODUCT_IS_VIRTUAL, isVirtual)
+        setBoolean(SELECTED_PRODUCT_IS_VIRTUAL, isVirtual)
 
-    fun isSelectedProductVirtual(): Boolean = getBoolean(DeletablePrefKey.SELECTED_PRODUCT_IS_VIRTUAL, false)
+    fun isSelectedProductVirtual(): Boolean = getBoolean(SELECTED_PRODUCT_IS_VIRTUAL, false)
 
     /**
      * Checks if the user has a saved order list tab position yet. If no position has been saved,
@@ -514,10 +538,10 @@ object AppPrefs {
     }
 
     fun getAppTheme(): ThemeOption =
-        ThemeOption.valueOf(getString(DeletablePrefKey.SELECTED_APP_THEME, DEFAULT.toString()))
+        ThemeOption.valueOf(getString(SELECTED_APP_THEME, DEFAULT.toString()))
 
     fun setAppTheme(theme: ThemeOption) {
-        setString(DeletablePrefKey.SELECTED_APP_THEME, theme.toString())
+        setString(SELECTED_APP_THEME, theme.toString())
     }
 
     /**
@@ -526,7 +550,7 @@ object AppPrefs {
      * events will be complete.
      */
     fun getUnifiedLoginLastSource(): String? {
-        val result = getString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_SOURCE)
+        val result = getString(UNIFIED_LOGIN_LAST_ACTIVE_SOURCE)
         return if (result.isNotEmpty()) {
             result
         } else {
@@ -535,7 +559,7 @@ object AppPrefs {
     }
 
     fun setUnifiedLoginLastSource(source: String) {
-        setString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_SOURCE, source)
+        setString(UNIFIED_LOGIN_LAST_ACTIVE_SOURCE, source)
     }
 
     /**
@@ -544,7 +568,7 @@ object AppPrefs {
      * events will be complete.
      */
     fun getUnifiedLoginLastFlow(): String? {
-        val result = getString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW)
+        val result = getString(UNIFIED_LOGIN_LAST_ACTIVE_FLOW)
         return if (result.isNotEmpty()) {
             result
         } else {
@@ -553,7 +577,7 @@ object AppPrefs {
     }
 
     fun setUnifiedLoginLastFlow(flow: String) {
-        setString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW, flow)
+        setString(UNIFIED_LOGIN_LAST_ACTIVE_FLOW, flow)
     }
 
     fun isCashOnDeliveryDisabledStateSkipped(
@@ -816,29 +840,29 @@ object AppPrefs {
             false
         )
 
-    fun getLocalNotificationWorkRequestId() = getString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_WORK_REQUEST)
+    fun getLocalNotificationWorkRequestId() = getString(PRE_LOGIN_NOTIFICATION_WORK_REQUEST)
 
     fun setLocalNotificationWorkRequestId(workRequestId: String) {
-        setString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_WORK_REQUEST, workRequestId)
+        setString(PRE_LOGIN_NOTIFICATION_WORK_REQUEST, workRequestId)
     }
 
-    fun getPreLoginNotificationDisplayedType() = getString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE)
+    fun getPreLoginNotificationDisplayedType() = getString(PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE)
 
     fun setPreLoginNotificationDisplayedType(notificationType: String) {
-        setString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE, notificationType)
+        setString(PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE, notificationType)
     }
 
     fun setPreLoginNotificationDisplayed(displayed: Boolean) {
-        setBoolean(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED, displayed)
+        setBoolean(PRE_LOGIN_NOTIFICATION_DISPLAYED, displayed)
     }
 
     fun isPreLoginNotificationBeenDisplayed(): Boolean =
-        getBoolean(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED, false)
+        getBoolean(PRE_LOGIN_NOTIFICATION_DISPLAYED, false)
 
-    fun getLoginEmail() = getString(DeletablePrefKey.LOGIN_EMAIL)
+    fun getLoginEmail() = getString(LOGIN_EMAIL)
 
     fun setLoginEmail(email: String) {
-        setString(DeletablePrefKey.LOGIN_EMAIL, email)
+        setString(LOGIN_EMAIL, email)
     }
 
     fun setOnboardingCarouselDisplayed(displayed: Boolean) {
@@ -862,12 +886,23 @@ object AppPrefs {
         setBoolean(UndeletablePrefKey.USER_CLICKED_ON_PAYMENTS_MORE_SCREEN, true)
     }
 
+    fun setActiveStatsGranularity(currentSiteId: Int, activeStatsGranularity: String) {
+        setString(getActiveStatsGranularityFilterKey(currentSiteId), activeStatsGranularity)
+    }
+
+    fun getActiveStatsGranularity(currentSiteId: Int) = getString(
+        getActiveStatsGranularityFilterKey(currentSiteId)
+    )
+
+    private fun getActiveStatsGranularityFilterKey(currentSiteId: Int) =
+        PrefKeyString("$ACTIVE_STATS_GRANULARITY:$currentSiteId")
+
     /**
      * Remove all user and site-related preferences.
      */
     fun resetUserPreferences() {
         val editor = getPreferences().edit()
-        DeletablePrefKey.values().forEach { a -> editor.remove(a.name) }
+        values().forEach { a -> editor.remove(a.name) }
         editor.remove(SelectedSite.SELECTED_SITE_LOCAL_ID)
         removePreferencesWithDynamicKey(editor)
         editor.apply()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -10,7 +10,6 @@ import androidx.preference.PreferenceManager
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.valueOf
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.ACTIVE_STATS_GRANULARITY
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_DO_NOT_SHOW_CASH_ON_DELIVERY_DISABLED_ONBOARDING_STATE
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_IS_PLUGIN_EXPLICITLY_SELECTED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_ONBOARDING_COMPLETED_STATUS_V2
@@ -22,33 +21,11 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.CARD_READER_UPSELL_BANN
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.DATABASE_DOWNGRADED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_COUPONS_ENABLED
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_PRODUCTS_FEATURE_ENABLED
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_USER_ELIGIBLE
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.IS_USING_V4_API
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.LOGIN_EMAIL
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.LOGIN_SITE_ADDRESS
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.LOGIN_USER_BYPASSED_JETPACK_REQUIRED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_END
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_CUSTOM_DATE_RANGE_START
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRE_LOGIN_NOTIFICATION_WORK_REQUEST
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_APP_THEME
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_PRODUCT_IS_VIRTUAL
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_PRODUCT_TYPE
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.SUPPORT_EMAIL
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.SUPPORT_NAME
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_SOURCE
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.USER_EMAIL
-import com.woocommerce.android.AppPrefs.DeletablePrefKey.values
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.ONBOARDING_CAROUSEL_DISPLAYED
 import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.tools.SelectedSite
@@ -117,7 +94,7 @@ object AppPrefs {
         CARD_READER_UPSELL_BANNER_DIALOG_DISMISSED_FOREVER,
         CARD_READER_UPSELL_BANNER_DIALOG_DISMISSED_REMIND_ME_LATER,
         CARD_READER_DO_NOT_SHOW_CASH_ON_DELIVERY_DISABLED_ONBOARDING_STATE,
-        ACTIVE_STATS_GRANULARITY
+        ACTIVE_STATS_GRANULARITY,
     }
 
     /**
@@ -222,8 +199,8 @@ object AppPrefs {
             .let { setString(UndeletablePrefKey.APP_INSTALATION_DATE, it) }
 
     var isProductAddonsEnabled: Boolean
-        get() = getBoolean(IS_PRODUCT_ADDONS_ENABLED, false)
-        set(value) = setBoolean(IS_PRODUCT_ADDONS_ENABLED, value)
+        get() = getBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, false)
+        set(value) = setBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, value)
 
     var isCouponsEnabled: Boolean
         get() = getBoolean(IS_COUPONS_ENABLED, false)
@@ -262,28 +239,28 @@ object AppPrefs {
 
     fun setSupportEmail(email: String?) {
         if (!email.isNullOrEmpty()) {
-            setString(SUPPORT_EMAIL, email)
+            setString(DeletablePrefKey.SUPPORT_EMAIL, email)
         } else {
-            remove(SUPPORT_EMAIL)
+            remove(DeletablePrefKey.SUPPORT_EMAIL)
         }
     }
 
-    fun getSupportEmail() = getString(SUPPORT_EMAIL)
+    fun getSupportEmail() = getString(DeletablePrefKey.SUPPORT_EMAIL)
 
     fun hasSupportEmail() = getSupportEmail().isNotEmpty()
 
     fun removeSupportEmail() {
-        remove(SUPPORT_EMAIL)
+        remove(DeletablePrefKey.SUPPORT_EMAIL)
     }
 
     fun setSupportName(name: String) {
-        setString(SUPPORT_NAME, name)
+        setString(DeletablePrefKey.SUPPORT_NAME, name)
     }
 
-    fun getSupportName() = getString(SUPPORT_NAME)
+    fun getSupportName() = getString(DeletablePrefKey.SUPPORT_NAME)
 
     fun removeSupportName() {
-        remove(SUPPORT_NAME)
+        remove(DeletablePrefKey.SUPPORT_NAME)
     }
 
     /**
@@ -366,17 +343,17 @@ object AppPrefs {
      * Method to check if the v4 stats UI is supported.
      */
 
-    fun isV4StatsSupported() = getBoolean(IS_USING_V4_API, false)
+    fun isV4StatsSupported() = getBoolean(DeletablePrefKey.IS_USING_V4_API, false)
 
-    fun setV4StatsSupported(isUsingV4Api: Boolean) = setBoolean(IS_USING_V4_API, isUsingV4Api)
+    fun setV4StatsSupported(isUsingV4Api: Boolean) = setBoolean(DeletablePrefKey.IS_USING_V4_API, isUsingV4Api)
 
-    fun isUserEligible() = getBoolean(IS_USER_ELIGIBLE, true)
+    fun isUserEligible() = getBoolean(DeletablePrefKey.IS_USER_ELIGIBLE, true)
 
-    fun setIsUserEligible(isUserEligible: Boolean) = setBoolean(IS_USER_ELIGIBLE, isUserEligible)
+    fun setIsUserEligible(isUserEligible: Boolean) = setBoolean(DeletablePrefKey.IS_USER_ELIGIBLE, isUserEligible)
 
-    fun getUserEmail() = getString(USER_EMAIL)
+    fun getUserEmail() = getString(DeletablePrefKey.USER_EMAIL)
 
-    fun setUserEmail(email: String) = setString(USER_EMAIL, email)
+    fun setUserEmail(email: String) = setString(DeletablePrefKey.USER_EMAIL, email)
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
         getString(getReceiptKey(localSiteId, remoteSiteId, selfHostedSiteId, orderId))
@@ -425,10 +402,10 @@ object AppPrefs {
     /**
      * Flag to check products features are enabled
      */
-    fun isProductsFeatureEnabled() = getBoolean(IS_PRODUCTS_FEATURE_ENABLED, false)
+    fun isProductsFeatureEnabled() = getBoolean(DeletablePrefKey.IS_PRODUCTS_FEATURE_ENABLED, false)
 
     fun setIsProductsFeatureEnabled(isProductsFeatureEnabled: Boolean) =
-        setBoolean(IS_PRODUCTS_FEATURE_ENABLED, isProductsFeatureEnabled)
+        setBoolean(DeletablePrefKey.IS_PRODUCTS_FEATURE_ENABLED, isProductsFeatureEnabled)
 
     fun isCrashReportingEnabled(): Boolean {
         // default to False for debug builds
@@ -467,38 +444,38 @@ object AppPrefs {
     }
 
     fun getSelectedShipmentTrackingProviderName(): String =
-        getString(SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME)
+        getString(DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME)
 
     fun setSelectedShipmentTrackingProviderName(providerName: String) {
-        setString(SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME, providerName)
+        setString(DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME, providerName)
     }
 
     fun getIsSelectedShipmentTrackingProviderCustom(): Boolean =
-        getBoolean(SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM, false)
+        getBoolean(DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM, false)
 
     fun setIsSelectedShipmentTrackingProviderNameCustom(isCustomProvider: Boolean) {
-        setBoolean(SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM, isCustomProvider)
+        setBoolean(DeletablePrefKey.SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM, isCustomProvider)
     }
 
     fun setLoginSiteAddress(loginSiteAddress: String) {
-        setString(LOGIN_SITE_ADDRESS, loginSiteAddress)
+        setString(DeletablePrefKey.LOGIN_SITE_ADDRESS, loginSiteAddress)
     }
 
-    fun getLoginSiteAddress() = getString(LOGIN_SITE_ADDRESS)
+    fun getLoginSiteAddress() = getString(DeletablePrefKey.LOGIN_SITE_ADDRESS)
 
     fun removeLoginSiteAddress() {
-        remove(LOGIN_SITE_ADDRESS)
+        remove(DeletablePrefKey.LOGIN_SITE_ADDRESS)
     }
 
     fun setLoginUserBypassedJetpackRequired(bypassedLogin: Boolean = true) {
-        setBoolean(LOGIN_USER_BYPASSED_JETPACK_REQUIRED, bypassedLogin)
+        setBoolean(DeletablePrefKey.LOGIN_USER_BYPASSED_JETPACK_REQUIRED, bypassedLogin)
     }
 
     fun getLoginUserBypassedJetpackRequired() =
-        getBoolean(LOGIN_USER_BYPASSED_JETPACK_REQUIRED, false)
+        getBoolean(DeletablePrefKey.LOGIN_USER_BYPASSED_JETPACK_REQUIRED, false)
 
     fun removeLoginUserBypassedJetpackRequired() {
-        remove(LOGIN_USER_BYPASSED_JETPACK_REQUIRED)
+        remove(DeletablePrefKey.LOGIN_USER_BYPASSED_JETPACK_REQUIRED)
     }
 
     fun getDatabaseDowngraded() = getBoolean(DATABASE_DOWNGRADED, false)
@@ -508,20 +485,20 @@ object AppPrefs {
     }
 
     fun setSelectedOrderListTab(selectedOrderListTabPosition: Int) {
-        setInt(SELECTED_ORDER_LIST_TAB_POSITION, selectedOrderListTabPosition)
+        setInt(DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION, selectedOrderListTabPosition)
     }
 
     fun getSelectedOrderListTabPosition() =
-        getInt(SELECTED_ORDER_LIST_TAB_POSITION, -1)
+        getInt(DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION, -1)
 
-    fun setSelectedProductType(type: ProductType) = setString(SELECTED_PRODUCT_TYPE, type.value)
+    fun setSelectedProductType(type: ProductType) = setString(DeletablePrefKey.SELECTED_PRODUCT_TYPE, type.value)
 
-    fun getSelectedProductType(): String = getString(SELECTED_PRODUCT_TYPE, "")
+    fun getSelectedProductType(): String = getString(DeletablePrefKey.SELECTED_PRODUCT_TYPE, "")
 
     fun setSelectedProductIsVirtual(isVirtual: Boolean) =
-        setBoolean(SELECTED_PRODUCT_IS_VIRTUAL, isVirtual)
+        setBoolean(DeletablePrefKey.SELECTED_PRODUCT_IS_VIRTUAL, isVirtual)
 
-    fun isSelectedProductVirtual(): Boolean = getBoolean(SELECTED_PRODUCT_IS_VIRTUAL, false)
+    fun isSelectedProductVirtual(): Boolean = getBoolean(DeletablePrefKey.SELECTED_PRODUCT_IS_VIRTUAL, false)
 
     /**
      * Checks if the user has a saved order list tab position yet. If no position has been saved,
@@ -538,10 +515,10 @@ object AppPrefs {
     }
 
     fun getAppTheme(): ThemeOption =
-        ThemeOption.valueOf(getString(SELECTED_APP_THEME, DEFAULT.toString()))
+        ThemeOption.valueOf(getString(DeletablePrefKey.SELECTED_APP_THEME, DEFAULT.toString()))
 
     fun setAppTheme(theme: ThemeOption) {
-        setString(SELECTED_APP_THEME, theme.toString())
+        setString(DeletablePrefKey.SELECTED_APP_THEME, theme.toString())
     }
 
     /**
@@ -550,7 +527,7 @@ object AppPrefs {
      * events will be complete.
      */
     fun getUnifiedLoginLastSource(): String? {
-        val result = getString(UNIFIED_LOGIN_LAST_ACTIVE_SOURCE)
+        val result = getString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_SOURCE)
         return if (result.isNotEmpty()) {
             result
         } else {
@@ -559,7 +536,7 @@ object AppPrefs {
     }
 
     fun setUnifiedLoginLastSource(source: String) {
-        setString(UNIFIED_LOGIN_LAST_ACTIVE_SOURCE, source)
+        setString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_SOURCE, source)
     }
 
     /**
@@ -568,7 +545,7 @@ object AppPrefs {
      * events will be complete.
      */
     fun getUnifiedLoginLastFlow(): String? {
-        val result = getString(UNIFIED_LOGIN_LAST_ACTIVE_FLOW)
+        val result = getString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW)
         return if (result.isNotEmpty()) {
             result
         } else {
@@ -577,7 +554,7 @@ object AppPrefs {
     }
 
     fun setUnifiedLoginLastFlow(flow: String) {
-        setString(UNIFIED_LOGIN_LAST_ACTIVE_FLOW, flow)
+        setString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW, flow)
     }
 
     fun isCashOnDeliveryDisabledStateSkipped(
@@ -840,29 +817,29 @@ object AppPrefs {
             false
         )
 
-    fun getLocalNotificationWorkRequestId() = getString(PRE_LOGIN_NOTIFICATION_WORK_REQUEST)
+    fun getLocalNotificationWorkRequestId() = getString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_WORK_REQUEST)
 
     fun setLocalNotificationWorkRequestId(workRequestId: String) {
-        setString(PRE_LOGIN_NOTIFICATION_WORK_REQUEST, workRequestId)
+        setString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_WORK_REQUEST, workRequestId)
     }
 
-    fun getPreLoginNotificationDisplayedType() = getString(PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE)
+    fun getPreLoginNotificationDisplayedType() = getString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE)
 
     fun setPreLoginNotificationDisplayedType(notificationType: String) {
-        setString(PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE, notificationType)
+        setString(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED_TYPE, notificationType)
     }
 
     fun setPreLoginNotificationDisplayed(displayed: Boolean) {
-        setBoolean(PRE_LOGIN_NOTIFICATION_DISPLAYED, displayed)
+        setBoolean(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED, displayed)
     }
 
     fun isPreLoginNotificationBeenDisplayed(): Boolean =
-        getBoolean(PRE_LOGIN_NOTIFICATION_DISPLAYED, false)
+        getBoolean(DeletablePrefKey.PRE_LOGIN_NOTIFICATION_DISPLAYED, false)
 
-    fun getLoginEmail() = getString(LOGIN_EMAIL)
+    fun getLoginEmail() = getString(DeletablePrefKey.LOGIN_EMAIL)
 
     fun setLoginEmail(email: String) {
-        setString(LOGIN_EMAIL, email)
+        setString(DeletablePrefKey.LOGIN_EMAIL, email)
     }
 
     fun setOnboardingCarouselDisplayed(displayed: Boolean) {
@@ -895,14 +872,14 @@ object AppPrefs {
     )
 
     private fun getActiveStatsGranularityFilterKey(currentSiteId: Int) =
-        PrefKeyString("$ACTIVE_STATS_GRANULARITY:$currentSiteId")
+        PrefKeyString("${DeletablePrefKey.ACTIVE_STATS_GRANULARITY}:$currentSiteId")
 
     /**
      * Remove all user and site-related preferences.
      */
     fun resetUserPreferences() {
         val editor = getPreferences().edit()
-        values().forEach { a -> editor.remove(a.name) }
+        DeletablePrefKey.values().forEach { a -> editor.remove(a.name) }
         editor.remove(SelectedSite.SELECTED_SITE_LOCAL_ID)
         removePreferencesWithDynamicKey(editor)
         editor.apply()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -203,6 +203,13 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun hasOnboardingCarouselBeenDisplayed(): Boolean = AppPrefs.hasOnboardingCarouselBeenDisplayed()
 
+    fun setActiveStatsGranularity(currentSiteId: Int, statsGranularity: String) {
+        AppPrefs.setActiveStatsGranularity(currentSiteId, statsGranularity)
+    }
+
+    fun getActiveStatsGranularity(currentSiteId: Int) =
+        AppPrefs.getActiveStatsGranularity(currentSiteId)
+
     /**
      * Card Reader Upsell
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -119,12 +119,6 @@ class MyStoreViewModel @Inject constructor(
                 coroutineScope {
                     launch { loadStoreStats(granularity) }
                     launch { loadTopPerformersStats(granularity) }
-                    launch {
-                        appPrefsWrapper.setActiveStatsGranularity(
-                            selectedSite.getSelectedSiteId(),
-                            granularity.name
-                        )
-                    }
                 }
             }
         }
@@ -149,6 +143,9 @@ class MyStoreViewModel @Inject constructor(
         usageTracksEventEmitter.interacted()
         _activeStatsGranularity.update { granularity }
         savedState[ACTIVE_STATS_GRANULARITY_KEY] = granularity
+        launch {
+            appPrefsWrapper.setActiveStatsGranularity(selectedSite.getSelectedSiteId(), granularity.name)
+        }
     }
 
     fun onSwipeToRefresh() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -33,11 +33,11 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
@@ -95,10 +95,8 @@ class MyStoreViewModel @Inject constructor(
     val hasOrders: LiveData<OrderState> = _hasOrders
 
     private val refreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    private var _activeStatsGranularity = MutableStateFlow(
-        savedState.get<StatsGranularity>(ACTIVE_STATS_GRANULARITY_KEY) ?: getSelectedStatsGranularityIfAny()
-    )
 
+    private val _activeStatsGranularity = savedState.getStateFlow(viewModelScope, getSelectedStatsGranularityIfAny())
     val activeStatsGranularity = _activeStatsGranularity.asLiveData()
 
     @VisibleForTesting val refreshStoreStats = BooleanArray(StatsGranularity.values().size) { true }
@@ -142,7 +140,6 @@ class MyStoreViewModel @Inject constructor(
     fun onStatsGranularityChanged(granularity: StatsGranularity) {
         usageTracksEventEmitter.interacted()
         _activeStatsGranularity.update { granularity }
-        savedState[ACTIVE_STATS_GRANULARITY_KEY] = granularity
         launch {
             appPrefsWrapper.setActiveStatsGranularity(selectedSite.getSelectedSiteId(), granularity.name)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -77,7 +77,6 @@ class MyStoreViewModel @Inject constructor(
     private companion object {
         const val NUM_TOP_PERFORMERS = 5
         const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
-        const val ACTIVE_STATS_GRANULARITY_KEY = "active_stats_granularity_key"
     }
 
     val performanceObserver: LifecycleObserver = myStoreTransactionLauncher

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -34,7 +34,7 @@ import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class MyStoreViewModelTest : BaseUnitTest() {
-    private val savedState: SavedStateHandle = mock()
+    private val savedState = SavedStateHandle()
     private val networkStatus: NetworkStatus = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val wooCommerceStore: WooCommerceStore = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.flow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -201,6 +202,32 @@ class MyStoreViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.DASHBOARD_MAIN_STATS_LOADED,
                 mapOf(AnalyticsTracker.KEY_RANGE to "weeks")
             )
+        }
+
+    @Test
+    fun `Given stats loaded, when stats granularity changes, then selected option is saved into prefs`() =
+        testBlocking {
+            whenViewModelIsCreated()
+            givenNetworkConnectivity(connected = true)
+            givenStatsLoadingResult(GetStats.LoadStatsResult.RevenueStatsSuccess(null))
+
+            sut.onStatsGranularityChanged(ANY_SELECTED_STATS_GRANULARITY)
+
+            verify(appPrefsWrapper).setActiveStatsGranularity(
+                0,
+                ANY_SELECTED_STATS_GRANULARITY.name
+            )
+        }
+
+    @Test
+    fun `Given stats granularity previously selected, when view model is created, stats are retrieved from prefs`() =
+        testBlocking {
+            whenever(appPrefsWrapper.getActiveStatsGranularity(anyInt()))
+                .thenReturn(ANY_SELECTED_STATS_GRANULARITY.name)
+
+            whenViewModelIsCreated()
+
+            verify(appPrefsWrapper).getActiveStatsGranularity(anyInt())
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6617 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Save the selected tab stats granularity to avoid unnecessary request. This will also enable us to see what is the most used stats granularity

### Testing instructions
- Login into the app
- Select a different tab than DAYS and kill the app
- Open the app again and check your last selected tab is selected
- Repeat the same test but changing between 2 different sites

### Images/gif

https://user-images.githubusercontent.com/2663464/187426349-0d6c8479-baac-452a-851b-55c405da2b62.mp4

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
