### PR TITLE
Don't display Reviews in add new product flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -66,11 +66,7 @@ class ProductDetailCardBuilder(
 ) {
     private lateinit var originalSku: String
 
-    suspend fun buildPropertyCards(
-        product: Product,
-        originalSku: String,
-        hideReviewsItem: Boolean = false
-    ): List<ProductPropertyCard> {
+    suspend fun buildPropertyCards(product: Product, originalSku: String): List<ProductPropertyCard> {
 
         this.originalSku = originalSku
 
@@ -78,11 +74,11 @@ class ProductDetailCardBuilder(
         cards.addIfNotEmpty(getPrimaryCard(product))
 
         when (product.productType) {
-            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product, hideReviewsItem))
-            VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product, hideReviewsItem))
-            GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product, hideReviewsItem))
-            EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product, hideReviewsItem))
-            OTHER -> cards.addIfNotEmpty(getOtherProductCard(product, hideReviewsItem))
+            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product))
+            VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product))
+            GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product))
+            EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product))
+            OTHER -> cards.addIfNotEmpty(getOtherProductCard(product))
         }
 
         return cards
@@ -98,12 +94,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getSimpleProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
+    private suspend fun getSimpleProductCard(product: Product): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                if (hideReviewsItem) null else product.productReviews(),
+                if (viewModel.isProductUnderCreation) null else product.productReviews(),
                 product.inventory(SIMPLE),
                 product.addons(),
                 product.shipping(),
@@ -117,12 +113,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getGroupedProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
+    private suspend fun getGroupedProductCard(product: Product): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.groupedProducts(),
-                if (hideReviewsItem) null else product.productReviews(),
+                if (viewModel.isProductUnderCreation) null else product.productReviews(),
                 product.inventory(GROUPED),
                 product.addons(),
                 product.categories(),
@@ -134,12 +130,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getExternalProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
+    private suspend fun getExternalProductCard(product: Product): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                if (hideReviewsItem) null else product.productReviews(),
+                if (viewModel.isProductUnderCreation) null else product.productReviews(),
                 product.externalLink(),
                 product.inventory(EXTERNAL),
                 product.addons(),
@@ -152,14 +148,14 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getVariableProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
+    private suspend fun getVariableProductCard(product: Product): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.warning(),
                 product.variations(),
                 product.variationAttributes(),
-                if (hideReviewsItem) null else product.productReviews(),
+                if (viewModel.isProductUnderCreation) null else product.productReviews(),
                 product.inventory(VARIABLE),
                 product.addons(),
                 product.shipping(),
@@ -176,11 +172,11 @@ class ProductDetailCardBuilder(
      * Used for product types the app doesn't support yet (ex: subscriptions), uses a subset
      * of properties since we can't be sure pricing, shipping, etc., are applicable
      */
-    private suspend fun getOtherProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
+    private suspend fun getOtherProductCard(product: Product): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
-                if (hideReviewsItem) null else product.productReviews(),
+                if (viewModel.isProductUnderCreation) null else product.productReviews(),
                 product.addons(),
                 product.categories(),
                 product.tags(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -69,7 +69,7 @@ class ProductDetailCardBuilder(
     suspend fun buildPropertyCards(
         product: Product,
         originalSku: String,
-        isProductUnderCreation: Boolean = false
+        hideReviewsItem: Boolean = false
     ): List<ProductPropertyCard> {
 
         this.originalSku = originalSku
@@ -78,11 +78,11 @@ class ProductDetailCardBuilder(
         cards.addIfNotEmpty(getPrimaryCard(product))
 
         when (product.productType) {
-            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product, isProductUnderCreation))
-            VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product, isProductUnderCreation))
-            GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product, isProductUnderCreation))
-            EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product, isProductUnderCreation))
-            OTHER -> cards.addIfNotEmpty(getOtherProductCard(product, isProductUnderCreation))
+            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product, hideReviewsItem))
+            VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product, hideReviewsItem))
+            GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product, hideReviewsItem))
+            EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product, hideReviewsItem))
+            OTHER -> cards.addIfNotEmpty(getOtherProductCard(product, hideReviewsItem))
         }
 
         return cards
@@ -98,12 +98,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getSimpleProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
+    private suspend fun getSimpleProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                if (isProductUnderCreation) null else product.productReviews(),
+                if (hideReviewsItem) null else product.productReviews(),
                 product.inventory(SIMPLE),
                 product.addons(),
                 product.shipping(),
@@ -117,12 +117,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getGroupedProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
+    private suspend fun getGroupedProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.groupedProducts(),
-                if (isProductUnderCreation) product.productReviews() else null,
+                if (hideReviewsItem) null else product.productReviews(),
                 product.inventory(GROUPED),
                 product.addons(),
                 product.categories(),
