### PR TITLE
[Login] Jetpack Connection: tracking and enable feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 10.3
 -----
 - [*] Login: fix an issue where the app shows that Jetpack is not installed when connecting using wrong account [https://github.com/woocommerce/woocommerce-android/pull/7330]
+- [**] Login: Add ability to connect Jetpack when signing with site credentials to a site that has Jetpack but not connected yet [https://github.com/woocommerce/woocommerce-android/pull/7375]
 
 10.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/FluxCExeptions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/FluxCExeptions.kt
@@ -1,5 +1,8 @@
 package com.woocommerce.android
 
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.store.Store.OnChangedError
 
 class WooException(val error: WooError) : Exception(error.message.orEmpty())
+
+class OnChangedException(val error: OnChangedError, override val message: String? = null) : Exception()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -102,6 +102,11 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     LOGIN_JETPACK_SETUP_BUTTON_TAPPED(siteless = true),
     LOGIN_JETPACK_SETUP_DISMISSED(siteless = true),
     LOGIN_JETPACK_SETUP_COMPLETED(siteless = true),
+    LOGIN_JETPACK_CONNECTION_ERROR_SHOWN(siteless = true),
+    LOGIN_JETPACK_CONNECT_BUTTON_TAPPED(siteless = true),
+    LOGIN_JETPACK_CONNECT_COMPLETED(siteless = true),
+    LOGIN_JETPACK_CONNECT_DISMISSED(siteless = true),
+    LOGIN_JETPACK_CONNECTION_VERIFICATION_FAILED(siteless = true),
 
     // -- Site Picker
     SITE_PICKER_STORES_SHOWN(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -103,6 +103,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     LOGIN_JETPACK_SETUP_DISMISSED(siteless = true),
     LOGIN_JETPACK_SETUP_COMPLETED(siteless = true),
     LOGIN_JETPACK_CONNECTION_ERROR_SHOWN(siteless = true),
+    LOGIN_JETPACK_CONNECTION_URL_FETCH_FAILED(siteless = true),
     LOGIN_JETPACK_CONNECT_BUTTON_TAPPED(siteless = true),
     LOGIN_JETPACK_CONNECT_COMPLETED(siteless = true),
     LOGIN_JETPACK_CONNECT_DISMISSED(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -715,7 +715,7 @@ class LoginActivity :
         userAvatarUrl: String?,
         checkJetpackAvailability: Boolean
     ) {
-        if (connectSiteInfo?.isJetpackConnected == true) {
+        if (connectSiteInfo?.isJetpackInstalled == true && connectSiteInfo?.isJetpackActive == true) {
             // If jetpack is present, but we can't find the connected email, then show account mismatch error
             val fragment = AccountMismatchErrorFragment().apply {
                 arguments = AccountMismatchErrorFragmentArgs(AccountMismatchPrimaryButton.CONNECT_JETPACK).toBundle()
@@ -1006,7 +1006,8 @@ class LoginActivity :
             connectSiteInfo = event.info.let {
                 ConnectSiteInfo(
                     isWPCom = it.isWPCom,
-                    isJetpackConnected = it.isJetpackConnected
+                    isJetpackInstalled = it.isJetpackConnected,
+                    isJetpackActive = it.isJetpackActive
                 )
             }
         }
@@ -1015,6 +1016,7 @@ class LoginActivity :
     @Parcelize
     private data class ConnectSiteInfo(
         val isWPCom: Boolean,
-        val isJetpackConnected: Boolean
+        val isJetpackInstalled: Boolean,
+        val isJetpackActive: Boolean
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.AccountRepository
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -94,9 +93,7 @@ class AccountMismatchErrorViewModel @Inject constructor(
         primaryButtonText = when (navArgs.primaryButton) {
             AccountMismatchPrimaryButton.SHOW_SITE_PICKER -> R.string.login_view_connected_stores
             AccountMismatchPrimaryButton.ENTER_NEW_SITE_ADDRESS -> R.string.login_site_picker_try_another_address
-            AccountMismatchPrimaryButton.CONNECT_JETPACK -> {
-                if (FeatureFlag.LOGIN_JETPACK_CONNECTION.isEnabled()) R.string.login_connect_jetpack_button else null
-            }
+            AccountMismatchPrimaryButton.CONNECT_JETPACK -> R.string.login_connect_jetpack_button
             AccountMismatchPrimaryButton.NONE -> null
         },
         primaryButtonAction = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -162,6 +162,12 @@ class AccountMismatchErrorViewModel @Inject constructor(
                 _loadingDialogMessage.value = null
                 step.value = Step.MainContent
                 triggerEvent(ShowSnackbar(R.string.login_jetpack_connection_url_failed))
+                analyticsTrackerWrapper.track(
+                    stat = AnalyticsEvent.LOGIN_JETPACK_CONNECTION_URL_FETCH_FAILED,
+                    errorContext = this.javaClass.simpleName,
+                    errorType = (it as? OnChangedException)?.error?.javaClass?.simpleName,
+                    errorDescription = it.message
+                )
             }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepository.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.accountmismatch
 
+import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -23,7 +24,7 @@ class AccountMismatchRepository @Inject constructor(
         return when {
             result.isError -> {
                 WooLog.w(WooLog.T.LOGIN, "Fetching Jetpack Connection URL failed: ${result.error.message}")
-                Result.failure(Exception(result.error.message))
+                Result.failure(OnChangedException(result.error, result.error.message))
             }
             else -> {
                 WooLog.d(WooLog.T.LOGIN, "Jetpack connection URL fetched successfully")
@@ -38,7 +39,7 @@ class AccountMismatchRepository @Inject constructor(
         return when {
             result.isError -> {
                 WooLog.w(WooLog.T.LOGIN, "Fetching Jetpack User failed error: $result.error.message")
-                Result.failure(Exception(result.error.message))
+                Result.failure(OnChangedException(result.error, result.error.message))
             }
             result.user?.wpcomEmail.isNullOrEmpty() -> {
                 WooLog.w(WooLog.T.LOGIN, "Cannot find Jetpack Email in response")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,8 +14,7 @@ enum class FeatureFlag {
     WC_SHIPPING_BANNER,
     UNIFIED_ORDER_EDITING,
     ORDER_CREATION_CUSTOMER_SEARCH,
-    PRE_LOGIN_NOTIFICATIONS,
-    LOGIN_JETPACK_CONNECTION;
+    PRE_LOGIN_NOTIFICATIONS;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -29,8 +28,7 @@ enum class FeatureFlag {
             ANALYTICS_HUB,
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            PRE_LOGIN_NOTIFICATIONS,
-            LOGIN_JETPACK_CONNECTION -> PackageUtils.isDebugBuild()
+            PRE_LOGIN_NOTIFICATIONS -> PackageUtils.isDebugBuild()
         }
     }
 }


### PR DESCRIPTION
Part of: #7307 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR has the following changes:
- Adds tracking
- Enables the Jetpack Connection feature and removes the feature flag.
- Enables the Jetpack Connection flow for all cases when Jetpack is installed and active, we don't check if it's connected to a different account, this is more useful than showing the Jetpack required error.
- Adds a back button handler to correctly dismiss the webview instead of navigating back.

### Testing instructions
1. Open the app, then sign in to a self hosted site that has Jetpack installed and active but not connected yet.
2. Use site credentials to sign in.
3. Notice the Jetpack Connection screen, and the event`login_jetpack_connection_error_shown`
4. Click on "Connect Jetpack to your account".
5. Confirm the event: `login_jetpack_connect_button_tapped`
6. Click on back button.
7. Confirm the event: `login_jetpack_connect_dismissed`.
8. Repeat 4, then continue the connection flow.
9. Confirm the event: `login_jetpack_connect_completed` after the connection.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
