### PR TITLE
Remove A/B and A/A tests code

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/wpcom/experiments.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/wpcom/experiments.json
@@ -3,14 +3,6 @@
         "method": "GET",
         "urlPathPattern": "/wpcom/v2/experiments/0.1.0/assignments/woocommerceandroid/(.*)",
         "queryParameters": {
-            // These two matchers below seem (from relatively thourough testing) to behave
-            // the same as logical AND. I could not have the "and" from WireMock docs work.
-            "experiment_names": {
-                "contains": "woocommerceandroid_explat_aa_test_202208"
-            },
-            "experiment_names": {
-                "contains": "woocommerceandroid_product_details_linked_products_banner"
-            }
         }
     },
     "response": {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ExperimentationModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ExperimentationModule.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.di
 
 import com.automattic.android.experimentation.ExPlat
-import com.automattic.android.experimentation.Experiment
 import com.woocommerce.android.BuildConfig
 import dagger.Module
 import dagger.Provides
@@ -23,18 +22,10 @@ class ExperimentationModule {
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
     ) = ExPlat(
         platform = ExperimentStore.Platform.WOOCOMMERCE_ANDROID,
-        experiments = setOf(
-            AA_TEST_202208
-        ),
+        experiments = emptySet(),
         experimentStore = experimentStore,
         appLogWrapper = appLogWrapper,
         coroutineScope = appCoroutineScope,
         isDebug = BuildConfig.DEBUG
     )
-
-    companion object {
-        val AA_TEST_202208 = object : Experiment {
-            override val identifier: String = "woocommerceandroid_explat_aa_test_202208"
-        }
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ExperimentationModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ExperimentationModule.kt
@@ -24,8 +24,7 @@ class ExperimentationModule {
     ) = ExPlat(
         platform = ExperimentStore.Platform.WOOCOMMERCE_ANDROID,
         experiments = setOf(
-            AA_TEST_202208,
-            AB_TEST_LINKED_PRODUCTS_PROMO
+            AA_TEST_202208
         ),
         experimentStore = experimentStore,
         appLogWrapper = appLogWrapper,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ExperimentationModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ExperimentationModule.kt
@@ -36,8 +36,5 @@ class ExperimentationModule {
         val AA_TEST_202208 = object : Experiment {
             override val identifier: String = "woocommerceandroid_explat_aa_test_202208"
         }
-        val AB_TEST_LINKED_PRODUCTS_PROMO = object : Experiment {
-            override val identifier: String = "woocommerceandroid_product_details_linked_products_banner"
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -7,13 +7,11 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.automattic.android.experimentation.ExPlat
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.di.ExperimentationModule
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
@@ -71,8 +69,7 @@ class MyStoreViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val myStoreTransactionLauncher: MyStoreTransactionLauncher,
-    private val explat: ExPlat
+    private val myStoreTransactionLauncher: MyStoreTransactionLauncher
 ) : ScopedViewModel(savedState) {
     private companion object {
         const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
@@ -104,7 +101,6 @@ class MyStoreViewModel @Inject constructor(
 
     init {
         ConnectionChangeReceiver.getEventBus().register(this)
-        initExPlat()
 
         _topPerformersState.value = TopPerformersState(isLoading = true)
 
@@ -331,17 +327,6 @@ class MyStoreViewModel @Inject constructor(
             totalSpend,
             wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: currency
         )
-
-    private fun initExPlat() {
-        explat.getVariation(
-            ExperimentationModule.AA_TEST_202208,
-            true
-        )
-        explat.getVariation(
-            ExperimentationModule.AB_TEST_LINKED_PRODUCTS_PROMO,
-            true
-        )
-    }
 
     private fun String.toImageUrl() =
         PhotonUtils.getPhotonImageUrl(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -141,9 +141,6 @@ class ProductDetailViewModel @Inject constructor(
 
     private val storedProduct = MutableStateFlow<Product?>(null)
 
-    // A/B test to determine whether to show the linked products promo
-    private var abTestLinkProductsPromoIsTreatment = false
-
     // view state for the product categories screen
     val productCategoriesViewStateData = LiveDataDelegate(savedState, ProductCategoriesViewState())
     private var productCategoriesViewState by productCategoriesViewStateData

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_LINKED_PRODUCTS
-import com.woocommerce.android.di.ExperimentationModule
 import com.woocommerce.android.extensions.addNewItem
 import com.woocommerce.android.extensions.clearList
 import com.woocommerce.android.extensions.containsItem
@@ -84,8 +83,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.model.experiments.Variation
-import org.wordpress.android.fluxc.store.ExperimentStore
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import java.math.BigDecimal
 import java.util.Collections
@@ -108,8 +105,7 @@ class ProductDetailViewModel @Inject constructor(
     private val variationRepository: VariationRepository,
     private val mediaFileUploadHandler: MediaFileUploadHandler,
     private val appPrefsWrapper: AppPrefsWrapper,
-    private val addonRepository: AddonRepository,
-    private val experimentStore: ExperimentStore
+    private val addonRepository: AddonRepository
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
@@ -291,13 +287,6 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     fun start() {
-        experimentStore.getCachedAssignments()
-            ?.variations
-            ?.get(ExperimentationModule.AB_TEST_LINKED_PRODUCTS_PROMO.identifier)
-            ?.let {
-                abTestLinkProductsPromoIsTreatment = it is Variation.Treatment
-            }
-
         val isRestoredFromSavedState = viewState.productDraft != null
         if (!isRestoredFromSavedState) {
             initializeViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1644,8 +1644,7 @@ class ProductDetailViewModel @Inject constructor(
      * doesn't already have linked products
      */
     private fun checkLinkedProductPromo() {
-        if (abTestLinkProductsPromoIsTreatment &&
-            appPrefsWrapper.isPromoBannerShown(PromoBannerType.LINKED_PRODUCTS).not() &&
+        if (appPrefsWrapper.isPromoBannerShown(PromoBannerType.LINKED_PRODUCTS).not() &&
             viewState.productDraft?.hasLinkedProducts() == false
         ) {
             appPrefsWrapper.setPromoBannerShown(PromoBannerType.LINKED_PRODUCTS, true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -449,8 +449,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
             appPrefsWrapper,
             usageTracksEventEmitter,
             analyticsTrackerWrapper,
-            myStoreTransactionLauncher = mock(),
-            explat = mock()
+            myStoreTransactionLauncher = mock()
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -239,8 +239,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 variationRepository,
                 mediaFileUploadHandler,
                 prefsWrapper,
-                addonRepository,
-                experimentStore = mock()
+                addonRepository
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -173,8 +173,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 variationRepository,
                 mediaFileUploadHandler,
                 prefs,
-                addonRepository,
-                experimentStore = mock()
+                addonRepository
             )
         )
 


### PR DESCRIPTION
Summary
==========
Fix issues #7473 and #7472 by removing all direct references to the Linked Products A/B and test A/A test configured in the Experimentation Platform and leaving only the ExPlat support code.

How to Test
==========
1. Open the app and verify if the promo banner for Linked Products visibility is now only tied to not having Linked Products configured and the AppPrefs' current state.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
