### PR TITLE
Nick/app widget logged out improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/WidgetUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/WidgetUtils.kt
@@ -48,6 +48,7 @@ class WidgetUtils
         errorMessage: Int,
         resourceProvider: ResourceProvider,
         context: Context,
+        showRetry: Boolean,
         widgetType: Class<*>
     ) {
         views.setOnClickPendingIntent(
@@ -61,6 +62,7 @@ class WidgetUtils
         )
         views.setViewVisibility(R.id.widget_content, View.GONE)
         views.setViewVisibility(R.id.widget_error, View.VISIBLE)
+        views.setViewVisibility(R.id.widget_retry_button, if (showRetry) View.VISIBLE else View.GONE)
         views.setTextViewText(
             R.id.widget_error_message,
             resourceProvider.getString(errorMessage)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/WidgetUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/WidgetUtils.kt
@@ -48,27 +48,32 @@ class WidgetUtils
         errorMessage: Int,
         resourceProvider: ResourceProvider,
         context: Context,
-        showRetry: Boolean,
+        hasAccessToken: Boolean,
         widgetType: Class<*>
     ) {
+        val pendingIntent = getPendingSelfIntent(context)
         views.setOnClickPendingIntent(
             R.id.widget_title_container,
-            PendingIntent.getActivity(
-                context,
-                0,
-                Intent(),
-                PENDING_INTENT_FLAGS
-            )
+            pendingIntent
         )
+
         views.setViewVisibility(R.id.widget_content, View.GONE)
         views.setViewVisibility(R.id.widget_error, View.VISIBLE)
-        views.setViewVisibility(R.id.widget_retry_button, if (showRetry) View.VISIBLE else View.GONE)
         views.setTextViewText(
             R.id.widget_error_message,
             resourceProvider.getString(errorMessage)
         )
-        val pendingSync = getRetryIntent(context, widgetType, appWidgetId)
-        views.setOnClickPendingIntent(R.id.widget_error, pendingSync)
+
+        // if the access token exists it means the user is logged in and is experiencing an error, in which
+        // case we show a Retry button that attempts to fetch stats again. if the user isn't logged in, we
+        // hide the Retry button and launch the app when the widget is clicked.
+        views.setViewVisibility(R.id.widget_retry_button, if (hasAccessToken) View.VISIBLE else View.GONE)
+        if (hasAccessToken) {
+            views.setOnClickPendingIntent(R.id.widget_error, getRetryIntent(context, widgetType, appWidgetId))
+        } else {
+            views.setOnClickPendingIntent(R.id.widget_error, pendingIntent)
+        }
+
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetUpdater.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetUpdater.kt
@@ -79,7 +79,7 @@ class TodayWidgetUpdater
                 errorMessage,
                 resourceProvider,
                 context,
-                showRetry = hasAccessToken,
+                hasAccessToken,
                 TodayStatsWidgetProvider::class.java
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetUpdater.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetUpdater.kt
@@ -79,6 +79,7 @@ class TodayWidgetUpdater
                 errorMessage,
                 resourceProvider,
                 context,
+                showRetry = hasAccessToken,
                 TodayStatsWidgetProvider::class.java
             )
         }


### PR DESCRIPTION
As part of #7288, this PR improves the stats today widget's logged out experience. Previously when logged out, the widget showed a Retry button that basically did nothing. This PR removes that button and launches the app when the widget is tapped.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
