### PR TITLE
Add dev options row to settings screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsFragment.kt
@@ -11,7 +11,6 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class DeveloperOptionsFragment : BaseFragment(R.layout.fragment_developer_options) {
-    override fun getFragmentTitle() = resources.getString(R.string.dev_options)
     private var _binding: FragmentDeveloperOptionsBinding? = null
     private val binding get() = _binding!!
     // private val viewModel: DeveloperOptionsViewModel by viewModels()
@@ -24,6 +23,8 @@ class DeveloperOptionsFragment : BaseFragment(R.layout.fragment_developer_option
         _binding = FragmentDeveloperOptionsBinding.inflate(inflater, container, false)
         return binding.root
     }
+
+    override fun getFragmentTitle() = resources.getString(R.string.dev_options)
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsFragment.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class DeveloperOptionsFragment : BaseFragment(R.layout.fragment_developer_options) {
+    override fun getFragmentTitle() = resources.getString(R.string.dev_options)
     private var _binding: FragmentDeveloperOptionsBinding? = null
     private val binding get() = _binding!!
     // private val viewModel: DeveloperOptionsViewModel by viewModels()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.ThemeOption
 import com.woocommerce.android.util.WooLog
@@ -161,6 +162,15 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                 trackSettingToggled(SETTING_NOTIFS_TONE, isChecked)
                 AppPrefs.setOrderNotificationsChaChingEnabled(isChecked)
             }
+        }
+
+        if (PackageUtils.isDebugBuild()) {
+            binding.optionDevelopers.visibility = View.VISIBLE
+            binding.optionDevelopers.setOnClickListener {
+                findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_developerOptionsFragment)
+            }
+        } else {
+            binding.optionDevelopers.visibility = View.GONE
         }
 
         binding.optionBetaFeatures.setOnClickListener {

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -21,6 +21,14 @@
             android:layout_height="wrap_content"
             app:optionTitle="@string/support_help" />
 
+        <View style="@style/Woo.Divider" />
+
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_developers"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/dev_options" />
+
         <LinearLayout
             android:id="@+id/store_settings_container"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -31,6 +31,9 @@
         <action
             android:id="@+id/action_mainSettingsFragment_to_nav_graph_jetpack_install"
             app:destination="@id/nav_graph_jetpack_install" />
+        <action
+            android:id="@+id/action_mainSettingsFragment_to_developerOptionsFragment"
+            app:destination="@id/developerOptionsFragment" />
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"
@@ -107,4 +110,8 @@
     </fragment>
     <action android:id="@+id/action_global_WPComWebViewFragment" app:destination="@id/WPComWebViewFragment"/>
     <include app:graph="@navigation/nav_graph_jetpack_install" />
+    <fragment
+        android:id="@+id/developerOptionsFragment"
+        android:name="com.woocommerce.android.ui.prefs.DeveloperOptionsFragment"
+        android:label="DeveloperOptionsFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1705,6 +1705,7 @@
     <string name="settings_about_title">About WooCommerce</string>
     <string name="settings_about_recommend_app_subject">WooCommerce</string>
     <string name="settings_about_recommend_app_message">Hey! Here is a link to download the WooCommerce app. I\'m really enjoying it and thought you might too. %1$s</string>
+    <string name="dev_options">Developer Options</string>
     <!--
         WCToggleSingleOptionView
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

###  Please merge #7489 before merging this PR 

Closes: #7478 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new row to the app Settings screen (MainSettings) and the navigation to the Developer Option fragment (#7489)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. **open the app in debug**
2. navigate to the menu screen
3. navigate to the settings screen
4. make sure the Developer Options row **is** displayed
5. make sure it navigates to the Developer Options Fragment
6. make sure the fragment title says `Developer Options`
7. **open the app in release**
8. navigate to the menu screen
9. navigate to the settings screen
10. make sure the Developer Options row is **not** displayed

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

### Debug Settings
| light | Dark |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/194391542-ec2676b4-f3d7-477b-a1f3-9ae0203d794b.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/194391537-2e526b2a-3ba6-4587-a715-2e4f314d94c6.png" width="350"/> |

### Debug Dev Options
| light | Dark |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/194391545-862f04b8-af6c-4e61-a173-c3672d3ad42d.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/194391544-2f9d2054-18ee-4f95-bcec-6c030e430352.png" width="350"/> |

### Release

 <img src="https://user-images.githubusercontent.com/30724184/194391568-729bfd46-06c5-4cc0-9d08-806d85c21ff4.png" width="350"/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
