### PR TITLE
Make the customer info in order details screen editable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -346,8 +346,7 @@ class OrderDetailFragment :
         binding.orderDetailCustomerInfo.updateCustomerInfo(
             order = order,
             isVirtualOrder = viewModel.hasVirtualProductsOnly(),
-            // Customer Info is read-only in UOE
-            isReadOnly = FeatureFlag.UNIFIED_ORDER_EDITING.isEnabled()
+            isReadOnly = false
         )
         binding.orderDetailPaymentInfo.updatePaymentInfo(
             order = order,


### PR DESCRIPTION
### Description
As reflected on pe5pgL-JG-p2, we noticed that upon releasing the Unified Order Editing feature, merchants started editing fewer customer notes & addresses.

To mitigate the downward trend we are re-introducing the old customer note & addresses editing experience merchants used to have by setting to `false` the `isReadOnly` property of the `OrderDetailCustomerInfo` view.

### Testing instructions
TC1
1. Create a new order
2. Check that you can add & edit customer notes & addresses

TC2
1. Navigate to an order
2. Check that you can add & edit customer notes & addresses

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/191745513-2d1c257f-bbe0-4c87-bb00-c21c062931fc.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->