### PR TITLE
issue/7517-product-search-sku-analytics

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -164,6 +164,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_STATUS = "status"
         const val KEY_TOTAL_DURATION = "total_duration"
         const val KEY_SEARCH = "search"
+        const val KEY_SEARCH_FILTER = "filter"
         const val KEY_TO = "to"
         const val KEY_TYPE = "type"
         const val KEY_CARRIER = "carrier"
@@ -217,6 +218,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_PURCHASE_FAILED = "purchase_failed"
         const val VALUE_PURCHASE_SUCCEEDED = "purchase_succeeded"
         const val VALUE_PURCHASE_READY = "purchase_ready"
+        const val VALUE_SEARCH_ALL = "all"
+        const val VALUE_SEARCH_SKU = "sku"
 
         const val KEY_FLOW = "flow"
         const val KEY_HAS_DIFFERENT_SHIPPING_DETAILS = "has_different_shipping_details"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -210,9 +210,17 @@ class ProductListViewModel @Inject constructor(
     }
 
     fun onSearchRequested() {
+        val searchFilter = if (viewState.isSkuSearch) {
+            AnalyticsTracker.VALUE_SEARCH_SKU
+        } else {
+            AnalyticsTracker.VALUE_SEARCH_ALL
+        }
         AnalyticsTracker.track(
             AnalyticsEvent.PRODUCT_LIST_SEARCHED,
-            mapOf(AnalyticsTracker.KEY_SEARCH to viewState.query)
+            mapOf(
+                AnalyticsTracker.KEY_SEARCH to viewState.query,
+                AnalyticsTracker.KEY_SEARCH_FILTER to searchFilter
+            )
         )
         refreshProducts()
     }


### PR DESCRIPTION
Closes: #7517

This small PR adds `filter=all|sku` to the `PRODUCT_LIST_SEARCHED` analytics event so we can determine how frequently users are searching by SKU.

To test:

* Search the product list by all products
* Verify that `filter=all` is passed [here](https://github.com/woocommerce/woocommerce-android/blob/bd118725621147acdb444baf2649d7eb1dda710a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt#L222)
* Search the product list by SKU
* Verify that `filter=sku` is passed

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.