### PR TITLE
Feature/7510 account creation UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -217,8 +217,7 @@ class LoginActivity :
         AnalyticsTracker.trackBackPressed(this)
         if (supportFragmentManager.backStackEntryCount != 0) {
             supportFragmentManager.popBackStack()
-        } else if (
-            navHostFragment.childFragmentManager.backStackEntryCount == 0) {
+        } else if (navHostFragment.childFragmentManager.backStackEntryCount == 0) {
             finish()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -348,6 +348,7 @@ class LoginActivity :
     override fun startOver() {
         // Clear logged in url from AppPrefs
         AppPrefs.removeLoginSiteAddress()
+        // This will clear the back stack and return user to LoginPrologueFragment
         supportFragmentManager.popBackStack(null, POP_BACK_STACK_INCLUSIVE)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -54,6 +54,7 @@ import com.woocommerce.android.ui.login.localnotifications.LoginNotificationSche
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailPasswordFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
+import com.woocommerce.android.ui.login.signup.SignUpFragment
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -370,6 +371,10 @@ class LoginActivity :
 
     override fun onNewToWooButtonClicked() {
         ChromeCustomTabUtils.launchUrl(this, AppUrls.NEW_TO_WOO_DOC)
+    }
+
+    override fun onGetStartedClicked() {
+        changeFragment(SignUpFragment(), true, "TAG")
     }
 
     private fun showMainActivityAndFinish() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -216,7 +216,7 @@ class LoginActivity :
         AnalyticsTracker.trackBackPressed(this)
         if (supportFragmentManager.backStackEntryCount != 0) {
             supportFragmentManager.popBackStack()
-        } else if (navController.backQueue.count() == 2) {
+        } else if (navHostFragment.childFragmentManager.backStackEntryCount == 0) {
             finish()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -242,14 +242,6 @@ class LoginActivity :
         }
     }
 
-    private fun showPrologueCarouselFragment() {
-        val fragment = LoginPrologueCarouselFragment.newInstance()
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.nav_host_fragment_login, fragment, LoginPrologueCarouselFragment.TAG)
-            .addToBackStack(LoginPrologueCarouselFragment.TAG)
-            .commitAllowingStateLoss()
-    }
-
     private fun showPrologue() {
         val graphInflater = navHostFragment.navController.navInflater
         val navGraph = graphInflater.inflate(R.navigation.nav_graph_login)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -216,7 +216,10 @@ class LoginActivity :
         AnalyticsTracker.trackBackPressed(this)
         if (supportFragmentManager.backStackEntryCount != 0) {
             supportFragmentManager.popBackStack()
-        } else if (navHostFragment.childFragmentManager.backStackEntryCount == 0) {
+        } else if (
+            navHostFragment.childFragmentManager.backStackEntryCount == 0 ||
+            navHostFragment.childFragmentManager.fragments[0] is LoginPrologueFragment
+        ) {
             finish()
         }
     }
@@ -322,12 +325,6 @@ class LoginActivity :
 
     private fun getLoginViaSiteAddressFragment(): LoginSiteAddressFragment? =
         supportFragmentManager.findFragmentByTag(LoginSiteAddressFragment.TAG) as? WooLoginSiteAddressFragment
-
-    private fun getPrologueFragment(): LoginPrologueFragment? =
-        supportFragmentManager.findFragmentByTag(LoginPrologueFragment.TAG) as? LoginPrologueFragment
-
-    private fun getPrologueSurveyFragment(): LoginPrologueSurveyFragment? =
-        supportFragmentManager.findFragmentByTag(LoginPrologueSurveyFragment.TAG) as? LoginPrologueSurveyFragment
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
@@ -447,14 +444,12 @@ class LoginActivity :
         changeFragment(loginSiteAddressFragment, true, LoginSiteAddressFragment.TAG)
     }
 
