### PR TITLE
Fixed background color of the products without pictures for the dark mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
@@ -39,7 +39,7 @@ class ProductItemView @JvmOverloads constructor(
     private val statusColor = ContextCompat.getColor(context, R.color.product_status_fg_other)
     private val statusPendingColor = ContextCompat.getColor(context, R.color.product_status_fg_pending)
     private val selectedBackgroundColor = ContextCompat.getColor(context, R.color.color_primary)
-    private val unSelectedBackgroundColor = ContextCompat.getColor(context, R.color.white)
+    private val unSelectedBackgroundColor = ContextCompat.getColor(context, R.color.color_on_primary_high)
 
     fun bind(
         product: Product,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7466
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We show white background and a white icon in the dark mode for the products without images. This PR fixes this

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open products list in both dark and normal mode
* Notice that the placeholder icons are visible now

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
### Before/After
![1](https://user-images.githubusercontent.com/4923871/192989024-fbfc69d2-e33a-43ec-a55f-553b08f54659.jpg)
![3](https://user-images.githubusercontent.com/4923871/192989037-f2ef4d0b-32a9-4ff8-b800-a2f12d23a137.jpg)
![2](https://user-images.githubusercontent.com/4923871/192989051-384c71dd-e88b-4985-a84e-9b05e2a67b89.jpg)
![4](https://user-images.githubusercontent.com/4923871/192989065-f98c5b83-cb0f-420c-b9b1-fa06cf0838d4.jpg)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
