### PR TITLE
Fix logic of signout function in AccountRepository

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -45,6 +45,7 @@ class AccountRepository @Inject constructor(
                 }
             }
         }
+        dispatcher.register(listener)
         dispatcher.dispatch(AccountActionBuilder.newSignOutAction())
         dispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction())
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -141,8 +141,6 @@ class MainPresenter @Inject constructor(
             // In all other login cases, this logic is handled by the login library
             mainView?.notifyTokenUpdated()
             dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
-        } else {
-            mainView?.showLoginScreen()
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2525-dee3d2f1a33b7fc711bae342d16a32433a62d9ce'
+    fluxCVersion = 'trunk-00e4f710060f07f46733e88d83768c01b686f180'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.53.0'
+    fluxCVersion = '2525-dee3d2f1a33b7fc711bae342d16a32433a62d9ce'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ Please don't merge until https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2525 is merged and commit hash is updated.

### Description
@nbradbury noticed an issue with the logout flow, the function `AppSettingsActivity#finishLogout` doesn't seem to be called after logout.
This was caused by two things:
1. In the PR https://github.com/woocommerce/woocommerce-android/pull/7311 I updated `AppSettingsPresenter` to reuse the same `AccountRepository#logout` function we use in other places in the app.
2. This function was basically broken because of an issue in FluxC, we don't assign the `causeOfChange` to the dispatched event after logout, which means we don't continue the coroutine.

This is not causing any issues currently, as we have this very old code in `MainActivity` here: https://github.com/woocommerce/woocommerce-android/blob/08ea76d3d2dd998d25bb4a0684db44ebd5deffed/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt#L145
This was added when there was a logout button in `MainActivity`, but it was left after moving the logout to the settings activity.

Side note: ~~should we remove this code now? my vote would be to remove it.~~ Done ✅ 

### Testing instructions
Put a breakpoint in `AppSettingsActivity#finishLogout`, then test logout from the app, and confirm the breakpoint is hit.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
