### PR TITLE
Check the order exits before displaying the order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -198,7 +198,8 @@ class OrderDetailViewModel @Inject constructor(
             )
             isFetchingData = false
 
-            displayOrderDetails()
+            if (hasOrder()) displayOrderDetails()
+
             viewState = viewState.copy(
                 isOrderDetailSkeletonShown = false,
                 isRefreshing = false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -633,7 +633,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.fetchOrderById(ORDER_ID)).thenReturn(null)
         whenever(orderDetailRepository.getOrderById(ORDER_ID)).thenReturn(null)
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
-        doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
 
         var snackbar: ShowSnackbar? = null
         viewModel.event.observeForever {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -632,6 +632,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `Display error message on fetch order error`() = testBlocking {
         whenever(orderDetailRepository.fetchOrderById(ORDER_ID)).thenReturn(null)
         whenever(orderDetailRepository.getOrderById(ORDER_ID)).thenReturn(null)
+        doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
+        doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
 
         var snackbar: ShowSnackbar? = null
         viewModel.event.observeForever {
@@ -641,6 +643,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, times(1)).fetchOrderById(ORDER_ID)
+        verify(viewModel, never()).order
 
         assertThat(snackbar).isEqualTo(ShowSnackbar(string.order_error_fetch_generic))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7315 

### Description
While fetching an order in the order details screen, if the app doesn't have a local version of the order and the `orderDetailRepository.fetchOrderById(orderId)` returned `null`, the app crashes when trying to display the order. 
To fix this crash I've introduced a check before calling `displayOrderDetails()` within the `fetchOrder` function to ensure we only call this function when there is an order to display.

### Testing instructions
To reproduce the error you can change the `start()` function to always fetch the order data and, within the fetchOrderAsync() function, update the `fetchedOrder` to be always null. I have created a git patch with these changes. You can apply the following patch to reproduce the error on the `release/10.1` branch and test that in this branch, the app doesn't crash with the same patch.
<details>
  <summary>Patch</summary>

```
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
index ec78428880..c0b9eb5d46 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -161,11 +161,7 @@ class OrderDetailViewModel @Inject constructor(
 
     fun start() {
         launch {
-            orderDetailRepository.getOrderById(navArgs.orderId)?.let {
-                order = it
-                displayOrderDetails()
-                fetchOrder(showSkeleton = false)
-            } ?: fetchOrder(showSkeleton = true)
+            fetchOrder(showSkeleton = true)
         }
     }
 
@@ -564,10 +560,10 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchOrderAsync() = async {
-        val fetchedOrder = orderDetailRepository.fetchOrderById(navArgs.orderId)
+        val fetchedOrder = null
         orderDetailsTransactionLauncher.onOrderFetched()
         if (fetchedOrder != null) {
-            order = fetchedOrder
+            //order = fetchedOrder
             fetchOrderProducts()
         } else {
             triggerEvent(ShowSnackbar(string.order_error_fetch_generic))

```

</details>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