-    private fun showPrologueFragment() = lifecycleScope.launchWhenStarted {
-        val prologueFragment = getPrologueFragment() ?: LoginPrologueFragment()
-        changeFragment(prologueFragment, true, LoginPrologueFragment.TAG)
+    private fun showPrologueFragmentFromCarousel() = lifecycleScope.launchWhenStarted {
+        navController.navigate(R.id.action_loginPrologueCarouselFragment_to_loginPrologueFragment)
     }
 
     private fun showPrologueSurveyFragment() {
-        val prologueSurveyFragment = getPrologueSurveyFragment() ?: LoginPrologueSurveyFragment()
-        changeFragment(prologueSurveyFragment, true, LoginPrologueSurveyFragment.TAG)
+        navController.navigate(R.id.loginPrologueSurveyFragment)
     }
 
     override fun loginViaSocialAccount(
@@ -915,12 +910,12 @@ class LoginActivity :
 
     override fun onCarouselFinished() {
         lifecycleScope.launchWhenStarted {
-            prologueExperiment.run(::showPrologueFragment, ::showPrologueSurveyFragment)
+            prologueExperiment.run(::showPrologueFragmentFromCarousel, ::showPrologueSurveyFragment)
         }
     }
 
     override fun onSurveyFinished() {
-        showPrologueFragment()
+        navController.navigate(R.id.action_loginPrologueSurveyFragment_to_loginPrologueFragment)
     }
 
     override fun onPasswordError() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -10,6 +10,7 @@ import android.view.MenuItem
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
@@ -217,9 +218,7 @@ class LoginActivity :
         if (supportFragmentManager.backStackEntryCount != 0) {
             supportFragmentManager.popBackStack()
         } else if (
-            navHostFragment.childFragmentManager.backStackEntryCount == 0 ||
-            navHostFragment.childFragmentManager.fragments[0] is LoginPrologueFragment
-        ) {
+            navHostFragment.childFragmentManager.backStackEntryCount == 0) {
             finish()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -350,9 +350,7 @@ class LoginActivity :
     override fun startOver() {
         // Clear logged in url from AppPrefs
         AppPrefs.removeLoginSiteAddress()
-
-        // Pop all the fragments from the backstack until we get to the Prologue fragment
-        supportFragmentManager.popBackStack(LoginPrologueFragment.TAG, 0)
+        supportFragmentManager.popBackStack(null, POP_BACK_STACK_INCLUSIVE)
     }
 
     override fun onPrimaryButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.LayoutRes
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -11,6 +12,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentLoginPrologueBinding
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
+import com.woocommerce.android.util.FeatureFlag
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -24,6 +26,7 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
         fun onPrimaryButtonClicked()
         fun onSecondaryButtonClicked()
         fun onNewToWooButtonClicked()
+        fun onGetStartedClicked()
     }
 
     constructor() : this(R.layout.fragment_login_prologue)
@@ -51,6 +54,11 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
 
         if (savedInstanceState == null) {
             unifiedLoginTracker.track(Flow.PROLOGUE, Step.PROLOGUE)
+        }
+
+        binding.buttonGetStarted?.isVisible = isVisible && FeatureFlag.STORE_CREATION_FLOW.isEnabled()
+        binding.buttonGetStarted?.setOnClickListener {
+            prologueFinishedListener?.onGetStartedClicked()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -56,8 +56,8 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
             unifiedLoginTracker.track(Flow.PROLOGUE, Step.PROLOGUE)
         }
 
-        binding.buttonGetStarted?.isVisible = isVisible && FeatureFlag.STORE_CREATION_FLOW.isEnabled()
-        binding.buttonGetStarted?.setOnClickListener {
+        binding.buttonGetStarted.isVisible = FeatureFlag.STORE_CREATION_FLOW.isEnabled()
+        binding.buttonGetStarted.setOnClickListener {
             prologueFinishedListener?.onGetStartedClicked()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -6,13 +6,18 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SignUpFragment : BaseFragment() {
+
+    private val viewModel: SignUpViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -20,13 +25,25 @@ class SignUpFragment : BaseFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-
             setContent {
                 WooThemeWithBackground {
-                    SignUpScreen()
+                    SignUpScreen(viewModel)
                 }
             }
         }
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+            }
+        }
+    }
 }
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -1,22 +1,32 @@
 package com.woocommerce.android.ui.login.signup
 
 import android.os.Bundle
