### PR TITLE
Add swipe thresholds

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
@@ -31,6 +31,8 @@ class SwipeToComplete(
     companion object {
         private const val NO_SWIPE_ABLE_SCREEN_PERCENT = 0.10
         const val OLD_STATUS = "old_status"
+        const val SWIPE_THRESHOLD = .5F
+        const val SWIPE_VELOCITY_THRESHOLD = 0F
     }
 
     private val displayMetrics = context.resources.displayMetrics
@@ -57,6 +59,9 @@ class SwipeToComplete(
     ): Boolean {
         return false
     }
+
+    override fun getSwipeThreshold(viewHolder: RecyclerView.ViewHolder) = SWIPE_THRESHOLD
+    override fun getSwipeVelocityThreshold(defaultValue: Float) = SWIPE_VELOCITY_THRESHOLD
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
         val pos = viewHolder.absoluteAdapterPosition

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
@@ -61,6 +61,7 @@ class SwipeToComplete(
     }
 
     override fun getSwipeThreshold(viewHolder: RecyclerView.ViewHolder) = SWIPE_THRESHOLD
+    override fun getSwipeEscapeVelocity(defaultValue: Float) = SWIPE_VELOCITY_THRESHOLD
     override fun getSwipeVelocityThreshold(defaultValue: Float) = SWIPE_VELOCITY_THRESHOLD
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {


### PR DESCRIPTION
Closes #7363

### Description
We relied on the default swipe threshold, assuming that the `onSwipe` callback within `SwipeToComplete` would only be triggered when the user swiped an order for more than half of the screen. With this idea in mind, we implemented the glance animation using the `dispatchTouchEvent` of RecyclerViews and swiping only a portion of the screen. We missed with this implementation that we also needed to restrict the velocity threshold. Using the default velocity threshold caused that in some devices, with a small screen or pixel density, the glance animation to trigger the `onSwipe` callback, automatically changing the status of the first non-completed order, as mentioned by a user [here](p1662415774740679-slack-C013AAPA4G0). With the changes introduced in this PR, we override the default velocity and swipe threshold to prevent the glance animation from auto-trigger the swipe-to-complete gesture.

original discussion: p1662451246710529-slack-C6H8C3G23

See on sec 14 of the following video that even with a small swipe the Swipe-To-Complete gesture could be triggered: 

https://user-images.githubusercontent.com/18119390/188732951-da0e4eb1-280d-438f-9cc3-5fd179cb5373.mp4

### Testing instructions
I will recommend using a small device for the tests 

TC1
1. Open orders list
2. Check that the swipe-to-complete gesture could not be triggered with small gestures

TC2
1. Create a Pixel 3 emulator with API 31
2. Run the `OrdersUITest`
3. Check that the swipe-to-complete is not triggered as in the video below

https://user-images.githubusercontent.com/18119390/188734423-31c77270-7e74-4912-9258-7acfb8928b15.mov

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/188734925-eb008cae-c21f-4f77-90ae-acc6b33eadd8.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->