### PR TITLE
Login: Open related Login help webpage section when opening it from "Jetpack Required" login screen.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android
 
+import com.woocommerce.android.support.HelpActivity.Origin.JETPACK_REQUIRED
 import com.woocommerce.android.support.HelpActivity.Origin.LOGIN_EMAIL
 import com.woocommerce.android.support.HelpActivity.Origin.LOGIN_SITE_ADDRESS
 import com.woocommerce.android.support.HelpActivity.Origin.LOGIN_USERNAME_PASSWORD
@@ -76,6 +77,7 @@ object AppUrls {
 
     private const val LOGIN_HELP_CENTER = "https://woocommerce.com/document/android-ios-apps-login-help-faq/"
     val LOGIN_HELP_CENTER_URLS = mapOf(
+        JETPACK_REQUIRED to "$LOGIN_HELP_CENTER#jetpack-required",
         LOGIN_EMAIL to "$LOGIN_HELP_CENTER#enter-wordpress-com-email-address-login-using-store-address-flow",
         LOGIN_SITE_ADDRESS to "$LOGIN_HELP_CENTER#enter-store-address",
         LOGIN_USERNAME_PASSWORD to "$LOGIN_HELP_CENTER#enter-store-credentials",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -235,7 +235,8 @@ class HelpActivity : AppCompatActivity() {
         SIGNUP_MAGIC_LINK("origin:signup-magic-link"),
         JETPACK_INSTALLATION("origin:jetpack-installation"),
         LOGIN_HELP_NOTIFICATION("origin:login-local-notification"),
-        SITE_PICKER_JETPACK_TIMEOUT("origin:site-picker-jetpack-error");
+        SITE_PICKER_JETPACK_TIMEOUT("origin:site-picker-jetpack-error"),
+        JETPACK_REQUIRED("origin:jetpack-missing");
 
         override fun toString(): String {
             return stringValue

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -236,7 +236,7 @@ class HelpActivity : AppCompatActivity() {
         JETPACK_INSTALLATION("origin:jetpack-installation"),
         LOGIN_HELP_NOTIFICATION("origin:login-local-notification"),
         SITE_PICKER_JETPACK_TIMEOUT("origin:site-picker-jetpack-error"),
-        JETPACK_REQUIRED("origin:jetpack-missing");
+        JETPACK_REQUIRED("origin:jetpack-required");
 
         override fun toString(): String {
             return stringValue

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -654,6 +654,10 @@ class LoginActivity :
         viewHelpAndSupport(Origin.LOGIN_SITE_ADDRESS)
     }
 
+    override fun helpJetpackRequired(siteAddress: String?) {
+        viewHelpAndSupport(Origin.JETPACK_REQUIRED)
+    }
+
     override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {
         unifiedLoginTracker.trackClick(Click.HELP_FINDING_SITE_ADDRESS)
         zendeskHelper.createNewTicket(this, Origin.LOGIN_SITE_ADDRESS, null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -186,7 +186,7 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
         with(binding.buttonHelp) {
             setOnClickListener {
                 AnalyticsTracker.track(AnalyticsEvent.LOGIN_NO_JETPACK_MENU_HELP_TAPPED)
-                loginListener?.helpSiteAddress(siteAddress)
+                jetpackLoginListener?.helpJetpackRequired(siteAddress)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.login.LoginListener
 import org.wordpress.android.login.LoginMode
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
@@ -65,6 +66,8 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
             return fragment
         }
     }
+
+    @Inject internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
 
     private var loginListener: LoginListener? = null
     private var jetpackLoginListener: LoginNoJetpackListener? = null
@@ -209,6 +212,8 @@ class LoginNoJetpackFragment : Fragment(layout.fragment_login_no_jetpack) {
 
     override fun onResume() {
         super.onResume()
+        unifiedLoginTracker.setStep(UnifiedLoginTracker.Step.JETPACK_NOT_CONNECTED)
+
         AnalyticsTracker.trackViewShown(this)
         AnalyticsTracker.track(AnalyticsEvent.LOGIN_NO_JETPACK_SCREEN_VIEWED)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackListener.kt
@@ -12,4 +12,5 @@ interface LoginNoJetpackListener {
         inputPassword: String?
     )
     fun startJetpackInstall(siteAddress: String? = null)
+    fun helpJetpackRequired(siteAddress: String?)
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318

⚠️ Requires https://github.com/woocommerce/woocommerce-android/pull/7319 to be merged first, please do not merge this unless https://github.com/woocommerce/woocommerce-android/pull/7319 is merged.

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This allows merchants to see "related help if they select "Help icon -> Help Center" from the "Jetpack Required" login screen.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start app in logged out state,
2. Select "Enter your store address",
3. Enter a self-hosted, WooCommerce but no Jetpack site address,
4. "Login with site credentials" screen is shown,
5. Login using the site's username and password,
6. "Jetpack required" login screen is shown,
7. Tap Help icon on top right,
8. Select "Help Center",
9. On the web page that's loaded, make sure it's the one that says "Jetpack Required"
10. Check tracking for: `🔵 Tracked: support_help_center_viewed, Properties: {"source_flow":"login_store_creds","source_step":"jetpack_not_connected","help_content_url":"https:\/\/woocommerce.com\/document\/android-ios-apps-login-help-faq\/#jetpack-required","is_debug":true}`

