### PR TITLE
MenuProvider usage for CustomerListFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
@@ -10,8 +10,10 @@ import android.view.ViewGroup
 import androidx.appcompat.widget.SearchView
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle.State
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
@@ -26,7 +28,8 @@ import javax.inject.Inject
 class CustomerListFragment :
     BaseFragment(),
     MenuItem.OnActionExpandListener,
-    SearchView.OnQueryTextListener {
+    SearchView.OnQueryTextListener,
+    MenuProvider {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel by viewModels<CustomerListViewModel>()
@@ -37,7 +40,7 @@ class CustomerListFragment :
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, State.RESUMED)
         setupObservers()
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -66,7 +69,7 @@ class CustomerListFragment :
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_search, menu)
 
         menu.findItem(R.id.menu_search)?.let { searchMenuItem ->
@@ -78,9 +81,9 @@ class CustomerListFragment :
                 searchView.setOnQueryTextListener(this)
             }
         }
-
-        super.onCreateOptionsMenu(menu, inflater)
     }
+
+    override fun onMenuItemSelected(menuItem: MenuItem) = false
 
     override fun onMenuItemActionExpand(item: MenuItem) = true
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7412
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds MenuProvider usage for CustomerListFragment to avoid usage of the deprecated methods

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open orders list
2. Start creating an order
3. Click "add customer"
4. Click on the "search" icon
5. Notice that the menu works and looks the same as before the change

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
### before/after

<img width="272" alt="2" src="https://user-images.githubusercontent.com/4923871/190980184-4473e130-6c85-4949-bf55-c8249f97cbc4.jpg">
<img width="272" alt="2" src="https://user-images.githubusercontent.com/4923871/190980182-42440042-9ba0-4d60-ad30-23c97ea2b13b.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
