### PR TITLE
Capitalize las updated label

### DIFF
--- a/WooCommerce/src/main/res/layout/stats_widget_header.xml
+++ b/WooCommerce/src/main/res/layout/stats_widget_header.xml
@@ -48,6 +48,6 @@
         android:layout_height="wrap_content"
         android:layout_alignStart="@+id/widget_title"
         android:layout_below="@+id/widget_title"
-        tools:text="as of 10:00 PM" />
+        tools:text="As of 10:00 PM" />
 
 </RelativeLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2607,5 +2607,5 @@
     <string name="stats_today_widget_configure_title">Today\'s store stats</string>
     <string name="stats_today_widget_description">WooCommerce Stats Today</string>
     <string name="stats_widget_error_no_data">Couldn\'t load data</string>
-    <string name="stats_widget_last_updated_message">as of %1$s</string>
+    <string name="stats_widget_last_updated_message">As of %1$s</string>
 </resources>


### PR DESCRIPTION
### Description
Small PR to capitalize the last updated label as recommended by design.
p1663224808145259/1663164757.251039-slack-C02KUCFCSFP

### Testing instructions
Open the widget and check that the "As of" message starts with a capital letter (A)

### Images/gif
<img width="300" src="https://user-images.githubusercontent.com/18119390/190641057-d981dcec-9f48-4ff4-9d3b-5e1a6f64c410.png" />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->