### PR TITLE
Fix build issue: add missing navigation argument to the second declaration of WPComWebViewFragment

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -99,6 +99,11 @@
             android:name="urlComparisonMode"
             android:defaultValue="PARTIAL"
             app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment$UrlComparisonMode" />
+        <argument
+            android:name="title"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
     </fragment>
     <action android:id="@+id/action_global_WPComWebViewFragment" app:destination="@id/WPComWebViewFragment"/>
     <include app:graph="@navigation/nav_graph_jetpack_install" />


### PR DESCRIPTION
### Description
In #7355, we added a new argument to the `WPComWebViewFragment`'s declaration in `nav_graph_main`, but since this destination is declared too in `nav_graph_settings`, we need to add it there too, failing to do so triggers a random build failure (like this https://buildkite.com/automattic/woocommerce-android/builds/5947).

This is similar to the issue fixed in #7246.

### Testing instructions
Just confirm the app builds fine all the time.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
