### PR TITLE
 order create menu deprecated

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreateEditFeeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreateEditFeeFragment.kt
@@ -9,9 +9,11 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditFeeBinding
@@ -32,7 +34,8 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class OrderCreateEditFeeFragment :
-    BaseFragment(R.layout.fragment_order_create_edit_fee) {
+    BaseFragment(R.layout.fragment_order_create_edit_fee),
+    MenuProvider {
     private val sharedViewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
     private val editFeeViewModel by viewModels<OrderCreateEditFeeViewModel>()
 
@@ -42,7 +45,7 @@ class OrderCreateEditFeeFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         with(FragmentOrderCreateEditFeeBinding.bind(view)) {
             bindViews()
             observeEvents()
@@ -54,18 +57,17 @@ class OrderCreateEditFeeFragment :
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
         doneMenuItem?.isEnabled = editFeeViewModel.viewStateData.liveData.value?.isDoneButtonEnabled ?: false
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> editFeeViewModel.onDoneSelected().let { true }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/notes/OrderCreateEditCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/notes/OrderCreateEditCustomerNoteFragment.kt
@@ -5,8 +5,10 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.core.widget.doAfterTextChanged
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditCustomerNoteBinding
@@ -14,7 +16,9 @@ import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 
-class OrderCreateEditCustomerNoteFragment : BaseFragment(R.layout.fragment_order_create_edit_customer_note) {
+class OrderCreateEditCustomerNoteFragment :
+    BaseFragment(R.layout.fragment_order_create_edit_customer_note),
+    MenuProvider {
     private val sharedViewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
 
     private var _binding: FragmentOrderCreateEditCustomerNoteBinding? = null
@@ -25,7 +29,7 @@ class OrderCreateEditCustomerNoteFragment : BaseFragment(R.layout.fragment_order
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         _binding = FragmentOrderCreateEditCustomerNoteBinding.bind(view)
         if (savedInstanceState == null) {
@@ -39,22 +43,21 @@ class OrderCreateEditCustomerNoteFragment : BaseFragment(R.layout.fragment_order
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
         doneMenuItem.isEnabled = hasChanges()
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 sharedViewModel.onCustomerNoteEdited(binding.customerOrderNoteEditor.text.toString())
                 findNavController().navigateUp()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreateEditProductSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/products/OrderCreateEditProductSelectionFragment.kt
@@ -8,8 +8,10 @@ import android.view.MenuItem.OnActionExpandListener
 import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.widget.SearchView
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
@@ -38,7 +40,8 @@ class OrderCreateEditProductSelectionFragment :
     BaseFragment(R.layout.fragment_order_create_edit_product_selection),
     OnLoadMoreListener,
     SearchView.OnQueryTextListener,
-    OnActionExpandListener {
+    OnActionExpandListener,
+    MenuProvider {
     private val sharedViewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
     private val productListViewModel by viewModels<OrderCreateEditProductSelectionViewModel>()
 
@@ -54,7 +57,7 @@ class OrderCreateEditProductSelectionFragment :
             productsList.layoutManager = LinearLayoutManager(requireActivity())
             setupObserversWith(this)
         }
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
     override fun onDestroyView() {
@@ -144,7 +147,7 @@ class OrderCreateEditProductSelectionFragment :
     override fun getFragmentTitle() = getString(R.string.order_creation_add_products)
 
     // region Search configuration and events
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_product_selection_fragment, menu)
 
         searchMenuItem = menu.findItem(R.id.menu_search)
@@ -152,18 +155,15 @@ class OrderCreateEditProductSelectionFragment :
         searchView?.queryHint = getString(R.string.product_search_hint)
         searchView?.findViewById<ImageView>(androidx.appcompat.R.id.search_close_btn)
             ?.setOnClickListener { onClearSearchButtonClicked() }
-
-        super.onCreateOptionsMenu(menu, inflater)
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu) {
+    override fun onPrepareMenu(menu: Menu) {
         searchMenuItem
             ?.takeIf { it.isActionViewExpanded != productListViewModel.isSearchActive }
             ?.restoreSearchMenuItemState()
-        super.onPrepareOptionsMenu(menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_search -> {
                 registerSearchListeners()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderCreateEditShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderCreateEditShippingFragment.kt
@@ -5,9 +5,11 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditShippingBinding
@@ -24,7 +26,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class OrderCreateEditShippingFragment : BaseFragment(R.layout.fragment_order_create_edit_shipping) {
+class OrderCreateEditShippingFragment :
+    BaseFragment(R.layout.fragment_order_create_edit_shipping),
+    MenuProvider {
     private val viewModel: OrderCreateEditShippingViewModel by viewModels()
     private val sharedViewModel: OrderCreateEditViewModel by hiltNavGraphViewModels(R.id.nav_graph_order_creations)
 
@@ -32,7 +36,7 @@ class OrderCreateEditShippingFragment : BaseFragment(R.layout.fragment_order_cre
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         val binding = FragmentOrderCreateEditShippingBinding.bind(view)
         binding.initUi()
         setupObservers(binding)
@@ -42,17 +46,16 @@ class OrderCreateEditShippingFragment : BaseFragment(R.layout.fragment_order_cre
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_done, menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return if (item.itemId == R.id.menu_done) {
             viewModel.onDoneButtonClicked()
             true
         } else {
-            super.onOptionsItemSelected(item)
+            false
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7414 
Closes: #7415 
Closes: #7416 
Closes: #7417
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaced deprecated menu usage:
* OrderCreateEditFeeFragment
* OrderCreateEditCustomerNoteFragment
* OrderCreateEditProductSelectionFragment
* OrderCreateEditShippingFragment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Start order creation
2. Add a fee and notice that the menu is the same 
3. Add a note and notice that the menu is the same 
4. Add a product. Start search and notice that the menu is the same 
5.  Add shipping and notice that the menu is the same 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

### Before/After



![8](https://user-images.githubusercontent.com/4923871/190987450-b705e051-bcd5-43c6-8260-236705217b07.jpg)
![4](https://user-images.githubusercontent.com/4923871/190987460-44f33aa4-441e-4cca-abc7-1ce5fc09a6f9.jpg)

![7](https://user-images.githubusercontent.com/4923871/190987454-df9b7365-eb12-47ec-8f55-3b7113a489c9.jpg)
![3](https://user-images.githubusercontent.com/4923871/190987463-6f920ff8-51cf-455a-966f-2491d351b529.jpg)

![6](https://user-images.githubusercontent.com/4923871/190987456-47996567-093d-4a22-900f-3468432aad8a.jpg)
![2](https://user-images.githubusercontent.com/4923871/190987466-44ad1b1b-6fba-49a9-a99f-54e7608f09bd.jpg)

![5](https://user-images.githubusercontent.com/4923871/190987458-4ed939b8-cd97-469a-98d4-619b4aadb4ae.jpg)
![1](https://user-images.githubusercontent.com/4923871/190987467-67f86c76-9b05-46f2-a280-86e748f2e810.jpg)


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
