### PR TITLE
Changed `is_editable` to `true` in mocks for non-completed orders.

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_all_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_all_detailed.json
@@ -101,7 +101,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-10-31T13:13:57",
                 "date_modified_gmt": "{{currentYear}}-10-31T13:13:57",
                 "date_paid_gmt": null
@@ -186,7 +186,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-10-28T22:25:43",
                 "date_modified_gmt": "{{currentYear}}-10-28T22:25:43",
                 "date_paid_gmt": null
@@ -271,7 +271,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-10-27T01:17:42",
                 "date_modified_gmt": "{{currentYear}}-10-27T01:17:42",
                 "date_paid_gmt": null
@@ -785,7 +785,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-28T11:07:13",
                 "date_modified_gmt": "{{currentYear}}-01-28T11:21:26",
                 "date_paid_gmt": "{{currentYear}}-01-28T11:07:50"
@@ -917,7 +917,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-28T08:18:30",
                 "date_modified_gmt": "{{currentYear}}-01-28T11:19:49",
                 "date_paid_gmt": null
@@ -987,7 +987,7 @@
                     "total": "-140.00"
                 }],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-27T10:16:01",
                 "date_modified_gmt": "{{currentYear}}-01-28T10:17:36",
                 "date_paid_gmt": "{{currentYear}}-01-28T10:16:35"
@@ -1201,7 +1201,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-01-31T11:26:08",
                 "date_modified_gmt": "{{currentYear}}-02-03T15:34:32",
                 "date_paid_gmt": "{{currentYear}}-01-28T11:26:54"
@@ -1267,7 +1267,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-28T13:02:43",
                 "date_modified_gmt": "{{currentYear}}-02-03T13:12:20",
                 "date_paid_gmt": "{{currentYear}}-01-28T10:03:05"
@@ -1349,7 +1349,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-27T10:14:22",
                 "date_modified_gmt": "{{currentYear}}-01-28T10:15:18",
                 "date_paid_gmt": "{{currentYear}}-01-28T10:14:46"
@@ -1462,7 +1462,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-03-01T20:36:54",
                 "date_modified_gmt": "{{currentYear}}-04-30T21:40:20",
                 "date_paid_gmt": null
@@ -1544,7 +1544,7 @@
                 "coupon_lines": [],
                 "refunds": [],
                 "payment_url": "",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-22T09:52:48",
                 "date_modified_gmt": "{{currentYear}}-06-14T16:49:49",
                 "date_paid_gmt": "{{currentYear}}-04-25T21:47:26"

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_any_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_any_detailed.json
@@ -78,7 +78,7 @@
                 "coupon_lines":[],
                 "refunds":[],
                 "payment_url": "https://automatticwidgets.wpcomstaging.com/checkout/order-pay/2201/?pay_for_order=true&key=wc_order_itGmODLV25QAx",
-                "is_editable": false,
+                "is_editable": true,
                 "date_created_gmt": "{{fnow offset='-10 minutes' format=customformat}}",
                 "date_modified_gmt": "{{fnow offset='-10 minutes' format=customformat}}",
                 "date_completed_gmt":null,

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_completed_pending_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_completed_pending_detailed.json
@@ -81,6 +81,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": false,
                 "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-01-26T11:28:00",
                 "date_modified_gmt": "{{currentYear}}-01-28T11:28:51",
                 "date_paid_gmt": "{{currentYear}}-01-28T11:28:30"
@@ -177,6 +179,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-12-13T16:46:34",
                 "date_modified_gmt": "{{currentYear}}-01-28T09:55:48",
                 "date_paid_gmt": "{{currentYear}}-06-14T16:48:53"
@@ -257,6 +261,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-12-12T19:18:16",
                 "date_modified_gmt": "{{currentYear}}-01-28T09:56:03",
                 "date_paid_gmt": null
@@ -352,6 +358,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": false,
                 "date_created_gmt": "{{currentYear}}-12-11T22:20:09",
                 "date_modified_gmt": "{{currentYear}}-01-28T09:55:35",
                 "date_paid_gmt": "{{currentYear}}-04-30T22:21:21"

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_processing_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_processing_detailed.json
@@ -97,6 +97,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": true,
                 "date_created_gmt": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-01-31T11:26:08",
                 "date_modified_gmt": "{{currentYear}}-02-03T15:34:32",
                 "date_paid_gmt": "{{currentYear}}-01-28T11:26:54"
@@ -161,6 +163,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-28T13:02:43",
                 "date_modified_gmt": "{{currentYear}}-02-03T13:12:20",
                 "date_paid_gmt": "{{currentYear}}-01-28T10:03:05"
@@ -241,6 +245,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-27T10:14:22",
                 "date_modified_gmt": "{{currentYear}}-01-28T10:15:18",
                 "date_paid_gmt": "{{currentYear}}-01-28T10:14:46"
@@ -352,6 +358,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-03-01T20:36:54",
                 "date_modified_gmt": "{{currentYear}}-04-30T21:40:20",
                 "date_paid_gmt": null
@@ -432,6 +440,8 @@
                 "fee_lines": [],
                 "coupon_lines": [],
                 "refunds": [],
+                "payment_url": "",
+                "is_editable": true,
                 "date_created_gmt": "{{currentYear}}-01-22T09:52:48",
                 "date_modified_gmt": "{{currentYear}}-06-14T16:49:49",
                 "date_paid_gmt": "{{currentYear}}-04-25T21:47:26"


### PR DESCRIPTION
Closes: #7317

### Description
Before the fix:

- When opening Orders list, for the orders that did not have `completed` status (e.g. for order `2789` which is `on-hold`, and for `2788` which is `processing`), the app tried to change the order status to `completed`
- After checking recent changes in mocks, I noticed that these lines were added (https://github.com/woocommerce/woocommerce-android/pull/7296/commits/84e8b43a62eda445dcbb79dc2078c8075d0e6349) to numerous orders mocks:

```
"payment_url": "",
"is_editable": false,
```

After some thinking I had an assumption that `"is_editable": false` is the cause of the issue: possibly, from seeing this value, the app saw that the order should not be editable (should be in some final state, with no further transitions), and tried to force the status change to `completed` for orders that had `"is_editable": false`, but did not have status `completed`.

### Testing instructions
- Seeing `createOrderTest` and `productListShowsAllProducts` green on CI.
- Optionally, running `createOrderTest` locally (creating a new Emulator image is preferred - this will give higher chances to reproduce the original bug).