@@ -134,12 +134,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getExternalProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
+    private suspend fun getExternalProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                if (isProductUnderCreation) null else product.productReviews(),
+                if (hideReviewsItem) null else product.productReviews(),
                 product.externalLink(),
                 product.inventory(EXTERNAL),
                 product.addons(),
@@ -152,14 +152,14 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getVariableProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
+    private suspend fun getVariableProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.warning(),
                 product.variations(),
                 product.variationAttributes(),
-                if (isProductUnderCreation) null else product.productReviews(),
+                if (hideReviewsItem) null else product.productReviews(),
                 product.inventory(VARIABLE),
                 product.addons(),
                 product.shipping(),
@@ -176,11 +176,11 @@ class ProductDetailCardBuilder(
      * Used for product types the app doesn't support yet (ex: subscriptions), uses a subset
      * of properties since we can't be sure pricing, shipping, etc., are applicable
      */
-    private suspend fun getOtherProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
+    private suspend fun getOtherProductCard(product: Product, hideReviewsItem: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
-                if (isProductUnderCreation) null else product.productReviews(),
+                if (hideReviewsItem) null else product.productReviews(),
                 product.addons(),
                 product.categories(),
                 product.tags(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -66,7 +66,12 @@ class ProductDetailCardBuilder(
 ) {
     private lateinit var originalSku: String
 
-    suspend fun buildPropertyCards(product: Product, originalSku: String, isProductUnderCreation: Boolean = false): List<ProductPropertyCard> {
+    suspend fun buildPropertyCards(
+        product: Product,
+        originalSku: String,
+        isProductUnderCreation: Boolean = false
+    ): List<ProductPropertyCard> {
+
         this.originalSku = originalSku
 
         val cards = mutableListOf<ProductPropertyCard>()
@@ -98,7 +103,7 @@ class ProductDetailCardBuilder(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                if(isProductUnderCreation) null else product.productReviews(),
+                if (isProductUnderCreation) null else product.productReviews(),
                 product.inventory(SIMPLE),
                 product.addons(),
                 product.shipping(),
@@ -117,7 +122,7 @@ class ProductDetailCardBuilder(
             type = SECONDARY,
             properties = listOf(
                 product.groupedProducts(),
-                if(isProductUnderCreation) product.productReviews() else null,
+                if (isProductUnderCreation) product.productReviews() else null,
                 product.inventory(GROUPED),
                 product.addons(),
                 product.categories(),
@@ -134,7 +139,7 @@ class ProductDetailCardBuilder(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                if(isProductUnderCreation) null else product.productReviews(),
+                if (isProductUnderCreation) null else product.productReviews(),
                 product.externalLink(),
                 product.inventory(EXTERNAL),
                 product.addons(),
@@ -154,7 +159,7 @@ class ProductDetailCardBuilder(
                 product.warning(),
                 product.variations(),
                 product.variationAttributes(),
-                if(isProductUnderCreation) null else product.productReviews(),
+                if (isProductUnderCreation) null else product.productReviews(),
                 product.inventory(VARIABLE),
                 product.addons(),
                 product.shipping(),
@@ -175,7 +180,7 @@ class ProductDetailCardBuilder(
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
-                if(isProductUnderCreation) null else product.productReviews(),
+                if (isProductUnderCreation) null else product.productReviews(),
                 product.addons(),
                 product.categories(),
                 product.tags(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -66,18 +66,18 @@ class ProductDetailCardBuilder(
 ) {
     private lateinit var originalSku: String
 
-    suspend fun buildPropertyCards(product: Product, originalSku: String): List<ProductPropertyCard> {
+    suspend fun buildPropertyCards(product: Product, originalSku: String, isProductUnderCreation: Boolean = false): List<ProductPropertyCard> {
         this.originalSku = originalSku
 
         val cards = mutableListOf<ProductPropertyCard>()
         cards.addIfNotEmpty(getPrimaryCard(product))
 
         when (product.productType) {
-            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product))
-            VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product))
-            GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product))
-            EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product))
-            OTHER -> cards.addIfNotEmpty(getOtherProductCard(product))
+            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product, isProductUnderCreation))
+            VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product, isProductUnderCreation))
+            GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product, isProductUnderCreation))
+            EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product, isProductUnderCreation))
+            OTHER -> cards.addIfNotEmpty(getOtherProductCard(product, isProductUnderCreation))
         }
 
         return cards
