### PR TITLE
[UI Tests] Starting UI tests from `LoginActivity` instead of `MainActivity`.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/login/WelcomeScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/login/WelcomeScreen.kt
@@ -20,7 +20,11 @@ class WelcomeScreen : Screen {
 
             Thread.sleep(1000)
 
-            return if (isElementDisplayed(CarouselScreen.SKIP_BUTTON)) {
+            return skipCarouselIfNeeded()
+        }
+
+        fun skipCarouselIfNeeded(): WelcomeScreen {
+            return if (Screen.isElementDisplayed(CarouselScreen.SKIP_BUTTON)) {
                 CarouselScreen().skip()
             } else {
                 WelcomeScreen()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
@@ -2,7 +2,6 @@
 
 package com.woocommerce.android.ui.main
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.helpers.InitializationRule
@@ -13,6 +12,7 @@ import com.woocommerce.android.screenshots.orders.OrderListScreen
 import com.woocommerce.android.screenshots.util.MocksReader
 import com.woocommerce.android.screenshots.util.OrderData
 import com.woocommerce.android.screenshots.util.iterator
+import com.woocommerce.android.ui.login.LoginActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.json.JSONObject
@@ -26,18 +26,15 @@ class OrdersUITest : TestBase() {
     val rule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeTestRule = createComposeRule()
-
-    @get:Rule(order = 2)
     val initRule = InitializationRule()
 
-    @get:Rule(order = 3)
-    var activityRule = ActivityTestRule(MainActivity::class.java)
+    @get:Rule(order = 2)
+    var activityRule = ActivityTestRule(LoginActivity::class.java)
 
     @Before
     fun setUp() {
         WelcomeScreen
-            .logoutIfNeeded(composeTestRule)
+            .skipCarouselIfNeeded()
             .selectLogin()
             .proceedWith(BuildConfig.SCREENSHOTS_URL)
             .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ProductsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ProductsUITest.kt
@@ -2,7 +2,6 @@
 
 package com.woocommerce.android.ui.main
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.helpers.InitializationRule
@@ -13,6 +12,7 @@ import com.woocommerce.android.screenshots.products.ProductListScreen
 import com.woocommerce.android.screenshots.util.MocksReader
 import com.woocommerce.android.screenshots.util.ProductData
 import com.woocommerce.android.screenshots.util.iterator
+import com.woocommerce.android.ui.login.LoginActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.json.JSONObject
@@ -26,18 +26,15 @@ class ProductsUITest : TestBase() {
     val rule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeTestRule = createComposeRule()
-
-    @get:Rule(order = 2)
     val initRule = InitializationRule()
 
-    @get:Rule(order = 3)
-    var activityRule = ActivityTestRule(MainActivity::class.java)
+    @get:Rule(order = 2)
+    var activityRule = ActivityTestRule(LoginActivity::class.java)
 
     @Before
     fun setUp() {
         WelcomeScreen
-            .logoutIfNeeded(composeTestRule)
+            .skipCarouselIfNeeded()
             .selectLogin()
             .proceedWith(BuildConfig.SCREENSHOTS_URL)
             .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.screenshots.reviews.ReviewsListScreen
 import com.woocommerce.android.screenshots.util.MocksReader
 import com.woocommerce.android.screenshots.util.ReviewData
 import com.woocommerce.android.screenshots.util.iterator
+import com.woocommerce.android.ui.login.LoginActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
@@ -32,12 +33,12 @@ class ReviewsUITest : TestBase() {
     val initRule = InitializationRule()
 
     @get:Rule(order = 3)
-    var activityRule = ActivityTestRule(MainActivity::class.java)
+    var activityRule = ActivityTestRule(LoginActivity::class.java)
 
     @Before
     fun setUp() {
         WelcomeScreen
-            .logoutIfNeeded(composeTestRule)
+            .skipCarouselIfNeeded()
             .selectLogin()
             .proceedWith(BuildConfig.SCREENSHOTS_URL)
             .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)


### PR DESCRIPTION
### Why

Only the first (chronologically) launched UI test really requires a login process. All subsequent tests start already logged in, and then log out and back in again:

```kotlin
    @Before
    fun setUp() {
        WelcomeScreen
            .logoutIfNeeded(composeTestRule)
            .selectLogin()
            .proceedWith
            // do more stuff
    }
```

While ideally I'd like the tests to start already logged in, skipping the login process, I still found no proper way to do this, so I went for an intermediary solution, when the tests are forced to start on Login screen. This avoids the need to log out at the beginning of the new test, and saves 10 second in all tests except for the first one.

### How

[ActivityTestRule](https://developer.android.com/reference/androidx/test/rule/ActivityTestRule) can be used to specify the Activity (i.e. Screen) which will be used to start the test. Instead of using `MainActivity` (which is a default value, and using it means: the screen shown on launch will be treated as starting screen), I went for using `LoginActivity`. The thing is, I can only use the screens for which `...Activity` file is present, and so far it seems only the login screen has it.

### Testing instructions
- CI is green