### PR TITLE
Add `detektAll --auto-correct` prompt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,8 @@ def detektAll = tasks.register("detektAll", io.gitlab.arturbosch.detekt.Detekt) 
 
 def detektAutoCorrectPrompt = tasks.register("detektAutoCorrectPrompt") {
     doLast {
-        if (detektAll.get().state.failure != null) {
+        def detektTask = detektAll.get()
+        if (detektTask.state.failure != null && !detektTask.autoCorrect) {
             println ".-----------------------------------------------------------------------------------------------------------------------------------.\n" +
                     "| 🛠  Did you know: you can ask Detekt to automatically resolve some of the issues by running `./gradlew detektAll --auto-correct` |\n" +
                     "'-----------------------------------------------------------------------------------------------------------------------------------'"

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
     }
 }
 
-tasks.register("detektAll", io.gitlab.arturbosch.detekt.Detekt) {
+def detektAll = tasks.register("detektAll", io.gitlab.arturbosch.detekt.Detekt) {
     description = "Custom DETEKT build for all modules"
     parallel = true
     ignoreFailures = false
@@ -60,6 +60,20 @@ tasks.register("detektAll", io.gitlab.arturbosch.detekt.Detekt) {
         xml.enabled = true
         txt.enabled = false
     }
+}
+
+def detektAutoCorrectPrompt = tasks.register("detektAutoCorrectPrompt") {
+    doLast {
+        if (detektAll.get().state.failure != null) {
+            println ".-----------------------------------------------------------------------------------------------------------------------------------.\n" +
+                    "| 🛠  Did you know: you can ask Detekt to automatically resolve some of the issues by running `./gradlew detektAll --auto-correct` |\n" +
+                    "'-----------------------------------------------------------------------------------------------------------------------------------'"
+        }
+    }
+}
+
+detektAll.configure{
+    finalizedBy detektAutoCorrectPrompt
 }
 
 dependencies {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Internal discussion: p1663172832791069-slack-C02QANACA

I'd like to propose a little prompt that will be printed out in case of `detektAll` task. I hope that it will raise awareness of very productive `--auto-correct` feature, which should save time for every developer.

It doesn't add build time overhead, and it's also not difficult for maintenance. In the worst case scenario, we'll just remove it.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Break some ktlint rules
2. Run `./gradlew detektAll`
3. Spot that there's `🛠  Did you know: (...)` message printed in the console

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="1422" alt="Screenshot 2022-10-12 at 13 42 41" src="https://user-images.githubusercontent.com/5845095/195335624-c4bfdca0-9c37-4f80-97e4-6f51e66a5922.png">



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->