### PR TITLE
Fix order status on creation flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -148,12 +148,16 @@ class OrderCreateEditRepository @Inject constructor(
         }
     }
 
+    private var isAutoDraftSupported: Boolean? = null
     private suspend fun isAutoDraftSupported(): Boolean {
+        isAutoDraftSupported?.let { return it }
         val version = withContext(dispatchers.io) {
             wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE)?.version
                 ?: "0.0"
         }
-        return version.semverCompareTo(AUTO_DRAFT_SUPPORTED_VERSION) >= 0
+        val isSupported = version.semverCompareTo(AUTO_DRAFT_SUPPORTED_VERSION) >= 0
+        isAutoDraftSupported = isSupported
+        return isSupported
     }
 
     private suspend fun Order.Status.toDataModel(): WCOrderStatusModel {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -162,7 +162,7 @@ class OrderCreateEditRepository @Inject constructor(
 
     private suspend fun Order.Status.toDataModel(): WCOrderStatusModel {
         val key = this.value
-        return when{
+        return when {
             key == AUTO_DRAFT && isAutoDraftSupported() -> WCOrderStatusModel(AUTO_DRAFT)
             // If AUTO_DRAFT is not supported, use PENDING state
             key == AUTO_DRAFT && isAutoDraftSupported().not() -> WCOrderStatusModel(CoreOrderStatus.PENDING.value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -376,9 +376,9 @@ class OrderCreateEditViewModel @Inject constructor(
                 if (mode is Mode.Edit) {
                     _orderDraft.drop(1)
                 } else {
-                    // When we are on the order creation flow we need to maintain the order status as auto-draft.
-                    // This way we the draft created order needed to sync price modifiers, don't send notifications or
-                    // sync its state in other devices
+                    // When we are in the order creation flow, we need to keep the order status as auto-draft.
+                    // In this way, when the draft of the created order needs to synchronize the price modifiers,
+                    // the application does not send notifications or synchronize its status on other devices.
                     _orderDraft.map { order -> order.copy(status = orderCreationStatus) }
                 }
             syncStrategy.syncOrderChanges(changes, retryOrderDraftUpdateTrigger)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -145,6 +145,8 @@ class OrderCreateEditViewModel @Inject constructor(
     val currentDraft
         get() = _orderDraft.value
 
+    private val orderCreationStatus = Order.Status.Custom(Order.Status.AUTO_DRAFT)
+
     init {
         when (mode) {
             Mode.Creation -> {
@@ -370,7 +372,15 @@ class OrderCreateEditViewModel @Inject constructor(
      */
     private fun monitorOrderChanges() {
         viewModelScope.launch {
-            val changes = if (mode is Mode.Edit) _orderDraft.drop(1) else _orderDraft
+            val changes =
+                if (mode is Mode.Edit) {
+                    _orderDraft.drop(1)
+                } else {
+                    // When we are on the order creation flow we need to maintain the order status as auto-draft.
+                    // This way we the draft created order needed to sync price modifiers, don't send notifications or
+                    // sync its state in other devices
+                    _orderDraft.map { order -> order.copy(status = orderCreationStatus) }
+                }
             syncStrategy.syncOrderChanges(changes, retryOrderDraftUpdateTrigger)
                 .collect { updateStatus ->
                     when (updateStatus) {
@@ -390,8 +400,13 @@ class OrderCreateEditViewModel @Inject constructor(
                                 multipleLinesContext = determineMultipleLinesContext(updateStatus.order)
                             )
                             _orderDraft.update { currentDraft ->
-                                // Keep the user's selected status
-                                updateStatus.order.copy(status = currentDraft.status)
+                                if (mode is Mode.Creation) {
+                                    // Once the order is synced, revert the auto-draft status and keep
+                                    // the user's selected one
+                                    updateStatus.order.copy(status = currentDraft.status)
+                                } else {
+                                    updateStatus.order
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Closes: #7394

### Description
When the order is on creation flow, a draft order is created on the backend to calculate the taxes and product totals. To prevent this draft order is displayed to the user, we hide it under the `auto-draft` status, indicating that this order is under creation. If during the order creation process, we update the order status and then one of the price modifiers (fee, shipping, or products), the backend will change the auto-draft status for the new one, showing the draft order if the app is opened on a different device. To solve this issue, the current PR always maintains the auto-draft/pending status on requests updating the order's draft price modifiers (requests of the order creation flow).

### Testing instructions
TC1

1. Prepare 2 separate devices/simulators. Or observe order status from wp-admin.
2. Start order creation.
3. Add some products and custom shipping line to trigger sync.
4. On 2nd device: notice that there is no notification or order in the list.
5. Update status to anything else ("Processing" for example).
6. Update shipping line to trigger sync.
7. On 2nd device: notice that there is no notification or order in the list.

TC2

1. Open orders list
2. Select an order
3. Tap on EDIT
4. Tap on the pencil icon in the order status
5. Change the order status and press APPLY
6. Press DONE
7. Check that the order status is updated to the status selected

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/191113415-d38ee1f0-2f95-4d33-a447-6013203883ab.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
