### PR TITLE
[Login] Fix site credentials login

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -72,6 +72,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthOptionsErrorType.UNKNO
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthOptionsFetched
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
+import org.wordpress.android.fluxc.store.SiteStore.OnConnectSiteInfoChecked
 import org.wordpress.android.login.AuthOptions
 import org.wordpress.android.login.GoogleFragment.GoogleListener
 import org.wordpress.android.login.Login2FaFragment
@@ -150,6 +151,8 @@ class LoginActivity :
 
     private var loginMode: LoginMode? = null
     private lateinit var binding: ActivityLoginBinding
+
+    private var isWPComSite: Boolean? = null
 
     override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
@@ -589,7 +592,7 @@ class LoginActivity :
         AppPrefs.setLoginSiteAddress(siteAddressClean)
 
         if (hasJetpack) {
-            showEmailLoginScreen()
+            showEmailLoginScreen(inputSiteAddress.takeIf { isWPComSite != true })
         } else {
             // Let user log in via site credentials first before showing Jetpack missing screen.
             loginViaSiteCredentials(inputSiteAddress)
@@ -966,5 +969,11 @@ class LoginActivity :
         if (event.error?.type == UNKNOWN_USER) {
             loginNotificationScheduler.onPasswordLoginError()
         }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = MAIN)
+    fun onFetchedConnectSiteInfo(event: OnConnectSiteInfoChecked) {
+        isWPComSite = event.info.isWPCom
     }
 }


### PR DESCRIPTION
### Description
After removing the Site credentials AB test in #7305 and #7309, we broke the site credentials login, as we always show the Email login screen without the option to use site credentials.

This PR fixes this by bringing the functionality back.

### Testing instructions
1. Open the app.
2. Sign in using a self-hosted site address.
3. Confirm the site credentials option is present.
4. Go back to the first screen.
5. Sign in using a WPCom site address.
6. Confirm the site credentials option is not shown.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
