### PR TITLE
Fix Multiple Substitutions Specified in Non-Positional Format Warnings

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -198,7 +198,7 @@
     <string name="login_wpcom">Continue with WordPress.com</string>
     <string name="login_store_address">Enter your store address</string>
     <string name="login_with_store_address">Log in with your store address</string>
-    <string name="login_configure_link">Read the %sconfiguration instructions%s.</string>
+    <string name="login_configure_link">Read the %1$sconfiguration instructions%2$s.</string>
 
     <string name="login_prologue_label_analytics">Track sales and high performing products</string>
     <string name="login_prologue_label_orders">Manage and edit orders on the go</string>
@@ -422,7 +422,7 @@
     <string name="order_creation_fee_percentage_calculated_amount">Calculated amount: %s</string>
     <string name="order_creation_customer_search_empty">No customers found</string>
     <string name="order_creation_customer_search_hint">Search customers</string>
-    <string name="order_creation_change_product_quantity">Change the product quantity from %d to %d</string>
+    <string name="order_creation_change_product_quantity">Change the product quantity from %1$d to %2$d</string>
     <!--
         Order Editing
     -->
@@ -886,8 +886,8 @@
     <string name="order_refunds_items_select_all">Select all</string>
     <string name="order_refunds_items_select_none">Select none</string>
     <string name="order_refunds_items_selected">%d items selected</string>
-    <string name="order_refunds_item_description">%s x %s each</string>
-    <string name="order_refunds_detail_item_description">%s (%s x %d)</string>
+    <string name="order_refunds_item_description">%1$s x %2$s each</string>
+    <string name="order_refunds_detail_item_description">%1$s (%2$s x %3$d)</string>
     <string name="order_refunds_products_refund">Products refund</string>
     <string name="order_refunds_shipping_refund">Shipping refund</string>
     <string name="order_refunds_fees_refund">Fees refund</string>
@@ -1076,7 +1076,7 @@
     <string name="card_reader_payment_send_receipt">Send receipt</string>
     <string name="card_reader_payment_save_for_later">Save receipt and continue</string>
 
-    <string name="card_reader_payment_description_v2">In-Person Payment for Order #%s for %s blog_id %s.</string>
+    <string name="card_reader_payment_description_v2">In-Person Payment for Order #%1$s for %2$s blog_id %3$s.</string>
     <string name="card_reader_payment_receipt_email_subject">Your receipt from %s</string>
     <string name="card_reader_payment_receipt_email_content">Thank you for your purchase! Click the link below for your payment receipt.\n\n%s</string>
     <string name="card_reader_payment_email_client_not_found">Can\'t detect your email client app</string>
@@ -1597,7 +1597,7 @@
     <string name="product_image_remove_confirmation">Are you sure you want to remove this image?</string>
     <string name="product_images_camera_error">Unable to access camera</string>
     <string name="product_images_uploading_single_notif_message">Uploading image…</string>
-    <string name="product_images_uploading_multi_notif_message">Uploading images…%d of %d</string>
+    <string name="product_images_uploading_multi_notif_message">Uploading images…%1$d of %2$d</string>
     <string name="product_images_upload_channel_title">Uploads</string>
     <string name="image_source_title">Select an upload method</string>
     <string name="image_source_device_chooser">Choose from device</string>
@@ -2038,8 +2038,8 @@
     <string name="coupon_list_item_label_active">Active</string>
     <string name="coupon_list_item_label_expired">Expired</string>
     <string name="coupon_list_item_label_everything">everything</string>
-    <string name="coupon_list_item_label_products_and_categories">%1s and %2s</string>
-    <string name="coupon_list_item_label_included_and_excluded">%1s excl. %2s</string>
+    <string name="coupon_list_item_label_products_and_categories">%1$s and %2$s</string>
+    <string name="coupon_list_item_label_included_and_excluded">%1$s excl. %2$s</string>
     <string name="coupon_list_empty_heading">No coupons found</string>
     <string name="coupon_list_wip_title">View and edit coupons</string>
     <string name="coupon_list_wip_message_enabled">We’ve been working on making it possible to view and edit coupons from your device!</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3816
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

#### Context

This fixes the many warnings we've been having for a while during `:WooCommerce:mergeVanillaReleaseResources` about strings having multiple `%s` or `%d` substitutions in a single string but not using the positional format (`%1$s` or `%2$d`) to differentiate each:
```
…/WooCommerce/src/main/res/values/strings.xml:1081:4: Multiple substitutions specified in non-positional format of
string resource string/card_reader_payment_description_v2. Did you mean to add the formatted="false" attribute?
```

We actually have many warnings about this during the build because despite only 8 original strings having that issue in our `values/strings.xml`, those copies were also translated by polyglots… without the positional parameter either, of course, so that led to probably about… 19 times more warnings in the output (a total of 8 x 19 = 152 lines), for each 8 issues in each `values-{lang}/strings.xml` files.

#### Timeline and fix propagation to translations

As a reminder:
 - The originals that this PR fixes will be sent to GlotPress during the next Code Freeze (for 10.5, on Sep 23).
 - The new originals should then be translated by polyglots — this time using the proper positional placeholders in their translations too, seeing them in the new originals
 - Finally, once we'll pull those translations back before 10.5 release, all the warnings about those (including in the translations) will finally be fixed and should not be seen in build logs again.

This is why this PR only fixes the originals (in `values/strings.xml`) and does not try to fix the translations (which will be overwritten by the next GlotPress download anyway)

#### Additional translation issues

In addition to the above, I have noticed that we have an extra Dutch specific problem (`values-nl`), related to the `variations_bulk_update_current_price` string, which has an `%@` value while it probably shouldn't:
- (PROBABLY) INCORRECT: `Huidige prijs is %@. %s`
- (POSSIBLY) CORRECT: `Huidige prijs is %s.`

```
.../WooCommerce/src/main/res/values-nl/strings.xml:156:4: Multiple substitutions specified in non-positional format of
string resource string/variations_bulk_update_current_price. Did you mean to add the formatted="false" attribute?
```

However, this should be probably fixed by polyglots themselves and then it would be automatically corrected once we'll pull those translations back, right? Cc @AliSoftware 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

 - Run `./gradlew :WooCommerce:mergeWasabiDebugResources` and validate that there are no warnings about "Multiple substitutions …" in the `values/strings.xml` file anymore.
 - Smoke-Test the app in English, especially the screens using those strings, to validate they still display the proper text.

PS: I did NOT thoroughly test the app with the new strings. Someone should probably smoke-test those changes just to be on the safe side, I guess.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

PS: A potential unintended area of impact might end-up being a crash when displaying those strings to the user, in case I got those positional placeholders wrong in the strings?

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
