### PR TITLE
Signed-in card reader purchase from upsell banner PR

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 10.8
 -----
-
+[*] [Internal] Signed-in card reader purchase from upsell banner both from the orders list and selection of a payment method (https://github.com/woocommerce/woocommerce-android/pull/7535)
 
 10.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -363,7 +363,12 @@ class OrderListFragment :
                     binding.upsellCardReaderComposeView.upsellCardReaderDismissView.visibility = View.GONE
                 }
                 is OrderListViewModel.OrderListEvent.OpenPurchaseCardReaderLink -> {
-                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+                    findNavController().navigate(
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                            urlToLoad = event.url,
+                            title = resources.getString(event.titleRes)
+                        )
+                    )
                 }
                 is OrderListViewModel.OrderListEvent.NotifyOrderChanged -> {
                     binding.orderListView.ordersList.adapter?.notifyItemChanged(event.position)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -535,7 +535,10 @@ class OrderListViewModel @Inject constructor(
     private fun onCtaClicked(source: String) {
         launch {
             triggerEvent(
-                OpenPurchaseCardReaderLink(bannerDisplayEligibilityChecker.getPurchaseCardReaderUrl(source))
+                OpenPurchaseCardReaderLink(
+                    bannerDisplayEligibilityChecker.getPurchaseCardReaderUrl(source),
+                    R.string.card_reader_purchase_card_reader
+                )
             )
         }
     }
@@ -682,7 +685,10 @@ class OrderListViewModel @Inject constructor(
         object DismissCardReaderUpsellBanner : OrderListEvent()
         object DismissCardReaderUpsellBannerViaRemindMeLater : OrderListEvent()
         object DismissCardReaderUpsellBannerViaDontShowAgain : OrderListEvent()
-        data class OpenPurchaseCardReaderLink(val url: String) : OrderListEvent()
+        data class OpenPurchaseCardReaderLink(
+            val url: String,
+            @StringRes val titleRes: Int,
+        ) : OrderListEvent()
         data class ShowRetryErrorSnack(
             val message: String,
             val retry: View.OnClickListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentTakePaymentBinding
@@ -36,7 +37,6 @@ import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.ui.payments.banner.PaymentsScreenBannerDismissDialog
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentDialogFragment
-import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -210,7 +210,12 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_take_payment)
                     binding.upsellCardReaderComposeView.upsellCardReaderDismissView.visibility = View.GONE
                 }
                 is SelectPaymentMethodViewModel.OpenPurchaseCardReaderLink -> {
-                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+                    findNavController().navigate(
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                            urlToLoad = event.url,
+                            title = resources.getString(event.titleRes)
+                        )
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -304,7 +305,10 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private fun onCtaClicked(source: String) {
         launch {
             triggerEvent(
-                OpenPurchaseCardReaderLink(bannerDisplayEligibilityChecker.getPurchaseCardReaderUrl(source))
+                OpenPurchaseCardReaderLink(
+                    bannerDisplayEligibilityChecker.getPurchaseCardReaderUrl(source),
+                    R.string.card_reader_purchase_card_reader
+                )
             )
         }
     }
@@ -347,7 +351,10 @@ class SelectPaymentMethodViewModel @Inject constructor(
     object DismissCardReaderUpsellBanner : MultiLiveEvent.Event()
     object DismissCardReaderUpsellBannerViaRemindMeLater : MultiLiveEvent.Event()
     object DismissCardReaderUpsellBannerViaDontShowAgain : MultiLiveEvent.Event()
-    data class OpenPurchaseCardReaderLink(val url: String) : MultiLiveEvent.Event()
+    data class OpenPurchaseCardReaderLink(
+        val url: String,
+        @StringRes val titleRes: Int,
+    ) : MultiLiveEvent.Event()
 
     data class SharePaymentUrl(
         val storeName: String,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7533
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Click "purchase card reader" from the order list. Notice that it uses WP authenticated web view
* Click "purchase card reader" from the selection of the payment methods. Notice that it uses WP authenticated web view

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/195662301-cd8986b1-9dee-4391-a3ae-4eda5d670079.mp4




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