+import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.text.HtmlCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.signup.SignUpViewModel.OnTermsOfServiceClicked
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.UrlUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.login.util.getColorResIdFromAttribute
+import org.wordpress.android.util.HtmlUtils
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SignUpFragment : BaseFragment() {
 
+    @Inject internal lateinit var urlUtils: UrlUtils
     private val viewModel: SignUpViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
@@ -27,7 +37,7 @@ class SignUpFragment : BaseFragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 WooThemeWithBackground {
-                    SignUpScreen(viewModel)
+                    SignUpScreen(viewModel, formattedTermsOfServiceText())
                 }
             }
         }
@@ -41,8 +51,25 @@ class SignUpFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is OnTermsOfServiceClicked -> openTermsOfServiceUrl()
+                is Exit -> findNavController().navigateUp()
             }
         }
+    }
+
+    private fun formattedTermsOfServiceText(): Spanned {
+        val primaryColorResId: Int = requireContext().getColorResIdFromAttribute(R.attr.colorSecondary)
+        val primaryColorHtml = HtmlUtils.colorResToHtmlColor(requireContext(), primaryColorResId)
+        return HtmlCompat.fromHtml(
+            getString(
+                R.string.continue_terms_of_service_text,
+                "<u><font color='$primaryColorHtml'>", "</font></u>"
+            ),
+            HtmlCompat.FROM_HTML_MODE_LEGACY
+        )
+    }
+
+    private fun openTermsOfServiceUrl() {
+        ChromeCustomTabUtils.launchUrl(requireContext(), urlUtils.tosUrlWithLocale)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.ui.login.signup
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SignUpFragment : BaseFragment() {
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    //TODO add layout
+                }
+            }
+        }
+    }
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -46,4 +46,3 @@ class SignUpFragment : BaseFragment() {
         }
     }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -1,16 +1,13 @@
 package com.woocommerce.android.ui.login.signup
 
 import android.os.Bundle
-import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.text.HtmlCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.signup.SignUpViewModel.OnTermsOfServiceClicked
@@ -19,8 +16,6 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UrlUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.login.util.getColorResIdFromAttribute
-import org.wordpress.android.util.HtmlUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -37,7 +32,7 @@ class SignUpFragment : BaseFragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 WooThemeWithBackground {
-                    SignUpScreen(viewModel, formattedTermsOfServiceText())
+                    SignUpScreen(viewModel)
                 }
             }
         }
@@ -55,18 +50,6 @@ class SignUpFragment : BaseFragment() {
                 is Exit -> findNavController().navigateUp()
             }
         }
-    }
-
-    private fun formattedTermsOfServiceText(): Spanned {
-        val primaryColorResId: Int = requireContext().getColorResIdFromAttribute(R.attr.colorSecondary)
-        val primaryColorHtml = HtmlUtils.colorResToHtmlColor(requireContext(), primaryColorResId)
-        return HtmlCompat.fromHtml(
-            getString(
-                R.string.continue_terms_of_service_text,
-                "<u><font color='$primaryColorHtml'>", "</font></u>"
-            ),
-            HtmlCompat.FROM_HTML_MODE_LEGACY
-        )
     }
 
     private fun openTermsOfServiceUrl() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -23,7 +23,7 @@ class SignUpFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    //TODO add layout
+                    SignUpScreen()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -32,9 +32,9 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 
 @Composable
