### PR TITLE
issue/fix-whats-new-link

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -76,7 +76,7 @@ object AppUrls {
     const val LOGIN_WITH_EMAIL_WHAT_IS_WORDPRESS_COM_ACCOUNT =
         "https://woocommerce.com/document/what-is-a-wordpress-com-account/"
 
-    const val NEW_TO_WOO_DOC = "https://woocommerce.com/document/woocommerce-features"
+    const val NEW_TO_WOO_DOC = "https://woocommerce.com/woocommerce-features"
 
     private const val LOGIN_HELP_CENTER = "https://woocommerce.com/document/android-ios-apps-login-help-faq/"
     val LOGIN_HELP_CENTER_URLS = mapOf(


### PR DESCRIPTION
This tiny PR fixes the "New to WooCommerce" link on the initial login screen, which previously was a 404 page.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.