### PR TITLE
Replace deprecated menu methods

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
@@ -11,6 +11,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment.Companion.SIMPLE_TEXT_EDITOR_RESULT
 import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorViewModel.SimpleTextEditorResult
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
@@ -36,7 +37,6 @@ class SimpleTextEditorFragment : BaseFragment(), BackPressListener {
     private val navArgs: SimpleTextEditorFragmentArgs by navArgs()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        setHasOptionsMenu(true)
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
@@ -11,8 +11,10 @@ import android.view.ViewGroup
 import android.widget.SearchView.OnQueryTextListener
 import androidx.appcompat.widget.SearchView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle.State
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.NavGraphMainDirections
@@ -54,7 +56,6 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        setHasOptionsMenu(true)
         _binding = FragmentCouponListBinding.inflate(inflater, container, false)
 
         val view = binding.root
@@ -72,6 +73,7 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupMenu()
         setupObservers()
     }
 
@@ -92,11 +94,22 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.menu_search, menu)
-        searchMenuItem = menu.findItem(R.id.menu_search)
-        initSearch()
+    private fun setupMenu() {
+        requireActivity().addMenuProvider(
+            object : MenuProvider {
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.menu_search, menu)
+                    searchMenuItem = menu.findItem(R.id.menu_search)
+                    initSearch()
+                }
+
+                override fun onMenuItemSelected(item: MenuItem): Boolean {
+                    return false
+                }
+            },
+            viewLifecycleOwner,
+            State.RESUMED
+        )
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7336
Closes: #7337
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR removes/replaced way of handling menus in 2 fragments:
* SimpleTextEditorFragment.kt
* CouponListFragment.kt

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Go to settings
* Enabled "Coupons" beta feature
* Go to the More Menu
* Open Coupons list and notice that there are no changes UI wise
* Open a coupon, open menu, click "edit coupon"
* In the new screen click "add description"
* notice that there are no changes UI wise

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

(before and after)

![2](https://user-images.githubusercontent.com/4923871/188142394-1d024245-1491-4d5c-9b1d-f0dfce8b4042.jpg)
![1](https://user-images.githubusercontent.com/4923871/188142395-200112dc-337c-419a-aeb7-5c75f75f1de2.jpg)


https://user-images.githubusercontent.com/4923871/188142422-893744b5-089e-477b-b252-09539fa59fe0.mp4

https://user-images.githubusercontent.com/4923871/188142417-ff15b6a7-e57b-486a-a1d1-23ed2141aba5.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
