### PR TITLE
Validate order's address only when order exits

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -168,7 +168,8 @@ class OrderDetailViewModel @Inject constructor(
                 displayOrderDetails()
                 fetchOrder(showSkeleton = false)
             } ?: fetchOrder(showSkeleton = true)
-            validateShippingAddress()
+
+            if (hasOrder()) validateShippingAddress()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -169,7 +169,7 @@ class OrderDetailViewModel @Inject constructor(
                 fetchOrder(showSkeleton = false)
             } ?: fetchOrder(showSkeleton = true)
 
-            if (hasOrder()) validateShippingAddress()
+            validateShippingAddress()
         }
     }
 
@@ -579,7 +579,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun validateShippingAddress() {
-        if (order.shippingAddress == Address.EMPTY) return
+        if (hasOrder().not() || order.shippingAddress == Address.EMPTY) return
         launch {
             addressValidator.validate(order.id, order.shippingAddress)
         }


### PR DESCRIPTION
Same problem as [the one solved here](https://github.com/woocommerce/woocommerce-android/pull/7316)
### Description
This small PR prevents the `IllegalArgumentException` that could happen if we try to validate the address of an order that is not initialized because there is no local existence of the order and the `fetchOrderById` function returned `null`. With these changes, we first check if the order exits before validating the address.

### Testing instructions
To reproduce the error you can change the `start()` function to always fetch the order data and, within the `fetchOrderAsync()` function, update the `fetchedOrder` value to be always `null`. I have created a git patch with these changes. You can apply the following patch to reproduce the error on `trunk` branch and test that in this branch, the app doesn't crash with the same patch.

<details>
  <summary>Patch</summary>

```
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
index ec78428880..c0b9eb5d46 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -161,11 +161,7 @@ class OrderDetailViewModel @Inject constructor(
 
     fun start() {
         launch {
-            orderDetailRepository.getOrderById(navArgs.orderId)?.let {
-                order = it
-                displayOrderDetails()
-                fetchOrder(showSkeleton = false)
-            } ?: fetchOrder(showSkeleton = true)
+            fetchOrder(showSkeleton = true)
         }
     }
 
@@ -564,10 +560,10 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchOrderAsync() = async {
-        val fetchedOrder = orderDetailRepository.fetchOrderById(navArgs.orderId)
+        val fetchedOrder = null
         orderDetailsTransactionLauncher.onOrderFetched()
         if (fetchedOrder != null) {
-            order = fetchedOrder
+            //order = fetchedOrder
             fetchOrderProducts()
         } else {
             triggerEvent(ShowSnackbar(string.order_error_fetch_generic))

```

</details>


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
