### PR TITLE
[Login] Explanation for account invitation when having an account mismatch using a WPCom site

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 - [*] Improved autofill capabilities for the login flow [https://github.com/woocommerce/woocommerce-android/pull/7461]
 - [**] Login: Add ability to connect Jetpack when signing with WPCom account to a site that has Jetpack but not connected yet [https://github.com/woocommerce/woocommerce-android/pull/7471]
 - [*] Fixes bug with visitor stats discrepancies between monthly and yearly granularities [https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2535]
-
+- [*] Show an explanation when getting an account mismatch using a WP.com site [https://github.com/woocommerce/woocommerce-android/pull/7491]
 
 10.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/WooDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/WooDialog.kt
@@ -5,7 +5,6 @@ import android.content.DialogInterface.OnClickListener
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.woocommerce.android.R.string
 import java.lang.ref.WeakReference
 
 /**
@@ -32,26 +31,24 @@ object WooDialog {
             return
         }
 
-        val message = messageId?.let {
-            activity.applicationContext.getString(it)
-        } ?: activity.applicationContext.getString(string.discard_message)
-
-        val positiveButtonTextId = positiveButtonId ?: string.discard
-        val negativeButtonTextId = negativeButtonId ?: string.keep_editing
-
         val builder = MaterialAlertDialogBuilder(activity)
-            .setMessage(message)
             .setCancelable(true)
-            .setPositiveButton(positiveButtonTextId, posBtnAction)
-            .setNegativeButton(negativeButtonTextId, negBtnAction)
             .setOnDismissListener { onCleared() }
-
-        neutBtAction?.let {
-            val neutralButtonTextId = neutralButtonId ?: string.product_detail_save_as_draft
-            builder.setNeutralButton(neutralButtonTextId, it)
-        }
-
-        titleId?.let { builder.setTitle(activity.applicationContext.getString(it)) }
+            .apply {
+                titleId?.let { setTitle(it) }
+            }
+            .apply {
+                messageId?.let { setMessage(messageId) }
+            }
+            .apply {
+                positiveButtonId?.let { setPositiveButton(it, posBtnAction) }
+            }
+            .apply {
+                negativeButtonId?.let { setNegativeButton(negativeButtonId, negBtnAction) }
+            }
+            .apply {
+                neutralButtonId?.let { setNeutralButton(it, neutBtAction) }
+            }
 
         dialogRef = WeakReference(builder.show())
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorView
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.OnJetpackConnectedEvent
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -86,6 +87,7 @@ class AccountMismatchErrorFragment : BaseFragment(), Listener {
                 is OnJetpackConnectedEvent -> onJetpackConnected(event)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowUiStringSnackbar -> uiMessageResolver.showSnack(event.message)
+                is ShowDialog -> event.showDialog()
                 is Exit -> findNavController().navigateUp()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -88,8 +88,16 @@ class AccountMismatchErrorFragment : BaseFragment(), Listener {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowUiStringSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowDialog -> event.showDialog()
-                is Exit -> findNavController().navigateUp()
+                is Exit -> navigateBack()
             }
+        }
+    }
+
+    private fun navigateBack() {
+        if (requireActivity() is LoginActivity) {
+            parentFragmentManager.popBackStack()
+        } else {
+            findNavController().navigateUp()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithNotice
-import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -21,7 +20,6 @@ import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment.Listener
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToEmailHelpDialogEvent
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToHelpScreen
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToLoginScreen
-import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToSiteAddressEvent
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.OnJetpackConnectedEvent
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -79,10 +77,6 @@ class AccountMismatchErrorFragment : BaseFragment(), Listener {
                         it.show(parentFragmentManager, LoginEmailHelpDialogFragment.TAG)
                     }
                 }
-                is NavigateToSiteAddressEvent -> findNavController().navigateSafely(
-                    AccountMismatchErrorFragmentDirections
-                        .actionAccountMismatchErrorFragmentToSitePickerSiteDiscoveryFragment()
-                )
                 is NavigateToLoginScreen -> navigateToLoginScreen()
                 is OnJetpackConnectedEvent -> onJetpackConnected(event)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -32,8 +32,6 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,33 +70,19 @@ fun AccountMismatchErrorScreen(viewModel: AccountMismatchErrorViewModel) {
     val webViewNavigator = rememberWebViewNavigator()
 
     viewModel.viewState.observeAsState().value?.let { viewState ->
-        val overrideBackButton by derivedStateOf {
-            viewState is ViewState.JetpackWebViewState ||
-                viewState is ViewState.SiteCredentialsViewState
-        }
-        val goBack = {
-            when (val state = viewModel.viewState.value) {
-                is ViewState.JetpackWebViewState -> state.onDismiss()
-                is ViewState.SiteCredentialsViewState -> state.onCancel()
-                else -> {
-                    // NO-OP
-                }
-            }
-        }
-
-        BackHandler(overrideBackButton, onBack = goBack)
+        BackHandler(onBack = viewState.onBackPressed)
 
         Scaffold(topBar = {
             TopAppBar(
                 backgroundColor = MaterialTheme.colors.surface,
                 title = { },
                 navigationIcon = {
-                    if (overrideBackButton) {
+                    if (viewState.showNavigationIcon) {
                         IconButton(onClick = {
                             if (webViewNavigator.canGoBack) {
                                 webViewNavigator.navigateBack()
                             } else {
-                                goBack()
+                                viewState.onBackPressed()
                             }
                         }) {
                             Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
@@ -407,7 +391,9 @@ private fun AccountMismatchPreview() {
                 secondaryButtonText = R.string.continue_button,
                 secondaryButtonAction = {},
                 inlineButtonText = R.string.continue_button,
-                inlineButtonAction = {}
+                inlineButtonAction = {},
+                showNavigationIcon = true,
+                onBackPressed = {}
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -110,16 +110,14 @@ class AccountMismatchErrorViewModel @Inject constructor(
             resourceProvider.getString(R.string.login_jetpack_not_connected, siteUrl)
         },
         primaryButtonText = when (navArgs.primaryButton) {
-            AccountMismatchPrimaryButton.SHOW_SITE_PICKER -> R.string.login_view_connected_stores
-            AccountMismatchPrimaryButton.ENTER_NEW_SITE_ADDRESS -> R.string.login_site_picker_try_another_address
             AccountMismatchPrimaryButton.CONNECT_JETPACK -> R.string.login_connect_jetpack_button
+            AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE -> R.string.login_connect_jetpack_button
             AccountMismatchPrimaryButton.NONE -> null
         },
         primaryButtonAction = {
             when (navArgs.primaryButton) {
-                AccountMismatchPrimaryButton.SHOW_SITE_PICKER -> showConnectedStores()
-                AccountMismatchPrimaryButton.ENTER_NEW_SITE_ADDRESS -> navigateToSiteAddressScreen()
                 AccountMismatchPrimaryButton.CONNECT_JETPACK -> startJetpackConnection()
+                AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE -> TODO()
                 AccountMismatchPrimaryButton.NONE ->
                     error("NONE as primary button shouldn't trigger the callback")
             }
@@ -365,6 +363,6 @@ class AccountMismatchErrorViewModel @Inject constructor(
     }
 
     enum class AccountMismatchPrimaryButton {
-        SHOW_SITE_PICKER, ENTER_NEW_SITE_ADDRESS, CONNECT_JETPACK, NONE
+        CONNECT_JETPACK, CONNECT_WPCOM_SITE, NONE
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchRepository.JetpackConnectionStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -110,14 +111,20 @@ class AccountMismatchErrorViewModel @Inject constructor(
             resourceProvider.getString(R.string.login_jetpack_not_connected, siteUrl)
         },
         primaryButtonText = when (navArgs.primaryButton) {
-            AccountMismatchPrimaryButton.CONNECT_JETPACK -> R.string.login_connect_jetpack_button
-            AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE -> R.string.login_connect_jetpack_button
+            AccountMismatchPrimaryButton.CONNECT_JETPACK -> R.string.login_account_mismatch_connect_jetpack
+            AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE -> R.string.login_account_mismatch_connect_wpcom
             AccountMismatchPrimaryButton.NONE -> null
         },
         primaryButtonAction = {
             when (navArgs.primaryButton) {
                 AccountMismatchPrimaryButton.CONNECT_JETPACK -> startJetpackConnection()
-                AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE -> TODO()
+                AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE -> triggerEvent(
+                    ShowDialog(
+                        titleId = R.string.login_account_mismatch_connect_wpcom_dialog_title,
+                        messageId = R.string.login_account_mismatch_connect_wpcom_dialog_message,
+                        positiveButtonId = R.string.continue_button
+                    )
+                )
                 AccountMismatchPrimaryButton.NONE ->
                     error("NONE as primary button shouldn't trigger the callback")
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchRepository.JetpackConnectionStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
@@ -202,14 +201,6 @@ class AccountMismatchErrorViewModel @Inject constructor(
             step.value = Step.FetchJetpackEmail
         }
     )
-
-    private fun showConnectedStores() {
-        triggerEvent(Exit)
-    }
-
-    private fun navigateToSiteAddressScreen() {
-        triggerEvent(NavigateToSiteAddressEvent)
-    }
 
     private fun loginWithDifferentAccount() {
         if (!accountRepository.isUserLoggedIn()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -355,7 +355,6 @@ class AccountMismatchErrorViewModel @Inject constructor(
     )
 
     object NavigateToHelpScreen : MultiLiveEvent.Event()
-    object NavigateToSiteAddressEvent : MultiLiveEvent.Event()
     object NavigateToEmailHelpDialogEvent : MultiLiveEvent.Event()
     object NavigateToLoginScreen : MultiLiveEvent.Event()
     data class OnJetpackConnectedEvent(val email: String, val isAuthenticated: Boolean) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -118,13 +118,17 @@ class AccountMismatchErrorViewModel @Inject constructor(
         primaryButtonAction = {
             when (navArgs.primaryButton) {
                 AccountMismatchPrimaryButton.CONNECT_JETPACK -> startJetpackConnection()
-                AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE -> triggerEvent(
-                    ShowDialog(
-                        titleId = R.string.login_account_mismatch_connect_wpcom_dialog_title,
-                        messageId = R.string.login_account_mismatch_connect_wpcom_dialog_message,
-                        positiveButtonId = R.string.continue_button
+                AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE -> {
+                    // We are re-using the same event as Jetpack connection here
+                    analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_CONNECT_BUTTON_TAPPED)
+                    triggerEvent(
+                        ShowDialog(
+                            titleId = R.string.login_account_mismatch_connect_wpcom_dialog_title,
+                            messageId = R.string.login_account_mismatch_connect_wpcom_dialog_message,
+                            positiveButtonId = R.string.continue_button
+                        )
                     )
-                )
+                }
                 AccountMismatchPrimaryButton.NONE ->
                     error("NONE as primary button shouldn't trigger the callback")
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -282,7 +282,8 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
         findNavController().navigateSafely(
             SitePickerFragmentDirections.actionSitePickerFragmentToAccountMismatchErrorFragment(
                 siteUrl = event.siteUrl,
-                primaryButton = event.primaryButton
+                primaryButton = event.primaryButton,
+                allowBackNavigation = event.hasConnectedStores
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerRepository.kt
@@ -27,6 +27,10 @@ class SitePickerRepository @Inject constructor(
     private val wooCommerceStore: WooCommerceStore
 ) {
     suspend fun getSites() = withContext(Dispatchers.IO) { siteStore.sites }
+        .filter {
+            // Take only sites returned from the WPCom /me/sites response
+            it.origin == SiteModel.ORIGIN_WPCOM_REST
+        }
 
     fun getSiteBySiteUrl(url: String) = SiteUtils.getSiteByMatchingUrl(siteStore, url)
         .takeIf {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -288,7 +288,8 @@ class SitePickerViewModel @Inject constructor(
                     triggerEvent(
                         NavigateToAccountMismatchScreen(
                             primaryButton = primaryButton,
-                            siteUrl = url
+                            siteUrl = url,
+                            hasConnectedStores = sitePickerViewState.hasConnectedStores ?: false
                         )
                     )
                 }
@@ -660,7 +661,8 @@ class SitePickerViewModel @Inject constructor(
         data class NavigateToWPComWebView(val url: String, val validationUrl: String) : SitePickerEvent()
         data class NavigateToAccountMismatchScreen(
             val primaryButton: AccountMismatchPrimaryButton,
-            val siteUrl: String
+            val siteUrl: String,
+            val hasConnectedStores: Boolean
         ) : SitePickerEvent()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -280,9 +280,8 @@ class SitePickerViewModel @Inject constructor(
         repository.fetchSiteInfo(url).fold(
             onSuccess = {
                 val primaryButton = when {
-                    !it.isWPCom -> AccountMismatchPrimaryButton.CONNECT_JETPACK
-                    sitePickerViewState.hasConnectedStores ?: false -> AccountMismatchPrimaryButton.SHOW_SITE_PICKER
-                    else -> AccountMismatchPrimaryButton.ENTER_NEW_SITE_ADDRESS
+                    it.isWPCom -> AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE
+                    else -> AccountMismatchPrimaryButton.CONNECT_JETPACK
                 }
                 if (event.value !is NavigateToAccountMismatchScreen) {
                     // The check is to avoid triggering the navigation multiple times

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -446,6 +446,10 @@
             android:name="primaryButton"
             app:argType="com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel$AccountMismatchPrimaryButton"
             android:defaultValue="NONE" />
+        <argument
+            android:name="allowBackNavigation"
+            app:argType="boolean"
+            android:defaultValue="true" />
         <action
             android:id="@+id/action_accountMismatchErrorFragment_to_sitePickerSiteDiscoveryFragment"
             app:destination="@id/sitePickerSiteDiscoveryFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -450,9 +450,5 @@
             android:name="allowBackNavigation"
             app:argType="boolean"
             android:defaultValue="true" />
-        <action
-            android:id="@+id/action_accountMismatchErrorFragment_to_sitePickerSiteDiscoveryFragment"
-            app:destination="@id/sitePickerSiteDiscoveryFragment"
-            app:popUpTo="@id/sitePickerFragment" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -271,12 +271,15 @@
     <string name="login_site_picker_enter_site_address">Enter a site address</string>
     <string name="site_discovery_postlogin_failure">A failure occurred, please contact support</string>
     <string name="login_site_picker_new_to_woo">New to WooCommerce</string>
-    <string name="login_connect_jetpack_button">Connect Jetpack to your account</string>
     <string name="login_simple_wpcom_site">The site %1$s is currently on a WordPress.com plan that does not support plugin installation. Please upgrade your plan to use WooCommerce.</string>
     <string name="login_jetpack_connection_verification_failed">Cannot verify your Jetpack connection. Please try again.</string>
     <string name="login_jetpack_verify_connection">Verifying Jetpack connection…</string>
     <string name="login_jetpack_connection_url_failed">Fetching connection data failed…</string>
     <string name="login_2fa_not_supported_self_hosted_site">2FA not supported for self-hosted sites. Please use an app-password.</string>
+    <string name="login_account_mismatch_connect_jetpack">Connect Jetpack to your account</string>
+    <string name="login_account_mismatch_connect_wpcom">Connect to the site</string>
+    <string name="login_account_mismatch_connect_wpcom_dialog_title">Connecting to a WordPress.com site</string>
+    <string name="login_account_mismatch_connect_wpcom_dialog_message">Please contact the site owner for an invitation to the site as a shop manager or administrator to use the app.</string>
     <!--
         My Store View
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -342,7 +342,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
                 )
             )
 
-            assertThat(viewModel.event.value).isEqualTo(NavigateToAccountMismatchScreen(CONNECT_JETPACK, url))
+            assertThat(viewModel.event.value).isEqualTo(NavigateToAccountMismatchScreen(CONNECT_JETPACK, url, true))
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7307

Please don't merge until #7485 is merged.

### Description
This PR handles the account mismatch case when using a WPCom site, since we can't handle the Jetpack connection like the other sites (at least AFAWK), we will just display a dialog with an explanation on how to connect.

Regarding the different changes and the reasoning behind them:
1. The main change is done in commits 789854d and 7522469.
2. The commit  c3f0f3c fixes an issue with our logic for dialogs, we were setting some defaults values that don't make sense (they are specific for the Discard changes dialog). This change shouldn't have any negative impact since the discard dialogs use their specific [function](https://github.com/woocommerce/woocommerce-android/blob/f609daa434f849467ce366a04a243aa896d7f86d/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt#L137) with the correct defaults.
3. The commits 30afdff and de727f6 are an improvement to back navigation, the idea is that we want to disallow navigating back to the previous screen if doesn't have a correct state, and this state here is specific to the Site Picker when there are no other sites, I also updated the UI to show the up button when the user can navigate back. 
4. The commit b4103e6 makes sure we show only sites that are originated from the WPCom REST API in the site picker, since we may be having some XMLRPC sites in the DB that are unrelated to what we need at this step.
 
### Testing instructions
1. Prepare two WPCom accounts.
2. Prepare a WPCom site.
3. Connect the site to one of the accounts.
4. Open the app then sign in using the site address.
5. Continue the login using WPCom account (use the account that's not connected to your site).
6. Notice the Account Mismatch error screen.
7. Click on "Connect to your site"
8. Notice the explanation dialog.

### Images/gif
<img width=360 src="https://user-images.githubusercontent.com/1657201/194331449-63534ad1-febc-47b0-b1f7-fc0a536a77e1.png"/> <img width=360 src="https://user-images.githubusercontent.com/1657201/194331473-258dc22b-ccbe-4a2b-9466-2c2509834d17.png"/>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
