### PR TITLE
[UI Tests] - Add customer note assertion to create order test

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/2201/2201_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/2201/2201_detailed.json
@@ -57,7 +57,7 @@
         },
         "payment_method": "",
         "payment_method_title": "",
-        "customer_note": "",
+        "customer_note": "Customer notes 123~",
         "number": "2201",
         "meta_data": [],
         "line_items": [

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_create_simple_product.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_create_simple_product.json
@@ -56,7 +56,7 @@
         },
         "payment_method": "",
         "payment_method_title": "",
-        "customer_note": "",
+        "customer_note": "Customer notes 123~",
         "number": "2201",
         "meta_data": [],
         "line_items": [

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/SingleOrderScreen.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.screenshots.util.NestedScrollViewExtension
 import com.woocommerce.android.screenshots.util.OrderData
 import com.woocommerce.android.screenshots.util.Screen
 import org.hamcrest.Matchers
+import org.hamcrest.core.AllOf.allOf
 
 class SingleOrderScreen : Screen {
     companion object {
@@ -18,6 +19,8 @@ class SingleOrderScreen : Screen {
         const val AMOUNT_SHIPPING = R.id.paymentInfo_shippingTotal
         const val AMOUNT_TOTAL = R.id.paymentInfo_total
         const val COLLECT_PAYMENT_BUTTON = R.id.paymentInfo_collectCardPresentPaymentButton
+        const val CUSTOMER_NOTE = R.id.customerInfo_customerNote
+        const val CUSTOMER_NOTE_TEXT_FIELD = R.id.notEmptyLabel
         const val ORDER_NUMBER_LABEL = R.id.orderStatus_subtitle
         const val ORDER_STATUS_CUSTOMER = R.id.orderStatus_header
         const val ORDER_STATUS_TAG = R.id.orderStatus_orderTags
@@ -55,6 +58,10 @@ class SingleOrderScreen : Screen {
         assertIdAndTextDisplayed(AMOUNT_SHIPPING, order.shippingAmount)
         assertIdAndTextDisplayed(AMOUNT_FEE, order.feeAmount)
         assertIdAndTextDisplayed(AMOUNT_TOTAL, order.total)
+
+        Espresso.onView(withId(CUSTOMER_NOTE))
+            .perform(NestedScrollViewExtension())
+        assertIdAndTextDisplayed(CUSTOMER_NOTE_TEXT_FIELD, order.customerNote)
 
         return this
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/UnifiedOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/orders/UnifiedOrderScreen.kt
@@ -18,10 +18,12 @@ import org.hamcrest.core.AllOf.allOf
 class UnifiedOrderScreen : Screen(ORDER_CREATION) {
     companion object {
         const val CREATE_BUTTON = R.id.menu_create
+        const val CUSTOMER_NOTE_EDITOR = R.id.customerOrderNote_editor
         const val CUSTOMER_SECTION = R.id.customer_section
         const val DONE_BUTTON = R.id.menu_done
         const val EDIT_STATUS_BUTTON = R.id.orderStatus_editButton
         const val FEE_BUTTON = R.id.fee_button
+        const val NOTES_SECTION = R.id.notes_section
         const val ORDER_CREATION = R.id.order_creation_root
         const val PAYMENT_SECTION = R.id.payment_section
         const val PRODUCTS_SECTION = R.id.products_section
@@ -73,6 +75,19 @@ class UnifiedOrderScreen : Screen(ORDER_CREATION) {
             .perform(ViewActions.clearText())
         Espresso.onView((allOf(withText("0"), withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))))
             .perform(ViewActions.replaceText("2.25"))
+
+        clickOn(DONE_BUTTON)
+        return this
+    }
+
+    fun addCustomerNotes(note: String): UnifiedOrderScreen {
+        Espresso.onView(withId(NOTES_SECTION))
+            .perform(NestedScrollViewExtension())
+        Espresso.onView(withText("Add note"))
+            .perform(click())
+
+        Espresso.onView(withId(CUSTOMER_NOTE_EDITOR))
+            .perform((ViewActions.replaceText(note)))
 
         clickOn(DONE_BUTTON)
         return this

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/DataClasses.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/util/DataClasses.kt
@@ -75,6 +75,7 @@ data class ProductData(
 
 data class OrderData(
     val customer: String,
+    val customerNoteRaw: String,
     val feeRaw: String,
     val id: Int,
     val productName: String,
@@ -84,6 +85,7 @@ data class OrderData(
 ) {
     // there is a white space in the text value returned by the element, adjusting here to match that
     val customerName = "$customer "
+    val customerNote = "\"$customerNoteRaw\""
     val feeAmount = "\$$feeRaw"
     val shippingAmount = "\$$shippingRaw"
     val status = orderStatusMap[statusRaw]

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
@@ -45,6 +45,9 @@ class OrdersUITest : TestBase() {
 
     @Test
     fun createOrderTest() {
+        val firstName = "Mira"
+        val note = "Customer notes 123~"
+        val status = "Processing"
         val ordersJSONArray = MocksReader().readOrderToArray()
 
         for (orderJSON in ordersJSONArray.iterator()) {
@@ -54,12 +57,13 @@ class OrdersUITest : TestBase() {
                 .createFABTap()
                 .newOrderTap()
                 .assertNewOrderScreen()
-                .updateOrderStatus("Processing")
+                .updateOrderStatus(status)
                 .addProductTap()
                 .assertOrderSelectProductScreen()
                 .selectProduct(orderData.productName)
                 .clickAddCustomerDetails()
-                .addCustomerDetails("Mira")
+                .addCustomerDetails(firstName)
+                .addCustomerNotes(note)
                 .addShipping()
                 .addFee()
                 .createOrder()
@@ -71,6 +75,7 @@ class OrdersUITest : TestBase() {
     private fun mapJSONToOrder(orderJSON: JSONObject): OrderData {
         return OrderData(
             customer = orderJSON.getJSONObject("billing").getString("first_name"),
+            customerNoteRaw = orderJSON.getString("customer_note"),
             feeRaw = orderJSON.getJSONArray("fee_lines").getJSONObject(0).getString("total"),
             id = orderJSON.getInt("id"),
             productName = orderJSON.getJSONArray("line_items").getJSONObject(0).getString("name"),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-android/issues/6186
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds customer note assertion to the `create order` test to complete the test. Also a small refactoring on the test where I moved customer name and status into constants.

### Testing instructions
Test should pass locally and in CI

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
