### PR TITLE
Fix wrongly formatted link strings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.text.HtmlCompat
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle.State
@@ -47,6 +48,7 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
 
     @Inject
     internal lateinit var appPrefsWrapper: AppPrefsWrapper
+
     @Inject
     internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
     private lateinit var whatIsWordPressLinkClickListener: Listener
@@ -77,9 +79,14 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
 
         setupButtons(btnBinding, appPrefsWrapper.getLoginSiteAddress().isNullOrBlank())
 
+        binding.btnLoginWhatIsWordpress.text =
+            HtmlCompat.fromHtml(getString(R.string.what_is_wordpress_link), HtmlCompat.FROM_HTML_MODE_LEGACY)
         binding.btnLoginWhatIsWordpress.setOnClickListener {
             whatIsWordPressLinkClickListener.onWhatIsWordPressLinkNoWpcomAccountScreenClicked()
         }
+
+        binding.btnFindConnectedEmail.text =
+            HtmlCompat.fromHtml(getString(R.string.login_need_help_finding_email), HtmlCompat.FROM_HTML_MODE_LEGACY)
         binding.btnFindConnectedEmail.setOnClickListener {
             loginListener?.showHelpFindingConnectedEmail()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -47,9 +47,11 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.text.HtmlCompat
 import coil.compose.AsyncImage
 import coil.request.ImageRequest.Builder
 import com.woocommerce.android.R
+import com.woocommerce.android.compose.utils.toAnnotatedString
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -242,7 +244,10 @@ private fun MainContent(
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         viewState.inlineButtonText?.let { buttonText ->
             WCTextButton(onClick = viewState.inlineButtonAction) {
-                Text(text = stringResource(id = buttonText))
+                Text(
+                    text = HtmlCompat.fromHtml(stringResource(id = buttonText), HtmlCompat.FROM_HTML_MODE_LEGACY)
+                        .toAnnotatedString()
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.LayoutRes
+import androidx.core.text.HtmlCompat
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.ui.dialog.WooDialog
@@ -34,7 +35,10 @@ class WooLoginEmailFragment : LoginEmailFragment() {
 
     override fun setupContent(rootView: ViewGroup) {
         super.setupContent(rootView)
-        rootView.findViewById<Button>(R.id.login_what_is_wordpress).setOnClickListener {
+        val whatIsWordPressText = rootView.findViewById<Button>(R.id.login_what_is_wordpress)
+        whatIsWordPressText.text =
+            HtmlCompat.fromHtml(getString(R.string.what_is_wordpress_link), HtmlCompat.FROM_HTML_MODE_LEGACY)
+        whatIsWordPressText.setOnClickListener {
             whatIsWordPressLinkClickListener.onWhatIsWordPressLinkClicked()
         }
 

--- a/WooCommerce/src/main/res/layout/fragment_login_email_screen.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_email_screen.xml
@@ -74,7 +74,6 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_large"
             android:layout_marginEnd="@dimen/margin_extra_large"
-            android:text="@string/what_is_wordpress_link"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/login_continue_button" />

--- a/WooCommerce/src/main/res/layout/fragment_login_no_wpcom_account_found.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_wpcom_account_found.xml
@@ -58,7 +58,6 @@
                 android:layout_marginTop="@dimen/minor_100"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
-                android:text="@string/what_is_wordpress_link"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/no_wp_account_msg" />
@@ -71,7 +70,6 @@
                 android:layout_marginTop="@dimen/minor_100"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
-                android:text="@string/login_need_help_finding_email"
                 android:textAllCaps="false"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -256,7 +256,7 @@
     <string name="login_jetpack_not_found">Jetpack not found. Please try again</string>
     <string name="login_jetpack_install">Install Jetpack</string>
     <string name="login_sign_in">Sign in</string>
-    <string name="login_need_help_finding_email"><u>Need help finding the required email?</u></string>
+    <string name="login_need_help_finding_email">&lt;u&gt;Need help finding the required email?&lt;/u&gt;</string>
     <string name="login_email_help_title">What email do I use to sign in?</string>
     <string name="login_email_help_desc">In your site admin you can find the email you used to connect to WordPress.com from the %1$sJetpack Dashboard%2$s under %3$sConnections &gt; Account connection%4$s</string>
     <string name="login_discovery_error_title">Connection error</string>
@@ -2538,7 +2538,7 @@
     <string name="enter_your_site_address">Enter your site address</string>
     <string name="reset_your_password">Reset your password</string>
     <string name="signup_confirmation_title">Signup confirmation</string>
-    <string name="what_is_wordpress_link"><u>What is WordPress.com?</u></string>
+    <string name="what_is_wordpress_link">&lt;u&gt;What is WordPress.com?&lt;/u&gt;</string>
 
     <string name="login_site_address">Site address</string>
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
Coming [from this](https://github.com/woocommerce/woocommerce-android/pull/7545#discussion_r1000413442). Fixed wrong formatted strings so that they can be translated in GlotPress.
 
### Testing instructions
Checked that the updated strings: `What is WordPress.com` and `Need help finding the required email?`  are properly underlined in the following screens: 

<img src="https://user-images.githubusercontent.com/2663464/196934249-3aa36ee2-572a-472d-8dc2-98a12a79a53f.png" width="200"/>

<img src="https://user-images.githubusercontent.com/2663464/196934259-2437b53c-d93b-4b5e-90b1-27bffb812cbe.png" width="200"/>

<img src="https://user-images.githubusercontent.com/2663464/196934272-9ddfab20-81d7-4fbf-a366-70a7534e3fa5.png" width="200"/>

The previous screenshots had been taken after applying these changes. 
