### PR TITLE
Always redirect the "Order card reader" link to Woocommerce regardless of the preferred plugin selected by the merchants.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/LearnMoreUrlProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/LearnMoreUrlProvider.kt
@@ -1,18 +1,33 @@
 package com.woocommerce.android.ui.payments.cardreader
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import dagger.Reusable
 import javax.inject.Inject
 
 @Reusable
-class LearnMoreUrlProvider @Inject constructor() {
+class LearnMoreUrlProvider @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val appPrefsWrapper: AppPrefsWrapper,
+) {
     fun provideLearnMoreUrlFor(learnMoreUrlType: LearnMoreUrlType): String {
+        val preferredPlugin = appPrefsWrapper.getCardReaderPreferredPlugin(
+            selectedSite.get().id,
+            selectedSite.get().siteId,
+            selectedSite.get().selfHostedSiteId
+        )
         return when (learnMoreUrlType) {
             LearnMoreUrlType.IN_PERSON_PAYMENTS -> {
                 AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS
             }
             LearnMoreUrlType.CASH_ON_DELIVERY -> {
-                AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY
+                when (preferredPlugin) {
+                    STRIPE_EXTENSION_GATEWAY -> AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY
+                    WOOCOMMERCE_PAYMENTS, null -> AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/LearnMoreUrlProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/LearnMoreUrlProvider.kt
@@ -1,36 +1,18 @@
 package com.woocommerce.android.ui.payments.cardreader
 
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
-import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
-import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import dagger.Reusable
 import javax.inject.Inject
 
 @Reusable
-class LearnMoreUrlProvider @Inject constructor(
-    private val selectedSite: SelectedSite,
-    private val appPrefsWrapper: AppPrefsWrapper,
-) {
+class LearnMoreUrlProvider @Inject constructor() {
     fun provideLearnMoreUrlFor(learnMoreUrlType: LearnMoreUrlType): String {
-        val preferredPlugin = appPrefsWrapper.getCardReaderPreferredPlugin(
-            selectedSite.get().id,
-            selectedSite.get().siteId,
-            selectedSite.get().selfHostedSiteId
-        )
         return when (learnMoreUrlType) {
             LearnMoreUrlType.IN_PERSON_PAYMENTS -> {
-                when (preferredPlugin) {
-                    STRIPE_EXTENSION_GATEWAY -> AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS
-                    WOOCOMMERCE_PAYMENTS, null -> AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS
-                }
+                AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS
             }
             LearnMoreUrlType.CASH_ON_DELIVERY -> {
-                when (preferredPlugin) {
-                    STRIPE_EXTENSION_GATEWAY -> AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY
-                    WOOCOMMERCE_PAYMENTS, null -> AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY
-                }
+                AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/LearnMoreUrlProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/LearnMoreUrlProviderTest.kt
@@ -1,13 +1,39 @@
 package com.woocommerce.android.ui.payments.cardreader
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider.LearnMoreUrlType.CASH_ON_DELIVERY
 import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider.LearnMoreUrlType.IN_PERSON_PAYMENTS
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
 
 class LearnMoreUrlProviderTest {
-    private val provider = LearnMoreUrlProvider()
+    private val selectedSite: SelectedSite = mock {
+        on(it.get()).thenReturn(SiteModel())
+    }
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
+
+    private val provider = LearnMoreUrlProvider(selectedSite, appPrefsWrapper)
+
+    @Test
+    fun `given preferred plugin WcPay, when providing learn more url for IPP, then WcPay learn more url returned`() {
+        // GIVEN
+        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
+            .thenReturn(WOOCOMMERCE_PAYMENTS)
+
+        // WHEN
+        val res = provider.provideLearnMoreUrlFor(IN_PERSON_PAYMENTS)
+
+        // THEN
+        assertThat(res).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
+    }
 
     @Test
     fun `when providing learn more url for IPP, then WcPay learn more url returned`() {
@@ -25,5 +51,44 @@ class LearnMoreUrlProviderTest {
 
         // THEN
         assertThat(res).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY)
+    }
+
+    @Test
+    fun `given preferred plugin WcPay, when providing learn more url for COD, then WcPay COD url returned`() {
+        // GIVEN
+        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
+            .thenReturn(WOOCOMMERCE_PAYMENTS)
+
+        // WHEN
+        val res = provider.provideLearnMoreUrlFor(CASH_ON_DELIVERY)
+
+        // THEN
+        assertThat(res).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY)
+    }
+
+    @Test
+    fun `given preferred plugin null, when providing learn more url for COD, then WcPay COD learn more url returned`() {
+        // GIVEN
+        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
+            .thenReturn(null)
+
+        // WHEN
+        val res = provider.provideLearnMoreUrlFor(CASH_ON_DELIVERY)
+
+        // THEN
+        assertThat(res).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY)
+    }
+
+    @Test
+    fun `given preferred plugin Stripe, when providing learn more url for COD, then Stripe COD url returned`() {
+        // GIVEN
+        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
+            .thenReturn(STRIPE_EXTENSION_GATEWAY)
+
+        // WHEN
+        val res = provider.provideLearnMoreUrlFor(CASH_ON_DELIVERY)
+
+        // THEN
+        assertThat(res).isEqualTo(AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/LearnMoreUrlProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/LearnMoreUrlProviderTest.kt
@@ -1,33 +1,16 @@
 package com.woocommerce.android.ui.payments.cardreader
 
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider.LearnMoreUrlType.CASH_ON_DELIVERY
 import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider.LearnMoreUrlType.IN_PERSON_PAYMENTS
-import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
-import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
 
 class LearnMoreUrlProviderTest {
-    private val selectedSite: SelectedSite = mock {
-        on(it.get()).thenReturn(SiteModel())
-    }
-    private val appPrefsWrapper: AppPrefsWrapper = mock()
-
-    private val provider = LearnMoreUrlProvider(selectedSite, appPrefsWrapper)
+    private val provider = LearnMoreUrlProvider()
 
     @Test
-    fun `given preferred plugin WcPay, when providing learn more url for IPP, then WcPay learn more url returned`() {
-        // GIVEN
-        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
-            .thenReturn(WOOCOMMERCE_PAYMENTS)
-
+    fun `when providing learn more url for IPP, then WcPay learn more url returned`() {
         // WHEN
         val res = provider.provideLearnMoreUrlFor(IN_PERSON_PAYMENTS)
 
@@ -36,67 +19,11 @@ class LearnMoreUrlProviderTest {
     }
 
     @Test
-    fun `given preferred plugin null, when providing learn more url for IPP, then WcPay learn more url returned`() {
-        // GIVEN
-        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
-            .thenReturn(null)
-
-        // WHEN
-        val res = provider.provideLearnMoreUrlFor(IN_PERSON_PAYMENTS)
-
-        // THEN
-        assertThat(res).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
-    }
-
-    @Test
-    fun `given preferred plugin Stripe, when providing learn more url for IPP, then Stripe learn more url returned`() {
-        // GIVEN
-        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
-            .thenReturn(STRIPE_EXTENSION_GATEWAY)
-
-        // WHEN
-        val res = provider.provideLearnMoreUrlFor(IN_PERSON_PAYMENTS)
-
-        // THEN
-        assertThat(res).isEqualTo(AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS)
-    }
-
-    @Test
-    fun `given preferred plugin WcPay, when providing learn more url for COD, then WcPay COD url returned`() {
-        // GIVEN
-        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
-            .thenReturn(WOOCOMMERCE_PAYMENTS)
-
+    fun `when providing learn more url for COD, then WcPay COD learn more url returned`() {
         // WHEN
         val res = provider.provideLearnMoreUrlFor(CASH_ON_DELIVERY)
 
         // THEN
         assertThat(res).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY)
-    }
-
-    @Test
-    fun `given preferred plugin null, when providing learn more url for COD, then WcPay COD learn more url returned`() {
-        // GIVEN
-        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
-            .thenReturn(null)
-
-        // WHEN
-        val res = provider.provideLearnMoreUrlFor(CASH_ON_DELIVERY)
-
-        // THEN
-        assertThat(res).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY)
-    }
-
-    @Test
-    fun `given preferred plugin Stripe, when providing learn more url for COD, then Stripe COD url returned`() {
-        // GIVEN
-        whenever(appPrefsWrapper.getCardReaderPreferredPlugin(any(), any(), any()))
-            .thenReturn(STRIPE_EXTENSION_GATEWAY)
-
-        // WHEN
-        val res = provider.provideLearnMoreUrlFor(CASH_ON_DELIVERY)
-
-        // THEN
-        assertThat(res).isEqualTo(AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7327 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR Always redirects the "Order card reader" link to Woocommerce regardless of the preferred plugin selected by the merchants. 

Read more about this here: p1661954050622359/1661951054.566359-slack-C025A8VV728

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Tapping on "Order card reader" when the preferred plugin is WcPay
1. Navigate to Menu -> Payments
2. Tap on the `Order card reader` row
3. Ensure the link opens the Woocommerce IPP page


#### Tapping on "Order card reader" when the preferred plugin is Stripe
1. Navigate to Menu -> Payments
2. Tap on the `Order card reader` row
3. Ensure the link opens the Woocommerce IPP page


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->