### PR TITLE
[Login] Explanation when signing using a non-atomic site

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/me/rest_me_sites.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/me/rest_me_sites.json
@@ -36,6 +36,7 @@
               "activate_plugins": true
             },
             "jetpack": true,
+            "jetpack_connection": true,
             "visible": true,
             "is_private": true,
             "organization_id": 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -24,5 +24,5 @@ val SiteModel.stateLogInformation: String
 fun SiteModel.getSiteName(): String = if (!TextUtils.isEmpty(name)) name else ""
 
 // The isWPCom property is set as true only for pure WPCom sites that don't have Jetpack connection
-val SiteModel.isNonAtomic
+val SiteModel.isSimpleWPComSite
     get() = isWPCom

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -22,3 +22,7 @@ val SiteModel.stateLogInformation: String
     }
 
 fun SiteModel.getSiteName(): String = if (!TextUtils.isEmpty(name)) name else ""
+
+// The isWPCom property is set as true only for pure WPCom sites that don't have Jetpack connection
+val SiteModel.isNonAtomic
+    get() = isWPCom

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.ShowWooUpgradeDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NonAtomicState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.StoreListState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.WooNotFoundState
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryFragment
@@ -122,6 +123,9 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
             new.noStoresBtnText?.takeIfNotEqualTo(old?.noStoresBtnText) {
                 binding.noStoresView.noStoresBtnText = it
             }
+            new.isNoStoresBtnVisible.takeIfNotEqualTo(old?.isNoStoresBtnVisible) {
+                binding.noStoresView.isNoStoresBtnVisible = it
+            }
             new.noStoresLabelText?.takeIfNotEqualTo(old?.noStoresLabelText) {
                 binding.noStoresView.noStoresText = it
             }
@@ -136,6 +140,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                     StoreListState -> updateStoreListView()
                     NoStoreState -> updateNoStoresView()
                     WooNotFoundState -> updateWooNotFoundView()
+                    NonAtomicState -> updateNonAtomicView()
                 }
             }
         }
@@ -197,6 +202,12 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
             viewModel.onInstallWooClicked()
         }
         binding.noStoresView.clickSecondaryAction {
+            viewModel.onViewConnectedStoresButtonClick()
+        }
+    }
+
+    private fun updateNonAtomicView() {
+        binding.loginEpilogueButtonBar.buttonPrimary.setOnClickListener {
             viewModel.onViewConnectedStoresButtonClick()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -36,7 +36,7 @@ import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.ShowWooUpgradeDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NonAtomicState
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.SimpleWPComState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.StoreListState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.WooNotFoundState
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryFragment
@@ -141,7 +141,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                     StoreListState -> updateStoreListView()
                     NoStoreState -> updateNoStoresView()
                     WooNotFoundState -> updateWooNotFoundView()
-                    NonAtomicState -> updateNonAtomicView()
+                    SimpleWPComState -> updateSimpleWPComView()
                 }
             }
         }
@@ -207,7 +207,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
         }
     }
 
