### PR TITLE
[UITTI] Renamed UI tests to make them appear in group in FTL tests list.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/OrdersUITest.kt
@@ -44,7 +44,7 @@ class OrdersUITest : TestBase() {
     }
 
     @Test
-    fun createOrderTest() {
+    fun e2eCreateOrderTest() {
         val firstName = "Mira"
         val note = "Customer notes 123~"
         val status = "Processing"

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ProductsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ProductsUITest.kt
@@ -44,7 +44,7 @@ class ProductsUITest : TestBase() {
     }
 
     @Test
-    fun productListShowsAllProducts() {
+    fun e2eProductListShowsAllProducts() {
         val productsJSONArray = MocksReader().readAllProductsToArray()
 
         for (productJSON in productsJSONArray.iterator()) {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/ReviewsUITest.kt
@@ -49,7 +49,7 @@ class ReviewsUITest : TestBase() {
     }
 
     @Test
-    fun reviewListShowsAllReviews() {
+    fun e2eReviewListShowsAllReviews() {
         val reviewsJSONArray = MocksReader().readAllReviewsToArray()
 
         reviewsJSONArray.iterator().forEach { review ->


### PR DESCRIPTION
### Why
See wordpress-mobile/WordPress-Android/pull/17268

Having a unified prefix for UI tests in Woo repo is even more justified than for WP, because here the Unit Tests start with `given`, `when`, `should`, which mixes up with current UI tests names even harder.

### How
See wordpress-mobile/WordPress-Android/pull/17268

### Testing instructions
- Check that [related FTL execution](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.edfd947f2636efe3/matrices/8209677103072645591/details?stepId=bs.6e7a58dc9bdd9119&testCaseId=39) has UI tests grouped, and now they can be filtered by using the `e2e` keyword.
