### PR TITLE
Merge 10.3 code freeze to trunk

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+10.4
+-----
+
+
 10.3
 -----
 - [*] Login: fix an issue where the app shows that Jetpack is not installed when connecting using wrong account [https://github.com/woocommerce/woocommerce-android/pull/7330]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,9 +74,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "10.2"
+            versionName "10.3-rc-1"
         }
-        versionCode 328
+        versionCode 329
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,18 +11,17 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_103"
+msgid ""
+"10.3:\n"
+"More stability fixes to help you log in much easier. Added the ability to set up Jetpack if it's not connected yet. And we fixed a bug where Jetpack can be incorrectly assumed as unavailable. Please keep your feedback coming!\n"
+msgstr ""
+
 msgctxt "release_note_102"
 msgid ""
 "10.2:\n"
 "Even though this release doesn’t have any new features, we still put a lot of love into it! We’ve added a new Help Center page that makes it easier for you to login to the app. You can also enable or disable the option to take card or cash payments on collection or delivery.\n"
 "Lastly, we’ve made some tweaks to improve performance. Please keep sending your feedback! We read every one of them!\n"
-"\n"
-msgstr ""
-
-msgctxt "release_note_101"
-msgid ""
-"10.1:\n"
-"Even though this release doesn’t have any new features, we still put a lot of love into it, including fixing an issue where you might be unnecessarily blocked from taking payments. Please continue to send us feedback – we are listening!\n"
 "\n"
 msgstr ""
 

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,3 +1,1 @@
-- [*] Login: fix an issue where the app shows that Jetpack is not installed when connecting using wrong account [https://github.com/woocommerce/woocommerce-android/pull/7330]
-- [**] Login: Add ability to connect Jetpack when signing with site credentials to a site that has Jetpack but not connected yet [https://github.com/woocommerce/woocommerce-android/pull/7375]
-
+More stability fixes to help you log in much easier. Added the ability to set up Jetpack if it's not connected yet. And we fixed a bug where Jetpack can be incorrectly assumed as unavailable. Please keep your feedback coming!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,3 +1,3 @@
-Even though this release doesn’t have any new features, we still put a lot of love into it! We’ve added a new Help Center page that makes it easier for you to login to the app. You can also enable or disable the option to take card or cash payments on collection or delivery.
-Lastly, we’ve made some tweaks to improve performance. Please keep sending your feedback! We read every one of them!
+- [*] Login: fix an issue where the app shows that Jetpack is not installed when connecting using wrong account [https://github.com/woocommerce/woocommerce-android/pull/7330]
+- [**] Login: Add ability to connect Jetpack when signing with site credentials to a site that has Jetpack but not connected yet [https://github.com/woocommerce/woocommerce-android/pull/7375]
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-e6e5fd7bb192c9ac24d826305bf39576426837ee'
+    fluxCVersion = '1.53.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -230,6 +230,7 @@
     <string name="login_with_a_different_account">Login with a different account</string>
     <string name="login_no_stores">We didn\'t find WooCommerce stores connected to this account.</string>
     <string name="login_wpcom_account_mismatch">It looks like %1$s is connected to a different WordPress.com account.</string>
+    <string name="login_jetpack_not_connected">It looks like your account is not connected to %1$s\'s Jetpack</string>
     <string name="login_try_another_account">Log in with another account</string>
     <string name="login_try_another_store">Try another store</string>
     <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site.</string>
@@ -268,6 +269,11 @@
     <string name="login_site_picker_enter_site_address">Enter a site address</string>
     <string name="site_discovery_postlogin_failure">A failure occurred, please contact support</string>
     <string name="login_site_picker_new_to_woo">New to WooCommerce</string>
+    <string name="login_connect_jetpack_button">Connect Jetpack to your account</string>
+    <string name="login_simple_wpcom_site">The site %1$s is currently on a WordPress.com plan that does not support plugin installation. Please upgrade your plan to use WooCommerce.</string>
+    <string name="login_jetpack_connection_verification_failed">Cannot verify your Jetpack connection. Please try again.</string>
+    <string name="login_jetpack_verify_connection">Verifying Jetpack connection…</string>
+    <string name="login_jetpack_connection_url_failed">Fetching connection data failed…</string>
     <!--
         My Store View
     -->


### PR DESCRIPTION
While working on the  "Merge 10.2 final to trunk" PR in #7377, I was expecting to see issues related the login strings due to the changes in #7330, but as far as I can tell, everything looks correct.

In #7330:
* `login_not_connected_to_account` was removed which seems to be still in effect
* `login_wpcom_account_mismatch` was added (seems to be a rename from `login_not_connected_to_account`) which is not changed in this PR
* `login_jetpack_not_connected` was added which is now imported to `fastlane/resources/values/strings.xml` as expected

@hichamboushaba If it's not too much trouble, can I ask you to test the feature in [`10.3-rc-1`](https://github.com/woocommerce/woocommerce-android/releases/tag/untagged-6d9f396775735c6953a2) to make sure the strings look as expected? The main worry is that when we import the strings from the login library, it may override the values from the app, so if a string belongs to the library it should not be modified in the client. Currently, this distinction is a little bit hard to identify because it seems we have strings with `login_` prefix that belong to the library as well as the client.