-fun SignUpScreen() {
+fun SignUpScreen(viewModel: SignUpViewModel) {
     Scaffold(topBar = {
-        Toolbar(onBackButtonClick = { /*TODO*/ })
+        Toolbar(onArrowBackPressed = viewModel::onBackPressed)
     }) {
         SignUpForm(onPrimaryButtonClicked = { /*TODO*/ })
     }
@@ -42,14 +42,14 @@ fun SignUpScreen() {
 
 @Composable
 private fun Toolbar(
-    onBackButtonClick: () -> Unit,
+    onArrowBackPressed: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     TopAppBar(
         backgroundColor = MaterialTheme.colors.surface,
         title = {},
         navigationIcon = {
-            IconButton(onClick = onBackButtonClick) {
+            IconButton(onClick = onArrowBackPressed) {
                 Icon(
                     Icons.Filled.ArrowBack,
                     contentDescription = stringResource(id = R.string.back)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.signup
 
 import android.content.res.Configuration
+import android.text.Spanned
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -29,19 +31,25 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.text.toSpanned
 import com.woocommerce.android.R
+import com.woocommerce.android.compose.utils.toAnnotatedString
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 
 @Composable
-fun SignUpScreen(viewModel: SignUpViewModel) {
+fun SignUpScreen(viewModel: SignUpViewModel, termsOfServiceText: Spanned) {
     BackHandler(onBack = viewModel::onBackPressed)
 
     Scaffold(topBar = {
         Toolbar(onArrowBackPressed = viewModel::onBackPressed)
     }) {
-        SignUpForm(onPrimaryButtonClicked = { /*TODO*/ })
+        SignUpForm(
+            termsOfServiceClicked = viewModel::onTermsOfServiceClicked,
+            termsOfServiceText = termsOfServiceText,
+            onPrimaryButtonClicked = { /*TODO*/ },
+        )
     }
 }
 
@@ -69,6 +77,8 @@ private fun Toolbar(
 @Composable
 private fun SignUpForm(
     modifier: Modifier = Modifier,
+    termsOfServiceText: Spanned,
+    termsOfServiceClicked: () -> Unit,
     onPrimaryButtonClicked: () -> Unit
 ) {
     Column(
@@ -99,9 +109,11 @@ private fun SignUpForm(
             label = stringResource(id = R.string.signup_password_hint),
             onValueChange = {},
         )
-        Text(
-            text = stringResource(id = R.string.signup_accept_terms_of_service),
+        ClickableText(
+            modifier = Modifier.fillMaxWidth(),
+            text = termsOfServiceText.toAnnotatedString(),
             style = MaterialTheme.typography.body2,
+            onClick = { termsOfServiceClicked() }
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         WCColoredButton(
@@ -121,5 +133,9 @@ private fun SignUpForm(
 @Preview(name = "large screen", device = Devices.NEXUS_10)
 @Composable
 fun SignUpFormPreview() {
-    SignUpForm(onPrimaryButtonClicked = {})
+    SignUpForm(
+        termsOfServiceText = "By continuing, you agree to our Terms of Service.".toSpanned(),
+        termsOfServiceClicked = {},
+        onPrimaryButtonClicked = {},
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -73,6 +75,7 @@ private fun SignUpForm(
         modifier = modifier
             .background(MaterialTheme.colors.surface)
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(dimensionResource(id = R.dimen.major_125)),
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -1,10 +1,10 @@
 package com.woocommerce.android.ui.login.signup
 
 import android.content.res.Configuration
-import android.text.Spanned
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -27,19 +26,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.text.toSpanned
 import com.woocommerce.android.R
-import com.woocommerce.android.compose.utils.toAnnotatedString
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 
 @Composable
-fun SignUpScreen(viewModel: SignUpViewModel, termsOfServiceText: Spanned) {
+fun SignUpScreen(viewModel: SignUpViewModel) {
     BackHandler(onBack = viewModel::onBackPressed)
 
     Scaffold(topBar = {
@@ -47,7 +47,6 @@ fun SignUpScreen(viewModel: SignUpViewModel, termsOfServiceText: Spanned) {
     }) {
         SignUpForm(
             termsOfServiceClicked = viewModel::onTermsOfServiceClicked,
-            termsOfServiceText = termsOfServiceText,
             onPrimaryButtonClicked = { /*TODO*/ },
         )
     }
@@ -77,7 +76,6 @@ private fun Toolbar(
 @Composable
 private fun SignUpForm(
     modifier: Modifier = Modifier,
-    termsOfServiceText: Spanned,
     termsOfServiceClicked: () -> Unit,
     onPrimaryButtonClicked: () -> Unit
 ) {
@@ -109,11 +107,8 @@ private fun SignUpForm(
             label = stringResource(id = R.string.signup_password_hint),
             onValueChange = {},
         )
-        ClickableText(
-            modifier = Modifier.fillMaxWidth(),
-            text = termsOfServiceText.toAnnotatedString(),
-            style = MaterialTheme.typography.body2,
-            onClick = { termsOfServiceClicked() }
+        TermsOfServiceText(
+            modifier = Modifier.clickable { termsOfServiceClicked() }
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         WCColoredButton(
@@ -125,6 +120,21 @@ private fun SignUpForm(
     }
 }
 
+@Composable
+private fun TermsOfServiceText(modifier: Modifier = Modifier) {
+    Text(
+        text = buildAnnotatedString {
+            append(stringResource(id = R.string.signup_terms_of_service_description))
+            append(" ")
+            pushStyle(SpanStyle(textDecoration = TextDecoration.Underline))
+            append(stringResource(id = R.string.signup_terms_of_service_linked_text))
+            toAnnotatedString()
+        },
+        style = MaterialTheme.typography.body2,
+        modifier = modifier,
+    )
+}
+
 @ExperimentalFoundationApi
 @Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
@@ -134,7 +144,6 @@ private fun SignUpForm(
 @Composable
 fun SignUpFormPreview() {
     SignUpForm(
-        termsOfServiceText = "By continuing, you agree to our Terms of Service.".toSpanned(),
         termsOfServiceClicked = {},
         onPrimaryButtonClicked = {},
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -1,0 +1,118 @@
+package com.woocommerce.android.ui.login.signup
+
+import android.content.res.Configuration
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCPasswordField
+
+@Composable
+fun SignUpScreen() {
+    Scaffold(topBar = {
+        Toolbar(onBackButtonClick = { /*TODO*/ })
+    }) {
+        SignUpForm(onPrimaryButtonClicked = { /*TODO*/ })
+    }
+}
+
+@Composable
+private fun Toolbar(
+    onBackButtonClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TopAppBar(
+        backgroundColor = MaterialTheme.colors.surface,
+        title = {},
+        navigationIcon = {
+            IconButton(onClick = onBackButtonClick) {
+                Icon(
+                    Icons.Filled.ArrowBack,
+                    contentDescription = stringResource(id = R.string.back)
+                )
+            }
+        },
+        elevation = 0.dp,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun SignUpForm(
+    modifier: Modifier = Modifier,
+    onPrimaryButtonClicked: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.colors.surface)
+            .fillMaxSize()
+            .padding(dimensionResource(id = R.dimen.major_125)),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+    ) {
+        Text(
+            text = stringResource(id = R.string.signup_get_started_label),
+            style = MaterialTheme.typography.h4,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = stringResource(id = R.string.signup_already_registered),
+            style = MaterialTheme.typography.body1,
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        WCOutlinedTextField(
+            value = "",
+            label = stringResource(id = R.string.signup_email_address_hint),
+            onValueChange = {},
+        )
+        WCPasswordField(
+            value = "",
+            label = stringResource(id = R.string.signup_password_hint),
+            onValueChange = {},
+        )
+        Text(
+            text = stringResource(id = R.string.signup_accept_terms_of_service),
+            style = MaterialTheme.typography.body2,
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        WCColoredButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { onPrimaryButtonClicked() }) {
+            Text(text = stringResource(id = R.string.signup_get_started_button))
+        }
+    }
+}
+
+@ExperimentalFoundationApi
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "small screen", device = Devices.PIXEL)
+@Preview(name = "mid screen", device = Devices.PIXEL_4)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
+@Composable
+fun SignUpFormPreview() {
+    SignUpForm(onPrimaryButtonClicked = {})
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.signup
 
 import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -33,6 +34,8 @@ import com.woocommerce.android.ui.compose.component.WCPasswordField
 
 @Composable
 fun SignUpScreen(viewModel: SignUpViewModel) {
+    BackHandler(onBack = viewModel::onBackPressed)
+
     Scaffold(topBar = {
         Toolbar(onArrowBackPressed = viewModel::onBackPressed)
     }) {
@@ -100,7 +103,8 @@ private fun SignUpForm(
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         WCColoredButton(
             modifier = Modifier.fillMaxWidth(),
-            onClick = { onPrimaryButtonClicked() }) {
+            onClick = { onPrimaryButtonClicked() }
+        ) {
             Text(text = stringResource(id = R.string.signup_get_started_button))
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -7,11 +7,8 @@ import javax.inject.Inject
 
 class SignUpViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-
-    ) : ScopedViewModel(savedStateHandle) {
-
+) : ScopedViewModel(savedStateHandle) {
     fun onBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -11,4 +11,11 @@ class SignUpViewModel @Inject constructor(
     fun onBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
+
+    fun onTermsOfServiceClicked() {
+        triggerEvent(OnTermsOfServiceClicked)
+    }
+
+    object OnTermsOfServiceClicked : MultiLiveEvent.Event()
+
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -17,5 +17,4 @@ class SignUpViewModel @Inject constructor(
     }
 
     object OnTermsOfServiceClicked : MultiLiveEvent.Event()
-
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.login.signup
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+
+class SignUpViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+
+    ) : ScopedViewModel(savedStateHandle) {
+
+    fun onBackPressed() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+}
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -13,7 +13,8 @@ enum class FeatureFlag {
     COUPONS_M2,
     WC_SHIPPING_BANNER,
     UNIFIED_ORDER_EDITING,
-    ORDER_CREATION_CUSTOMER_SEARCH;
+    ORDER_CREATION_CUSTOMER_SEARCH,
+    STORE_CREATION_FLOW;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -26,7 +27,8 @@ enum class FeatureFlag {
             UNIFIED_ORDER_EDITING -> true
             ANALYTICS_HUB,
             MORE_MENU_INBOX,
-            WC_SHIPPING_BANNER -> PackageUtils.isDebugBuild()
+            WC_SHIPPING_BANNER,
+            STORE_CREATION_FLOW -> PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/main/res/layout-land/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_prologue.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_surface">
@@ -73,6 +72,19 @@
         app:layout_constraintBottom_toTopOf="@id/button_login_wpcom"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_get_started"
+        style="@style/Woo.Button.Colored.White"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_100"
+        android:text="@string/signup_get_started_button"
+        android:textAllCaps="false"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/button_login_wpcom" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button_login_wpcom"

--- a/WooCommerce/src/main/res/layout-sw600dp/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout-sw600dp/fragment_login_prologue.xml
@@ -99,9 +99,23 @@
         android:layout_marginBottom="@dimen/major_150"
         android:text="@string/login_store_address"
         android:textAllCaps="false"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/button_get_started"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintWidth_percent="0.5" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_get_started"
+        style="@style/Woo.Button.Colored.White"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_150"
+        android:text="@string/signup_get_started_button"
+        android:textAllCaps="false"
+        android:visibility="gone"
+        app:layout_constraintWidth_percent="0.5"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/activity_login.xml
+++ b/WooCommerce/src/main/res/layout/activity_login.xml
@@ -1,13 +1,17 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:id="@+id/snack_root"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              android:baselineAligned="true">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/snack_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:baselineAligned="true"
+    android:orientation="vertical">
 
-    <FrameLayout
-        android:id="@+id/fragment_container"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment_login"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph_login" />
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
@@ -37,8 +37,8 @@
         android:id="@+id/imageView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
         android:layout_marginTop="@dimen/major_400"
+        android:adjustViewBounds="true"
         android:importantForAccessibility="no"
         android:src="@drawable/img_prologue_reviews"
         app:layout_constraintEnd_toEndOf="parent"
@@ -51,15 +51,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:gravity="center"
-        android:textStyle="bold"
-        tools:layout_width="200dp"
         android:layout_marginTop="@dimen/major_300"
+        android:gravity="center"
+        android:text="@string/lets_get_started"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/newToWooButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/imageView"
-        app:layout_constraintBottom_toTopOf="@id/newToWooButton"
-        android:text="@string/lets_get_started" />
+        tools:layout_width="200dp" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/newToWooButton"
@@ -69,10 +69,10 @@
         android:layout_marginBottom="@dimen/major_150"
         android:text="@string/login_prologue_new_to_woo"
         android:textAllCaps="false"
-        app:layout_constraintTop_toBottomOf="@id/prologueTitle"
         app:layout_constraintBottom_toTopOf="@id/button_login_wpcom"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/prologueTitle" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button_login_wpcom"
@@ -95,6 +95,19 @@
         android:layout_marginBottom="@dimen/major_150"
         android:text="@string/login_store_address"
         android:textAllCaps="false"
+        app:layout_constraintBottom_toTopOf="@id/button_get_started" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_get_started"
+        style="@style/Woo.Button.Colored.White"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_150"
+        android:text="@string/login_get_started"
+        android:textAllCaps="false"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
@@ -105,7 +105,7 @@
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginEnd="@dimen/major_100"
         android:layout_marginBottom="@dimen/major_150"
-        android:text="@string/login_get_started"
+        android:text="@string/signup_get_started_button"
         android:textAllCaps="false"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_login.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_login.xml
@@ -22,6 +22,31 @@
     <fragment
         android:id="@+id/loginPrologueCarouselFragment"
         android:name="com.woocommerce.android.ui.login.LoginPrologueCarouselFragment"
-        android:label="fragment_login_prologue_carousel" />
+        android:label="fragment_login_prologue_carousel">
+        <action
+            android:id="@+id/action_loginPrologueCarouselFragment_to_loginPrologueFragment"
+            app:destination="@id/loginPrologueFragment"
+            app:enterAnim="@anim/default_enter_anim"
+            app:exitAnim="@anim/default_exit_anim"
+            app:popEnterAnim="@anim/default_pop_enter_anim"
+            app:popExitAnim="@anim/default_pop_exit_anim"
+            app:popUpTo="@+id/loginPrologueFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/loginPrologueSurveyFragment"
+        android:name="com.woocommerce.android.ui.login.LoginPrologueSurveyFragment"
+        android:label="fragment_login_prologue_survey">
+        <action
+            android:id="@+id/action_loginPrologueSurveyFragment_to_loginPrologueFragment"
+            app:destination="@id/loginPrologueFragment"
+            app:enterAnim="@anim/default_enter_anim"
+            app:exitAnim="@anim/default_exit_anim"
+            app:popEnterAnim="@anim/default_pop_enter_anim"
+            app:popExitAnim="@anim/default_pop_exit_anim"
+            app:popUpTo="@+id/loginPrologueFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
 
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_login.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_login.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_login"
+    app:startDestination="@id/loginPrologueFragment">
+
+    <include app:graph="@navigation/nav_graph_store_creation" />
+
+    <fragment
+        android:id="@+id/loginPrologueFragment"
+        android:name="com.woocommerce.android.ui.login.LoginPrologueFragment"
+        android:label="fragment_login_prologue">
+        <action
+            android:id="@+id/action_loginPrologueFragment_to_signupFragment"
+            app:destination="@id/nav_graph_store_creation"
+            app:enterAnim="@anim/default_enter_anim"
+            app:exitAnim="@anim/default_exit_anim"
+            app:popEnterAnim="@anim/default_pop_enter_anim"
+            app:popExitAnim="@anim/default_pop_exit_anim" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/loginPrologueCarouselFragment"
+        android:name="com.woocommerce.android.ui.login.LoginPrologueCarouselFragment"
+        android:label="fragment_login_prologue_carousel" />
+
+</navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_login.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_login.xml
@@ -30,8 +30,7 @@
             app:exitAnim="@anim/default_exit_anim"
             app:popEnterAnim="@anim/default_pop_enter_anim"
             app:popExitAnim="@anim/default_pop_exit_anim"
-            app:popUpTo="@+id/loginPrologueFragment"
-            app:popUpToInclusive="true" />
+            app:popUpTo="@+id/nav_graph_login" />
     </fragment>
 
     <fragment
@@ -45,8 +44,7 @@
             app:exitAnim="@anim/default_exit_anim"
             app:popEnterAnim="@anim/default_pop_enter_anim"
             app:popExitAnim="@anim/default_pop_exit_anim"
-            app:popUpTo="@+id/loginPrologueFragment"
-            app:popUpToInclusive="true" />
+            app:popUpTo="@+id/nav_graph_login" />
     </fragment>
 
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_store_creation"
+    app:startDestination="@id/signupFragment">
+
+    <fragment
+        android:id="@+id/signupFragment"
+        android:name="com.woocommerce.android.ui.login.signup.SignUpFragment"
+        android:label="fragment_sign_up" />
+
+</navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -321,6 +321,8 @@
     <string name="signup_already_registered">First, let’s create your account. Already registered? Log in</string>
     <string name="signup_email_address_hint">Your email address</string>
     <string name="signup_password_hint">Choose a password</string>
+    <string name="signup_terms_of_service_description">By continuing, you agree to our</string>
+    <string name="signup_terms_of_service_linked_text">Terms of Service.</string>
 
     <!--
         Analytics View

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -321,7 +321,6 @@
     <string name="signup_already_registered">First, let’s create your account. Already registered? Log in</string>
     <string name="signup_email_address_hint">Your email address</string>
     <string name="signup_password_hint">Choose a password</string>
-    <string name="signup_accept_terms_of_service">By continuing, you agree to our Terms of Service.</string>
 
     <!--
         Analytics View

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -202,7 +202,6 @@
     <string name="login_with_store_address">Log in with your store address</string>
     <string name="login_configure_link">Read the %1$sconfiguration instructions%2$s.</string>
     <string name="login_with_qr_code">Scan QR code to login</string>
-    <string name="login_get_started">Get started</string>
 
     <string name="login_prologue_label_analytics">Track sales and high performing products</string>
     <string name="login_prologue_label_orders">Manage and edit orders on the go</string>
@@ -313,6 +312,16 @@
     <string name="my_store_stats_availability_title">We can\'t display your\n store\'s analytics</string>
     <string name="my_store_stats_availability_description">Make sure you are running the latest version of WooCommerce on your site and that you have WooCommerce Admin activated.\n\nStill need help? %1$s</string>
     <string name="my_store_stats_availability_contact_us">Contact us</string>
+
+    <!--
+        Sign Up Flow
+    -->
+    <string name="signup_get_started_button">Get started</string>
+    <string name="signup_get_started_label">Get started \nin minutes</string>
+    <string name="signup_already_registered">First, let’s create your account. Already registered? Log in</string>
+    <string name="signup_email_address_hint">Your email address</string>
+    <string name="signup_password_hint">Choose a password</string>
+    <string name="signup_accept_terms_of_service">By continuing, you agree to our Terms of Service.</string>
 
     <!--
         Analytics View

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -202,6 +202,7 @@
     <string name="login_with_store_address">Log in with your store address</string>
     <string name="login_configure_link">Read the %1$sconfiguration instructions%2$s.</string>
     <string name="login_with_qr_code">Scan QR code to login</string>
+    <string name="login_get_started">Get started</string>
 
     <string name="login_prologue_label_analytics">Track sales and high performing products</string>
     <string name="login_prologue_label_orders">Manage and edit orders on the go</string>
@@ -2622,4 +2623,6 @@
     <string name="stats_today_widget_description">WooCommerce Stats Today</string>
     <string name="stats_widget_error_no_data">Couldn\'t load data</string>
     <string name="stats_widget_last_updated_message">As of %1$s</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7510
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Adds UI to the first step of the store creation flow: Account creation. 
This PR also includes adding Android Navigation starting from `LoginActivity` so we can use `nav_graphs` from now on in the store creation flow. I presume login simplification will also follow this road when decoupling from the authentication library. 

This also adds a feature flag to only display the store creation access point for debug builds. Please don't pay much attention to the newly added "Get started" button in `LoginPrologue` as the design is not final. 

### Testing instructions
- Open the app and navigate to the new screen for account creation
- Check that "Accept terms of Service" opens the correct website
- Check that back navigation works as expected

### Images/gif


https://user-images.githubusercontent.com/2663464/195661508-a6ab5d63-bb5c-4c39-88e2-2b72ca129f46.mp4

