### PR TITLE
Fix crash in Account Mismatch screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -718,7 +718,9 @@ class LoginActivity :
         if (connectSiteInfo?.isJetpackInstalled == true && connectSiteInfo?.isJetpackActive == true) {
             // If jetpack is present, but we can't find the connected email, then show account mismatch error
             val fragment = AccountMismatchErrorFragment().apply {
-                arguments = AccountMismatchErrorFragmentArgs(AccountMismatchPrimaryButton.CONNECT_JETPACK).toBundle()
+                arguments = AccountMismatchErrorFragmentArgs(
+                    primaryButton = AccountMismatchPrimaryButton.CONNECT_JETPACK
+                ).toBundle()
             }
             changeFragment(
                 fragment = fragment,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -719,6 +719,7 @@ class LoginActivity :
             // If jetpack is present, but we can't find the connected email, then show account mismatch error
             val fragment = AccountMismatchErrorFragment().apply {
                 arguments = AccountMismatchErrorFragmentArgs(
+                    siteUrl = siteAddress,
                     primaryButton = AccountMismatchPrimaryButton.CONNECT_JETPACK
                 ).toBundle()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -48,7 +48,7 @@ class AccountMismatchErrorViewModel @Inject constructor(
 
     private val navArgs: AccountMismatchErrorFragmentArgs by savedStateHandle.navArgs()
     private val userAccount = accountRepository.getUserAccount()
-    private val siteUrl = navArgs.siteUrl ?: appPrefsWrapper.getLoginSiteAddress()!!
+    private val siteUrl = navArgs.siteUrl
     private val site: Deferred<SiteModel> = async(start = LAZY) {
         accountMismatchRepository.getSiteByUrl(siteUrl) ?: error("The site is not cached")
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -48,7 +48,7 @@ class AccountMismatchErrorViewModel @Inject constructor(
 
     private val navArgs: AccountMismatchErrorFragmentArgs by savedStateHandle.navArgs()
     private val userAccount = accountRepository.getUserAccount()
-    private val siteUrl = appPrefsWrapper.getLoginSiteAddress()!!
+    private val siteUrl = navArgs.siteUrl ?: appPrefsWrapper.getLoginSiteAddress()!!
     private val site: Deferred<SiteModel> = async(start = LAZY) {
         accountMismatchRepository.getSiteByUrl(siteUrl) ?: error("The site is not cached")
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -159,7 +159,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 is NavigateToSiteAddressEvent -> navigateToAddressScreen()
                 is NavigateToEmailHelpDialogEvent -> navigateToNeedHelpFindingEmailScreen()
                 is NavigateToWPComWebView -> navigateToWPComWebView(event)
-                is NavigateToAccountMismatchScreen -> navigateToAccountMismatchScreen(event.hasConnectedStores)
+                is NavigateToAccountMismatchScreen -> navigateToAccountMismatchScreen(event)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowDialog -> event.showDialog()
                 is Logout -> onLogout()
@@ -275,10 +275,11 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
         )
     }
 
-    private fun navigateToAccountMismatchScreen(hasConnectedStores: Boolean) {
+    private fun navigateToAccountMismatchScreen(event: NavigateToAccountMismatchScreen) {
         findNavController().navigateSafely(
             SitePickerFragmentDirections.actionSitePickerFragmentToAccountMismatchErrorFragment(
-                primaryButton = if (hasConnectedStores) AccountMismatchPrimaryButton.SHOW_SITE_PICKER
+                siteUrl = event.siteUrl,
+                primaryButton = if (event.hasConnectedStores) AccountMismatchPrimaryButton.SHOW_SITE_PICKER
                 else AccountMismatchPrimaryButton.ENTER_NEW_SITE_ADDRESS
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -276,7 +276,12 @@ class SitePickerViewModel @Inject constructor(
         )
         trackLoginEvent(currentStep = UnifiedLoginTracker.Step.WRONG_WP_ACCOUNT)
         if (event.value !is NavigateToAccountMismatchScreen) {
-            triggerEvent(NavigateToAccountMismatchScreen(sitePickerViewState.hasConnectedStores ?: false))
+            triggerEvent(
+                NavigateToAccountMismatchScreen(
+                    hasConnectedStores = sitePickerViewState.hasConnectedStores ?: false,
+                    siteUrl = url
+                )
+            )
         }
     }
 
@@ -631,7 +636,10 @@ class SitePickerViewModel @Inject constructor(
         object NavigateToSiteAddressEvent : SitePickerEvent()
         data class NavigateToHelpFragmentEvent(val origin: HelpActivity.Origin) : SitePickerEvent()
         data class NavigateToWPComWebView(val url: String, val validationUrl: String) : SitePickerEvent()
-        data class NavigateToAccountMismatchScreen(val hasConnectedStores: Boolean) : SitePickerEvent()
+        data class NavigateToAccountMismatchScreen(
+            val hasConnectedStores: Boolean,
+            val siteUrl: String
+        ) : SitePickerEvent()
     }
 
     enum class SitePickerState {

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -441,9 +441,7 @@
         android:label="AccountMismatchErrorFragment">
         <argument
             android:name="siteUrl"
-            app:argType="string"
-            app:nullable="true"
-            android:defaultValue="@null" />
+            app:argType="string" />
         <argument
             android:name="primaryButton"
             app:argType="com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel$AccountMismatchPrimaryButton"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -440,6 +440,11 @@
         android:name="com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment"
         android:label="AccountMismatchErrorFragment">
         <argument
+            android:name="siteUrl"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null" />
+        <argument
             android:name="primaryButton"
             app:argType="com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel$AccountMismatchPrimaryButton"
             android:defaultValue="NONE" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -331,7 +331,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
                 )
             )
 
-            assertThat(viewModel.event.value).isEqualTo(NavigateToAccountMismatchScreen(true))
+            assertThat(viewModel.event.value).isEqualTo(NavigateToAccountMismatchScreen(true, url))
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7400 

### Description
In the `AccountMismatchErrorViewModel` I was assuming that we'll always have the site address saved in the app's storage, but I missed one case for this, check the test steps to understand more.

### Testing instructions
1. Checkout `trunk`
2. Open the app, then sign in using an account that's not connected to any store.
3. In the No Stores error, click on "Enter a site address".
4. Enter the site address of a site that's connected to a different account.
5. Notice the crash.
6. Checkout this branch.
7. Repeat 2 to 4.
8. Confirm the app doesn't crash.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
