### PR TITLE
Fix dependency injection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetListRemoteViewsFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetListRemoteViewsFactory.kt
@@ -7,23 +7,38 @@ import android.widget.RemoteViews
 import android.widget.RemoteViewsService.RemoteViewsFactory
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.appwidgets.stats.StatsWidgetProvider.Companion.SITE_ID_KEY
-import javax.inject.Inject
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 
 /**
  * Class extends [RemoteViewsFactory] and acts as an interface for the current day stats widget ListView adapter
  */
-class TodayWidgetListRemoteViewsFactory @Inject constructor(
+class TodayWidgetListRemoteViewsFactory(
     val context: Context,
     intent: Intent
 ) : RemoteViewsFactory {
-    // TODO this injection doesn't work
-    @Inject lateinit var viewModel: TodayWidgetListViewModel
-    @Inject lateinit var widgetUpdater: TodayWidgetUpdater
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface TodayWidgetListEntryPoint {
+        fun viewModel(): TodayWidgetListViewModel
+        fun widgetUpdater(): TodayWidgetUpdater
+    }
+
+    lateinit var viewModel: TodayWidgetListViewModel
+    lateinit var widgetUpdater: TodayWidgetUpdater
 
     private val siteId: Int = intent.getIntExtra(SITE_ID_KEY, 0)
     private val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
 
     override fun onCreate() {
+        val hiltEntryPoint =
+            EntryPointAccessors.fromApplication(context, TodayWidgetListEntryPoint::class.java)
+        viewModel = hiltEntryPoint.viewModel()
+        widgetUpdater = hiltEntryPoint.widgetUpdater()
+
         viewModel.start(siteId, appWidgetId)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetListViewModel.kt
@@ -1,29 +1,24 @@
 package com.woocommerce.android.ui.appwidgets.stats.today
 
 import androidx.annotation.LayoutRes
-import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
-import com.woocommerce.android.viewmodel.ScopedViewModel
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.runBlocking
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
-@HiltViewModel
 class TodayWidgetListViewModel @Inject constructor(
-    savedState: SavedStateHandle,
     private val siteStore: SiteStore,
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter,
     private val repository: TodayWidgetListViewRepository,
     private val appPrefsWrapper: AppPrefsWrapper
-) : ScopedViewModel(savedState) {
+) {
     private var siteId: Int? = null
     private var appWidgetId: Int? = null
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
This PR fixes the broken dependency injection on `TodayWidgetListRemoteViewsFactory`. It solves the issue by using the [inject dependencies in classes not supported by Hilt](https://developer.android.com/training/dependency-injection/hilt-android#not-supported) approach from Google Docs.

### Testing instructions
1. Install the App
2. Add the widget to the screen and check nothing breaks

### Images/gif
<img src="https://user-images.githubusercontent.com/18119390/189159620-3808ab5a-03ad-4c1b-8526-0c98e40f44f5.png" width="300" />


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