-    private fun updateNonAtomicView() {
+    private fun updateSimpleWPComView() {
         binding.loginEpilogueButtonBar.buttonPrimary.setOnClickListener {
             viewModel.onViewConnectedStoresButtonClick()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -231,6 +231,9 @@ class SitePickerViewModel @Inject constructor(
                 // The url doesn't match any sites for this account.
                 showAccountMismatchScreen(url)
             }
+            site.isWPCom -> {
+                loadNonAtomicView(site)
+            }
             !site.hasWooCommerce -> {
                 // Show not woo store message view.
                 loadWooNotFoundView(site)
@@ -251,6 +254,7 @@ class SitePickerViewModel @Inject constructor(
             isPrimaryBtnVisible = true,
             primaryBtnText = resourceProvider.getString(string.login_site_picker_enter_site_address),
             noStoresLabelText = resourceProvider.getString(string.login_no_stores),
+            isNoStoresBtnVisible = true,
             noStoresBtnText = resourceProvider.getString(string.login_site_picker_new_to_woo),
             currentSitePickerState = SitePickerState.NoStoreState
         )
@@ -292,8 +296,20 @@ class SitePickerViewModel @Inject constructor(
             isPrimaryBtnVisible = isWooInstallationEnabled,
             primaryBtnText = resourceProvider.getString(string.login_install_woo),
             noStoresLabelText = resourceProvider.getString(string.login_not_woo_store, site.url),
+            isNoStoresBtnVisible = true,
             noStoresBtnText = resourceProvider.getString(string.login_view_connected_stores),
             currentSitePickerState = SitePickerState.WooNotFoundState
+        )
+    }
+
+    private fun loadNonAtomicView(site: SiteModel) {
+        sitePickerViewState = sitePickerViewState.copy(
+            isNoStoresViewVisible = true,
+            isPrimaryBtnVisible = sitePickerViewState.hasConnectedStores == true,
+            primaryBtnText = resourceProvider.getString(string.login_view_connected_stores),
+            noStoresLabelText = resourceProvider.getString(string.login_non_atomic_site, site.url),
+            isNoStoresBtnVisible = false,
+            currentSitePickerState = SitePickerState.NonAtomicState
         )
     }
 
@@ -578,6 +594,7 @@ class SitePickerViewModel @Inject constructor(
         val isProgressDiaLogVisible: Boolean = false,
         val isPrimaryBtnVisible: Boolean = false,
         val isSecondaryBtnVisible: Boolean = false,
+        val isNoStoresBtnVisible: Boolean = false,
         val currentSitePickerState: SitePickerState = SitePickerState.StoreListState
     ) : Parcelable
 
@@ -612,6 +629,6 @@ class SitePickerViewModel @Inject constructor(
     }
 
     enum class SitePickerState {
-        StoreListState, NoStoreState, WooNotFoundState
+        StoreListState, NoStoreState, WooNotFoundState, NonAtomicState
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -339,7 +339,12 @@ class SitePickerViewModel @Inject constructor(
         val cleanedUrl = siteModel.url.replaceFirst(protocolRegex, "")
 
         loginSiteAddress = cleanedUrl
-        loadWooNotFoundView(siteModel)
+
+        if (siteModel.isWPCom) {
+            loadNonAtomicView(siteModel)
+        } else {
+            loadWooNotFoundView(siteModel)
+        }
     }
 
     fun onViewConnectedStoresButtonClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.experiment.JetpackTimeoutExperiment
 import com.woocommerce.android.extensions.getSiteName
+import com.woocommerce.android.extensions.isNonAtomic
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
@@ -231,7 +232,7 @@ class SitePickerViewModel @Inject constructor(
                 // The url doesn't match any sites for this account.
                 showAccountMismatchScreen(url)
             }
-            site.isWPCom -> {
+            site.isNonAtomic -> {
                 loadNonAtomicView(site)
             }
             !site.hasWooCommerce -> {
@@ -331,7 +332,7 @@ class SitePickerViewModel @Inject constructor(
         analyticsTrackerWrapper.track(
             stat = AnalyticsEvent.SITE_PICKER_NON_WOO_SITE_TAPPED,
             properties = mapOf(
-                AnalyticsTracker.KEY_IS_NON_ATOMIC to (!siteModel.isJetpackConnected && !siteModel.isJetpackCPConnected)
+                AnalyticsTracker.KEY_IS_NON_ATOMIC to siteModel.isNonAtomic
             )
         )
         // Strip protocol from site's URL
@@ -340,7 +341,7 @@ class SitePickerViewModel @Inject constructor(
 
         loginSiteAddress = cleanedUrl
 
-        if (siteModel.isWPCom) {
+        if (siteModel.isNonAtomic) {
             loadNonAtomicView(siteModel)
         } else {
             loadWooNotFoundView(siteModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -14,7 +14,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.experiment.JetpackTimeoutExperiment
 import com.woocommerce.android.extensions.getSiteName
-import com.woocommerce.android.extensions.isNonAtomic
+import com.woocommerce.android.extensions.isSimpleWPComSite
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
@@ -232,8 +232,8 @@ class SitePickerViewModel @Inject constructor(
                 // The url doesn't match any sites for this account.
                 showAccountMismatchScreen(url)
             }
-            site.isNonAtomic -> {
-                loadNonAtomicView(site)
+            site.isSimpleWPComSite -> {
+                loadSimpleWPComView(site)
             }
             !site.hasWooCommerce -> {
                 // Show not woo store message view.
@@ -303,14 +303,14 @@ class SitePickerViewModel @Inject constructor(
         )
     }
 
-    private fun loadNonAtomicView(site: SiteModel) {
+    private fun loadSimpleWPComView(site: SiteModel) {
         sitePickerViewState = sitePickerViewState.copy(
             isNoStoresViewVisible = true,
             isPrimaryBtnVisible = sitePickerViewState.hasConnectedStores == true,
             primaryBtnText = resourceProvider.getString(string.login_view_connected_stores),
-            noStoresLabelText = resourceProvider.getString(string.login_non_atomic_site, site.url),
+            noStoresLabelText = resourceProvider.getString(string.login_simple_wpcom_site, site.url),
             isNoStoresBtnVisible = false,
-            currentSitePickerState = SitePickerState.NonAtomicState
+            currentSitePickerState = SitePickerState.SimpleWPComState
         )
     }
 
@@ -332,7 +332,7 @@ class SitePickerViewModel @Inject constructor(
         analyticsTrackerWrapper.track(
             stat = AnalyticsEvent.SITE_PICKER_NON_WOO_SITE_TAPPED,
             properties = mapOf(
-                AnalyticsTracker.KEY_IS_NON_ATOMIC to siteModel.isNonAtomic
+                AnalyticsTracker.KEY_IS_NON_ATOMIC to siteModel.isSimpleWPComSite
             )
         )
         // Strip protocol from site's URL
@@ -341,8 +341,8 @@ class SitePickerViewModel @Inject constructor(
 
         loginSiteAddress = cleanedUrl
 
-        if (siteModel.isNonAtomic) {
-            loadNonAtomicView(siteModel)
+        if (siteModel.isSimpleWPComSite) {
+            loadSimpleWPComView(siteModel)
         } else {
             loadWooNotFoundView(siteModel)
         }
@@ -635,6 +635,6 @@ class SitePickerViewModel @Inject constructor(
     }
 
     enum class SitePickerState {
-        StoreListState, NoStoreState, WooNotFoundState, NonAtomicState
+        StoreListState, NoStoreState, WooNotFoundState, SimpleWPComState
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -314,7 +314,7 @@ class SitePickerViewModel @Inject constructor(
         )
     }
 
-    private fun getUserInfo() = accountRepository.getUserAccount().let {
+    private fun getUserInfo() = accountRepository.getUserAccount()?.let {
         UserInfo(displayName = it.displayName, username = it.userName ?: "", userAvatarUrl = it.avatarUrl)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/views/LoginNoStoresView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/views/LoginNoStoresView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import androidx.core.view.isVisible
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.databinding.ViewLoginNoStoresBinding
 
@@ -25,6 +26,8 @@ class LoginNoStoresView @JvmOverloads constructor(
         set(value) {
             binding.btnSecondaryAction.text = value
         }
+
+    var isNoStoresBtnVisible by binding.btnSecondaryAction::isVisible
 
     fun clickSecondaryAction(onClickListener: ((view: View) -> Unit)) {
         binding.btnSecondaryAction.setOnClickListener(onClickListener)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -269,7 +269,7 @@
     <string name="login_site_picker_enter_site_address">Enter a site address</string>
     <string name="site_discovery_postlogin_failure">A failure occurred, please contact support</string>
     <string name="login_site_picker_new_to_woo">New to WooCommerce</string>
-    <string name="login_non_atomic_site">It seems that your site %1$s is a simple WordPress.com site that cannot install plugins. Please upgrade your plan to use WooCommerce.</string>
+    <string name="login_non_atomic_site">The site %1$s is currently on a WordPress.com plan that does not support plugin installation. Please upgrade your plan to use WooCommerce.</string>
     <!--
         My Store View
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -268,6 +268,7 @@
     <string name="login_site_picker_enter_site_address">Enter a site address</string>
     <string name="site_discovery_postlogin_failure">A failure occurred, please contact support</string>
     <string name="login_site_picker_new_to_woo">New to WooCommerce</string>
+    <string name="login_non_atomic_site">It seems that your site %1$s is a simple WordPress.com site that cannot install plugins. Please upgrade your plan to use WooCommerce.</string>
     <!--
         My Store View
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -269,7 +269,7 @@
     <string name="login_site_picker_enter_site_address">Enter a site address</string>
     <string name="site_discovery_postlogin_failure">A failure occurred, please contact support</string>
     <string name="login_site_picker_new_to_woo">New to WooCommerce</string>
-    <string name="login_non_atomic_site">The site %1$s is currently on a WordPress.com plan that does not support plugin installation. Please upgrade your plan to use WooCommerce.</string>
+    <string name="login_simple_wpcom_site">The site %1$s is currently on a WordPress.com plan that does not support plugin installation. Please upgrade your plan to use WooCommerce.</string>
     <!--
         My Store View
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -691,7 +691,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given entered site is non-atomic, when loading site picker, then display non-atomic site state`() =
+    fun `given entered site is a simple WPCom site, when loading site picker, then display simple site state`() =
         testBlocking {
             givenTheScreenIsFromLogin(true)
             givenThatUserLoggedInFromEnteringSiteAddress(
@@ -704,9 +704,9 @@ class SitePickerViewModelTest : BaseUnitTest() {
 
             val state = viewModel.sitePickerViewStateData.liveData.captureValues().last()
 
-            assertThat(state.currentSitePickerState).isEqualTo(SitePickerViewModel.SitePickerState.NonAtomicState)
+            assertThat(state.currentSitePickerState).isEqualTo(SitePickerViewModel.SitePickerState.SimpleWPComState)
             assertThat(state.isNoStoresViewVisible).isTrue
-            assertThat(state.noStoresLabelText).isEqualTo(resourceProvider.getString(R.string.login_non_atomic_site))
+            assertThat(state.noStoresLabelText).isEqualTo(resourceProvider.getString(R.string.login_simple_wpcom_site))
             assertThat(state.isNoStoresBtnVisible).isFalse
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -690,6 +690,26 @@ class SitePickerViewModelTest : BaseUnitTest() {
             assertThat(isProgressShown).containsExactly(false, true, false)
         }
 
+    @Test
+    fun `given entered site is non-atomic, when loading site picker, then display non-atomic site state`() =
+        testBlocking {
+            givenTheScreenIsFromLogin(true)
+            givenThatUserLoggedInFromEnteringSiteAddress(
+                expectedSiteList[1].apply {
+                    setIsWPCom(true)
+                }
+            )
+            whenSitesAreFetched()
+            whenViewModelIsCreated()
+
+            val state = viewModel.sitePickerViewStateData.liveData.captureValues().last()
+
+            assertThat(state.currentSitePickerState).isEqualTo(SitePickerViewModel.SitePickerState.NonAtomicState)
+            assertThat(state.isNoStoresViewVisible).isTrue
+            assertThat(state.noStoresLabelText).isEqualTo(resourceProvider.getString(R.string.login_non_atomic_site))
+            assertThat(state.isNoStoresBtnVisible).isFalse
+        }
+
     private fun SiteModel.clone(): SiteModel {
         // A quick way for supporting cloning SiteModel without changing SiteModel class itself
         val gson = Gson()


### PR DESCRIPTION
Closes: #7344 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds a new state to the site picker for handling non-atomic sites, we want to explain to our users that they can't install Woo because the site is a "Simple WordPress.com site".

### Testing instructions
1. Create a simple WordPress.com site.
2. Open the app, and sign in using the site address.
3. Notice the new error state.
4. Click on Login using a different account.
5. Sign in using the WPCom credentials.
6. On the site picker, pick the non-atomic site.
7. Notice the same error state.

### Images/gif
<img src="https://user-images.githubusercontent.com/1657201/188476389-e939b80a-b4fa-4c36-b203-ab9d9274e72c.png" width=360 />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