@@ -93,12 +93,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getSimpleProductCard(product: Product): ProductPropertyCard {
+    private suspend fun getSimpleProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                product.productReviews(),
+                if(isProductUnderCreation) null else product.productReviews(),
                 product.inventory(SIMPLE),
                 product.addons(),
                 product.shipping(),
@@ -112,12 +112,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getGroupedProductCard(product: Product): ProductPropertyCard {
+    private suspend fun getGroupedProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.groupedProducts(),
-                product.productReviews(),
+                if(isProductUnderCreation) product.productReviews() else null,
                 product.inventory(GROUPED),
                 product.addons(),
                 product.categories(),
@@ -129,12 +129,12 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getExternalProductCard(product: Product): ProductPropertyCard {
+    private suspend fun getExternalProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                product.productReviews(),
+                if(isProductUnderCreation) null else product.productReviews(),
                 product.externalLink(),
                 product.inventory(EXTERNAL),
                 product.addons(),
@@ -147,14 +147,14 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private suspend fun getVariableProductCard(product: Product): ProductPropertyCard {
+    private suspend fun getVariableProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
                 product.warning(),
                 product.variations(),
                 product.variationAttributes(),
-                product.productReviews(),
+                if(isProductUnderCreation) null else product.productReviews(),
                 product.inventory(VARIABLE),
                 product.addons(),
                 product.shipping(),
@@ -171,11 +171,11 @@ class ProductDetailCardBuilder(
      * Used for product types the app doesn't support yet (ex: subscriptions), uses a subset
      * of properties since we can't be sure pricing, shipping, etc., are applicable
      */
-    private suspend fun getOtherProductCard(product: Product): ProductPropertyCard {
+    private suspend fun getOtherProductCard(product: Product, isProductUnderCreation: Boolean): ProductPropertyCard {
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
-                product.productReviews(),
+                if(isProductUnderCreation) null else product.productReviews(),
                 product.addons(),
                 product.categories(),
                 product.tags(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1033,7 +1033,8 @@ class ProductDetailViewModel @Inject constructor(
     private fun updateCards(product: Product) {
         launch(dispatchers.io) {
             mutex.withLock {
-                val cards = cardBuilder.buildPropertyCards(product, storedProduct.value?.sku ?: "")
+                val cards =
+                    cardBuilder.buildPropertyCards(product, storedProduct.value?.sku ?: "", isProductUnderCreation)
                 withContext(dispatchers.main) {
                     _productDetailCards.value = cards
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1033,8 +1033,7 @@ class ProductDetailViewModel @Inject constructor(
     private fun updateCards(product: Product) {
         launch(dispatchers.io) {
             mutex.withLock {
-                val cards =
-                    cardBuilder.buildPropertyCards(product, storedProduct.value?.sku ?: "", isProductUnderCreation)
+                val cards = cardBuilder.buildPropertyCards(product, storedProduct.value?.sku ?: "")
                 withContext(dispatchers.main) {
                     _productDetailCards.value = cards
                 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.ui.products.categories.ProductCategoriesRepositor
 import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
 import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
-import com.woocommerce.android.ui.products.models.ProductProperty.RatingBar
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
@@ -106,7 +105,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     private val defaultPricingGroup: Map<String, String> =
         mapOf("" to resources.getString(R.string.product_price_empty))
 
-    private val expectedCards = listOf(
+    private val addNewProductExpectedCards = listOf(
         ProductPropertyCard(
             type = ProductPropertyCard.Type.PRIMARY,
             properties = listOf(
@@ -126,12 +125,6 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                     defaultPricingGroup,
                     R.drawable.ic_gridicons_money,
                     showTitle = false
-                ),
-                RatingBar(
-                    R.string.product_reviews,
-                    resources.getString(R.string.product_ratings_count_zero),
-                    0F,
-                    R.drawable.ic_reviews
                 ),
                 PropertyGroup(
                     R.string.product_inventory,
@@ -192,7 +185,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the product detail properties correctly`() = testBlocking {
+    fun `Displays the product detail properties correctly in add new product flow`() = testBlocking {
         viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
         var cards: List<ProductPropertyCard>? = null
@@ -200,9 +193,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
             cards = it.map { card -> productUtils.stripCallbacks(card) }
         }
 
-        viewModel.start()
-
-        assertThat(cards).isEqualTo(expectedCards)
+        assertThat(cards).isEqualTo(addNewProductExpectedCards)
     }
 
     @Test


### PR DESCRIPTION
Remove Reviews item from ProductDetail screen in case product is not published yet (it's being created).

Closes: #6904

### Description
As described in #6904 we show **Reviews** element during product creation. This PR adds a check against the` ProductDetailViewModel.isProductUnderCreation` property to hide or show the Reviews element.

### Testing instructions
Add a new product (of any type) inside the app. Before the product is created using "Publish" button, there should not be a Reviews element visible in the product creation form.

**Reviews** element should become visible right after the new product is published. 

**Reviews** element should always be visible if the product is published and has reviews enabled.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
