### PR TITLE
Fix for the crash related to Google's autofill service

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -21,12 +21,14 @@ class WooLoginEmailFragment : LoginEmailFragment() {
 
     override fun setupContent(rootView: ViewGroup) {
         super.setupContent(rootView)
-        with(rootView) {
-            findViewById<Button>(R.id.login_what_is_wordpress).setOnClickListener {
-                whatIsWordPressLinkClickListener.onWhatIsWordPressLinkClicked()
-            }
-            findViewById<WPLoginInputRow>(R.id.login_email_row).editText.showKeyboardWithDelay(0)
+        rootView.findViewById<Button>(R.id.login_what_is_wordpress).setOnClickListener {
+            whatIsWordPressLinkClickListener.onWhatIsWordPressLinkClicked()
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        requireView().findViewById<WPLoginInputRow>(R.id.login_email_row).editText.showKeyboardWithDelay(0)
     }
 
     override fun onAttach(context: Context) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The login library attempts to use google's CredentialsApi when the "email" edit text gets focused. If this happens "too early" apparently the CredentialsApi is not get initialised properly

[Crash in Sentry](https://sentry.io/organizations/a8c/issues/3643875696/?project=1459556&query=is%3Aunresolved+client+must+not+be+null&statsPeriod=14d)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

To reproduce run the flow:
* Open the app
* Click on "Continue with wp login"


It should crash when:
* Autofill service disabled   (apparently it uses google's autofill then anyway, at least login library attempts to use it)
* google's autofill enabled

Run the same flow on this branch and it should not crash with all the different combinations of the autofill

// cc @spencertransier 
