### PR TITLE
Fab with anchor view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -42,10 +42,9 @@ interface UIMessageResolver {
             snackbarRoot,
             snackbarRoot.context.getString(stringResId, *stringArgs),
             snackbarRoot.context.getString(R.string.install),
-            actionListener
-        ).apply {
-            anchorViewId?.let { setAnchorView(it) }
-        }
+            actionListener,
+            anchorViewId
+        )
     }
 
     /**
@@ -66,10 +65,9 @@ interface UIMessageResolver {
             snackbarRoot,
             String.format(message, *stringArgs),
             actionText,
-            actionListener
-        ).apply {
-            anchorViewId?.let { setAnchorView(it) }
-        }
+            actionListener,
+            anchorViewId
+        )
     }
 
     /**
@@ -90,10 +88,9 @@ interface UIMessageResolver {
             snackbarRoot,
             snackbarRoot.context.getString(message, *stringArgs),
             actionText,
-            actionListener
-        ).apply {
-            anchorViewId?.let { setAnchorView(it) }
-        }
+            actionListener,
+            anchorViewId
+        )
     }
 
     /**
@@ -112,10 +109,9 @@ interface UIMessageResolver {
             snackbarRoot,
             snackbarRoot.context.getString(stringResId, *stringArgs),
             snackbarRoot.context.getString(R.string.undo),
-            actionListener
-        ).apply {
-            anchorViewId?.let { setAnchorView(it) }
-        }
+            actionListener,
+            anchorViewId
+        )
     }
 
     /**
@@ -134,10 +130,9 @@ interface UIMessageResolver {
             snackbarRoot,
             String.format(message, *stringArgs),
             snackbarRoot.context.getString(R.string.undo),
-            actionListener
-        ).apply {
-            anchorViewId?.let { setAnchorView(it) }
-        }
+            actionListener,
+            anchorViewId
+        )
     }
 
     /**
@@ -156,10 +151,9 @@ interface UIMessageResolver {
             snackbarRoot,
             snackbarRoot.context.getString(stringResId, *stringArgs),
             snackbarRoot.context.getString(R.string.retry),
-            actionListener
-        ).apply {
-            anchorViewId?.let { setAnchorView(it) }
-        }
+            actionListener,
+            anchorViewId
+        )
     }
 
     /**
@@ -176,10 +170,9 @@ interface UIMessageResolver {
             snackbarRoot,
             message,
             snackbarRoot.context.getString(R.string.retry),
-            actionListener
-        ).apply {
-            anchorViewId?.let { setAnchorView(it) }
-        }
+            actionListener,
+            anchorViewId
+        )
     }
 
     /**
@@ -237,12 +230,24 @@ private fun getIndefiniteSnackbarWithAction(
     view: View,
     msg: String,
     actionString: String,
-    actionListener: View.OnClickListener
+    actionListener: View.OnClickListener,
+    anchorViewId: Int?
 ) = Snackbar.make(view, msg, BaseTransientBottomBar.LENGTH_INDEFINITE).setAction(actionString, actionListener)
+    .apply {
+        anchorViewId?.let {
+            setAnchorView(it)
+        }
+    }
 
 private fun getSnackbarWithAction(
     view: View,
     msg: String,
     actionString: String,
-    actionListener: View.OnClickListener
+    actionListener: View.OnClickListener,
+    anchorViewId: Int?
 ) = Snackbar.make(view, msg, BaseTransientBottomBar.LENGTH_LONG).setAction(actionString, actionListener)
+    .apply {
+        anchorViewId?.let {
+            setAnchorView(it)
+        }
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -14,7 +14,7 @@ import com.woocommerce.android.model.UiString
  * class defines the snackbar root, the ease of injecting it straight into presenters for error handling without
  * having to pass directives over to the view, and ui testability.
  *
- * @see com.woocommerce.android.ui.main.MainUIMessageResolver
+ * @see com.woocommerce.android.ui.message.DefaultUIMessageResolver
  */
 interface UIMessageResolver {
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -23,6 +23,8 @@ interface UIMessageResolver {
      */
     val snackbarRoot: ViewGroup
 
+    var anchorViewId: Int?
+
     /**
      * Create and return a snackbar displaying a message to restart the app once the in app update has been
      * successfully installed
@@ -41,7 +43,9 @@ interface UIMessageResolver {
             snackbarRoot.context.getString(stringResId, *stringArgs),
             snackbarRoot.context.getString(R.string.install),
             actionListener
-        )
+        ).apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
     }
 
     /**
@@ -63,7 +67,9 @@ interface UIMessageResolver {
             String.format(message, *stringArgs),
             actionText,
             actionListener
-        )
+        ).apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
     }
 
     /**
@@ -85,7 +91,9 @@ interface UIMessageResolver {
             snackbarRoot.context.getString(message, *stringArgs),
             actionText,
             actionListener
-        )
+        ).apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
     }
 
     /**
@@ -105,7 +113,9 @@ interface UIMessageResolver {
             snackbarRoot.context.getString(stringResId, *stringArgs),
             snackbarRoot.context.getString(R.string.undo),
             actionListener
-        )
+        ).apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
     }
 
     /**
@@ -125,7 +135,9 @@ interface UIMessageResolver {
             String.format(message, *stringArgs),
             snackbarRoot.context.getString(R.string.undo),
             actionListener
-        )
+        ).apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
     }
 
     /**
@@ -145,7 +157,9 @@ interface UIMessageResolver {
             snackbarRoot.context.getString(stringResId, *stringArgs),
             snackbarRoot.context.getString(R.string.retry),
             actionListener
-        )
+        ).apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
     }
 
     /**
@@ -163,7 +177,9 @@ interface UIMessageResolver {
             message,
             snackbarRoot.context.getString(R.string.retry),
             actionListener
-        )
+        ).apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
     }
 
     /**
@@ -174,21 +190,31 @@ interface UIMessageResolver {
      */
     fun getSnack(@StringRes stringResId: Int, vararg stringArgs: String = arrayOf()) = Snackbar.make(
         snackbarRoot, snackbarRoot.context.getString(stringResId, *stringArgs), BaseTransientBottomBar.LENGTH_LONG
-    )
+    ).apply {
+        anchorViewId?.let { setAnchorView(it) }
+    }
 
     /**
      * Display a snackbar with the provided message.
      *
      * @param [msg] The message to display in the snackbar
      */
-    fun showSnack(msg: String) = Snackbar.make(snackbarRoot, msg, BaseTransientBottomBar.LENGTH_LONG).show()
+    fun showSnack(msg: String) = Snackbar.make(snackbarRoot, msg, BaseTransientBottomBar.LENGTH_LONG)
+        .apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
+        .show()
 
     /**
      * Display a snackbar with the provided string resource.
      *
      * @param [msgId] The resource ID of the message to display in the snackbar
      */
-    fun showSnack(@StringRes msgId: Int) = Snackbar.make(snackbarRoot, msgId, BaseTransientBottomBar.LENGTH_LONG).show()
+    fun showSnack(@StringRes msgId: Int) = Snackbar.make(snackbarRoot, msgId, BaseTransientBottomBar.LENGTH_LONG)
+        .apply {
+            anchorViewId?.let { setAnchorView(it) }
+        }
+        .show()
 
     /**
      * Display a snackbar with the provided [UiString].
@@ -200,6 +226,8 @@ interface UIMessageResolver {
             is UiString.UiStringRes ->
                 Snackbar.make(snackbarRoot, message.stringRes, BaseTransientBottomBar.LENGTH_LONG)
             is UiString.UiStringText -> Snackbar.make(snackbarRoot, message.text, BaseTransientBottomBar.LENGTH_LONG)
+        }.apply {
+            anchorViewId?.let { setAnchorView(it) }
         }
         snackbar.show()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -203,13 +203,6 @@ class MainActivity :
                 hideBottomNav()
             }
         }
-
-        override fun onFragmentPreCreated(fm: FragmentManager, f: Fragment, savedInstanceState: Bundle?) {
-            super.onFragmentPreCreated(fm, f, savedInstanceState)
-            if (isDialogDestination(navController.currentDestination!!)) return
-
-            uiMessageResolver.anchorViewId = null
-        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -166,9 +166,7 @@ class MainActivity :
 
     private val fragmentLifecycleObserver: FragmentLifecycleCallbacks = object : FragmentLifecycleCallbacks() {
         override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
-            val currentDestination = navController.currentDestination!!
-            val isDialogDestination = currentDestination.navigatorName == DIALOG_NAVIGATOR_NAME
-            if (isDialogDestination) return
+            if (isDialogDestination(navController.currentDestination!!)) return
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -203,6 +203,13 @@ class MainActivity :
                 hideBottomNav()
             }
         }
+
+        override fun onFragmentPreCreated(fm: FragmentManager, f: Fragment, savedInstanceState: Bundle?) {
+            super.onFragmentPreCreated(fm, f, savedInstanceState)
+            if (isDialogDestination(navController.currentDestination!!)) return
+
+            uiMessageResolver.anchorViewId = null
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainUIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainUIMessageResolver.kt
@@ -12,4 +12,5 @@ class MainUIMessageResolver @Inject constructor(activity: Activity) : UIMessageR
             "To be able to use UIMessageResolver, the activity has to contain a Layout with id snack_root"
         }
     }
+    override var anchorViewId: Int? = null
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/message/DefaultUIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/message/DefaultUIMessageResolver.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.main
+package com.woocommerce.android.ui.message
 
 import android.app.Activity
 import android.view.ViewGroup
@@ -6,7 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.UIMessageResolver
 import javax.inject.Inject
 
-class MainUIMessageResolver @Inject constructor(activity: Activity) : UIMessageResolver {
+class DefaultUIMessageResolver @Inject constructor(activity: Activity) : UIMessageResolver {
     override val snackbarRoot: ViewGroup by lazy {
         requireNotNull(activity.findViewById(R.id.snack_root)) {
             "To be able to use UIMessageResolver, the activity has to contain a Layout with id snack_root"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/message/UIMessageResolverModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/message/UIMessageResolverModule.kt
@@ -1,16 +1,14 @@
-package com.woocommerce.android.ui.main
+package com.woocommerce.android.ui.message
 
 import com.woocommerce.android.ui.base.UIMessageResolver
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
-import dagger.hilt.android.scopes.ActivityScoped
 
 @InstallIn(ActivityComponent::class)
 @Module
 interface UIMessageResolverModule {
-    @ActivityScoped
     @Binds
-    fun provideUiMessageResolver(mainUIMessageResolver: MainUIMessageResolver): UIMessageResolver
+    fun provideUiMessageResolver(defaultUIMessageResolver: DefaultUIMessageResolver): UIMessageResolver
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -179,6 +179,8 @@ class OrderListFragment :
 
         view.doOnPreDraw { startPostponedEnterTransition() }
 
+        uiMessageResolver.anchorViewId = binding.createOrderButton.id
+
         binding.orderListView.init(currencyFormatter = currencyFormatter, orderListListener = this)
         ViewGroupCompat.setTransitionGroup(binding.orderRefreshLayout, true)
         binding.orderRefreshLayout.apply {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -91,7 +91,11 @@ class ProductListFragment :
         setHasOptionsMenu(true)
 
         _binding = FragmentProductListBinding.bind(view)
+
         view.doOnPreDraw { startPostponedEnterTransition() }
+
+        uiMessageResolver.anchorViewId = binding.addProductButton.id
+
         setupObservers(viewModel)
         setupResultHandlers()
         ViewGroupCompat.setTransitionGroup(binding.productsRefreshLayout, true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -94,8 +94,6 @@ class ProductListFragment :
 
         view.doOnPreDraw { startPostponedEnterTransition() }
 
-        uiMessageResolver.anchorViewId = binding.addProductButton.id
-
         setupObservers(viewModel)
         setupResultHandlers()
         ViewGroupCompat.setTransitionGroup(binding.productsRefreshLayout, true)
@@ -457,8 +455,14 @@ class ProductListFragment :
 
     private fun showAddProductButton(show: Boolean) {
         when (show) {
-            true -> binding.addProductButton.show()
-            else -> binding.addProductButton.hide()
+            true -> {
+                uiMessageResolver.anchorViewId = binding.addProductButton.id
+                binding.addProductButton.show()
+            }
+            else -> {
+                uiMessageResolver.anchorViewId = null
+                binding.addProductButton.hide()
+            }
         }
     }
 


### PR DESCRIPTION
Closes: #7351

### Description
When the app shows a SnackBar message on a screen with a FAB, the SnackBar message is displayed on top of the FAB, preventing the user from interacting with the button while the message is shown. This PR solves this issue by following the [material design guidelines](https://material.io/components/snackbars#behavior). Now the `anchorViewId` field is added to the `UIMessageResolver`, and on Fragments that set this field, the SnackBar messages are shown on top of the anchor view.

### Testing instructions
TC1 

1. Select Orders in the Bottom Navigation control
2. Swipe-To-Complete a non-completed order
3. Check that the SnackBar message is shown on top of the FAB

TC2

Turn Wifi off on the device
1. Select Orders in the Bottom Navigation control
2. Swipe-To-Refresh the data
3. Check that the SnackBar error message is shown on top of the FAB
4. Select Products in the Bottom Navigation control
5. Swipe-To-Refresh the data
6. Check that the SnackBar error message is shown on top of the FAB
7. Select Menu in the Bottom Navigation control
8. Tap Switch store
9. Check that the SnackBar error message is shown on top of the Bottom Navigation control

### Images/gif

https://user-images.githubusercontent.com/18119390/190441366-9f7bbc8b-873a-4138-a9b4-e6596b3b4ca6.mp4




- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
