### PR TITLE
Add "view analytics" button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -9,12 +9,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentAnalyticsBinding
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class AnalyticsFragment :
-    TopLevelFragment(R.layout.fragment_analytics) {
+    BaseFragment(R.layout.fragment_analytics) {
     companion object {
         const val KEY_DATE_RANGE_SELECTOR_RESULT = "key_order_status_result"
     }
@@ -38,12 +38,6 @@ class AnalyticsFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-
-    override fun shouldExpandToolbar(): Boolean = true
-
-    override fun scrollToTop() {
-        return
     }
 
     private fun openDateRangeSelector() = findNavController().navigateSafely(buildDialogDateRangeSelectorArguments())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -74,6 +74,7 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewDetail
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
 import com.woocommerce.android.ui.moremenu.MoreMenuFragmentDirections
+import com.woocommerce.android.ui.mystore.MyStoreFragmentDirections
 import com.woocommerce.android.ui.orders.list.OrderListFragmentDirections
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
@@ -570,6 +571,11 @@ class MainActivity :
         AnalyticsTracker.track(AnalyticsEvent.MAIN_MENU_SETTINGS_TAPPED)
         val intent = Intent(this, AppSettingsActivity::class.java)
         startActivityForResult(intent, RequestCodes.SETTINGS)
+    }
+
+    override fun showAnalytics() {
+        val action = MyStoreFragmentDirections.actionMyStoreToAnalytics()
+        navController.navigateSafely(action)
     }
 
     override fun updateSelectedSite() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -51,4 +51,6 @@ interface MainNavigationRouter {
 
     fun showFeedbackSurvey()
     fun showSettingsScreen()
+
+    fun showAnalytics()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -3,11 +3,16 @@ package com.woocommerce.android.ui.mystore
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup.LayoutParams
+import androidx.core.view.MenuProvider
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle.State
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.AppBarLayout
@@ -42,6 +47,7 @@ import com.woocommerce.android.ui.mystore.MyStoreViewModel.VisitorStatsViewState
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
@@ -58,7 +64,7 @@ import kotlin.math.abs
 
 @AndroidEntryPoint
 @OptIn(FlowPreview::class)
-class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
+class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store), MenuProvider {
     companion object {
         val TAG: String = MyStoreFragment::class.java.simpleName
 
@@ -117,7 +123,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, State.RESUMED)
 
         initTabLayout()
 
@@ -221,6 +227,20 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                 else -> event.isHandled = false
             }
         }
+    }
+
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
+        if (FeatureFlag.ANALYTICS_HUB.isEnabled()) {
+            inflater.inflate(R.menu.menu_analytics, menu)
+        }
+    }
+
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        if (menuItem.itemId == R.id.menu_analytics) {
+            mainNavigationRouter?.showAnalytics()
+            return true
+        }
+        return false
     }
 
     private fun onJetpackCpConnected(benefitsBanner: BenefitsBannerUiModel) {

--- a/WooCommerce/src/main/res/menu/menu_analytics.xml
+++ b/WooCommerce/src/main/res/menu/menu_analytics.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_analytics"
+        android:icon="@drawable/ic_menu_analytics"
+        android:title="@string/analytics"
+        app:showAsAction="ifRoom|collapseActionView" />
+</menu>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -22,6 +22,13 @@
         <action
             android:id="@+id/action_myStore_to_jetpackBenefitsDialog"
             app:destination="@id/nav_graph_jetpack_install" />
+        <action
+            android:id="@+id/action_myStore_to_analytics"
+            app:destination="@id/analytics"
+            app:enterAnim="@anim/activity_fade_in"
+            app:exitAnim="@null"
+            app:popEnterAnim="@null"
+            app:popExitAnim="@anim/activity_fade_out" />
     </fragment>
     <fragment
         android:id="@+id/orders"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7546
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds "View Analytics" button in top-right corner of the MyStore fragment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Install & open app (in debug)
2. Click on the icon top right corner of My Store screen
3. Assert you're redirected to analytics screen.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width=250 src=https://user-images.githubusercontent.com/5845095/196199800-a115a398-ab01-492c-bb4d-57871bbb2c8b.png>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
