### PR TITLE
Login: Use the new Login help webpage when opening it from "Enter Email Address" login screen.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android
 
-import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
+import com.woocommerce.android.support.HelpActivity.Origin.LOGIN_SITE_ADDRESS
 
 object AppUrls {
     const val APP_HELP_CENTER = "https://docs.woocommerce.com/document/android/"
@@ -74,6 +74,6 @@ object AppUrls {
 
     const val LOGIN_HELP_CENTER_MAIN_URL = "https://woocommerce.com/document/android-ios-apps-login-help-faq/"
     val LOGIN_HELP_CENTER_URLS = mapOf(
-        ENTER_SITE_ADDRESS to "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"
+        LOGIN_SITE_ADDRESS to "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android
 
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_EMAIL_ADDRESS
+
 object AppUrls {
     const val APP_HELP_CENTER = "https://docs.woocommerce.com/document/android/"
     const val APP_FEATURE_REQUEST = "http://ideas.woocommerce.com/forums/133476-woocommerce?category_id=84283"
@@ -69,4 +71,8 @@ object AppUrls {
         "https://woocommerce.com/document/what-is-a-wordpress-com-account/"
 
     const val NEW_TO_WOO_DOC = "https://woocommerce.com/document/woocommerce-features"
+
+    val LOGIN_HELP_CENTER_URLS = mapOf(
+        ENTER_EMAIL_ADDRESS to "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -72,6 +72,7 @@ object AppUrls {
 
     const val NEW_TO_WOO_DOC = "https://woocommerce.com/document/woocommerce-features"
 
+    const val LOGIN_HELP_CENTER_MAIN_URL = "https://woocommerce.com/document/android-ios-apps-login-help-faq/"
     val LOGIN_HELP_CENTER_URLS = mapOf(
         ENTER_EMAIL_ADDRESS to "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -74,6 +74,6 @@ object AppUrls {
 
     const val LOGIN_HELP_CENTER_MAIN_URL = "https://woocommerce.com/document/android-ios-apps-login-help-faq/"
     val LOGIN_HELP_CENTER_URLS = mapOf(
-        LOGIN_SITE_ADDRESS to "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"
+        LOGIN_SITE_ADDRESS to "$LOGIN_HELP_CENTER_MAIN_URL#enter-store-address"
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android
 
-import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_EMAIL_ADDRESS
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
 
 object AppUrls {
     const val APP_HELP_CENTER = "https://docs.woocommerce.com/document/android/"
@@ -74,6 +74,6 @@ object AppUrls {
 
     const val LOGIN_HELP_CENTER_MAIN_URL = "https://woocommerce.com/document/android-ios-apps-login-help-faq/"
     val LOGIN_HELP_CENTER_URLS = mapOf(
-        ENTER_EMAIL_ADDRESS to "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"
+        ENTER_SITE_ADDRESS to "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -384,6 +384,11 @@ class AnalyticsTracker private constructor(private val context: Context) {
         // -- Experiments
         const val KEY_EXPERIMENT_VARIANT = "experiment_variant"
 
+        // -- Help Center
+        const val KEY_SOURCE_FLOW = "source_flow"
+        const val KEY_SOURCE_STEP = "source_step"
+        const val KEY_HELP_CONTENT_URL = "help_content_url"
+
         var sendUsageStats: Boolean = true
             set(value) {
                 if (value != field) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -65,7 +65,7 @@ class HelpActivity : AppCompatActivity() {
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener {
             if (loginStepFromExtras != null && loginFlowFromExtras != null) {
-                showLoginHelpCenter(loginStepFromExtras!!, loginFlowFromExtras!!)
+                showLoginHelpCenter(originFromExtras, loginStepFromExtras!!, loginFlowFromExtras!!)
             } else {
                 showZendeskFaq()
             }
@@ -183,8 +183,8 @@ class HelpActivity : AppCompatActivity() {
         zendeskHelper.showAllTickets(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)
     }
 
-    private fun showLoginHelpCenter(loginStepFromExtras: Step, loginFlowFromExtras: Flow) {
-        val helpCenterUrl = AppUrls.LOGIN_HELP_CENTER_URLS[loginStepFromExtras] ?: AppUrls.LOGIN_HELP_CENTER_MAIN_URL
+    private fun showLoginHelpCenter(originFromExtras: Origin, loginStepFromExtras: Step, loginFlowFromExtras: Flow) {
+        val helpCenterUrl = AppUrls.LOGIN_HELP_CENTER_URLS[originFromExtras] ?: AppUrls.LOGIN_HELP_CENTER_MAIN_URL
         ChromeCustomTabUtils.launchUrl(this, helpCenterUrl)
 
         AnalyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -17,8 +17,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_S
 import com.woocommerce.android.databinding.ActivityHelpBinding
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
-import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
@@ -47,9 +45,6 @@ class HelpActivity : AppCompatActivity() {
         intent.extras?.getStringArrayList(EXTRA_TAGS_KEY)
     }
 
-    private val loginStepFromExtras by lazy { intent.extras?.get(LOGIN_STEP_KEY) as Step? }
-    private val loginFlowFromExtras by lazy { intent.extras?.get(LOGIN_FLOW_KEY) as Flow? }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -64,8 +59,11 @@ class HelpActivity : AppCompatActivity() {
         binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.General) }
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener {
-            if (loginStepFromExtras != null && loginFlowFromExtras != null) {
-                showLoginHelpCenter(originFromExtras, loginStepFromExtras!!, loginFlowFromExtras!!)
+            val step = intent.extras?.getString(LOGIN_STEP_KEY)
+            val flow = intent.extras?.getString(LOGIN_FLOW_KEY)
+
+            if (step != null && flow != null) {
+                showLoginHelpCenter(originFromExtras, step, flow)
             } else {
                 showZendeskFaq()
             }
@@ -183,7 +181,7 @@ class HelpActivity : AppCompatActivity() {
         zendeskHelper.showAllTickets(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)
     }
 
-    private fun showLoginHelpCenter(originFromExtras: Origin, loginStepFromExtras: Step, loginFlowFromExtras: Flow) {
+    private fun showLoginHelpCenter(originFromExtras: Origin, loginStepFromExtras: String, loginFlowFromExtras: String) {
         val helpCenterUrl = AppUrls.LOGIN_HELP_CENTER_URLS[originFromExtras] ?: AppUrls.LOGIN_HELP_CENTER_MAIN_URL
         ChromeCustomTabUtils.launchUrl(this, helpCenterUrl)
 
@@ -255,8 +253,8 @@ class HelpActivity : AppCompatActivity() {
             context: Context,
             origin: Origin,
             extraSupportTags: List<String>?,
-            step: Step? = null,
-            flow: Flow? = null
+            step: String? = null,
+            flow: String? = null
         ): Intent {
             val intent = Intent(context, HelpActivity::class.java)
             intent.putExtra(ORIGIN_KEY, origin)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -245,8 +245,8 @@ class HelpActivity : AppCompatActivity() {
     companion object {
         private const val ORIGIN_KEY = "ORIGIN_KEY"
         private const val EXTRA_TAGS_KEY = "EXTRA_TAGS_KEY"
-        private const val LOGIN_STEP_KEY = "LOGIN_STEP_KEY"
         private const val LOGIN_FLOW_KEY = "LOGIN_FLOW_KEY"
+        private const val LOGIN_STEP_KEY = "LOGIN_STEP_KEY"
 
         @JvmStatic
         fun createIntent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -59,11 +59,11 @@ class HelpActivity : AppCompatActivity() {
         binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.General) }
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener {
-            val step = intent.extras?.getString(LOGIN_STEP_KEY)
-            val flow = intent.extras?.getString(LOGIN_FLOW_KEY)
+            val loginFlow = intent.extras?.getString(LOGIN_FLOW_KEY)
+            val loginStep = intent.extras?.getString(LOGIN_STEP_KEY)
 
-            if (step != null && flow != null) {
-                showLoginHelpCenter(originFromExtras, step, flow)
+            if (loginFlow != null && loginStep != null) {
+                showLoginHelpCenter(originFromExtras, loginFlow, loginStep)
             } else {
                 showZendeskFaq()
             }
@@ -181,13 +181,13 @@ class HelpActivity : AppCompatActivity() {
         zendeskHelper.showAllTickets(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)
     }
 
-    private fun showLoginHelpCenter(originFromExtras: Origin, loginStepFromExtras: String, loginFlowFromExtras: String) {
+    private fun showLoginHelpCenter(originFromExtras: Origin, loginFlow: String, loginStep: String) {
         val helpCenterUrl = AppUrls.LOGIN_HELP_CENTER_URLS[originFromExtras] ?: AppUrls.LOGIN_HELP_CENTER_MAIN_URL
         AnalyticsTracker.track(
             stat = AnalyticsEvent.SUPPORT_HELP_CENTER_VIEWED,
             properties = mapOf(
-                KEY_SOURCE_FLOW to loginFlowFromExtras,
-                KEY_SOURCE_STEP to loginStepFromExtras,
+                KEY_SOURCE_FLOW to loginFlow,
+                KEY_SOURCE_STEP to loginStep,
                 KEY_HELP_CONTENT_URL to helpCenterUrl
             )
         )
@@ -253,8 +253,8 @@ class HelpActivity : AppCompatActivity() {
             context: Context,
             origin: Origin,
             extraSupportTags: List<String>?,
-            step: String? = null,
-            flow: String? = null
+            loginFlow: String? = null,
+            loginStep: String? = null
         ): Intent {
             val intent = Intent(context, HelpActivity::class.java)
             intent.putExtra(ORIGIN_KEY, origin)
@@ -262,8 +262,8 @@ class HelpActivity : AppCompatActivity() {
                 intent.putStringArrayListExtra(EXTRA_TAGS_KEY, extraSupportTags as ArrayList<String>?)
             }
 
-            if (step != null) intent.putExtra(LOGIN_STEP_KEY, step)
-            if (flow != null) intent.putExtra(LOGIN_FLOW_KEY, flow)
+            if (loginFlow != null) intent.putExtra(LOGIN_FLOW_KEY, loginFlow)
+            if (loginStep != null) intent.putExtra(LOGIN_STEP_KEY, loginStep)
 
             return intent
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -15,6 +15,8 @@ import com.woocommerce.android.databinding.ActivityHelpBinding
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
@@ -224,7 +226,9 @@ class HelpActivity : AppCompatActivity() {
         fun createIntent(
             context: Context,
             origin: Origin,
-            extraSupportTags: List<String>?
+            extraSupportTags: List<String>?,
+            step: Step? = null,
+            flow: Flow? = null
         ): Intent {
             val intent = Intent(context, HelpActivity::class.java)
             intent.putExtra(ORIGIN_KEY, origin)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -183,8 +183,6 @@ class HelpActivity : AppCompatActivity() {
 
     private fun showLoginHelpCenter(originFromExtras: Origin, loginStepFromExtras: String, loginFlowFromExtras: String) {
         val helpCenterUrl = AppUrls.LOGIN_HELP_CENTER_URLS[originFromExtras] ?: AppUrls.LOGIN_HELP_CENTER_MAIN_URL
-        ChromeCustomTabUtils.launchUrl(this, helpCenterUrl)
-
         AnalyticsTracker.track(
             stat = AnalyticsEvent.SUPPORT_HELP_CENTER_VIEWED,
             properties = mapOf(
@@ -193,6 +191,8 @@ class HelpActivity : AppCompatActivity() {
                 KEY_HELP_CONTENT_URL to helpCenterUrl
             )
         )
+
+        ChromeCustomTabUtils.launchUrl(this, helpCenterUrl)
     }
 
     private fun showZendeskFaq() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -181,8 +181,8 @@ class HelpActivity : AppCompatActivity() {
         zendeskHelper.showAllTickets(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)
     }
 
-    private fun showLoginHelpCenter(originFromExtras: Origin, loginFlow: String, loginStep: String) {
-        val helpCenterUrl = AppUrls.LOGIN_HELP_CENTER_URLS[originFromExtras] ?: AppUrls.LOGIN_HELP_CENTER_MAIN_URL
+    private fun showLoginHelpCenter(origin: Origin, loginFlow: String, loginStep: String) {
+        val helpCenterUrl = AppUrls.LOGIN_HELP_CENTER_URLS[origin] ?: AppUrls.APP_HELP_CENTER
         AnalyticsTracker.track(
             stat = AnalyticsEvent.SUPPORT_HELP_CENTER_VIEWED,
             properties = mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HELP_CONTENT_URL
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_STEP
 import com.woocommerce.android.databinding.ActivityHelpBinding
@@ -46,8 +47,8 @@ class HelpActivity : AppCompatActivity() {
         intent.extras?.getStringArrayList(EXTRA_TAGS_KEY)
     }
 
-    private val loginStepFromExtras by lazy { intent.extras?.getString(LOGIN_STEP_KEY) }
-    private val loginFlowFromExtras by lazy { intent.extras?.getString(LOGIN_FLOW_KEY) }
+    private val loginStepFromExtras by lazy { intent.extras?.get(LOGIN_STEP_KEY) as Step? }
+    private val loginFlowFromExtras by lazy { intent.extras?.get(LOGIN_FLOW_KEY) as Flow? }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -182,12 +183,16 @@ class HelpActivity : AppCompatActivity() {
         zendeskHelper.showAllTickets(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)
     }
 
-    private fun showLoginHelpCenter(loginStepFromExtras: String, loginFlowFromExtras: String) {
+    private fun showLoginHelpCenter(loginStepFromExtras: Step, loginFlowFromExtras: Flow) {
+        val helpCenterUrl = AppUrls.LOGIN_HELP_CENTER_URLS[loginStepFromExtras] ?: AppUrls.LOGIN_HELP_CENTER_MAIN_URL
+        ChromeCustomTabUtils.launchUrl(this, helpCenterUrl)
+
         AnalyticsTracker.track(
             stat = AnalyticsEvent.SUPPORT_HELP_CENTER_VIEWED,
             properties = mapOf(
                 KEY_SOURCE_FLOW to loginFlowFromExtras,
-                KEY_SOURCE_STEP to loginStepFromExtras
+                KEY_SOURCE_STEP to loginStepFromExtras,
+                KEY_HELP_CONTENT_URL to helpCenterUrl
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -652,7 +652,7 @@ class LoginActivity :
     }
 
     override fun helpSiteAddress(url: String?) {
-        viewHelpAndSupport(origin = Origin.LOGIN_SITE_ADDRESS)
+        viewHelpAndSupport(Origin.LOGIN_SITE_ADDRESS)
     }
 
     override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -41,7 +41,6 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow.LOGIN_SITE_ADDRESS
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Source
-import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
 import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType
 import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.DEFAULT_HELP

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -645,7 +645,7 @@ class LoginActivity :
 
     private fun viewHelpAndSupport(origin: Origin, flow: Flow? = null, step: Step? = null) {
         val extraSupportTags = arrayListOf(ZendeskExtraTags.connectingJetpack)
-        startActivity(HelpActivity.createIntent(this, origin, extraSupportTags))
+        startActivity(HelpActivity.createIntent(this, origin, extraSupportTags, step, flow))
     }
 
     override fun helpSiteAddress(url: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -643,17 +643,16 @@ class LoginActivity :
         // TODO: Support self-signed SSL sites and show dialog (only needed when XML-RPC support is added)
     }
 
-    private fun viewHelpAndSupport(origin: Origin, flow: Flow? = null, step: Step? = null) {
+    private fun viewHelpAndSupport(origin: Origin) {
         val extraSupportTags = arrayListOf(ZendeskExtraTags.connectingJetpack)
+        val flow = unifiedLoginTracker.getFlow()
+        val step = unifiedLoginTracker.previousStepBeforeHelpStep
+
         startActivity(HelpActivity.createIntent(this, origin, extraSupportTags, flow?.value, step?.value))
     }
 
     override fun helpSiteAddress(url: String?) {
-        viewHelpAndSupport(
-            origin = Origin.LOGIN_SITE_ADDRESS,
-            flow = unifiedLoginTracker.getFlow(),
-            step = unifiedLoginTracker.previousStepBeforeHelpStep
-        )
+        viewHelpAndSupport(origin = Origin.LOGIN_SITE_ADDRESS)
     }
 
     override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -654,7 +654,6 @@ class LoginActivity :
             flow = unifiedLoginTracker.getFlow(),
             step = unifiedLoginTracker.previousStepBeforeHelpStep
         )
-
     }
 
     override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow.LOGIN_SITE_ADDRESS
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Source
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
 import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType
 import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.DEFAULT_HELP
@@ -642,7 +643,7 @@ class LoginActivity :
         // TODO: Support self-signed SSL sites and show dialog (only needed when XML-RPC support is added)
     }
 
-    private fun viewHelpAndSupport(origin: Origin) {
+    private fun viewHelpAndSupport(origin: Origin, flow: Flow? = null, step: Step? = null) {
         val extraSupportTags = arrayListOf(ZendeskExtraTags.connectingJetpack)
         startActivity(HelpActivity.createIntent(this, origin, extraSupportTags))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -649,7 +649,12 @@ class LoginActivity :
     }
 
     override fun helpSiteAddress(url: String?) {
-        viewHelpAndSupport(Origin.LOGIN_SITE_ADDRESS)
+        viewHelpAndSupport(
+            origin = Origin.LOGIN_SITE_ADDRESS,
+            flow = unifiedLoginTracker.getFlow(),
+            step = unifiedLoginTracker.previousStepBeforeHelpStep
+        )
+
     }
 
     override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -645,7 +645,7 @@ class LoginActivity :
 
     private fun viewHelpAndSupport(origin: Origin, flow: Flow? = null, step: Step? = null) {
         val extraSupportTags = arrayListOf(ZendeskExtraTags.connectingJetpack)
-        startActivity(HelpActivity.createIntent(this, origin, extraSupportTags, step, flow))
+        startActivity(HelpActivity.createIntent(this, origin, extraSupportTags, step?.value, flow?.value))
     }
 
     override fun helpSiteAddress(url: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -645,7 +645,7 @@ class LoginActivity :
 
     private fun viewHelpAndSupport(origin: Origin, flow: Flow? = null, step: Step? = null) {
         val extraSupportTags = arrayListOf(ZendeskExtraTags.connectingJetpack)
-        startActivity(HelpActivity.createIntent(this, origin, extraSupportTags, step?.value, flow?.value))
+        startActivity(HelpActivity.createIntent(this, origin, extraSupportTags, flow?.value, step?.value))
     }
 
     override fun helpSiteAddress(url: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -26,13 +26,22 @@ class UnifiedLoginTracker
     var currentStep: Step? = null
         private set
 
+    // Saves the previous step before going to the Help step.
+    // Used to offer specific login help page section depending on which login step
+    var previousStepBeforeHelpStep: Step? = null
+        private set
+
     @JvmOverloads
     fun track(
         flow: Flow? = currentFlow,
         step: Step
     ) {
         currentFlow = flow
+        if (step == Step.HELP) {
+            previousStepBeforeHelpStep = currentStep
+        }
         currentStep = step
+
         if (currentFlow != null && currentStep != null) {
             analyticsTracker.track(
                 stat = AnalyticsEvent.UNIFIED_LOGIN_STEP,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -27,7 +27,7 @@ class UnifiedLoginTracker
         private set
 
     // Saves the previous step before going to the Help step.
-    // Used to offer specific login help page section depending on which login step
+    // Used for tracking purposes on the Login Help Center feature.
     var previousStepBeforeHelpStep: Step? = null
         private set
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This allows merchants to see "Enter Email Address"-related help if they select "Help icon -> Help Center" from the "Enter Email Address" screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Start app in logged out state,
2. Select "Enter your store address",
3. Tap Help icon on top right,
4. Select "Help Center",
5. On the web page that's loaded, make sure it's the one that says "Enter Store Address" and "Where can I find my store address". The content should be the same as the one in https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address
6. Check tracking for: `🔵 Tracked: support_help_center_viewed, Properties: {"source_flow":"login_site_address","source_step":"start","help_content_url":"https:\/\/woocommerce.com\/document\/android-ios-apps-login-help-faq\/#enter-store-address","is_debug":true}`

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

The following help page should be shown:

<img src="https://user-images.githubusercontent.com/266376/187883430-f01bdc98-b64f-4909-bb51-e01bad1f10fd.png" width="42%" />
