### PR TITLE
Upsell card reader banner re-appears after dismissal and doing the pull to refresh on the order listing screen.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -198,6 +198,13 @@ class OrderListFragment :
         binding.orderFiltersCard.setClickListener { viewModel.onFiltersButtonTapped() }
         initCreateOrderFAB(binding.createOrderButton)
         initSwipeBehaviour()
+        updateBannerState()
+    }
+
+    private fun updateBannerState() {
+        lifecycleScope.launch {
+            viewModel.updateBannerState()
+        }
     }
 
     private fun initSwipeBehaviour() {
@@ -339,7 +346,6 @@ class OrderListFragment :
         }
 
         viewModel.pagedListData.observe(viewLifecycleOwner) {
-            updateBannerState(it.size)
             updatePagedListData(it)
         }
 
@@ -426,13 +432,6 @@ class OrderListFragment :
             new.filterCount.takeIfNotEqualTo(old?.filterCount) { filterCount ->
                 binding.orderFiltersCard.updateFilterSelection(filterCount)
             }
-        }
-    }
-
-    private fun updateBannerState(orderListSize: Int) {
-        val isLandScape = DisplayUtils.isLandscape(context)
-        lifecycleScope.launch {
-            viewModel.updateBannerState(isLandScape, orderListSize)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -19,7 +19,6 @@ import androidx.core.view.doOnPreDraw
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.paging.PagedList
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -66,7 +65,6 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
@@ -198,13 +196,6 @@ class OrderListFragment :
         binding.orderFiltersCard.setClickListener { viewModel.onFiltersButtonTapped() }
         initCreateOrderFAB(binding.createOrderButton)
         initSwipeBehaviour()
-        updateBannerState()
-    }
-
-    private fun updateBannerState() {
-        lifecycleScope.launch {
-            viewModel.updateBannerState()
-        }
     }
 
     private fun initSwipeBehaviour() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -115,7 +115,15 @@ class OrderListViewModel @Inject constructor(
     internal var viewState by viewStateLiveData
 
     private val _pagedListData = MediatorLiveData<PagedOrdersList>()
-    val pagedListData: LiveData<PagedOrdersList> = _pagedListData
+    val pagedListData: LiveData<PagedOrdersList>
+        get() {
+            return _pagedListData.map {
+                viewModelScope.launch {
+                    updateBannerState(landscapeChecker, _pagedListData.value.isNullOrEmpty())
+                }
+                it
+            }
+        }
 
     private val _isLoadingMore = MediatorLiveData<Boolean>()
     val isLoadingMore: LiveData<Boolean> = _isLoadingMore
@@ -196,10 +204,6 @@ class OrderListViewModel @Inject constructor(
             canShowCardReaderUpsellBanner(System.currentTimeMillis()) &&
             !isLandScape &&
             !isOrderListEmpty
-    }
-
-    suspend fun updateBannerState() {
-        updateBannerState(landscapeChecker, _pagedListData.value.isNullOrEmpty())
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -360,9 +364,7 @@ class OrderListViewModel @Inject constructor(
 
         _pagedListData.addSource(pagedListWrapper.data) { pagedList ->
             pagedList?.let {
-                viewModelScope.launch {
-                    updateBannerState(landscapeChecker, it.isNullOrEmpty())
-                }
+
                 _pagedListData.value = it
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -188,11 +188,16 @@ class OrderListViewModel @Inject constructor(
         }
     }
 
-    suspend fun updateBannerState() {
+    private suspend fun shouldDisplayBanner(isLandScape: Boolean, orderListSize: Int): Boolean {
+        return bannerDisplayEligibilityChecker.isEligibleForInPersonPayments() &&
+            canShowCardReaderUpsellBanner(System.currentTimeMillis()) &&
+            !isLandScape &&
+            orderListSize > 0
+    }
+
+    suspend fun updateBannerState(isLandScape: Boolean, orderListSize: Int) {
         bannerState.value = BannerState(
-            shouldDisplayBanner =
-            bannerDisplayEligibilityChecker.isEligibleForInPersonPayments() &&
-                canShowCardReaderUpsellBanner(System.currentTimeMillis()),
+            shouldDisplayBanner = shouldDisplayBanner(isLandScape, orderListSize),
             onPrimaryActionClicked = {
                 onCtaClicked(AnalyticsTracker.KEY_BANNER_ORDER_LIST)
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/LandscapeChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/LandscapeChecker.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.wordpress.android.util.DisplayUtils
+import javax.inject.Inject
+
+@Reusable
+class LandscapeChecker @Inject constructor(@ApplicationContext private val context: Context) {
+    fun isLandscape() = DisplayUtils.isLandscape(context)
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.payments.banner.BannerDisplayEligibilityChecker
 import com.woocommerce.android.ui.payments.banner.BannerState
+import com.woocommerce.android.util.LandscapeChecker
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -92,6 +93,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val getSelectedOrderFiltersCount: GetSelectedOrderFiltersCount = mock()
     private val bannerDisplayEligibilityChecker: BannerDisplayEligibilityChecker = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val landscapeChecker: LandscapeChecker = mock()
 
     @Before
     fun setup() = testBlocking {
@@ -127,7 +129,8 @@ class OrderListViewModelTest : BaseUnitTest() {
             getSelectedOrderFiltersCount = getSelectedOrderFiltersCount,
             bannerDisplayEligibilityChecker = bannerDisplayEligibilityChecker,
             orderListTransactionLauncher = mock(),
-            analyticsTrackerWrapper = analyticsTrackerWrapper
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            landscapeChecker = landscapeChecker,
         )
     }
 
@@ -461,7 +464,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // WHEN
             viewModel.bannerState.value?.onPrimaryActionClicked?.invoke()
@@ -481,9 +484,10 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
+            whenever(landscapeChecker.isLandscape()).thenReturn(true)
 
             // WHEN
-            viewModel.updateBannerState(true, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // Then
             assertThat(
@@ -500,9 +504,10 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
+            whenever(landscapeChecker.isLandscape()).thenReturn(false)
 
             // WHEN
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // Then
             assertThat(
@@ -521,7 +526,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
 
             // WHEN
-            viewModel.updateBannerState(false, 0)
+            viewModel.updateBannerState(landscapeChecker, true)
 
             // Then
             assertThat(
@@ -540,7 +545,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
 
             // WHEN
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // Then
             assertThat(
@@ -557,7 +562,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // WHEN
             viewModel.bannerState.value?.onDismissClicked?.invoke()
@@ -599,7 +604,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // WHEN
             viewModel.bannerState.value?.onDismissClicked?.invoke()
@@ -639,7 +644,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(false)
 
             // WHEN
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // THEN
             assertFalse(viewModel.bannerState.value?.shouldDisplayBanner!!)
@@ -656,7 +661,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
 
             // WHEN
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // THEN
             assertTrue(viewModel.bannerState.value?.shouldDisplayBanner!!)
@@ -703,7 +708,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
             val captor = argumentCaptor<String>()
 
             // WHEN
@@ -721,7 +726,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // WHEN
             val title = viewModel.bannerState.value?.title
@@ -737,7 +742,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // WHEN
             val description = viewModel.bannerState.value?.description
@@ -753,7 +758,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // WHEN
             val primaryActionLabel = viewModel.bannerState.value?.primaryActionLabel
@@ -769,7 +774,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             // WHEN
             val chipLabel = viewModel.bannerState.value?.chipLabel
@@ -785,7 +790,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState(false, 1)
+            viewModel.updateBannerState(landscapeChecker, false)
 
             verify(analyticsTrackerWrapper).track(
                 AnalyticsEvent.FEATURE_CARD_SHOWN,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.OpenPurchaseCardReaderLink
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.payments.banner.BannerDisplayEligibilityChecker
+import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -460,7 +461,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // WHEN
             viewModel.bannerState.value?.onPrimaryActionClicked?.invoke()
@@ -473,6 +474,82 @@ class OrderListViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given landscape mode, when viewmodel init, then do not display banner`() {
+        runTest {
+            // GIVEN
+            whenever(
+                bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
+            ).thenReturn(true)
+            whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
+
+            // WHEN
+            viewModel.updateBannerState(true, 1)
+
+            // Then
+            assertThat(
+                (viewModel.bannerState.value as BannerState).shouldDisplayBanner
+            ).isFalse
+        }
+    }
+
+    @Test
+    fun `given portrait mode, when viewmodel init, then display the banner`() {
+        runTest {
+            // GIVEN
+            whenever(
+                bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
+            ).thenReturn(true)
+            whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
+
+            // WHEN
+            viewModel.updateBannerState(false, 1)
+
+            // Then
+            assertThat(
+                (viewModel.bannerState.value as BannerState).shouldDisplayBanner
+            ).isTrue
+        }
+    }
+
+    @Test
+    fun `given 0 orders, when viewmodel init, then do not display the banner`() {
+        runTest {
+            // GIVEN
+            whenever(
+                bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
+            ).thenReturn(true)
+            whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
+
+            // WHEN
+            viewModel.updateBannerState(false, 0)
+
+            // Then
+            assertThat(
+                (viewModel.bannerState.value as BannerState).shouldDisplayBanner
+            ).isFalse
+        }
+    }
+
+    @Test
+    fun `given more than 0 orders, when viewmodel init, then display the banner`() {
+        runTest {
+            // GIVEN
+            whenever(
+                bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
+            ).thenReturn(true)
+            whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
+
+            // WHEN
+            viewModel.updateBannerState(false, 1)
+
+            // Then
+            assertThat(
+                (viewModel.bannerState.value as BannerState).shouldDisplayBanner
+            ).isTrue
+        }
+    }
+
+    @Test
     fun `given upsell banner, when banner is dismissed, then trigger DismissCardReaderUpsellBanner event`() {
         runTest {
             // GIVEN
@@ -480,7 +557,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // WHEN
             viewModel.bannerState.value?.onDismissClicked?.invoke()
@@ -522,7 +599,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // WHEN
             viewModel.bannerState.value?.onDismissClicked?.invoke()
@@ -562,7 +639,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(false)
 
             // WHEN
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // THEN
             assertFalse(viewModel.bannerState.value?.shouldDisplayBanner!!)
@@ -579,7 +656,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
 
             // WHEN
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // THEN
             assertTrue(viewModel.bannerState.value?.shouldDisplayBanner!!)
@@ -626,7 +703,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
             val captor = argumentCaptor<String>()
 
             // WHEN
@@ -644,7 +721,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // WHEN
             val title = viewModel.bannerState.value?.title
@@ -660,7 +737,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // WHEN
             val description = viewModel.bannerState.value?.description
@@ -676,7 +753,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // WHEN
             val primaryActionLabel = viewModel.bannerState.value?.primaryActionLabel
@@ -692,7 +769,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             // WHEN
             val chipLabel = viewModel.bannerState.value?.chipLabel
@@ -708,7 +785,7 @@ class OrderListViewModelTest : BaseUnitTest() {
                 bannerDisplayEligibilityChecker.canShowCardReaderUpsellBanner(anyLong())
             ).thenReturn(true)
             whenever(bannerDisplayEligibilityChecker.isEligibleForInPersonPayments()).thenReturn(true)
-            viewModel.updateBannerState()
+            viewModel.updateBannerState(false, 1)
 
             verify(analyticsTrackerWrapper).track(
                 AnalyticsEvent.FEATURE_CARD_SHOWN,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7445 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Upsell card reader banner re-appears after dismissal and doing the pull to refresh on the order listing screen.

**Steps to reproduce**

1. Navigate to the order listing screen
2. Dismiss the banner
3. **Without navigating to any other screen**, Pull to refresh in the order listing screen.
4. Notice the Banner re-appears again.

This PR fixes this as well as refactors the Banner display requirements logic.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/1331230/191910420-44f276f6-c371-4820-bf70-ddc3ec2388f7.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
