### PR TITLE
Replaces deprecated menu methods

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -7,10 +7,12 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.core.content.ContextCompat
+import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialContainerTransform
@@ -73,7 +75,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderProductActionListener {
+class OrderDetailFragment :
+    BaseFragment(R.layout.fragment_order_detail),
+    OrderProductActionListener,
+    MenuProvider {
     companion object {
         val TAG: String = OrderDetailFragment::class.java.simpleName
     }
@@ -135,7 +140,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
 
         _binding = FragmentOrderDetailBinding.bind(view)
 
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         setupObservers(viewModel)
         setupOrderEditingObservers(orderEditingViewModel)
         setupResultHandlers(viewModel)
@@ -162,28 +167,26 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         _binding = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_order_detail, menu)
         val menuEditOrder = menu.findItem(R.id.menu_edit_order)
         menuEditOrder.isVisible = FeatureFlag.UNIFIED_ORDER_EDITING.isEnabled()
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
+    override fun onPrepareMenu(menu: Menu) {
         menu.findItem(R.id.menu_edit_order)?.let {
             it.isEnabled = viewModel.hasOrder()
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_edit_order -> {
                 viewModel.onEditClicked()
                 true
             }
             else -> {
-                super.onOptionsItemSelected(item)
+                false
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -9,7 +9,9 @@ import android.view.MenuItem
 import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
+import androidx.core.view.MenuProvider
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -21,7 +23,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
-abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
+abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener, MenuProvider {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
@@ -72,7 +74,6 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
     @CallSuper
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
         if (savedInstanceState == null) {
             trackEventStarted()
         }
@@ -81,39 +82,37 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
     @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         setupObservers()
     }
 
     @CallSuper
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
     }
 
     @CallSuper
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
+    override fun onPrepareMenu(menu: Menu) {
         updateDoneMenuItem()
     }
 
     private fun setupObservers() {
         sharedViewModel.event.observe(
-            viewLifecycleOwner,
-            { event ->
-                when (event) {
-                    is MultiLiveEvent.Event.ShowSnackbar -> {
-                        uiMessageResolver.showSnack(event.message)
-                    }
+            viewLifecycleOwner
+        ) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ShowSnackbar -> {
+                    uiMessageResolver.showSnack(event.message)
                 }
             }
-        )
+        }
 
         sharedViewModel.start()
     }
 
     @CallSuper
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 if (saveChanges()) {
@@ -121,7 +120,7 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
                 }
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
@@ -5,7 +5,9 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -29,14 +31,15 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class OrderFilterCategoriesFragment :
     BaseFragment(R.layout.fragment_order_filter_list),
-    BackPressListener {
+    BackPressListener,
+    MenuProvider {
     companion object {
         const val KEY_UPDATED_FILTER_OPTIONS = "key_updated_filter_options"
     }
 
     private val viewModel: OrderFilterCategoriesViewModel by viewModels()
 
-    lateinit var orderFilterCategoryAdapter: OrderFilterCategoryAdapter
+    private lateinit var orderFilterCategoryAdapter: OrderFilterCategoryAdapter
 
     private var clearAllMenuItem: MenuItem? = null
 
@@ -51,7 +54,7 @@ class OrderFilterCategoriesFragment :
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentOrderFilterListBinding.bind(view)
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         setUpObservers(viewModel)
 
         setUpFiltersRecyclerView(binding)
@@ -63,20 +66,19 @@ class OrderFilterCategoriesFragment :
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_clear, menu)
         clearAllMenuItem = menu.findItem(R.id.menu_clear)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_clear -> {
                 viewModel.onClearFilters()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
@@ -42,7 +42,6 @@ class OrderFilterOptionsFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
 
         val binding = FragmentOrderFilterListBinding.bind(view)
         setUpObservers(viewModel)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7419
Closes: #7420 
Closes: #7421 
Closes: #7422 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaces deprecated menu methods from:
* OrderDetailFragment
* BaseOrderEditingFragment
* OrderFilterCategoriesFragment
* OrderFilterOptionsFragment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open orders' details and notice that the menu is the same
2. Change `UNIFIED_ORDER_EDITING` to false. Open order details. Open Billing details, add a note, and shipping address, and notice that the menu is the same
3. Click "filters" in the order list and notice that the menu is the same
4.  Click "filters" in the order list. Click "date range". Notice that the menu is the same

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![8](https://user-images.githubusercontent.com/4923871/191012678-d5d12601-d5b4-4798-bd7b-3e26383ba4ab.jpg)
![4](https://user-images.githubusercontent.com/4923871/191012695-760fb02d-da86-4176-815e-d0f097b3e58a.jpg)

![7](https://user-images.githubusercontent.com/4923871/191012681-2bc5f7af-2861-4821-8aaf-c1f5becc9e1a.jpg)
![3](https://user-images.githubusercontent.com/4923871/191012699-e56fb485-41bd-4184-939b-ed35b4e734ae.jpg)

![6](https://user-images.githubusercontent.com/4923871/191012686-2f6ce110-005a-403b-a1a3-48e182d12458.jpg)
![2](https://user-images.githubusercontent.com/4923871/191012702-9539c609-8478-45f3-a8a7-7ba564e7c05b.jpg)

![5](https://user-images.githubusercontent.com/4923871/191012688-43b282eb-024c-4e92-838b-6de4b59430b1.jpg)
![1](https://user-images.githubusercontent.com/4923871/191012705-38923575-def9-47e0-a805-4754aa8d7f30.jpg)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
