### PR TITLE
Removed redundant setHasOptionsMenu call. Removed commented code

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -57,7 +57,6 @@ import javax.inject.Inject
 import kotlin.math.abs
 
 @AndroidEntryPoint
-@Suppress("ForbiddenComment")
 @OptIn(FlowPreview::class)
 class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     companion object {
@@ -119,7 +118,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
 
         initTabLayout()
 
@@ -302,30 +300,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         super.onDestroyView()
         _binding = null
     }
-
-    /*
-    Hide Settings icon on My Store, because it is moved to the "More" screen.
-    We temporarily comment out the code instead of deleting, because we might want to restore it later,
-    based on merchants feedbacks.
-
-    TODO: Maybe restore Settings icon on My Store, depending on merchants feedbacks.
-    For more context: https://github.com/woocommerce/woocommerce-android/issues/5586
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_action_bar, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_settings -> {
-                (activity as? MainNavigationRouter)?.showSettingsScreen()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-     */
 
     private fun showStats(revenueStatsModel: RevenueStatsUiModel?) {
         addTabLayoutToAppBar()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7370
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open the main screen's my store tab
* Notice that menu is missing, the same as it used to be


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
