### PR TITLE
Refactor menu methods

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
@@ -121,7 +121,7 @@ class LoginDiscoveryErrorFragment : Fragment(layout.fragment_login_discovery_err
                 )
             }
         }
-        requireActivity().addMenuProvider(this,viewLifecycleOwner, Lifecycle.State.RESUMED)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
@@ -9,7 +9,9 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.text.HtmlCompat
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -22,7 +24,7 @@ import org.wordpress.android.login.LoginListener
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class LoginDiscoveryErrorFragment : Fragment(layout.fragment_login_discovery_error) {
+class LoginDiscoveryErrorFragment : Fragment(layout.fragment_login_discovery_error), MenuProvider {
     companion object {
         const val TAG = "LoginDiscoveryErrorFragment"
         const val ARG_SITE_ADDRESS = "SITE-ARG_SITE_ADDRESS"
@@ -81,8 +83,6 @@ class LoginDiscoveryErrorFragment : Fragment(layout.fragment_login_discovery_err
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setHasOptionsMenu(true)
-
         val binding = FragmentLoginDiscoveryErrorBinding.bind(view)
         val toolbar = view.findViewById(R.id.toolbar) as Toolbar
         (activity as AppCompatActivity).setSupportActionBar(toolbar)
@@ -121,15 +121,15 @@ class LoginDiscoveryErrorFragment : Fragment(layout.fragment_login_discovery_err
                 )
             }
         }
+        requireActivity().addMenuProvider(this,viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.menu_login, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.menu_login, menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == R.id.help) {
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        if (menuItem.itemId == R.id.help) {
             AnalyticsTracker.track(AnalyticsEvent.LOGIN_DISCOVERY_ERROR_MENU_HELP_TAPPED)
             loginListener?.helpSiteAddress(siteAddress)
             return true


### PR DESCRIPTION
Closes: #7353

### Description
The PR refactored the way of handling menus in LoginDiscoveryErrorFragment

### Testing instructions
The testing instructions would be to log out and log in again with a user who because of a security measure needs to log in using username and password. For simplicity, I created this patch to launch the Fragment when the LoginActivity is opened.

<details>
  <summary>Patch</summary>

```
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
index 250b18995e..acdbd7f97b 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -234,11 +234,20 @@ class LoginActivity :
     }
 
     private fun showPrologue() {
-        if (!appPrefsWrapper.hasOnboardingCarouselBeenDisplayed()) {
-            showPrologueCarouselFragment()
-        } else {
-            showPrologueFragment()
-        }
+        val loginDiscoveryErrorFragment = LoginDiscoveryErrorFragment.newInstance(
+            "site.com",
+            "user name",
+            "user",
+            "password",
+            null,
+            R.string.login_discovery_error_ssl
+        )
+        changeFragment(loginDiscoveryErrorFragment, true, LoginUsernamePasswordFragment.TAG)
+        /* if (!appPrefsWrapper.hasOnboardingCarouselBeenDisplayed()) {
+             showPrologueCarouselFragment()
+         } else {
+             showPrologueFragment()
+         }*/
     }
 
     private fun hasMagicLinkLoginIntent(): Boolean {
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
index 09e03fdbd3..16194f7664 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
@@ -156,6 +156,6 @@ class LoginDiscoveryErrorFragment : Fragment(layout.fragment_login_discovery_err
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
         AnalyticsTracker.track(AnalyticsEvent.LOGIN_DISCOVERY_ERROR_SCREEN_VIEWED)
-        unifiedLoginTracker.track(step = Step.CONNECTION_ERROR)
+        //unifiedLoginTracker.track(step = Step.CONNECTION_ERROR)
     }
 }
```

</details>
### Images/gif

https://user-images.githubusercontent.com/18119390/188649621-20d4c9d7-232c-457f-8f2e-8d6a004ff82b.mp4


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
