### PR TITLE
Handle Jetpack Connection for non-connected sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 10.9
 -----
-
+- [**] Login: add support for Jetpack connection to sites that have Jetpack but don't have any connected accounts [https://github.com/woocommerce/woocommerce-android/pull/7545]
 
 10.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,8 +2,7 @@
 10.9
 -----
 - [**] Login: add support for Jetpack connection to sites that have Jetpack but don't have any connected accounts [https://github.com/woocommerce/woocommerce-android/pull/7545]
-[*] [Internal] In-Person Payments: add UTM parameters to card reader purchase URLs to allow attribution [https://github.com/woocommerce/woocommerce-android/pull/7554]
-
+- [*] [Internal] In-Person Payments: add UTM parameters to card reader purchase URLs to allow attribution [https://github.com/woocommerce/woocommerce-android/pull/7554]
 
 10.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -78,6 +78,9 @@ object AppUrls {
 
     const val NEW_TO_WOO_DOC = "https://woocommerce.com/woocommerce-features"
 
+    const val WORPRESS_COM_TERMS = "https://wordpress.com/tos"
+    const val JETPACK_SYNC_POLICY = "https://jetpack.com/support/what-data-does-jetpack-sync"
+
     private const val LOGIN_HELP_CENTER = "https://woocommerce.com/document/android-ios-apps-login-help-faq/"
     val LOGIN_HELP_CENTER_URLS = mapOf(
         LOGIN_EMAIL to "$LOGIN_HELP_CENTER#enter-wordpress-com-email-address-login-using-store-address-flow",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/TextExts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/TextExts.kt
@@ -1,0 +1,71 @@
+package com.woocommerce.android.ui.compose
+
+import android.graphics.Typeface
+import android.text.style.StyleSpan
+import android.text.style.URLSpan
+import android.text.style.UnderlineSpan
+import androidx.annotation.StringRes
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.core.text.HtmlCompat
+
+const val URL_ANNOTATION_TAG = "url"
+
+/**
+ * Creates an [AnnotatedString] from the passed String resource.
+ *
+ * Source: https://stackoverflow.com/a/70757314 with some adjustments
+ */
+@Composable
+fun annotatedStringRes(@StringRes stringResId: Int, vararg args: Any): AnnotatedString {
+    val string = stringResource(id = stringResId, args)
+    val spanned = HtmlCompat.fromHtml(string, HtmlCompat.FROM_HTML_MODE_LEGACY)
+
+    return buildAnnotatedString {
+        append(spanned.toString())
+
+        for (span in spanned.getSpans(0, spanned.length, Any::class.java)) {
+            val startIndex = spanned.getSpanStart(span)
+            val endIndex = spanned.getSpanEnd(span)
+
+            when (span) {
+                is StyleSpan -> span.toSpanStyle()?.let {
+                    addStyle(style = it, start = startIndex, end = endIndex)
+                }
+                is UnderlineSpan -> {
+                    addStyle(SpanStyle(textDecoration = TextDecoration.Underline), start = startIndex, end = endIndex)
+                }
+                is URLSpan -> {
+                    addStyle(
+                        style = TextStyle.Default.copy(color = MaterialTheme.colors.secondary).toSpanStyle(),
+                        start = startIndex,
+                        end = endIndex
+                    )
+                    addStringAnnotation(
+                        tag = URL_ANNOTATION_TAG,
+                        annotation = span.url,
+                        start = startIndex,
+                        end = endIndex
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun StyleSpan.toSpanStyle(): SpanStyle? {
+    return when (style) {
+        Typeface.BOLD -> SpanStyle(fontWeight = FontWeight.Bold)
+        Typeface.ITALIC -> SpanStyle(fontStyle = FontStyle.Italic)
+        Typeface.BOLD_ITALIC -> SpanStyle(fontWeight = FontWeight.Bold, fontStyle = FontStyle.Italic)
+        else -> null
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker.Source
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragmentArgs
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchErrorType
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchPrimaryButton
 import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType
 import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.DEFAULT_HELP
@@ -677,7 +678,8 @@ class LoginActivity :
             val fragment = AccountMismatchErrorFragment().apply {
                 arguments = AccountMismatchErrorFragmentArgs(
                     siteUrl = siteAddress,
-                    primaryButton = AccountMismatchPrimaryButton.CONNECT_JETPACK
+                    primaryButton = AccountMismatchPrimaryButton.CONNECT_JETPACK,
+                    errorType = AccountMismatchErrorType.ACCOUNT_NOT_CONNECTED
                 ).toBundle()
             }
             changeFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -673,7 +673,7 @@ class LoginActivity :
         userAvatarUrl: String?,
         checkJetpackAvailability: Boolean
     ) {
-        if (connectSiteInfo?.isJetpackActive == true && connectSiteInfo?.isJetpackConnected == true) {
+        if (connectSiteInfo?.isJetpackActive == true) {
             // If jetpack is present, but we can't find the connected email, then show account mismatch error
             val fragment = AccountMismatchErrorFragment().apply {
                 arguments = AccountMismatchErrorFragmentArgs(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -49,8 +50,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest.Builder
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
+import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
@@ -62,6 +66,7 @@ import com.woocommerce.android.ui.compose.component.WebViewNavigator
 import com.woocommerce.android.ui.compose.component.rememberWebViewNavigator
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.ViewState
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import org.wordpress.android.fluxc.network.UserAgent
 
 @OptIn(ExperimentalAnimationApi::class)
@@ -211,6 +216,24 @@ fun AccountMismatchErrorScreen(viewState: ViewState.MainState, modifier: Modifie
             secondaryButtonClick = viewState.secondaryButtonAction,
             modifier = Modifier.fillMaxWidth()
         )
+
+        if (viewState.showJetpackTermsConsent) {
+            val consent = annotatedStringRes(stringResId = R.string.login_jetpack_connection_consent)
+            val context = LocalContext.current
+            ClickableText(
+                text = consent,
+                style = MaterialTheme.typography.caption.copy(textAlign = TextAlign.Center)
+            ) {
+                consent.getStringAnnotations(tag = URL_ANNOTATION_TAG, start = it, end = it)
+                    .firstOrNull()
+                    ?.let { annotation ->
+                        when (annotation.item) {
+                            "terms" -> ChromeCustomTabUtils.launchUrl(context, AppUrls.WORPRESS_COM_TERMS)
+                            "sync" -> ChromeCustomTabUtils.launchUrl(context, AppUrls.JETPACK_SYNC_POLICY)
+                        }
+                    }
+            }
+        }
     }
 }
 
@@ -392,6 +415,7 @@ private fun AccountMismatchPreview() {
                 secondaryButtonAction = {},
                 inlineButtonText = R.string.continue_button,
                 inlineButtonAction = {},
+                showJetpackTermsConsent = true,
                 showNavigationIcon = true,
                 onBackPressed = {}
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -138,6 +138,7 @@ class AccountMismatchErrorViewModel @Inject constructor(
         inlineButtonText = if (navArgs.errorType == WPCOM_ACCOUNT_MISMATCH) R.string.login_need_help_finding_email
         else null,
         inlineButtonAction = { helpFindingEmail() },
+        showJetpackTermsConsent = navArgs.primaryButton == AccountMismatchPrimaryButton.CONNECT_JETPACK,
         showNavigationIcon = navArgs.allowBackNavigation,
         onBackPressed = {
             if (navArgs.allowBackNavigation) {
@@ -316,6 +317,7 @@ class AccountMismatchErrorViewModel @Inject constructor(
             val secondaryButtonAction: () -> Unit,
             @StringRes val inlineButtonText: Int?,
             val inlineButtonAction: () -> Unit,
+            val showJetpackTermsConsent: Boolean,
             override val showNavigationIcon: Boolean,
             override val onBackPressed: () -> Unit
         ) : ViewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchErrorType.WPCOM_ACCOUNT_MISMATCH
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchRepository.JetpackConnectionStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -103,12 +104,11 @@ class AccountMismatchErrorViewModel @Inject constructor(
                 displayName = it.displayName.orEmpty()
             )
         },
-        message = if (accountRepository.isUserLoggedIn()) {
-            // When the user is already connected using WPCom account, show account mismatch error
-            resourceProvider.getString(R.string.login_wpcom_account_mismatch, siteUrl)
-        } else {
-            // Explain that account is not connected to Jetpack
-            resourceProvider.getString(R.string.login_jetpack_not_connected, siteUrl)
+        message = when (navArgs.errorType) {
+            AccountMismatchErrorType.WPCOM_ACCOUNT_MISMATCH ->
+                resourceProvider.getString(R.string.login_wpcom_account_mismatch, siteUrl)
+            AccountMismatchErrorType.ACCOUNT_NOT_CONNECTED ->
+                resourceProvider.getString(R.string.login_jetpack_not_connected, siteUrl)
         },
         primaryButtonText = when (navArgs.primaryButton) {
             AccountMismatchPrimaryButton.CONNECT_JETPACK -> R.string.login_account_mismatch_connect_jetpack
@@ -135,7 +135,7 @@ class AccountMismatchErrorViewModel @Inject constructor(
         },
         secondaryButtonText = R.string.login_try_another_account,
         secondaryButtonAction = { loginWithDifferentAccount() },
-        inlineButtonText = if (accountRepository.isUserLoggedIn()) R.string.login_need_help_finding_email
+        inlineButtonText = if (navArgs.errorType == WPCOM_ACCOUNT_MISMATCH) R.string.login_need_help_finding_email
         else null,
         inlineButtonAction = { helpFindingEmail() },
         showNavigationIcon = navArgs.allowBackNavigation,
@@ -382,5 +382,14 @@ class AccountMismatchErrorViewModel @Inject constructor(
 
     enum class AccountMismatchPrimaryButton {
         CONNECT_JETPACK, CONNECT_WPCOM_SITE, NONE
+    }
+
+    /**
+     * This state is just to allow different wordings depending on which flow resulted in this error screen depending
+     * on whether we can confirm that the site is connected to a different account or not.
+     */
+    enum class AccountMismatchErrorType {
+        WPCOM_ACCOUNT_MISMATCH,
+        ACCOUNT_NOT_CONNECTED
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepository.kt
@@ -32,7 +32,7 @@ class AccountMismatchRepository @Inject constructor(
 
     suspend fun fetchJetpackConnectionUrl(site: SiteModel): Result<String> {
         WooLog.d(WooLog.T.LOGIN, "Fetching Jetpack Connection URL")
-        val result = jetpackStore.fetchJetpackConnectionUrl(site)
+        val result = jetpackStore.fetchJetpackConnectionUrl(site, autoRegisterSiteIfNeeded = true)
         return when {
             result.isError -> {
                 WooLog.w(WooLog.T.LOGIN, "Fetching Jetpack Connection URL failed: ${result.error.message}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchErrorType
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAccountMismatchScreen
@@ -284,7 +285,8 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
             SitePickerFragmentDirections.actionSitePickerFragmentToAccountMismatchErrorFragment(
                 siteUrl = event.siteUrl,
                 primaryButton = event.primaryButton,
-                allowBackNavigation = event.hasConnectedStores
+                allowBackNavigation = event.hasConnectedStores,
+                errorType = AccountMismatchErrorType.WPCOM_ACCOUNT_MISMATCH
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -213,7 +213,9 @@ class SitePickerViewModel @Inject constructor(
         }
         sitePickerViewState = sitePickerViewState.copy(
             hasConnectedStores = filteredSites.isNotEmpty(),
-            isPrimaryBtnVisible = wooSites.isNotEmpty()
+            isPrimaryBtnVisible = wooSites.isNotEmpty(),
+            isNoStoresViewVisible = false,
+            currentSitePickerState = SitePickerState.StoreListState
         )
         loginSiteAddress?.let { processLoginSiteAddress(it) }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -20,9 +20,12 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchErrorType
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchPrimaryButton
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.CreateZendeskTicket
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.NavigateToHelpScreen
+import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.ShowJetpackConnectionError
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.StartJetpackInstallation
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -75,6 +78,7 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
                     startActivity(HelpActivity.createIntent(requireContext(), Origin.LOGIN_SITE_ADDRESS, null))
                 }
                 is StartJetpackInstallation -> startJetpackInstallation(event.siteAddress)
+                is ShowJetpackConnectionError -> showJetpackErrorScreen(event.siteAddress)
                 is Logout -> onLogout()
                 is ExitWithResult<*> -> navigateBackWithResult(SITE_PICKER_SITE_ADDRESS_RESULT, event.data)
                 is Exit -> findNavController().navigateUp()
@@ -100,6 +104,18 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
                 urlToTriggerExit = JETPACK_CONNECTED_REDIRECT_URL,
                 urlComparisonMode = WPComWebViewFragment.UrlComparisonMode.EQUALITY
             )
+        )
+    }
+
+    private fun showJetpackErrorScreen(siteAddress: String) {
+        findNavController().navigate(
+            SitePickerSiteDiscoveryFragmentDirections
+                .actionSitePickerSiteDiscoveryFragmentToAccountMismatchErrorFragment(
+                    siteUrl = siteAddress,
+                    allowBackNavigation = true,
+                    primaryButton = AccountMismatchPrimaryButton.CONNECT_JETPACK,
+                    errorType = AccountMismatchErrorType.ACCOUNT_NOT_CONNECTED
+                )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
+import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchErrorType
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchPrimaryButton
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -89,6 +90,9 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
     private fun setupResultHandlers() {
         handleNotice(WPComWebViewFragment.WEBVIEW_RESULT) {
             viewModel.onJetpackInstalled()
+        }
+        handleNotice(AccountMismatchErrorFragment.JETPACK_CONNECTED_NOTICE) {
+            viewModel.onJetpackConnected()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -203,6 +203,10 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
         navigateBackToSitePicker()
     }
 
+    fun onJetpackConnected() {
+        navigateBackToSitePicker()
+    }
+
     private fun navigateBackToSitePicker() {
         fetchedSiteUrl.let { url ->
             requireNotNull(url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -179,8 +179,9 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
                 when {
                     !it.exists -> inlineErrorFlow.value = R.string.invalid_site_url_message
                     !it.isWordPress -> stepFlow.value = Step.NotWordpress
-                    !it.isWPCom && (!it.hasJetpack || !it.isJetpackConnected) ->
+                    !it.isWPCom && !it.isJetpackActive ->
                         stepFlow.value = Step.JetpackUnavailable
+                    !it.isWPCom && !it.isJetpackConnected -> navigateToJetpackConnectionError()
                     else -> navigateBackToSitePicker()
                 }
             },
@@ -206,6 +207,13 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
         fetchedSiteUrl.let { url ->
             requireNotNull(url)
             triggerEvent(ExitWithResult(url))
+        }
+    }
+
+    private fun navigateToJetpackConnectionError() {
+        fetchedSiteUrl.let { url ->
+            requireNotNull(url)
+            triggerEvent(ShowJetpackConnectionError(url))
         }
     }
 
@@ -253,4 +261,5 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
     object CreateZendeskTicket : MultiLiveEvent.Event()
     object NavigateToHelpScreen : MultiLiveEvent.Event()
     data class StartJetpackInstallation(val siteAddress: String) : MultiLiveEvent.Event()
+    data class ShowJetpackConnectionError(val siteAddress: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -447,6 +447,9 @@
             app:argType="com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel$AccountMismatchPrimaryButton"
             android:defaultValue="NONE" />
         <argument
+            android:name="errorType"
+            app:argType="com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel$AccountMismatchErrorType" />
+        <argument
             android:name="allowBackNavigation"
             app:argType="boolean"
             android:defaultValue="true" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -434,7 +434,11 @@
     <fragment
         android:id="@+id/sitePickerSiteDiscoveryFragment"
         android:name="com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryFragment"
-        android:label="SitePickerSiteDiscoveryFragment" />
+        android:label="SitePickerSiteDiscoveryFragment" >
+        <action
+            android:id="@+id/action_sitePickerSiteDiscoveryFragment_to_accountMismatchErrorFragment"
+            app:destination="@id/accountMismatchErrorFragment" />
+    </fragment>
     <fragment
         android:id="@+id/accountMismatchErrorFragment"
         android:name="com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -437,8 +437,7 @@
         android:label="SitePickerSiteDiscoveryFragment" >
         <action
             android:id="@+id/action_sitePickerSiteDiscoveryFragment_to_accountMismatchErrorFragment"
-            app:destination="@id/accountMismatchErrorFragment"
-            app:popUpTo="@id/sitePickerFragment" />
+            app:destination="@id/accountMismatchErrorFragment" />
     </fragment>
     <fragment
         android:id="@+id/accountMismatchErrorFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -437,7 +437,8 @@
         android:label="SitePickerSiteDiscoveryFragment" >
         <action
             android:id="@+id/action_sitePickerSiteDiscoveryFragment_to_accountMismatchErrorFragment"
-            app:destination="@id/accountMismatchErrorFragment" />
+            app:destination="@id/accountMismatchErrorFragment"
+            app:popUpTo="@id/sitePickerFragment" />
     </fragment>
     <fragment
         android:id="@+id/accountMismatchErrorFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -281,6 +281,7 @@
     <string name="login_account_mismatch_connect_wpcom">Connect to the site</string>
     <string name="login_account_mismatch_connect_wpcom_dialog_title">Connecting to a WordPress.com site</string>
     <string name="login_account_mismatch_connect_wpcom_dialog_message">Please contact the site owner for an invitation to the site as a shop manager or administrator to use the app.</string>
+    <string name="login_jetpack_connection_consent">By tapping the Connect Jetpack button, you agree to our &lt;a href=\'terms\'&gt;Terms of Service&lt;/a&gt; and to &lt;a href=\'sync\'&gt;share details&lt;/a&gt; with WordPress.com.</string>
     <!--
         My Store View
     -->

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.56.0'
+    fluxCVersion = '2538-397f9ed8144c1696be625808ff5ecb9530c6040c'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2538-397f9ed8144c1696be625808ff5ecb9530c6040c'
+    fluxCVersion = 'trunk-07afc659a11446fa7462978682fda3ca28cf8f54'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #7525

Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2538

### Description
This PR implements the changes required by #7525, which is handling the Jetpack connection for non-connected sites (sites without site-level connection).
I went with the second approach: calling the connection URL using the network client `no-redirect` and grabbing up the `Location` header from the response, this allows auto-sign in to the WordPress.com account to work nicely in the WebView.

### Testing instructions
For all the scenarios below, please prepare a site that's not connected to Jetpack.

##### Case 1: Connect to Jetpack from the post-login discovery
1. Use a WordPress.com that's not connected to any site.
2. Open the app, then login using WordPress.com account.
3. Notice the "No Stores" error screen.
4. Click on "Enter site address"
5. Enter the site address URL, and then the site credentials.
6. Notice the Jetpack Connection screen.
7. Confirm the presence of WordPress.com consent at the bottom of the screen.
8. Click on "Connect Jetpack to your account"
9. Confirm that a WebView is opened, and that you are automatically signed in to your WordPress.com account.
10. Approve the connection.
11. Confirm you are signed in correctly to the site.

##### Case 2: Connect to Jetpack using site credentials
1. Make sure to clear the app's data.
2. Open the app, then sign in using the site address.
4. Enter the site credentials.
5. Notice the Jetpack connection error screen.
6. Click on "Connect Jetpack to your account"
7. Continue the connection on the WebView.
8. Confirm that WordPress.com account confirmation screen is opened after the connection.
9. Enter the password or the magic link for confirmation.
10. Confirm that you are signed in to the app.

### Images/gif
<img src=https://user-images.githubusercontent.com/1657201/196190494-09139d0d-ab98-41e4-bec6-351b8ac7e9c5.png width=360 />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
