### PR TITLE
Remove necessity of entering credentials in the card reader purchase flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
@@ -60,7 +60,7 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview), UrlI
                 }
             }
             this.settings.javaScriptEnabled = true
-            settings.userAgentString = userAgent.getUserAgent()
+            settings.userAgentString = userAgent.userAgent
         }
 
         loadAuthenticatedUrl(binding.webView, navArgs.urlToLoad)
@@ -105,6 +105,8 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview), UrlI
         }
         return ""
     }
+
+    override fun getFragmentTitle() = navArgs.title ?: super.getFragmentTitle()
 
     override fun onRequestAllowBackPress(): Boolean {
         navigateBackWithNotice(WEBVIEW_DISMISSED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.transition.Slide
 import androidx.transition.TransitionManager
 import com.google.android.material.textview.MaterialTextView
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentCardReaderHubBinding
@@ -63,7 +64,9 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                     )
                 }
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow -> {
-                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+                    findNavController().navigate(
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
+                    )
                 }
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderManualsScreen -> {
                     findNavController().navigateSafely(R.id.action_cardReaderHubFragment_to_cardReaderManualsFragment)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
@@ -65,7 +65,10 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                 }
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow -> {
                     findNavController().navigate(
-                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                            urlToLoad = event.url,
+                            title = resources.getString(event.titleRes)
+                        )
                     )
                 }
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToCardReaderManualsScreen -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.payments.cardreader.hub
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -233,7 +234,12 @@ class CardReaderHubViewModel @Inject constructor(
 
     private fun onPurchaseCardReaderClicked() {
         trackEvent(AnalyticsEvent.PAYMENTS_HUB_ORDER_CARD_READER_TAPPED)
-        triggerEvent(CardReaderHubEvents.NavigateToPurchaseCardReaderFlow(cardReaderPurchaseUrl))
+        triggerEvent(
+            CardReaderHubEvents.NavigateToPurchaseCardReaderFlow(
+                url = cardReaderPurchaseUrl,
+                titleRes = R.string.card_reader_purchase_card_reader
+            )
+        )
     }
 
     private fun onCardReaderManualsClicked() {
@@ -325,7 +331,10 @@ class CardReaderHubViewModel @Inject constructor(
 
     sealed class CardReaderHubEvents : MultiLiveEvent.Event() {
         data class NavigateToCardReaderDetail(val cardReaderFlowParam: CardReaderFlowParam) : CardReaderHubEvents()
-        data class NavigateToPurchaseCardReaderFlow(val url: String) : CardReaderHubEvents()
+        data class NavigateToPurchaseCardReaderFlow(
+            val url: String,
+            @StringRes val titleRes: Int
+        ) : CardReaderHubEvents()
         object NavigateToPaymentCollectionScreen : CardReaderHubEvents()
         object NavigateToCardReaderManualsScreen : CardReaderHubEvents()
         data class NavigateToCardReaderOnboardingScreen(

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -300,6 +300,11 @@
             android:name="urlComparisonMode"
             android:defaultValue="PARTIAL"
             app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment$UrlComparisonMode" />
+        <argument
+            android:name="title"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
     </fragment>
     <action
         android:id="@+id/action_global_WPComWebViewFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -180,7 +180,8 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         assertThat(viewModel.event.value)
             .isEqualTo(
                 CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow(
-                    "${AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY}US"
+                    url = "${AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY}US",
+                    titleRes = R.string.card_reader_purchase_card_reader
                 )
             )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7349
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds usage of the WP token in order to remove Remove necessity of entering credentials in the card reader purchase flow

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Go to the more menu
* Click on Payments
* Click on Order Card Reader
* Follow the flow and notice that you don't need to enter credentials anymore

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/188607943-498eecac-f7e1-487d-a8cd-767bb8a6d19a.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
