### PR TITLE
Simplified login preparations

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/RequestCodes.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/RequestCodes.kt
@@ -6,7 +6,6 @@ package com.woocommerce.android
 object RequestCodes {
     private const val BASE_REQUEST_CODE = 100
 
-    const val ADD_ACCOUNT = BASE_REQUEST_CODE + 0
     const val SETTINGS = BASE_REQUEST_CODE + 1
     const val IN_APP_UPDATE = BASE_REQUEST_CODE + 3
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorFragment.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.common
 
-import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -23,7 +21,7 @@ import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin.USER_ELIGIBILITY_ERROR
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.login.LoginActivity
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -31,7 +29,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
@@ -123,14 +120,7 @@ class UserEligibilityErrorFragment : BaseFragment(layout.fragment_user_eligibili
                     findNavController().navigateUp()
                 }
                 is Logout -> {
-                    requireActivity().apply {
-                        setResult(Activity.RESULT_CANCELED)
-                        val intent = Intent(activity, LoginActivity::class.java)
-                        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-                        LoginMode.WOO_LOGIN_MODE.putInto(intent)
-                        startActivity(intent)
-                        finish()
-                    }
+                    (requireActivity() as MainActivity).showLoginScreen()
                 }
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -249,7 +249,7 @@ class LoginActivity :
         if (!appPrefsWrapper.hasOnboardingCarouselBeenDisplayed()) {
             navGraph.setStartDestination(R.id.loginPrologueCarouselFragment)
         } else {
-            navGraph.setStartDestination(R.id.loginPrologueFragment)
+            navGraph.setStartDestination(R.id.legacyLoginPrologueFragment)
         }
         navController.graph = navGraph
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorFragment.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorView
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.NavigateToLoginScreen
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.OnJetpackConnectedEvent
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -112,11 +113,16 @@ class AccountMismatchErrorFragment : BaseFragment(), Listener {
     }
 
     private fun navigateToLoginScreen() {
-        val intent = Intent(context, LoginActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            LoginMode.WOO_LOGIN_MODE.putInto(this)
+        val activity = requireActivity()
+        if (activity is MainActivity) {
+            activity.showLoginScreen()
+        } else {
+            val intent = Intent(context, LoginActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                LoginMode.WOO_LOGIN_MODE.putInto(this)
+            }
+            startActivity(intent)
         }
-        startActivity(intent)
     }
 
     override fun onEmailNeedMoreHelpClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -3,7 +3,6 @@
 package com.woocommerce.android.ui.main
 
 import android.animation.ValueAnimator
-import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Intent
 import android.content.res.Resources.Theme
@@ -529,12 +528,6 @@ class MainActivity :
     public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
-            RequestCodes.ADD_ACCOUNT -> {
-                if (resultCode == Activity.RESULT_OK) {
-                    // TODO Launch next screen
-                }
-                return
-            }
             RequestCodes.SETTINGS -> {
                 // beta features have changed. Restart activity for changes to take effect
                 if (resultCode == AppSettingsActivity.RESULT_CODE_BETA_OPTIONS_CHANGED) {
@@ -556,7 +549,7 @@ class MainActivity :
         selectedSite.reset()
         val intent = Intent(this, LoginActivity::class.java)
         LoginMode.WOO_LOGIN_MODE.putInto(intent)
-        startActivityForResult(intent, RequestCodes.ADD_ACCOUNT)
+        startActivity(intent)
         finish()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -544,13 +544,13 @@ class MainActivity :
         }
     }
 
-    @Suppress("DEPRECATION")
     override fun showLoginScreen() {
         selectedSite.reset()
-        val intent = Intent(this, LoginActivity::class.java)
-        LoginMode.WOO_LOGIN_MODE.putInto(intent)
+        val intent = Intent(this, LoginActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            LoginMode.WOO_LOGIN_MODE.putInto(this)
+        }
         startActivity(intent)
-        finish()
     }
 
     override fun showUserEligibilityErrorScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -78,6 +78,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowP
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.products.ProductListFragmentDirections
 import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -238,7 +239,7 @@ class MainActivity :
         super.onCreate(savedInstanceState)
 
         // Verify authenticated session
-        if (!presenter.userIsLoggedIn()) {
+        if (!presenter.userIsLoggedIn() && !FeatureFlag.SIMPLIFIED_LOGIN.isEnabled()) {
             showLoginScreen()
             return
         }
@@ -546,11 +547,17 @@ class MainActivity :
 
     override fun showLoginScreen() {
         selectedSite.reset()
-        val intent = Intent(this, LoginActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            LoginMode.WOO_LOGIN_MODE.putInto(this)
+        if (FeatureFlag.SIMPLIFIED_LOGIN.isEnabled()) {
+            // TODO check if we need to confirm the user logout before restarting
+            restart()
+        } else {
+            val intent = Intent(this, LoginActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                LoginMode.WOO_LOGIN_MODE.putInto(this)
+            }
+            startActivity(intent)
+            finish()
         }
-        startActivity(intent)
     }
 
     override fun showUserEligibilityErrorScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
@@ -39,6 +40,7 @@ class MainActivityViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val notificationHandler: NotificationMessageHandler,
     private val featureAnnouncementRepository: FeatureAnnouncementRepository,
+    accountRepository: AccountRepository,
     private val buildConfigWrapper: BuildConfigWrapper,
     private val prefs: AppPrefs,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
@@ -52,7 +54,11 @@ class MainActivityViewModel @Inject constructor(
         }
     }
 
-    val startDestination = if (selectedSite.exists()) R.id.dashboard else R.id.sitePickerFragment
+    val startDestination = when {
+        !accountRepository.isUserLoggedIn() -> R.id.nav_graph_login
+        !selectedSite.exists() -> R.id.sitePickerFragment
+        else -> R.id.dashboard
+    }
 
     val moreMenuBadgeState = combine(
         unseenReviewsCountHandler.observeUnseenCount(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -15,12 +15,12 @@ import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
+import com.woocommerce.android.ui.simplifiedlogin.data.AccountRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.WooLog

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/simplifiedlogin/data/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/simplifiedlogin/data/AccountRepository.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.ui.simplifiedlogin.data
+
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.SITE_PICKER
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.AccountAction.SIGN_OUT
+import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+class AccountRepository @Inject constructor(
+    private val accountStore: AccountStore,
+    private val dispatcher: Dispatcher
+) {
+    fun getUserAccount(): AccountModel? = accountStore.account.takeIf { it.userId != 0L }
+
+    fun isUserLoggedIn() = accountStore.hasAccessToken()
+
+    suspend fun logout(): Boolean = suspendCancellableCoroutine { continuation ->
+        val listener = object : Any() {
+            @Suppress("unused")
+            @Subscribe(threadMode = MAIN)
+            fun onAccountChanged(event: OnAccountChanged) {
+                if (event.causeOfChange == SIGN_OUT) {
+                    dispatcher.unregister(this)
+                    if (!continuation.isActive) return
+
+                    if (event.isError) {
+                        WooLog.e(
+                            SITE_PICKER,
+                            "Account error [type = ${event.causeOfChange}] : " +
+                                "${event.error.type} > ${event.error.message}"
+                        )
+                        continuation.resume(false)
+                    } else if (!isUserLoggedIn()) {
+                        continuation.resume(true)
+                    }
+                }
+            }
+        }
+        dispatcher.register(listener)
+        dispatcher.dispatch(AccountActionBuilder.newSignOutAction())
+        dispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction())
+
+        continuation.invokeOnCancellation {
+            dispatcher.unregister(listener)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/simplifiedlogin/prologue/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/simplifiedlogin/prologue/LoginPrologueFragment.kt
@@ -1,0 +1,63 @@
+package com.woocommerce.android.ui.simplifiedlogin.prologue
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.isVisible
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentLoginPrologueBinding
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.login.UnifiedLoginTracker
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.FeatureFlag
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+open class LoginPrologueFragment : BaseFragment(R.layout.fragment_login_prologue) {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    @Inject
+    lateinit var unifiedLoginTracker: UnifiedLoginTracker
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val binding = FragmentLoginPrologueBinding.bind(view)
+
+        binding.buttonLoginStore.setOnClickListener {
+            // Login with site address
+            TODO()
+        }
+
+        binding.buttonLoginWpcom.setOnClickListener {
+            // Login with WordPress.com account
+            TODO()
+        }
+
+        binding.newToWooButton.setOnClickListener {
+            AnalyticsTracker.track(AnalyticsEvent.LOGIN_NEW_TO_WOO_BUTTON_TAPPED)
+            ChromeCustomTabUtils.launchUrl(requireContext(), AppUrls.NEW_TO_WOO_DOC)
+        }
+
+        if (savedInstanceState == null) {
+            unifiedLoginTracker.track(Flow.PROLOGUE, Step.PROLOGUE)
+        }
+
+        binding.buttonGetStarted.isVisible = FeatureFlag.STORE_CREATION_FLOW.isEnabled()
+        binding.buttonGetStarted.setOnClickListener {
+            findNavController().navigate(LoginPrologueFragmentDirections.actionLoginPrologueFragmentToSignupFragment())
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+        unifiedLoginTracker.setFlowAndStep(Flow.PROLOGUE, Step.PROLOGUE)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/simplifiedlogin/prologue/LoginPrologueViewPagerItemFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/simplifiedlogin/prologue/LoginPrologueViewPagerItemFragment.kt
@@ -1,0 +1,67 @@
+package com.woocommerce.android.ui.simplifiedlogin.prologue
+
+import android.os.Bundle
+import android.view.View
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentLoginPrologueViewpagerItemBinding
+import com.woocommerce.android.extensions.hide
+import org.wordpress.android.util.DisplayUtils
+
+/**
+ * Displays a single image and text label in the login prologue view pager
+ */
+class LoginPrologueViewPagerItemFragment : Fragment(R.layout.fragment_login_prologue_viewpager_item) {
+    companion object {
+        private const val ARG_DRAWABLE_ID = "drawable_id"
+        private const val ARG_TITLE_ID = "title_id"
+        private const val ARG_SUBTITLE_ID = "subtitle_id"
+
+        private const val RATIO_PORTRAIT = 0.6f
+        private const val RATIO_LANDSCAPE = 0.2f
+
+        fun newInstance(
+            @DrawableRes drawableId: Int,
+            @StringRes titleId: Int,
+            @StringRes subtitleId: Int
+        ): LoginPrologueViewPagerItemFragment {
+            LoginPrologueViewPagerItemFragment().also { fragment ->
+                fragment.arguments = Bundle().also { bundle ->
+                    bundle.putInt(ARG_DRAWABLE_ID, drawableId)
+                    bundle.putInt(ARG_TITLE_ID, titleId)
+                    bundle.putInt(ARG_SUBTITLE_ID, subtitleId)
+                }
+                return fragment
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        arguments?.let { args ->
+            val binding = FragmentLoginPrologueViewpagerItemBinding.bind(view)
+            binding.prologueTitle.setText(args.getInt(ARG_TITLE_ID))
+            binding.prologueSubtitle.setText(args.getInt(ARG_SUBTITLE_ID))
+
+            val isLandscape = DisplayUtils.isLandscape(context)
+            val isTablet = DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)
+
+            // hide images in landscape unless this device is a tablet
+            if (isLandscape && !isTablet) {
+                binding.imageView.hide()
+            } else {
+                binding.imageView.setImageResource(args.getInt(ARG_DRAWABLE_ID))
+            }
+
+            // adjust the view sizes based on orientation
+            val ratio = if (isLandscape) {
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * RATIO_LANDSCAPE).toInt()
+            } else {
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * RATIO_PORTRAIT).toInt()
+            }
+            binding.prologueTitle.layoutParams.width = ratio
+            binding.imageView.layoutParams.width = ratio
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.sitepicker
 
-import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
@@ -22,7 +20,6 @@ import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
-import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -48,7 +45,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -290,11 +286,7 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
     }
 
     private fun onLogout() {
-        activity?.setResult(Activity.RESULT_CANCELED)
-        val intent = Intent(context, LoginActivity::class.java)
-        LoginMode.WOO_LOGIN_MODE.putInto(intent)
-        startActivity(intent)
-        activity?.finish()
+        (requireActivity() as MainActivity).showLoginScreen()
     }
 
     override fun onEmailNeedMoreHelpClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.sitepicker.sitediscovery
 
-import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -19,8 +17,8 @@ import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.CreateZendeskTicket
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.NavigateToHelpScreen
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.StartJetpackInstallation
@@ -28,7 +26,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -104,10 +101,6 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
     }
 
     private fun onLogout() {
-        requireActivity().setResult(Activity.RESULT_CANCELED)
-        val intent = Intent(context, LoginActivity::class.java)
-        LoginMode.WOO_LOGIN_MODE.putInto(intent)
-        startActivity(intent)
-        requireActivity().finish()
+        (requireActivity() as MainActivity).showLoginScreen()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,7 +14,8 @@ enum class FeatureFlag {
     WC_SHIPPING_BANNER,
     UNIFIED_ORDER_EDITING,
     ORDER_CREATION_CUSTOMER_SEARCH,
-    STORE_CREATION_FLOW;
+    STORE_CREATION_FLOW,
+    SIMPLIFIED_LOGIN;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -29,6 +30,7 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             STORE_CREATION_FLOW -> PackageUtils.isDebugBuild()
+            SIMPLIFIED_LOGIN -> false
         }
     }
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_login.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_login.xml
@@ -7,8 +7,21 @@
     <include app:graph="@navigation/nav_graph_store_creation" />
 
     <fragment
-        android:id="@+id/loginPrologueFragment"
+        android:id="@+id/legacyLoginPrologueFragment"
         android:name="com.woocommerce.android.ui.login.LoginPrologueFragment"
+        android:label="fragment_login_prologue">
+        <action
+            android:id="@+id/action_loginPrologueFragment_to_signupFragment"
+            app:destination="@id/nav_graph_store_creation"
+            app:enterAnim="@anim/default_enter_anim"
+            app:exitAnim="@anim/default_exit_anim"
+            app:popEnterAnim="@anim/default_pop_enter_anim"
+            app:popExitAnim="@anim/default_pop_exit_anim" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/loginPrologueFragment"
+        android:name="com.woocommerce.android.ui.simplifiedlogin.prologue.LoginPrologueFragment"
         android:label="fragment_login_prologue">
         <action
             android:id="@+id/action_loginPrologueFragment_to_signupFragment"
@@ -25,7 +38,7 @@
         android:label="fragment_login_prologue_carousel">
         <action
             android:id="@+id/action_loginPrologueCarouselFragment_to_loginPrologueFragment"
-            app:destination="@id/loginPrologueFragment"
+            app:destination="@id/legacyLoginPrologueFragment"
             app:enterAnim="@anim/default_enter_anim"
             app:exitAnim="@anim/default_exit_anim"
             app:popEnterAnim="@anim/default_pop_enter_anim"
@@ -39,7 +52,7 @@
         android:label="fragment_login_prologue_survey">
         <action
             android:id="@+id/action_loginPrologueSurveyFragment_to_loginPrologueFragment"
-            app:destination="@id/loginPrologueFragment"
+            app:destination="@id/legacyLoginPrologueFragment"
             app:enterAnim="@anim/default_enter_anim"
             app:exitAnim="@anim/default_exit_anim"
             app:popEnterAnim="@anim/default_pop_enter_anim"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -13,6 +13,7 @@
     <include app:graph="@navigation/nav_graph_payment_flow" />
     <include app:graph="@navigation/nav_graph_jetpack_install" />
     <include app:graph="@navigation/nav_graph_coupons" />
+    <include app:graph="@navigation/nav_graph_login" />
 
     <fragment
         android:id="@+id/dashboard"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature.Payments
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
+import com.woocommerce.android.ui.simplifiedlogin.data.AccountRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -70,6 +71,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     private val savedStateHandle: SavedStateHandle = SavedStateHandle()
     private val selectedSite: SelectedSite = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val accountRepository: AccountRepository = mock()
 
     private val siteStore: SiteStore = mock()
     private val siteModel: SiteModel = SiteModel().apply {
@@ -449,6 +451,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 selectedSite,
                 notificationMessageHandler,
                 featureAnnouncementRepository,
+                accountRepository,
                 buildConfigWrapper,
                 prefs,
                 analyticsTrackerWrapper,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
This PR contains changes to prepare for a separate login flow, and the changes are:
1. It moves the navigation flow inside the MainActivity, which would be more consistent with the rest of screens, and allow better reusability of fragments at different states of the login flow (before and after site picker).
2. I'm aiming for having reusable repositories for this, so I added a `data` package and a first implementation of `AccountRepository` (copied from the previous one for now), IMO the login screens might depend on the same logic multiple times, and it's better to have a Repository by endpoint instead of by screen, for example for the `AccountRepository`, it would be responsible for anything related to sign-in and account fetching.

### Testing instructions
1. Make sure you are signed out.
3. Enable the feature flag SIMPLIFIED_LOGIN manually.
4. Open the app.
5. Confirm the `LoginPrologueFragment` from the package `simplifiedlogin` is used.
6. Click on `Get started`
7. Confirm the account creation UI fragment is shown.

The other actions are not implemented on this PR.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
