### PR TITLE
[Login] extract the account mismatch view to a separate screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 -----
 - [*] SitePicker: Reduces Jetpack timeout loading times and shows new error dialog  [https://github.com/woocommerce/woocommerce-android/pull/7271
 - [*] My store stats: Save selected stats granularity in My store tab between app session and site switching [https://github.com/woocommerce/woocommerce-android/pull/7304
+- [*] [Internal] extract the account mismatch error to a standalone screen [https://github.com/woocommerce/woocommerce-android/pull/7311]
 
 10.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -1,0 +1,54 @@
+package com.woocommerce.android.ui.login
+
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.SITE_PICKER
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.AccountAction.SIGN_OUT
+import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+class AccountRepository @Inject constructor(
+    private val accountStore: AccountStore,
+    private val dispatcher: Dispatcher
+) {
+    fun getUserAccount() = accountStore.account
+
+    fun isUserLoggedIn() = accountStore.hasAccessToken()
+
+    suspend fun logout(): Boolean = suspendCancellableCoroutine { continuation ->
+        val listener = object : Any() {
+            @Suppress("unused")
+            @Subscribe(threadMode = MAIN)
+            fun onAccountChanged(event: OnAccountChanged) {
+                if (event.causeOfChange == SIGN_OUT) {
+                    dispatcher.unregister(this)
+                    if (!continuation.isActive) return
+
+                    if (event.isError) {
+                        WooLog.e(
+                            SITE_PICKER,
+                            "Account error [type = ${event.causeOfChange}] : " +
+                                "${event.error.type} > ${event.error.message}"
+                        )
+                        continuation.resume(false)
+                    } else if (!isUserLoggedIn()) {
+                        continuation.resume(true)
+                    }
+                }
+            }
+        }
+        dispatcher.dispatch(AccountActionBuilder.newSignOutAction())
+        dispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction())
+
+        continuation.invokeOnCancellation {
+            dispatcher.unregister(listener)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -1,12 +1,12 @@
 package com.woocommerce.android.ui.login.accountmismatch
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
@@ -14,10 +14,13 @@ import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToHelpScreen
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToSiteAddressEvent
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.login.LoginMode
 
 @AndroidEntryPoint
 class AccountMismatchErrorFragment : BaseFragment() {
@@ -53,7 +56,16 @@ class AccountMismatchErrorFragment : BaseFragment() {
                     AccountMismatchErrorFragmentDirections
                         .actionAccountMismatchErrorFragmentToSitePickerSiteDiscoveryFragment()
                 )
+                is Logout -> onLogout()
             }
         }
+    }
+
+    private fun onLogout() {
+        val intent = Intent(context, LoginActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            LoginMode.WOO_LOGIN_MODE.putInto(this)
+        }
+        startActivity(intent)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -8,18 +8,51 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.support.HelpActivity
+import com.woocommerce.android.support.HelpActivity.Origin
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToHelpScreen
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToSiteAddressEvent
+import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class AccountMismatchErrorFragment : Fragment() {
+class AccountMismatchErrorFragment : BaseFragment() {
     private val viewModel: AccountMismatchErrorViewModel by viewModels()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
             setContent {
-                AccountMismatchErrorScreen()
+                WooThemeWithBackground {
+                    AccountMismatchErrorScreen(viewModel)
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is NavigateToHelpScreen -> {
+                    startActivity(HelpActivity.createIntent(requireContext(), Origin.LOGIN_SITE_ADDRESS, null))
+                }
+                is NavigateToSiteAddressEvent -> findNavController().navigateSafely(
+                    AccountMismatchErrorFragmentDirections
+                        .actionAccountMismatchErrorFragmentToSitePickerSiteDiscoveryFragment()
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -11,10 +11,12 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.support.HelpActivity
-import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
+import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
+import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment.Listener
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToEmailHelpDialogEvent
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToHelpScreen
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToSiteAddressEvent
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -23,7 +25,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.login.LoginMode
 
 @AndroidEntryPoint
-class AccountMismatchErrorFragment : BaseFragment() {
+class AccountMismatchErrorFragment : BaseFragment(), Listener {
     private val viewModel: AccountMismatchErrorViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
@@ -50,7 +52,18 @@ class AccountMismatchErrorFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is NavigateToHelpScreen -> {
-                    startActivity(HelpActivity.createIntent(requireContext(), Origin.LOGIN_SITE_ADDRESS, null))
+                    startActivity(
+                        HelpActivity.createIntent(
+                            context = requireContext(),
+                            origin = HelpActivity.Origin.LOGIN_SITE_ADDRESS,
+                            extraSupportTags = null
+                        )
+                    )
+                }
+                is NavigateToEmailHelpDialogEvent -> {
+                    LoginEmailHelpDialogFragment.newInstance(this).also {
+                        it.show(parentFragmentManager, LoginEmailHelpDialogFragment.TAG)
+                    }
                 }
                 is NavigateToSiteAddressEvent -> findNavController().navigateSafely(
                     AccountMismatchErrorFragmentDirections
@@ -67,5 +80,15 @@ class AccountMismatchErrorFragment : BaseFragment() {
             LoginMode.WOO_LOGIN_MODE.putInto(this)
         }
         startActivity(intent)
+    }
+
+    override fun onEmailNeedMoreHelpClicked() {
+        startActivity(
+            HelpActivity.createIntent(
+                context = requireContext(),
+                origin = HelpActivity.Origin.LOGIN_CONNECTED_EMAIL_HELP,
+                extraSupportTags = null
+            )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorView
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToHelpScreen
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToSiteAddressEvent
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.login.LoginMode
@@ -70,6 +71,7 @@ class AccountMismatchErrorFragment : BaseFragment(), Listener {
                         .actionAccountMismatchErrorFragmentToSitePickerSiteDiscoveryFragment()
                 )
                 is Logout -> onLogout()
+                is Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.login.accountmismatch
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AccountMismatchErrorFragment : Fragment() {
+    private val viewModel: AccountMismatchErrorViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                AccountMismatchErrorScreen()
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -1,8 +1,212 @@
 package com.woocommerce.android.ui.login.accountmismatch
 
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest.Builder
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
-fun AccountMismatchErrorScreen() {
-    TODO("Not yet implemented")
+fun AccountMismatchErrorScreen(viewModel: AccountMismatchErrorViewModel) {
+    viewModel.viewState.observeAsState().value?.let { viewState ->
+        Scaffold(topBar = {
+            TopAppBar(
+                backgroundColor = MaterialTheme.colors.surface,
+                title = { Text(stringResource(id = R.string.login_site_picker_enter_site_address)) },
+                actions = {
+                    IconButton(onClick = { TODO() }) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_help_24dp),
+                            contentDescription = stringResource(id = R.string.help)
+                        )
+                    }
+                },
+                elevation = 0.dp
+            )
+        }) { paddingValues ->
+            AccountMismatchErrorScreen(viewState = viewState, modifier = Modifier.padding(paddingValues))
+        }
+    }
+}
+
+@Composable
+fun AccountMismatchErrorScreen(viewState: AccountMismatchErrorViewModel.ViewState, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(dimensionResource(id = R.dimen.major_100)),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+    ) {
+        MainContent(
+            viewState = viewState,
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+        )
+
+        ButtonBar(
+            primaryButtonText = stringResource(id = viewState.primaryButtonText),
+            primaryButtonClick = viewState.primaryButtonAction,
+            secondaryButtonText = stringResource(id = viewState.secondaryButtonText),
+            secondaryButtonClick = viewState.secondaryButtonAction,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun MainContent(
+    viewState: AccountMismatchErrorViewModel.ViewState,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+    ) {
+        UserInfo(
+            avatarUrl = viewState.avatarUrl,
+            displayName = viewState.displayName,
+            username = viewState.username
+        )
+
+        Image(
+            painter = painterResource(id = R.drawable.img_woo_no_stores),
+            contentDescription = null,
+            modifier = Modifier
+                .padding(dimensionResource(id = R.dimen.major_100))
+                .weight(1f, fill = false)
+        )
+        Text(
+            text = stringResource(id = R.string.login_not_connected_to_account, viewState.siteUrl),
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        WCTextButton(onClick = viewState.inlineButtonAction) {
+            Text(text = stringResource(id = viewState.inlineButtonText))
+        }
+    }
+}
+
+@Composable
+private fun UserInfo(avatarUrl: String, displayName: String, username: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AsyncImage(
+            model = Builder(LocalContext.current)
+                .data(avatarUrl)
+                .crossfade(true)
+                .build(),
+            placeholder = painterResource(R.drawable.img_gravatar_placeholder),
+            error = painterResource(R.drawable.img_gravatar_placeholder),
+            contentDescription = stringResource(R.string.login_avatar_content_description),
+            contentScale = ContentScale.FillWidth,
+            modifier = Modifier
+                .size(dimensionResource(R.dimen.image_major_72))
+                .clip(CircleShape)
+        )
+
+        Text(
+            text = displayName,
+            style = MaterialTheme.typography.h5,
+            color = colorResource(id = R.color.color_on_surface_high)
+        )
+        Text(
+            text = username,
+            style = MaterialTheme.typography.body1
+        )
+    }
+}
+
+@Composable
+private fun ButtonBar(
+    primaryButtonText: String,
+    primaryButtonClick: () -> Unit,
+    secondaryButtonText: String,
+    secondaryButtonClick: () -> Unit,
+    modifier: Modifier
+) {
+    val configuration = LocalConfiguration.current
+    when (configuration.orientation) {
+        Configuration.ORIENTATION_LANDSCAPE -> Row(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+        ) {
+            WCColoredButton(onClick = primaryButtonClick, modifier = Modifier.weight(1f)) {
+                Text(text = primaryButtonText)
+            }
+            WCOutlinedButton(onClick = secondaryButtonClick, modifier = Modifier.weight(1f)) {
+                Text(text = secondaryButtonText)
+            }
+        }
+        else -> Column(modifier = modifier) {
+            WCColoredButton(onClick = primaryButtonClick, modifier = Modifier.fillMaxWidth()) {
+                Text(text = primaryButtonText)
+            }
+            WCOutlinedButton(onClick = secondaryButtonClick, modifier = Modifier.fillMaxWidth()) {
+                Text(text = secondaryButtonText)
+            }
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun AccountMismatchPreview() {
+    WooThemeWithBackground {
+        AccountMismatchErrorScreen(
+            viewState = AccountMismatchErrorViewModel.ViewState(
+                siteUrl = "url",
+                displayName = "displayname",
+                username = "username",
+                avatarUrl = "",
+                primaryButtonText = R.string.continue_button,
+                primaryButtonAction = {},
+                secondaryButtonText = R.string.continue_button,
+                secondaryButtonAction = {},
+                inlineButtonText = R.string.continue_button,
+                inlineButtonAction = {}
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -80,6 +80,7 @@ fun AccountMismatchErrorScreen(viewState: AccountMismatchErrorViewModel.ViewStat
             viewState = viewState,
             modifier = Modifier
                 .weight(1f)
+                .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
         )
 
@@ -167,26 +168,26 @@ private fun ButtonBar(
     secondaryButtonClick: () -> Unit,
     modifier: Modifier
 ) {
+    @Composable
+    fun Buttons(modifier: Modifier) {
+        WCColoredButton(onClick = primaryButtonClick, modifier = modifier) {
+            Text(text = primaryButtonText)
+        }
+        WCOutlinedButton(onClick = secondaryButtonClick, modifier = modifier) {
+            Text(text = secondaryButtonText)
+        }
+    }
+
     val configuration = LocalConfiguration.current
     when (configuration.orientation) {
         Configuration.ORIENTATION_LANDSCAPE -> Row(
             modifier = modifier,
             horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
         ) {
-            WCColoredButton(onClick = primaryButtonClick, modifier = Modifier.weight(1f)) {
-                Text(text = primaryButtonText)
-            }
-            WCOutlinedButton(onClick = secondaryButtonClick, modifier = Modifier.weight(1f)) {
-                Text(text = secondaryButtonText)
-            }
+            Buttons(modifier = Modifier.weight(1f))
         }
         else -> Column(modifier = modifier) {
-            WCColoredButton(onClick = primaryButtonClick, modifier = Modifier.fillMaxWidth()) {
-                Text(text = primaryButtonText)
-            }
-            WCOutlinedButton(onClick = secondaryButtonClick, modifier = Modifier.fillMaxWidth()) {
-                Text(text = secondaryButtonText)
-            }
+            Buttons(modifier = Modifier.fillMaxWidth())
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.login.accountmismatch
 
 import android.content.res.Configuration
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,9 +50,9 @@ fun AccountMismatchErrorScreen(viewModel: AccountMismatchErrorViewModel) {
         Scaffold(topBar = {
             TopAppBar(
                 backgroundColor = MaterialTheme.colors.surface,
-                title = { Text(stringResource(id = R.string.login_site_picker_enter_site_address)) },
+                title = { },
                 actions = {
-                    IconButton(onClick = { TODO() }) {
+                    IconButton(onClick = viewModel::onHelpButtonClick) {
                         Icon(
                             painter = painterResource(id = R.drawable.ic_help_24dp),
                             contentDescription = stringResource(id = R.string.help)
@@ -70,6 +71,7 @@ fun AccountMismatchErrorScreen(viewModel: AccountMismatchErrorViewModel) {
 fun AccountMismatchErrorScreen(viewState: AccountMismatchErrorViewModel.ViewState, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
+            .background(MaterialTheme.colors.surface)
             .fillMaxSize()
             .padding(dimensionResource(id = R.dimen.major_100)),
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -191,7 +191,6 @@ private fun ButtonBar(
     }
 }
 
-
 @Preview
 @Composable
 private fun AccountMismatchPreview() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.login.accountmismatch
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun AccountMismatchErrorScreen() {
+    TODO("Not yet implemented")
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -54,7 +54,6 @@ class AccountMismatchErrorViewModel @Inject constructor(
     }.asLiveData()
 
     private fun showConnectedStores() {
-        appPrefsWrapper.removeLoginSiteAddress()
         triggerEvent(Exit)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.login.AccountRepository
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.login.accountmismatch
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AccountMismatchErrorViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -1,12 +1,89 @@
 package com.woocommerce.android.ui.login.accountmismatch
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.R
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.flow
+import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
 
 @HiltViewModel
 class AccountMismatchErrorViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val accountStore: AccountStore,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: AccountMismatchErrorFragmentArgs by savedStateHandle.navArgs()
+    val viewState = flow {
+        val userInfo = accountStore.account
+
+        emit(
+            ViewState(
+                siteUrl = appPrefsWrapper.getLoginSiteAddress()!!,
+                avatarUrl = userInfo?.avatarUrl.orEmpty(),
+                username = userInfo?.userName.orEmpty(),
+                displayName = userInfo?.displayName.orEmpty(),
+                primaryButtonText = if (navArgs.hasConnectedStores) {
+                    R.string.login_view_connected_stores
+                } else {
+                    R.string.login_site_picker_try_another_address
+                },
+                primaryButtonAction = {
+                    if (navArgs.hasConnectedStores) {
+                        showConnectedStores()
+                    } else {
+                        navigateToSiteAddressScreen()
+                    }
+                },
+                secondaryButtonText = R.string.login_try_another_account,
+                secondaryButtonAction = { logout() },
+                inlineButtonText = R.string.login_need_help_finding_email,
+                inlineButtonAction = { helpFindingEmail() }
+            )
+        )
+    }.asLiveData()
+
+    private fun showConnectedStores() {
+        appPrefsWrapper.removeLoginSiteAddress()
+        triggerEvent(Exit)
+    }
+
+    private fun navigateToSiteAddressScreen() {
+        triggerEvent(NavigateToSiteAddressEvent)
+    }
+
+    private fun logout() {
+        TODO("Not yet implemented")
+    }
+
+    private fun helpFindingEmail() {
+        TODO("Not yet implemented")
+    }
+
+    fun onHelpButtonClick() {
+        triggerEvent(NavigateToHelpScreen)
+    }
+
+    data class ViewState(
+        val siteUrl: String,
+        val avatarUrl: String,
+        val displayName: String,
+        val username: String,
+        @StringRes val primaryButtonText: Int,
+        val primaryButtonAction: () -> Unit,
+        @StringRes val secondaryButtonText: Int,
+        val secondaryButtonAction: () -> Unit,
+        @StringRes val inlineButtonText: Int,
+        val inlineButtonAction: () -> Unit
+    )
+
+    object NavigateToHelpScreen : MultiLiveEvent.Event()
+    object NavigateToSiteAddressEvent : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
@@ -71,7 +72,7 @@ class AccountMismatchErrorViewModel @Inject constructor(
     }
 
     private fun helpFindingEmail() {
-        TODO("Not yet implemented")
+        triggerEvent(NavigateToEmailHelpDialogEvent)
     }
 
     fun onHelpButtonClick() {
@@ -93,4 +94,5 @@ class AccountMismatchErrorViewModel @Inject constructor(
 
     object NavigateToHelpScreen : MultiLiveEvent.Event()
     object NavigateToSiteAddressEvent : MultiLiveEvent.Event()
+    object NavigateToEmailHelpDialogEvent : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -5,24 +5,26 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.flow
-import org.wordpress.android.fluxc.store.AccountStore
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class AccountMismatchErrorViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val accountStore: AccountStore,
+    private val accountRepository: AccountRepository,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: AccountMismatchErrorFragmentArgs by savedStateHandle.navArgs()
     val viewState = flow {
-        val userInfo = accountStore.account
+        val userInfo = accountRepository.getUserAccount()
 
         emit(
             ViewState(
@@ -59,8 +61,13 @@ class AccountMismatchErrorViewModel @Inject constructor(
         triggerEvent(NavigateToSiteAddressEvent)
     }
 
-    private fun logout() {
-        TODO("Not yet implemented")
+    private fun logout() = launch {
+        accountRepository.logout().let {
+            if (it) {
+                appPrefsWrapper.removeLoginSiteAddress()
+                triggerEvent(Logout)
+            }
+        }
     }
 
     private fun helpFindingEmail() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenter.kt
@@ -6,11 +6,7 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
-import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
 import javax.inject.Inject

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAccountMismatchScreen
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToEmailHelpDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToHelpFragmentEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToMainActivityEvent
@@ -154,6 +155,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 is NavigateToSiteAddressEvent -> navigateToAddressScreen()
                 is NavigateToEmailHelpDialogEvent -> navigateToNeedHelpFindingEmailScreen()
                 is NavigateToWPComWebView -> navigateToWPComWebView(event)
+                is NavigateToAccountMismatchScreen -> navigateToAccountMismatchScreen(event.hasConnectedStores)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowDialog -> event.showDialog()
                 is Logout -> onLogout()
@@ -273,6 +275,12 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 urlToLoad = event.url,
                 urlToTriggerExit = event.validationUrl
             )
+        )
+    }
+
+    private fun navigateToAccountMismatchScreen(hasConnectedStores: Boolean) {
+        findNavController().navigateSafely(
+            SitePickerFragmentDirections.actionSitePickerFragmentToAccountMismatchErrorFragment(hasConnectedStores)
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -34,7 +34,6 @@ import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToSiteAddressEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.ShowWooUpgradeDialogEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.AccountMismatchState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.StoreListState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.WooNotFoundState
@@ -136,7 +135,6 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 when (it) {
                     StoreListState -> updateStoreListView()
                     NoStoreState -> updateNoStoresView()
-                    AccountMismatchState -> updateAccountMismatchView(new.hasConnectedStores == true)
                     WooNotFoundState -> updateWooNotFoundView()
                 }
             }
@@ -190,19 +188,6 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
         }
         binding.noStoresView.clickSecondaryAction {
             viewModel.onNewToWooClick()
-        }
-    }
-
-    private fun updateAccountMismatchView(hasConnectedStores: Boolean) {
-        binding.loginEpilogueButtonBar.buttonPrimary.setOnClickListener {
-            if (hasConnectedStores) {
-                viewModel.onViewConnectedStoresButtonClick()
-            } else {
-                viewModel.onEnterSiteAddressClick()
-            }
-        }
-        binding.noStoresView.clickSecondaryAction {
-            viewModel.onNeedHelpFindingEmailButtonClick()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerRepository.kt
@@ -6,15 +6,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.AccountAction
-import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAccountMismatchScreen
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitesListItem.Header
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitesListItem.NonWooSiteUiModel
@@ -263,17 +264,7 @@ class SitePickerViewModel @Inject constructor(
             )
         )
         trackLoginEvent(currentStep = UnifiedLoginTracker.Step.WRONG_WP_ACCOUNT)
-        sitePickerViewState = sitePickerViewState.copy(
-            isNoStoresViewVisible = true,
-            isPrimaryBtnVisible = sitePickerViewState.hasConnectedStores == true || !loginSiteAddress.isNullOrEmpty(),
-            primaryBtnText = resourceProvider.getString(
-                if (sitePickerViewState.hasConnectedStores == true) string.login_view_connected_stores
-                else string.login_site_picker_try_another_address
-            ),
-            noStoresLabelText = resourceProvider.getString(string.login_not_connected_to_account, url),
-            noStoresBtnText = resourceProvider.getString(string.login_need_help_finding_email),
-            currentSitePickerState = SitePickerState.AccountMismatchState
-        )
+        triggerEvent(NavigateToAccountMismatchScreen(sitePickerViewState.hasConnectedStores ?: false))
     }
 
     private fun loadWooNotFoundView(site: SiteModel) {
@@ -601,6 +592,7 @@ class SitePickerViewModel @Inject constructor(
         object NavigateToSiteAddressEvent : SitePickerEvent()
         data class NavigateToHelpFragmentEvent(val origin: HelpActivity.Origin) : SitePickerEvent()
         data class NavigateToWPComWebView(val url: String, val validationUrl: String) : SitePickerEvent()
+        data class NavigateToAccountMismatchScreen(val hasConnectedStores: Boolean) : SitePickerEvent()
     }
 
     enum class SitePickerState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -168,7 +168,7 @@ class SitePickerViewModel @Inject constructor(
         }
 
         if (filteredSites.isEmpty()) {
-            loginSiteAddress?.let { loadAccountMismatchView(it) } ?: loadNoStoreView()
+            loginSiteAddress?.let { showAccountMismatchScreen(it) } ?: loadNoStoreView()
             return
         }
 
@@ -225,7 +225,7 @@ class SitePickerViewModel @Inject constructor(
         when {
             site == null -> {
                 // The url doesn't match any sites for this account.
-                loadAccountMismatchView(url)
+                showAccountMismatchScreen(url)
             }
             !site.hasWooCommerce -> {
                 // Show not woo store message view.
@@ -257,7 +257,7 @@ class SitePickerViewModel @Inject constructor(
      * to a site that is not connected to the account the user logged
      * in with.
      */
-    private fun loadAccountMismatchView(url: String) {
+    private fun showAccountMismatchScreen(url: String) {
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SITE_PICKER_AUTO_LOGIN_ERROR_NOT_CONNECTED_TO_USER,
             mapOf(
@@ -600,6 +600,6 @@ class SitePickerViewModel @Inject constructor(
     }
 
     enum class SitePickerState {
-        StoreListState, NoStoreState, AccountMismatchState, WooNotFoundState
+        StoreListState, NoStoreState, WooNotFoundState
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.extensions.getSiteName
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAccountMismatchScreen
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
@@ -50,6 +51,7 @@ class SitePickerViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val selectedSite: SelectedSite,
     private val repository: SitePickerRepository,
+    private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val unifiedLoginTracker: UnifiedLoginTracker,
@@ -289,7 +291,7 @@ class SitePickerViewModel @Inject constructor(
         )
     }
 
-    private fun getUserInfo() = repository.getUserAccount().let {
+    private fun getUserInfo() = accountRepository.getUserAccount().let {
         UserInfo(displayName = it.displayName, username = it.userName ?: "", userAvatarUrl = it.avatarUrl)
     }
 
@@ -354,8 +356,8 @@ class SitePickerViewModel @Inject constructor(
     fun onTryAnotherAccountButtonClick() {
         trackLoginEvent(clickEvent = UnifiedLoginTracker.Click.TRY_ANOTHER_ACCOUNT)
         launch {
-            repository.logout().let {
-                if (!repository.isUserLoggedIn()) {
+            accountRepository.logout().let {
+                if (it) {
                     appPrefsWrapper.removeLoginSiteAddress()
                     triggerEvent(Logout)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -266,7 +266,9 @@ class SitePickerViewModel @Inject constructor(
             )
         )
         trackLoginEvent(currentStep = UnifiedLoginTracker.Step.WRONG_WP_ACCOUNT)
-        triggerEvent(NavigateToAccountMismatchScreen(sitePickerViewState.hasConnectedStores ?: false))
+        if (event.value !is NavigateToAccountMismatchScreen) {
+            triggerEvent(NavigateToAccountMismatchScreen(sitePickerViewState.hasConnectedStores ?: false))
+        }
     }
 
     private fun loadWooNotFoundView(site: SiteModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -39,6 +40,7 @@ import kotlin.text.RegexOption.IGNORE_CASE
 class SitePickerSiteDiscoveryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val sitePickRepository: SitePickerRepository,
+    private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
@@ -209,8 +211,8 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
 
     private fun logout() {
         launch {
-            sitePickRepository.logout().let {
-                if (it && sitePickRepository.isUserLoggedIn()) {
+            accountRepository.logout().let {
+                if (it) {
                     triggerEvent(Logout)
                 }
             }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -59,7 +59,7 @@
             app:enterAnim="@anim/activity_fade_in"
             app:exitAnim="@null"
             app:popEnterAnim="@null"
-            app:popExitAnim="@anim/activity_fade_out" >
+            app:popExitAnim="@anim/activity_fade_out">
             <argument
                 android:name="mode"
                 app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
@@ -173,7 +173,7 @@
             app:destination="@id/nav_graph_coupons" />
         <action
             android:id="@+id/action_moreMenu_to_paymentFlow"
-            app:destination="@id/paymentFlow" >
+            app:destination="@id/paymentFlow">
             <argument
                 android:name="cardReaderFlowParam"
                 app:argType="com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam"
@@ -359,7 +359,7 @@
     <dialog
         android:id="@+id/orderCreationBottomSheetFragment"
         android:name="com.woocommerce.android.ui.orders.list.OrderCreationBottomSheetFragment"
-        tools:layout="@layout/dialog_order_creation_bottom_sheet" >
+        tools:layout="@layout/dialog_order_creation_bottom_sheet">
         <action
             android:id="@+id/action_orderCreationBottomSheetFragment_to_simplePaymentsMovedBottomSheetFragment"
             app:destination="@id/simplePaymentsMovedBottomSheetFragment"
@@ -396,6 +396,13 @@
         <action
             android:id="@+id/action_sitePickerFragment_to_sitePickerSiteDiscoveryFragment"
             app:destination="@id/sitePickerSiteDiscoveryFragment" />
+        <action
+            android:id="@+id/action_sitePickerFragment_to_accountMismatchErrorFragment"
+            app:destination="@id/accountMismatchErrorFragment"
+            app:enterAnim="@anim/activity_fade_in"
+            app:exitAnim="@null"
+            app:popEnterAnim="@null"
+            app:popExitAnim="@anim/activity_fade_out" />
     </fragment>
     <fragment
         android:id="@+id/simpleTextEditorFragment"
@@ -423,4 +430,16 @@
         android:id="@+id/sitePickerSiteDiscoveryFragment"
         android:name="com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryFragment"
         android:label="SitePickerSiteDiscoveryFragment" />
+    <fragment
+        android:id="@+id/accountMismatchErrorFragment"
+        android:name="com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment"
+        android:label="AccountMismatchErrorFragment">
+        <argument
+            android:name="hasConnectedStores"
+            app:argType="boolean" />
+        <action
+            android:id="@+id/action_accountMismatchErrorFragment_to_sitePickerSiteDiscoveryFragment"
+            app:destination="@id/sitePickerSiteDiscoveryFragment"
+            app:popUpTo="@id/sitePickerFragment" />
+    </fragment>
 </navigation>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.prefs
 
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.payments.cardreader.ClearCardReaderDataAction
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,8 +18,6 @@ import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
-import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
 import kotlin.test.assertEquals
 
@@ -27,7 +26,7 @@ class AppSettingsPresenterTest : BaseUnitTest() {
     private val appSettingsContractView: AppSettingsContract.View = mock()
 
     private val dispatcher: Dispatcher = mock()
-    private val accountStore: AccountStore = mock()
+    private val accountRepository: AccountRepository = mock()
     private val clearCardReaderDataAction: ClearCardReaderDataAction = mock()
 
     private lateinit var appSettingsPresenter: AppSettingsPresenter
@@ -38,7 +37,7 @@ class AppSettingsPresenterTest : BaseUnitTest() {
     fun setup() {
         appSettingsPresenter = AppSettingsPresenter(
             dispatcher,
-            accountStore,
+            accountRepository,
             mock(),
             clearCardReaderDataAction
         )
@@ -48,7 +47,9 @@ class AppSettingsPresenterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Verifies that logging out from settings results in signing out and settings closing`() {
+    fun `Verifies that logging out from settings results in signing out and settings closing`() = testBlocking {
+        whenever(accountRepository.logout()).thenReturn(true)
+
         appSettingsPresenter.logout()
 
         // Logging out should first trigger device unregistration for push notifications
@@ -58,16 +59,10 @@ class AppSettingsPresenterTest : BaseUnitTest() {
         // Simulate device unregistered for push notifications
         appSettingsPresenter.onDeviceUnregistered(OnDeviceUnregistered())
 
-        // Unregistration should trigger both an account signout and stored WordPress.com site removal
-        actionCaptor = argumentCaptor()
-        verify(dispatcher, times(3)).dispatch(actionCaptor.capture())
-        assertEquals(AccountAction.SIGN_OUT, actionCaptor.secondValue.type)
-        assertEquals(SiteAction.REMOVE_WPCOM_AND_JETPACK_SITES, actionCaptor.thirdValue.type)
+        // Unregistration should trigger logout
+        verify(accountRepository).logout()
 
-        // Simulate access token cleared, and the resulting OnAuthenticationChanged
-        doReturn(false).whenever(accountStore).hasAccessToken()
-        appSettingsPresenter.onAuthenticationChanged(OnAuthenticationChanged())
-
+        // Check UI
         verify(appSettingsContractView).finishLogout()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -8,15 +8,12 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.NotificationAction
-import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
 import kotlin.test.assertEquals


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7307 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This is the first step in implementing the account mismatch improvements, the extraction here will allow us two points:
1. It will make adding functionality to the account mismatch screen easier.
2. It will allow reusing the screen to fix the bug #7299.

But this turned out to be bigger than I expected 🤷.

### Testing instructions
1. Open the app and use "Enter site address" for login.
2. Enter the address of a Jetpack site that's connected to a different account.
4. Continue signing.
5. Notice the account mismatch error: if your account has other sites, it will show "View connected stores", otherwise it will show "Try another address" 

### Images/gif
|  |  |
| - | - |
| <img src="https://user-images.githubusercontent.com/1657201/187700713-3a371d2a-e290-428b-afcf-93239caf1eee.png"/> | <img src="https://user-images.githubusercontent.com/1657201/187703169-95aba5a8-f4d5-4c6a-b6a8-83bf6bbec147.png"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
