### PR TITLE
[Login] Implement WPCom auto login in the Jetpack connection WebView

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComAuthenticatedWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComAuthenticatedWebView.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.common.wpcomwebview
+
+import android.annotation.SuppressLint
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.viewinterop.AndroidView
+import org.wordpress.android.fluxc.network.UserAgent
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun WPComAuthenticatedWebView(
+    url: String,
+    authenticator: WPComWebViewAuthenticator,
+    userAgent: UserAgent,
+    onUrlLoaded: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var progress by remember { mutableStateOf(0) }
+    var lastLoadedUrl by remember { mutableStateOf("") }
+
+    Column(modifier = modifier) {
+        LinearProgressIndicator(
+            progress = (progress / 100f),
+            modifier = Modifier
+                .fillMaxWidth()
+                .alpha(if (progress == 100) 0f else 1f)
+        )
+
+        AndroidView(
+            factory = { context ->
+                WebView(context).apply {
+                    this.webViewClient = object : WebViewClient() {
+                        override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+                            url?.let { onUrlLoaded(it) }
+                        }
+
+                        override fun onLoadResource(view: WebView?, url: String?) {
+                            url?.let { onUrlLoaded(it) }
+                        }
+                    }
+                    this.webChromeClient = object : WebChromeClient() {
+                        override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                            if (newProgress == 100 || newProgress - progress >= 5) {
+                                progress = newProgress
+                            }
+                        }
+                    }
+                    this.settings.javaScriptEnabled = true
+                    this.settings.userAgentString = userAgent.userAgent
+                }
+            }
+        ) { webView ->
+            if (lastLoadedUrl == url) return@AndroidView
+            lastLoadedUrl = url
+            authenticator.authenticateAndLoadUrl(webView, url)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewAuthenticator.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.common.wpcomwebview
+
+import android.webkit.WebView
+import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.util.WooLog
+import org.wordpress.android.fluxc.store.AccountStore
+import java.io.UnsupportedEncodingException
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import javax.inject.Inject
+
+private const val WPCOM_LOGIN_URL = "https://wordpress.com/wp-login.php"
+
+class WPComWebViewAuthenticator @Inject constructor(
+    private val accountStore: AccountStore
+) {
+    fun authenticateAndLoadUrl(webView: WebView, url: String) {
+        val postData = getAuthPostData(url)
+        webView.postUrl(WPCOM_LOGIN_URL, postData.toByteArray())
+    }
+
+    private fun getAuthPostData(redirectUrl: String): String {
+        val username = accountStore.account.userName.takeIf { it.isNotNullOrEmpty() } ?: return ""
+        val token = accountStore.accessToken.takeIf { it.isNotNullOrEmpty() } ?: return ""
+
+        val utf8 = StandardCharsets.UTF_8.name()
+        try {
+            var postData = String.format(
+                "log=%s&redirect_to=%s",
+                URLEncoder.encode(username, utf8),
+                URLEncoder.encode(redirectUrl, utf8)
+            )
+
+            // Add token authorization
+            postData += "&authorization=Bearer " + URLEncoder.encode(token, utf8)
+
+            return postData
+        } catch (e: UnsupportedEncodingException) {
+            WooLog.e(WooLog.T.UTILS, e)
+        }
+        return ""
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewAuthenticator.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.util.Locale
 import javax.inject.Inject
 
 private const val WPCOM_LOGIN_URL = "https://wordpress.com/wp-login.php"
@@ -19,6 +20,7 @@ class WPComWebViewAuthenticator @Inject constructor(
         webView.postUrl(WPCOM_LOGIN_URL, postData.toByteArray())
     }
 
+    @Suppress("ReturnCount")
     private fun getAuthPostData(redirectUrl: String): String {
         val username = accountStore.account.userName.takeIf { it.isNotNullOrEmpty() } ?: return ""
         val token = accountStore.accessToken.takeIf { it.isNotNullOrEmpty() } ?: return ""
@@ -26,9 +28,10 @@ class WPComWebViewAuthenticator @Inject constructor(
         val utf8 = StandardCharsets.UTF_8.name()
         try {
             var postData = String.format(
+                Locale.ROOT,
                 "log=%s&redirect_to=%s",
                 URLEncoder.encode(username, utf8),
-                URLEncoder.encode(redirectUrl, utf8)
+                URLEncoder.encode(redirectUrl, utf8),
             )
 
             // Add token authorization

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 
-
 /**
  * This fragments allows loading specific pages from WordPress.com with the current user logged in.
  * It accepts two parameters:

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewFragment.kt
@@ -14,17 +14,10 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment.UrlComparisonMode.EQUALITY
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment.UrlComparisonMode.PARTIAL
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
-import com.woocommerce.android.util.WooLog
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.util.StringUtils
-import java.io.UnsupportedEncodingException
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import javax.inject.Inject
 
-private const val WPCOM_LOGIN_URL = "https://wordpress.com/wp-login.php"
 
 /**
  * This fragments allows loading specific pages from WordPress.com with the current user logged in.
@@ -42,7 +35,7 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview), UrlI
     private val webViewClient by lazy { WPComWebViewClient(this) }
     private val navArgs: WPComWebViewFragmentArgs by navArgs()
 
-    @Inject lateinit var accountStore: AccountStore
+    @Inject lateinit var wpcomWebViewAuthenticator: WPComWebViewAuthenticator
 
     @Inject lateinit var userAgent: UserAgent
 
@@ -63,17 +56,7 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview), UrlI
             settings.userAgentString = userAgent.userAgent
         }
 
-        loadAuthenticatedUrl(binding.webView, navArgs.urlToLoad)
-    }
-
-    private fun loadAuthenticatedUrl(webView: WebView, urlToLoad: String) {
-        val postData = getAuthenticationPostData(
-            urlToLoad = urlToLoad,
-            username = accountStore.account.userName,
-            token = accountStore.accessToken
-        )
-
-        webView.postUrl(WPCOM_LOGIN_URL, postData.toByteArray())
+        wpcomWebViewAuthenticator.authenticateAndLoadUrl(binding.webView, navArgs.urlToLoad)
     }
 
     override fun onLoadUrl(url: String) {
@@ -85,25 +68,6 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview), UrlI
         if (isAdded && navArgs.urlToTriggerExit?.matchesUrl(url) == true) {
             navigateBackWithNotice(WEBVIEW_RESULT)
         }
-    }
-
-    private fun getAuthenticationPostData(urlToLoad: String, username: String, token: String): String {
-        val utf8 = StandardCharsets.UTF_8.name()
-        try {
-            var postData = String.format(
-                "log=%s&redirect_to=%s",
-                URLEncoder.encode(StringUtils.notNullStr(username), utf8),
-                URLEncoder.encode(StringUtils.notNullStr(urlToLoad), utf8)
-            )
-
-            // Add token authorization
-            postData += "&authorization=Bearer " + URLEncoder.encode(token, utf8)
-
-            return postData
-        } catch (e: UnsupportedEncodingException) {
-            WooLog.e(WooLog.T.UTILS, e)
-        }
-        return ""
     }
 
     override fun getFragmentTitle() = navArgs.title ?: super.getFragmentTitle()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
@@ -22,10 +22,10 @@ import org.wordpress.android.fluxc.network.UserAgent
 @Composable
 fun WCWebView(
     url: String,
-    authenticator: WPComWebViewAuthenticator,
     userAgent: UserAgent,
     onUrlLoaded: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    wpComAuthenticator: WPComWebViewAuthenticator? = null
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
     var progress by remember { mutableStateOf(0) }
@@ -73,7 +73,7 @@ fun WCWebView(
         ) { webView ->
             if (lastLoadedUrl == url) return@AndroidView
             lastLoadedUrl = url
-            authenticator.authenticateAndLoadUrl(webView, url)
+            wpComAuthenticator?.authenticateAndLoadUrl(webView, url) ?: webView.loadUrl(url)
             canGoBack = webView.canGoBack()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.common.wpcomwebview
+package com.woocommerce.android.ui.compose.component
 
 import android.annotation.SuppressLint
 import android.webkit.WebChromeClient
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
-fun WPComAuthenticatedWebView(
+fun WCWebView(
     url: String,
     authenticator: WPComWebViewAuthenticator,
     userAgent: UserAgent,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
@@ -30,6 +30,7 @@ fun WCWebView(
     userAgent: UserAgent,
     onUrlLoaded: (String) -> Unit,
     modifier: Modifier = Modifier,
+    captureBackPresses: Boolean = true,
     wpComAuthenticator: WPComWebViewAuthenticator? = null,
     webViewNavigator: WebViewNavigator = rememberWebViewNavigator()
 ) {
@@ -38,7 +39,7 @@ fun WCWebView(
     var lastLoadedUrl by remember { mutableStateOf("") }
     var canGoBack by remember { mutableStateOf(false) }
 
-    BackHandler(canGoBack) {
+    BackHandler(captureBackPresses && canGoBack) {
         webView?.goBack()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.OnBackPressedCallback
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
@@ -24,7 +23,6 @@ import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorView
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToLoginScreen
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToSiteAddressEvent
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.OnJetpackConnectedEvent
-import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.ViewState
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -46,19 +44,6 @@ class AccountMismatchErrorFragment : BaseFragment(), Listener {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    private val backButtonCallback = object : OnBackPressedCallback(false) {
-        override fun handleOnBackPressed() {
-            // The callback is enabled only when showing the WebView
-            when (val state = viewModel.viewState.value) {
-                is ViewState.JetpackWebViewState -> state.onDismiss()
-                is ViewState.SiteCredentialsViewState -> state.onCancel()
-                else -> {
-                    // NO-OP
-                }
-            }
-        }
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -73,15 +58,10 @@ class AccountMismatchErrorFragment : BaseFragment(), Listener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backButtonCallback)
         setupObservers()
     }
 
     private fun setupObservers() {
-        viewModel.viewState.observe(viewLifecycleOwner) {
-            backButtonCallback.isEnabled = it is ViewState.JetpackWebViewState ||
-                it is ViewState.SiteCredentialsViewState
-        }
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is NavigateToHelpScreen -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchRepository.JetpackConnectionStatus
@@ -53,9 +54,10 @@ class AccountMismatchErrorViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val accountMismatchRepository: AccountMismatchRepository,
     private val resourceProvider: ResourceProvider,
-    private val userAgent: UserAgent,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val unifiedLoginTracker: UnifiedLoginTracker,
+    val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    val userAgent: UserAgent
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val JETPACK_PLANS_URL = "wordpress.com/jetpack/connect/plans"
@@ -186,7 +188,6 @@ class AccountMismatchErrorViewModel @Inject constructor(
     private fun prepareJetpackConnectionState(connectionUrl: String) = ViewState.JetpackWebViewState(
         connectionUrl = connectionUrl,
         successConnectionUrls = listOf(siteUrl, JETPACK_PLANS_URL),
-        userAgent = userAgent.userAgent,
         onDismiss = {
             analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_CONNECT_DISMISSED)
             step.value = Step.MainContent
@@ -322,7 +323,6 @@ class AccountMismatchErrorViewModel @Inject constructor(
         data class JetpackWebViewState(
             val connectionUrl: String,
             val successConnectionUrls: List<String>,
-            val userAgent: String,
             val onDismiss: () -> Unit,
             val onConnected: () -> Unit
         ) : ViewState


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7307 

Don't merge until #7471 is merged.

### Description
This PR introduces a Compose component `WCWebView`, a WebView wrapper, with navigation features (captures back button events, and can be controlled using an optional component too), and it supports auto-login to the WPCom account by passing an instance of the `WPComAuthenticator` class.
The Accompanist library has a `WebView` component, but it's still in a beta release, and depends on Compose 1.3.0, the implementation we have here is a bit simpler, but borrows some ideas from their implementation.

### Testing instructions
1. Clear the app's data to ensure the WebView's cookies are cleared.
2. Follow the same testing steps of #7471 (Scenario 1)

### Images/gif

https://user-images.githubusercontent.com/1657201/194061808-6c7d8e13-1142-4d96-b505-7149607770a5.mov


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
