### PR TITLE
7373 replace menu calls create order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -57,7 +57,6 @@ import javax.inject.Inject
 import kotlin.math.abs
 
 @AndroidEntryPoint
-@Suppress("ForbiddenComment")
 @OptIn(FlowPreview::class)
 class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     companion object {
@@ -119,7 +118,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
 
         initTabLayout()
 
@@ -302,30 +300,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         super.onDestroyView()
         _binding = null
     }
-
-    /*
-    Hide Settings icon on My Store, because it is moved to the "More" screen.
-    We temporarily comment out the code instead of deleting, because we might want to restore it later,
-    based on merchants feedbacks.
-
-    TODO: Maybe restore Settings icon on My Store, depending on merchants feedbacks.
-    For more context: https://github.com/woocommerce/woocommerce-android/issues/5586
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_action_bar, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_settings -> {
-                (activity as? MainNavigationRouter)?.showSettingsScreen()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-     */
 
     private fun showStats(revenueStatsModel: RevenueStatsUiModel?) {
         addTabLayoutToAppBar()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
@@ -5,9 +5,11 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditCustomerAddressBinding
@@ -37,7 +39,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class OrderCreateEditCustomerAddFragment : BaseFragment(R.layout.fragment_order_create_edit_customer_address) {
+class OrderCreateEditCustomerAddFragment :
+    BaseFragment(R.layout.fragment_order_create_edit_customer_address),
+    MenuProvider {
     private companion object {
         const val SELECT_BILLING_COUNTRY_REQUEST = "select_billing_country_request"
         const val SELECT_BILLING_STATE_REQUEST = "select_billing_state_request"
@@ -59,7 +63,7 @@ class OrderCreateEditCustomerAddFragment : BaseFragment(R.layout.fragment_order_
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         inflateLayout(view)
         setupLocationHandling()
         observeEvents()
@@ -259,8 +263,7 @@ class OrderCreateEditCustomerAddFragment : BaseFragment(R.layout.fragment_order_
         findNavController().navigateSafely(action)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
 
         if (FeatureFlag.ORDER_CREATION_CUSTOMER_SEARCH.isEnabled()) {
@@ -281,7 +284,7 @@ class OrderCreateEditCustomerAddFragment : BaseFragment(R.layout.fragment_order_
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 addressViewModel.onDoneSelected(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -6,8 +6,10 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -50,7 +52,10 @@ import java.math.BigDecimal
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_edit_form), BackPressListener {
+class OrderCreateEditFormFragment :
+    BaseFragment(R.layout.fragment_order_create_edit_form),
+    BackPressListener,
+    MenuProvider {
     private val viewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter
@@ -80,7 +85,7 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         with(FragmentOrderCreateEditFormBinding.bind(view)) {
             setupObserversWith(this)
             setupHandleResults()
@@ -88,7 +93,7 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_order_creation, menu)
 
@@ -103,7 +108,7 @@ class OrderCreateEditFormFragment : BaseFragment(R.layout.fragment_order_create_
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_create -> {
                 viewModel.onCreateOrderClicked(viewModel.currentDraft)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -114,7 +114,7 @@ class OrderCreateEditFormFragment :
                 viewModel.onCreateOrderClicked(viewModel.currentDraft)
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7372
Closes: #7373
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaces  deprecated menu calls:
* OrderCreateEditFormFragment
* OrderCreateEditCustomerAddFragment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open an order
* Click `edit`
* Notice that menu buttons are the same and they are working
* Click `add customer`
* Notice that menu buttons are the same and they are working


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
