### PR TITLE
FAB improvements

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/OrderListScreen.kt
@@ -8,7 +8,6 @@ class OrderListScreen : Screen {
         const val LIST_VIEW = R.id.ordersList
         const val LIST_ITEM = R.id.linearLayout
         const val SEARCH_BUTTON = R.id.menu_search
-        const val CREATE_ORDER_BUTTON = R.id.createOrderButton
         const val CREATE_ORDER_OPTION = R.id.order_creation_button
         const val CREATE_SIMPLE_PAYMENT_OPTION = R.id.simple_payment_button
     }
@@ -27,7 +26,7 @@ class OrderListScreen : Screen {
     }
 
     fun createFABTap(): OrderListScreen {
-        clickOn(CREATE_ORDER_BUTTON)
+        clickOn(R.id.fab)
         return this
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/ProductListScreen.kt
@@ -27,7 +27,7 @@ class ProductListScreen : Screen {
     }
 
     fun tapOnCreateProduct(): ProductListScreen {
-        clickOn(R.id.addProductButton)
+        clickOn(R.id.fab)
         return this
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -5,6 +5,7 @@ import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.FabStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 
@@ -13,6 +14,7 @@ open class BaseFragment : Fragment, BaseFragmentView {
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
     open val activityAppBarStatus: AppBarStatus = AppBarStatus.Visible()
+    open val fabStatus: FabStatus = FabStatus.Hidden
 
     @CallSuper
     override fun onHiddenChanged(hidden: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/FabStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/FabStatus.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.main
+
+import android.view.View
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.woocommerce.android.R
+import org.wordpress.android.mediapicker.util.setImageResourceWithTint
+
+sealed class FabStatus {
+    object Hidden : FabStatus()
+    data class Visible(
+        @StringRes
+        val contentDescription: Int,
+        @DrawableRes
+        val icon: Int,
+        @ColorRes
+        val tint: Int = R.color.white,
+        @ColorRes
+        val backgroundTint: Int? = R.color.color_secondary,
+        val onClick: View.OnClickListener? = null
+    ) : FabStatus()
+}
+
+fun FloatingActionButton.setVisibleFabStatus(status: FabStatus.Visible) {
+    this.setImageResourceWithTint(status.icon, status.tint)
+    status.backgroundTint?.let {
+        this.backgroundTintList = AppCompatResources.getColorStateList(this.context, it)
+    }
+    setOnClickListener(status.onClick)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -31,6 +31,7 @@ import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.NavHostFragment
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.NavGraphMainDirections
@@ -203,6 +204,25 @@ class MainActivity :
                 showBottomNav()
             } else {
                 hideBottomNav()
+            }
+
+            when (val fabStatus = (f as? BaseFragment)?.fabStatus ?: AppBarStatus.Hidden) {
+                FabStatus.Hidden -> hideFAB()
+                is FabStatus.Visible -> {
+                    if (binding.fab.isVisible) {
+                        val listener = object : FloatingActionButton.OnVisibilityChangedListener() {
+                            override fun onHidden(fab: FloatingActionButton) {
+                                super.onHidden(fab)
+                                binding.fab.setVisibleFabStatus(fabStatus)
+                                showFAB()
+                            }
+                        }
+                        binding.fab.hide(listener)
+                    } else {
+                        binding.fab.setVisibleFabStatus(fabStatus)
+                        showFAB()
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -558,6 +558,14 @@ class MainActivity :
         navController.navigateSafely(action)
     }
 
+    override fun showFAB() {
+        binding.fab.show()
+    }
+
+    override fun hideFAB() {
+        binding.fab.hide()
+    }
+
     @Suppress("DEPRECATION")
     override fun showSettingsScreen() {
         AnalyticsTracker.track(AnalyticsEvent.MAIN_MENU_SETTINGS_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
@@ -29,5 +29,7 @@ interface MainContract {
         fun hideProgressDialog()
         fun showProgressDialog(@StringRes stringId: Int)
         fun showUserEligibilityErrorScreen()
+        fun showFAB()
+        fun hideFAB()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.paging.PagedList
 import androidx.recyclerview.widget.ItemTouchHelper
-import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialFadeThrough
 import com.woocommerce.android.AppConstants
@@ -36,7 +35,6 @@ import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.extensions.pinFabAboveBottomNavigationBar
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS_AND_ORDER_CREATION
@@ -46,6 +44,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
+import com.woocommerce.android.ui.main.FabStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.OrderStatusUpdateSource
@@ -96,6 +95,13 @@ class OrderListFragment :
         snackBar?.dismiss()
         super.onStop()
     }
+
+    override val fabStatus: FabStatus
+        get() = FabStatus.Visible(
+            icon = R.drawable.ic_add,
+            contentDescription = R.string.orderlist_create_order_button_description,
+            onClick = { showOrderCreationBottomSheet() }
+        )
 
     // Alias for interacting with [viewModel.isSearching] so the value is always identical
     // to the real value on the UI side.
@@ -196,7 +202,6 @@ class OrderListFragment :
             searchHandler.postDelayed({ searchView?.setQuery(searchQuery, true) }, 100)
         }
         binding.orderFiltersCard.setClickListener { viewModel.onFiltersButtonTapped() }
-        initCreateOrderFAB(binding.createOrderButton)
         initSwipeBehaviour()
         val isLandscape = DisplayUtils.isLandscape(context)
         if (!isLandscape) {
@@ -311,11 +316,6 @@ class OrderListFragment :
             }
             else -> super.onOptionsItemSelected(item)
         }
-    }
-
-    private fun initCreateOrderFAB(fabButton: FloatingActionButton) {
-        fabButton.setOnClickListener { showOrderCreationBottomSheet() }
-        pinFabAboveBottomNavigationBar(fabButton)
     }
 
     private fun isChildFragmentShowing() = (activity as? MainNavigationRouter)?.isChildFragmentShowing() ?: false

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -35,8 +35,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:importantForAccessibility="yes"
-                    app:layout_collapseMode="parallax"
                     android:visibility="gone"
+                    app:layout_collapseMode="parallax"
                     tools:text="Subtitle shop name"
                     tools:visibility="visible" />
 
@@ -47,8 +47,8 @@
 
             <View
                 android:id="@+id/app_bar_divider"
-                android:layout_gravity="bottom"
                 style="@style/Woo.Divider"
+                android:layout_gravity="bottom"
                 android:visibility="gone" />
         </com.google.android.material.appbar.AppBarLayout>
 
@@ -65,6 +65,16 @@
                 android:layout_height="match_parent"
                 app:defaultNavHost="true" />
         </FrameLayout>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/major_100"
+            android:layout_gravity="bottom|end"
+            android:visibility="gone"
+            tools:ignore="ContentDescription" />
+
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <com.woocommerce.android.ui.network.OfflineStatusBarView

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -49,17 +49,5 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/upsellCardReaderComposeView"
             tools:visibility="gone" />
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/createOrderButton"
-            style="@style/Woo.AddButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
-            android:contentDescription="@string/orderlist_create_order_button_description"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
-
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -84,18 +84,5 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             tools:visibility="gone" />
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/addProductButton"
-            style="@style/Woo.AddButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
-            android:contentDescription="@string/add_products_button"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            tools:visibility="visible" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>


### PR DESCRIPTION

Closes: #7351

### Description
When the app shows a SnackBar message on a screen with a FAB, the SnackBar message is displayed on top of the FAB, preventing the user from interacting with the button while the message is shown. A Coordinator layout could handle this problem by default, with the only requirement that the FAB needs to be a direct child of the Coordinator layout. 
Our MainActivity currently wraps the content Fragments in a Coordinator Layout, but as we added the FABs inside the Fragments layouts, these can not interact with the MainActivity's Coordinator Layout (so we don't have the default animation). In this PR, I tried to solve this issue by adding a shared FAB inside the MainActivity's Coordinator Layout and exposing a state and functions to interact with the shared FAB, similar to what we do with the `AppBarStatus`.

### Testing instructions
TC1
1. Select Orders on the Bottom Navigation Component
2. Press the FAB button
3. Check that the Create Order bottom sheet is displayed 

TC2
1. Select Products on the Bottom Navigation Component
2. Press the FAB button
3. Check that the "Select a product type" bottom sheet is displayed 

TC3
1. Select Orders on the Bottom Navigation Component
2. Swipe to complete a non-completed order
3. Check that the SnackBar message indicating the order is completed is not shown on top of the FAB

### Images/gif

https://user-images.githubusercontent.com/18119390/188484099-8c7f19e8-491a-4707-ad21-3bd018724bcc.mp4


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
