### PR TITLE
Replaced deprecated menu methods usage. InboxFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxFragment.kt
@@ -9,7 +9,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -21,7 +23,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class InboxFragment : BaseFragment() {
+class InboxFragment : BaseFragment(), MenuProvider {
     private val viewModel: InboxViewModel by viewModels()
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
@@ -33,7 +35,7 @@ class InboxFragment : BaseFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         return ComposeView(requireContext()).apply {
             // Dispose of the Composition when the view's LifecycleOwner is destroyed
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -50,13 +52,12 @@ class InboxFragment : BaseFragment() {
         setupObservers()
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_inbox, menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_dismiss_all -> {
                 viewModel.dismissAllNotes()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7348
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaced deprecated menu related methods usage in the InboxFragment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Go to the more menu tap
* Click on inbox
* Notice that the menu has not changed and works in the same way as before

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

### before and after

![2](https://user-images.githubusercontent.com/4923871/188571267-4cfe2982-5374-4f3b-ac16-1d35f4d6da72.jpg)
![1](https://user-images.githubusercontent.com/4923871/188571275-806cf6f6-77cc-4baf-bfa0-b6fb4f60e283.jpg)



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
