### PR TITLE
Display site name on site verification error snackbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -160,12 +160,20 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 is NavigateToEmailHelpDialogEvent -> navigateToNeedHelpFindingEmailScreen()
                 is NavigateToWPComWebView -> navigateToWPComWebView(event)
                 is NavigateToAccountMismatchScreen -> navigateToAccountMismatchScreen(event)
-                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is ShowSnackbar -> showSnackbar(event)
                 is ShowDialog -> event.showDialog()
                 is Logout -> onLogout()
                 is Exit -> findNavController().navigateUp()
                 else -> event.isHandled = false
             }
+        }
+    }
+
+    private fun showSnackbar(event: ShowSnackbar) {
+        if (event.args.isNotEmpty()) {
+            uiMessageResolver.getSnack(event.message, *event.args).show()
+        } else {
+            uiMessageResolver.showSnack(event.message)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -160,20 +160,13 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 is NavigateToEmailHelpDialogEvent -> navigateToNeedHelpFindingEmailScreen()
                 is NavigateToWPComWebView -> navigateToWPComWebView(event)
                 is NavigateToAccountMismatchScreen -> navigateToAccountMismatchScreen(event)
-                is ShowSnackbar -> showSnackbar(event)
+                is ShowSnackbar -> uiMessageResolver.getSnack(stringResId = event.message, stringArgs = event.args)
+                    .show()
                 is ShowDialog -> event.showDialog()
                 is Logout -> onLogout()
                 is Exit -> findNavController().navigateUp()
                 else -> event.isHandled = false
             }
-        }
-    }
-
-    private fun showSnackbar(event: ShowSnackbar) {
-        if (event.args.isNotEmpty()) {
-            uiMessageResolver.getSnack(event.message, *event.args).show()
-        } else {
-            uiMessageResolver.showSnack(event.message)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7494
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Properly display the site name when site verification fails inside site picker: 

![connect](https://user-images.githubusercontent.com/3903757/194355444-3aac4b58-3dda-4b90-8b20-c107b103c84c.png)

### Testing instructions
Pick a site from the site picker that has Jetpack connection error. To reproduce this: 
- Login into the app
- Once you are in the Site Picker open `wc-core` for one of the listed sites and disable Jetpack
- Select the site where you've disabled Jetpack
- Click continue
- Verify snackbar displays the name of the site correctly. 

### Images/gif

https://user-images.githubusercontent.com/2663464/194399778-10f2fd7e-6f79-4cc2-aa15-a2b5e8015e3d.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
