### PR TITLE
Fix issue causing duplicate files when uploading multiple files

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 10.6
 -----
-
+- [*] Fixed a bug that caused having duplicate when uploading multiple images [https://github.com/woocommerce/woocommerce-android/pull/7459]
 
 10.5
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ ext {
     materialVersion = '1.6.1'
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
-    mediapickerVersion = '59-7c4eaacd5fe13cce2492fe1cc410500811f82f8b'
+    mediapickerVersion = 'trunk-6d9cbe0b1a0f0f2163b6ab6e0e5b2aadc6511ddd'
     wordPressLoginVersion = '0.20.0'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ ext {
     materialVersion = '1.6.1'
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
-    mediapickerVersion = '0.1.0'
+    mediapickerVersion = '59-7c4eaacd5fe13cce2492fe1cc410500811f82f8b'
     wordPressLoginVersion = '0.20.0'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'


### PR DESCRIPTION
Closes: #6348

### Description
When uploading multiple files, we create a temporary file to the app's cache, this was using logic from the MediaPicker library, and it had a bug that it overrides files if it was called multiple times at the same time (uploading multiple files from multiple threads).
My first attempt was to make the code synchronized to avoid multiple concurrent calls, but since it doesn't fully fix the issue (it just hides it, but if the device is fast enough to make two sequential calls in the same millisecond, we'll still have the bug), I tried to fix the issue in the library itself, and here is the PR https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/59 fixes the bug.

### Testing instructions
1. Open the app on a device that has Android 11 or later.
2. Open a product.
3. Click on Add images.
4. Select multiple images.
5. Confirm all images are uploaded successfully.
6. Repeat multiple times to confirm no duplication happens now.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
