### PR TITLE
Widget/last updated message

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetUpdater.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayWidgetUpdater.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.appwidgets.WidgetUpdater
 import com.woocommerce.android.ui.appwidgets.WidgetUtils
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
@@ -26,7 +27,8 @@ class TodayWidgetUpdater
     private val accountStore: AccountStore,
     private val networkStatus: NetworkStatus,
     private val resourceProvider: ResourceProvider,
-    private val widgetUtils: WidgetUtils
+    private val widgetUtils: WidgetUtils,
+    private val dateUtils: DateUtils
 ) : WidgetUpdater {
     override fun updateAppWidget(
         context: Context,
@@ -46,6 +48,14 @@ class TodayWidgetUpdater
         if (networkAvailable && hasAccessToken && siteModel != null) {
             views.setTextViewText(R.id.widget_title, siteModel.getTitle(context.getString(R.string.my_store)))
             views.setViewVisibility(R.id.widget_type, View.VISIBLE)
+
+            views.setTextViewText(
+                R.id.widget_update_time,
+                String.format(
+                    resourceProvider.getString(R.string.stats_widget_last_updated_message),
+                    dateUtils.getCurrentTime()
+                )
+            )
 
             siteModel.let {
                 views.setOnClickPendingIntent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -20,6 +20,7 @@ class DateUtils @Inject constructor(
 ) {
     private val friendlyMonthDayFormat: SimpleDateFormat = SimpleDateFormat("MMM d", locale)
     private val friendlyMonthDayYearFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", locale)
+    private val friendlyTimeFormat: SimpleDateFormat = SimpleDateFormat("h:mm a", locale)
 
     private val weekOfYearStartingMondayFormat: SimpleDateFormat = SimpleDateFormat("yyyy-'W'ww", locale).apply {
         calendar = Calendar.getInstance().apply {
@@ -508,6 +509,11 @@ class DateUtils @Inject constructor(
      * Returns current date
      */
     fun getCurrentDate() = Date()
+
+    /**
+     * Returns current date in the format h:mm a
+     */
+    fun getCurrentTime(): String = friendlyTimeFormat.format(getCurrentDate())
 
     /**
      * Returns a Calendar object with argument date applied argument operation

--- a/WooCommerce/src/main/res/layout/stats_widget_header.xml
+++ b/WooCommerce/src/main/res/layout/stats_widget_header.xml
@@ -1,46 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/widget_title_container"
     style="@style/Woo.StatsWidgetHeader"
     android:layout_width="match_parent"
-    android:minHeight="@dimen/stats_widget_header_height"
     android:layout_height="@dimen/stats_widget_header_height"
-    android:orientation="horizontal"
     android:gravity="center_vertical"
-    tools:showIn="@layout/stats_widget_list"
-    tools:ignore="UseCompoundDrawables">
+    android:minHeight="@dimen/stats_widget_header_height"
+    android:orientation="horizontal"
+    tools:ignore="UseCompoundDrawables"
+    tools:showIn="@layout/stats_widget_list">
 
     <ImageView
         android:id="@+id/widget_app_icon"
-        style="@style/Woo.StatsWidgetSiteIcon"
-        android:importantForAccessibility="no"
         android:layout_width="@dimen/image_minor_80"
         android:layout_height="@dimen/image_minor_80"
+        android:layout_alignTop="@+id/widget_title"
+        android:layout_alignBottom="@+id/widget_update_time"
+        android:importantForAccessibility="no"
         android:src="@mipmap/ic_launcher_round"
-        tools:src="@mipmap/ic_launcher_round"/>
+        tools:src="@mipmap/ic_launcher_round" />
 
-    <LinearLayout
-        android:orientation="vertical"
+    <TextView
+        android:id="@+id/widget_title"
+        style="@style/Woo.StatsWidgetTitle"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/minor_100"
+        android:layout_toEndOf="@+id/widget_app_icon"
+        android:layout_toStartOf="@+id/widget_type"
+        tools:text="@string/my_store" />
 
-        <TextView
-            android:id="@+id/widget_title"
-            style="@style/Woo.StatsWidgetTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="@string/my_store"/>
+    <TextView
+        android:id="@+id/widget_type"
+        style="@style/Woo.StatsWidgetSubtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignBaseline="@+id/widget_title"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="@dimen/minor_10"
+        android:text="@string/today" />
 
-        <TextView
-            android:id="@+id/widget_type"
-            style="@style/Woo.StatsWidgetSubtitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/today"
-            android:visibility="gone"
-            tools:visibility="visible"/>
+    <TextView
+        android:id="@+id/widget_update_time"
+        style="@style/Woo.StatsWidgetSubtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignStart="@+id/widget_title"
+        android:layout_below="@+id/widget_title"
+        tools:text="as of 10:00 PM" />
 
-    </LinearLayout>
-</LinearLayout>
+</RelativeLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2607,4 +2607,5 @@
     <string name="stats_today_widget_configure_title">Today\'s store stats</string>
     <string name="stats_today_widget_description">WooCommerce Stats Today</string>
     <string name="stats_widget_error_no_data">Couldn\'t load data</string>
+    <string name="stats_widget_last_updated_message">as of %1$s</string>
 </resources>


### PR DESCRIPTION
### Description
This PR adds the last updated message to the widget. To achieve this, it changes the widget's layout to add the new text field, following the design the team agreed in p1663164757251039-slack-C02KUCFCSFP and adding the new `getCurrentTime()` function o the date utils class.

### Testing instructions
TC1

1. Add the Today widget to the home screen and check that the widget displays the last updated message 

TC2 

1. Open the WooCommerce app
2. Pull to refresh the `Today` tab within MyStore Screen
3. Check that the widget's last updated message changes

### Images/gif

<img width="300" src="https://user-images.githubusercontent.com/18119390/190247086-dad52db1-24ad-4ddd-854a-6d5c3ada327f.png" />



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->