### PR TITLE
Fix order details performance transaction validation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/WooPlugin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/WooPlugin.kt
@@ -4,4 +4,6 @@ data class WooPlugin(
     val isInstalled: Boolean,
     val isActive: Boolean,
     val version: String?
-)
+) {
+    val isOperational = isInstalled && isActive
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -642,27 +642,22 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchShipmentTrackingAsync() = async {
-        pluginsInformation[WooCommerceStore.WooPlugin.WOO_SHIPMENT_TRACKING.pluginName]
-            ?.takeIf { plugin ->
-                !plugin.isInstalled || !plugin.isActive
-            }?.let {
-                // Fetch data only when the plugin is installed and active
-                return@async
-            }
-        val result = orderDetailRepository.fetchOrderShipmentTrackingList(navArgs.orderId)
-        appPrefs.setTrackingExtensionAvailable(result == SUCCESS)
+        val plugin = pluginsInformation[WooCommerceStore.WooPlugin.WOO_SHIPMENT_TRACKING.pluginName]
+
+        if (plugin == null || plugin.isOperational) {
+            val result = orderDetailRepository.fetchOrderShipmentTrackingList(navArgs.orderId)
+            appPrefs.setTrackingExtensionAvailable(result == SUCCESS)
+        }
+
         orderDetailsTransactionLauncher.onShipmentTrackingFetched()
     }
 
     private fun fetchOrderShippingLabelsAsync() = async {
-        pluginsInformation[WooCommerceStore.WooPlugin.WOO_SERVICES.pluginName]
-            ?.takeIf { plugin ->
-                !plugin.isInstalled || !plugin.isActive
-            }?.let {
-                // Fetch data only when the plugin is installed and active
-                return@async
-            }
-        orderDetailRepository.fetchOrderShippingLabels(navArgs.orderId)
+        val plugin = pluginsInformation[WooCommerceStore.WooPlugin.WOO_SERVICES.pluginName]
+
+        if (plugin == null || plugin.isOperational) {
+            orderDetailRepository.fetchOrderShippingLabels(navArgs.orderId)
+        }
         orderDetailsTransactionLauncher.onShippingLabelFetched()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -649,7 +649,7 @@ class OrderDetailViewModel @Inject constructor(
             appPrefs.setTrackingExtensionAvailable(result == SUCCESS)
         }
 
-        orderDetailsTransactionLauncher.onShipmentTrackingFetched()
+        orderDetailsTransactionLauncher.onShipmentTrackingFetchingCompleted()
     }
 
     private fun fetchOrderShippingLabelsAsync() = async {
@@ -658,7 +658,7 @@ class OrderDetailViewModel @Inject constructor(
         if (plugin == null || plugin.isOperational) {
             orderDetailRepository.fetchOrderShippingLabels(navArgs.orderId)
         }
-        orderDetailsTransactionLauncher.onShippingLabelFetched()
+        orderDetailsTransactionLauncher.onShippingLabelFetchingCompleted()
     }
 
     private fun loadOrderShippingLabels(): ListInfo<ShippingLabel> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncher.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
 @ViewModelScoped
@@ -83,7 +82,6 @@ class OrderDetailsTransactionLauncher @Inject constructor(
                 waitingTimeTracker.start()
             }
             Lifecycle.Event.ON_DESTROY -> {
-                AppLog.w(AppLog.T.API, "Aborting. Not met conditions: ${conditionsToSatisfy.value}")
                 performanceTransactionId?.let {
                     performanceTransactionRepository.finishTransaction(it, TransactionStatus.ABORTED)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncher.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
 @ViewModelScoped
@@ -82,6 +83,7 @@ class OrderDetailsTransactionLauncher @Inject constructor(
                 waitingTimeTracker.start()
             }
             Lifecycle.Event.ON_DESTROY -> {
+                AppLog.w(AppLog.T.API, "Aborting. Not met conditions: ${conditionsToSatisfy.value}")
                 performanceTransactionId?.let {
                     performanceTransactionRepository.finishTransaction(it, TransactionStatus.ABORTED)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncher.kt
@@ -57,13 +57,13 @@ class OrderDetailsTransactionLauncher @Inject constructor(
 
     fun onOrderFetched() = satisfyCondition(Conditions.ORDER_FETCHED)
 
-    fun onShippingLabelFetched() = satisfyCondition(Conditions.SHIPPING_LABEL_FETCHED)
+    fun onShippingLabelFetchingCompleted() = satisfyCondition(Conditions.SHIPPING_LABEL_FETCHED)
 
     fun onNotesFetched() = satisfyCondition(Conditions.NOTES_FETCHED)
 
     fun onRefundsFetched() = satisfyCondition(Conditions.REFUNDS_FETCHED)
 
-    fun onShipmentTrackingFetched() = satisfyCondition(Conditions.SHIPMENT_TRACKINGS_FETCHED)
+    fun onShipmentTrackingFetchingCompleted() = satisfyCondition(Conditions.SHIPMENT_TRACKINGS_FETCHED)
 
     fun onPackageCreationEligibleFetched() = satisfyCondition(Conditions.PACKAGE_CREATION_ELIGIBLE_FETCHED)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1520,7 +1520,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository).fetchOrderShippingLabels(any())
-        verify(orderDetailsTransactionLauncher).onShippingLabelFetched()
+        verify(orderDetailsTransactionLauncher).onShippingLabelFetchingCompleted()
     }
 
     @Test
@@ -1539,7 +1539,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, never()).fetchOrderShippingLabels(any())
-        verify(orderDetailsTransactionLauncher).onShippingLabelFetched()
+        verify(orderDetailsTransactionLauncher).onShippingLabelFetchingCompleted()
     }
 
     @Test
@@ -1558,7 +1558,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, never()).fetchOrderShippingLabels(any())
-        verify(orderDetailsTransactionLauncher).onShippingLabelFetched()
+        verify(orderDetailsTransactionLauncher).onShippingLabelFetchingCompleted()
     }
 
     @Test
@@ -1577,7 +1577,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository).fetchOrderShipmentTrackingList(any())
-        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetched()
+        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetchingCompleted()
     }
 
     @Test
