### PR TITLE
Usage of menu provide on the LoginSiteCheckErrorFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginSiteCheckErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginSiteCheckErrorFragment.kt
@@ -8,7 +8,9 @@ import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle.State
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentLoginSiteCheckErrorBinding
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
@@ -18,7 +20,7 @@ import org.wordpress.android.login.LoginListener
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class LoginSiteCheckErrorFragment : Fragment(R.layout.fragment_login_site_check_error) {
+class LoginSiteCheckErrorFragment : Fragment(R.layout.fragment_login_site_check_error), MenuProvider {
     companion object {
         const val TAG = "LoginGenericErrorFragment"
         const val ARG_SITE_ADDRESS = "SITE-ADDRESS"
@@ -49,7 +51,7 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.fragment_login_site_check_
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, State.RESUMED)
         activity?.title = getString(R.string.log_in)
 
         val binding = FragmentLoginSiteCheckErrorBinding.bind(view)
@@ -86,12 +88,11 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.fragment_login_site_check_
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_login, menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.help) {
             unifiedLoginTracker.trackClick(Click.SHOW_HELP)
             loginListener?.helpSiteAddress(siteAddress)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7368 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaces usage of the deprecated menu methods in the `LoginSiteCheckErrorFragment`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Use login by store address
* Enter non-wp website address
* Notice that the menu is the same as before the change 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/4923871/189079320-93aba3dc-94f8-4020-8db0-92c6da725740.jpg" width=300 />
<img src="https://user-images.githubusercontent.com/4923871/189079325-5312d5c0-a5e0-4fa2-9e25-19e2671b8b35.jpg" width=300 />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
