### PR TITLE
Fix issue with Jetpack connection in site credentials flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewAuthenticator.kt
@@ -16,8 +16,13 @@ class WPComWebViewAuthenticator @Inject constructor(
     private val accountStore: AccountStore
 ) {
     fun authenticateAndLoadUrl(webView: WebView, url: String) {
-        val postData = getAuthPostData(url)
-        webView.postUrl(WPCOM_LOGIN_URL, postData.toByteArray())
+        getAuthPostData(url).let { postData ->
+            if (postData.isNotEmpty()) {
+                webView.postUrl(WPCOM_LOGIN_URL, postData.toByteArray())
+            } else {
+                webView.loadUrl(url)
+            }
+        }
     }
 
     @Suppress("ReturnCount")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -672,7 +672,7 @@ class LoginActivity :
         userAvatarUrl: String?,
         checkJetpackAvailability: Boolean
     ) {
-        if (connectSiteInfo?.isJetpackInstalled == true && connectSiteInfo?.isJetpackActive == true) {
+        if (connectSiteInfo?.isJetpackActive == true && connectSiteInfo?.isJetpackConnected == true) {
             // If jetpack is present, but we can't find the connected email, then show account mismatch error
             val fragment = AccountMismatchErrorFragment().apply {
                 arguments = AccountMismatchErrorFragmentArgs(
@@ -979,7 +979,7 @@ class LoginActivity :
             connectSiteInfo = event.info.let {
                 ConnectSiteInfo(
                     isWPCom = it.isWPCom,
-                    isJetpackInstalled = it.isJetpackConnected,
+                    isJetpackConnected = it.isJetpackConnected,
                     isJetpackActive = it.isJetpackActive
                 )
             }
@@ -989,7 +989,7 @@ class LoginActivity :
     @Parcelize
     private data class ConnectSiteInfo(
         val isWPCom: Boolean,
-        val isJetpackInstalled: Boolean,
+        val isJetpackConnected: Boolean,
         val isJetpackActive: Boolean
     ) : Parcelable
 }


### PR DESCRIPTION
### Description
In the PR #7485, I added ability to auto-authenticate the user to their WordPress.com account when they want to connect their Jetpack account, but I missed the case of when we don't have WordPress.com credentials yet, this caused the flow to break when using site credentials for login.

This PR fixes this by fall backing to load unauthenticated URL when we don't have the data to `POST` to login.

@spencertransier heads up, this PR fixes an issue in the current RC, it's not super urgent though, so if you want to hold a bit after the merge to wait for other fixes, feel free to do it.

### Testing instructions
Follow the testing steps of #7364 and confirm you can execute the flow correctly using this branch.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