@@ -1596,7 +1596,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, never()).fetchOrderShipmentTrackingList(any())
-        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetched()
+        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetchingCompleted()
     }
 
     @Test
@@ -1615,7 +1615,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, never()).fetchOrderShipmentTrackingList(any())
-        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetched()
+        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetchingCompleted()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderInfo
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.ViewState
+import com.woocommerce.android.ui.orders.details.OrderDetailsTransactionLauncher
 import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingRepository
 import com.woocommerce.android.ui.payments.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
@@ -102,6 +103,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val savedState = OrderDetailFragmentArgs(orderId = ORDER_ID).initSavedStateHandle()
 
     private val productImageMap = mock<ProductImageMap>()
+    private val orderDetailsTransactionLauncher = mock<OrderDetailsTransactionLauncher>()
 
     private val order = OrderTestUtils.generateTestOrder(ORDER_ID)
     private val orderInfo = OrderInfo(OrderTestUtils.generateTestOrder(ORDER_ID))
@@ -151,7 +153,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 cardReaderTracker,
                 analyticsTraWrapper,
                 shippingLabelOnboardingRepository,
-                mock(),
+                orderDetailsTransactionLauncher,
                 addressValidator
             )
         )
@@ -1517,7 +1519,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(orderDetailRepository, times(1)).fetchOrderShippingLabels(any())
+        verify(orderDetailRepository).fetchOrderShippingLabels(any())
+        verify(orderDetailsTransactionLauncher).onShippingLabelFetched()
     }
 
     @Test
@@ -1536,6 +1539,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, never()).fetchOrderShippingLabels(any())
+        verify(orderDetailsTransactionLauncher).onShippingLabelFetched()
     }
 
     @Test
@@ -1554,6 +1558,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, never()).fetchOrderShippingLabels(any())
+        verify(orderDetailsTransactionLauncher).onShippingLabelFetched()
     }
 
     @Test
@@ -1571,7 +1576,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(orderDetailRepository, times(1)).fetchOrderShipmentTrackingList(any())
+        verify(orderDetailRepository).fetchOrderShipmentTrackingList(any())
+        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetched()
     }
 
     @Test
@@ -1590,6 +1596,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, never()).fetchOrderShipmentTrackingList(any())
+        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetched()
     }
 
     @Test
@@ -1608,6 +1615,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(orderDetailRepository, never()).fetchOrderShipmentTrackingList(any())
+        verify(orderDetailsTransactionLauncher).onShipmentTrackingFetched()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncherTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailsTransactionLauncherTest.kt
@@ -55,10 +55,10 @@ class OrderDetailsTransactionLauncherTest : BaseUnitTest() {
         sut.onStateChanged(mock(), Lifecycle.Event.ON_CREATE)
 
         sut.onOrderFetched()
-        sut.onShippingLabelFetched()
+        sut.onShippingLabelFetchingCompleted()
         sut.onNotesFetched()
         sut.onRefundsFetched()
-        sut.onShipmentTrackingFetched()
+        sut.onShipmentTrackingFetchingCompleted()
         sut.onPackageCreationEligibleFetched()
 
         verify(performanceTransactionRepository).finishTransaction(transactionId, TransactionStatus.SUCCESSFUL)
@@ -70,10 +70,10 @@ class OrderDetailsTransactionLauncherTest : BaseUnitTest() {
         sut.onStateChanged(mock(), Lifecycle.Event.ON_DESTROY)
 
         sut.onOrderFetched()
-        sut.onShippingLabelFetched()
+        sut.onShippingLabelFetchingCompleted()
         sut.onNotesFetched()
         sut.onRefundsFetched()
-        sut.onShipmentTrackingFetched()
+        sut.onShipmentTrackingFetchingCompleted()
         sut.onPackageCreationEligibleFetched()
 
         verify(performanceTransactionRepository, never()).finishTransaction(transactionId, TransactionStatus.SUCCESSFUL)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7428
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR makes plugin-related conditions of Performance Transaction Launcher satisfied in case, when user does not have shipping labels or shipment tracking plugins.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
0. Disable shipping labels and/or shipment tracking (?) plugin (is there "shipment tracking" plugin?)
1. Open Order Details
2. Go to Sentry Performance.
3. Select OrderDetails transaction. Envirnoment: `debug`.
4. Select `Filter Recent Transaction`
5. Make sure that the new transaction is visible


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
