### PR TITLE
issue/7449-one-per-order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 10.5
 -----
-[**] Fixed a bug that cuased new products to default to ome per order [https://github.com/woocommerce/woocommerce-android/pull/7450]
+[**] Fixed a bug that caused new products to default to one per order [https://github.com/woocommerce/woocommerce-android/pull/7450]
 
 10.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 10.5
 -----
-
+[**] Fixed a bug that cuased new products to default to ome per order [https://github.com/woocommerce/woocommerce-android/pull/7450]
 
 10.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -78,7 +78,7 @@ object ProductHelper {
             attributes = listOf(),
             saleEndDateGmt = null,
             saleStartDateGmt = null,
-            isSoldIndividually = true,
+            isSoldIndividually = false,
             taxStatus = ProductTaxStatus.Taxable,
             isSaleScheduled = false,
             menuOrder = 0,


### PR DESCRIPTION
Closes: #7449

This tiny PR corrects a bug that caused "Limit to one per order" to default to true when creating a new product. To test:

* Start product creation
* Tap Inventory
* Verify "Limit to one per order" isn't checked by default


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
