### PR TITLE
Removed redundant `setHasOptionsMenu` usage FeedbackCompletedFragment and FeedbackSurveyFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -32,8 +32,6 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment(R.layout.fragme
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setHasOptionsMenu(true)
-
         val binding = FragmentFeedbackCompletedBinding.bind(view)
         val contactUsText = getString(R.string.feedback_completed_contact_us)
         binding.completionHelpGuide.setClickableText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -44,8 +44,6 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment(R.layout.fragment_
     private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setHasOptionsMenu(true)
-
         _binding = FragmentFeedbackSurveyBinding.bind(view)
 
         configureWebView()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7345 
Closes: #7346
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removes redundant usage of `setHasOptionsMenu` methods

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Change in `FeedbackPrefs` to
```
    val userFeedbackIsDue: Boolean
        get() = true
```
* Open my store screen
* Click on `Could be better
* Notice that the menu has not changed
* Fill the survey
* Notice that the menu has not changed on the next screen

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### before and after

<img width="378" alt="image" src="https://user-images.githubusercontent.com/4923871/188449412-94da649a-a779-4d27-93cc-c9e0352a7bf6.jpg"/>
<img width="378" alt="image" src="https://user-images.githubusercontent.com/4923871/188449419-025ddc2e-1f2c-485e-8a6d-92deef80b339.jpg"/>

<img width="378" alt="image" src="https://user-images.githubusercontent.com/4923871/188449465-1492a6dc-4f30-4576-a925-2ad710d7511f.png">
<img width="381" alt="image" src="https://user-images.githubusercontent.com/4923871/188449509-a1f129a8-9213-45ab-b620-2ed36ed297b9.png">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
