### PR TITLE
Add Developer Screen feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -13,6 +13,7 @@ enum class FeatureFlag {
     COUPONS_M2,
     WC_SHIPPING_BANNER,
     UNIFIED_ORDER_EDITING,
+    DEVELOPER_SETTINGS,
     ORDER_CREATION_CUSTOMER_SEARCH;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -26,6 +27,7 @@ enum class FeatureFlag {
             UNIFIED_ORDER_EDITING -> true
             ANALYTICS_HUB,
             MORE_MENU_INBOX,
+            DEVELOPER_SETTINGS,
             WC_SHIPPING_BANNER -> PackageUtils.isDebugBuild()
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7458 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Introducing a new feature flag for the new developer screen

Project context: pdfdoF-1r8-p2
p1664897582683019-slack-CGPNUU63E


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->