### PR TITLE
Adding lazy init to avoid crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -155,9 +155,9 @@ class LoginActivity :
 
     private var loginMode: LoginMode? = null
     private lateinit var binding: ActivityLoginBinding
-    private val navController: NavController by lazy {
-        navHostFragment.navController
-    }
+
+    // Lazy init required to avoid crash. Full context: github.com/woocommerce/woocommerce-android/pull/7581
+    private val navController: NavController by lazy { navHostFragment.navController }
     private val navHostFragment: NavHostFragment by lazy {
         supportFragmentManager.findFragmentById(R.id.nav_host_fragment_login) as NavHostFragment
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -155,8 +155,12 @@ class LoginActivity :
 
     private var loginMode: LoginMode? = null
     private lateinit var binding: ActivityLoginBinding
-    private lateinit var navController: NavController
-    private lateinit var navHostFragment: NavHostFragment
+    private val navController: NavController by lazy {
+        navHostFragment.navController
+    }
+    private val navHostFragment: NavHostFragment by lazy {
+        supportFragmentManager.findFragmentById(R.id.nav_host_fragment_login) as NavHostFragment
+    }
 
     private var connectSiteInfo: ConnectSiteInfo? = null
 
@@ -177,8 +181,6 @@ class LoginActivity :
 
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_login) as NavHostFragment
-        navController = navHostFragment.navController
 
         val loginHelpNotification = getLoginHelpNotification()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #7578
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
In the Login flow we are currently using Android Navigation graphs alongside "traditional" way using `supportFragmentManager.beginTransaction()` approach. The goal is to migrate everything to use Android Navigation only and a "Single Activity" approach. Until we do that we might encounter some issues like this crash. 

When `LoginActivity` is destroyed (enable don't keep activities setting to test this) if we navigate back to the app after opening a link in Chrome for example, the app will crash with the following error: 
```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.woocommerce.android.dev/com.woocommerce.android.ui.login.LoginActivity}: java.lang.ClassCastException: com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment cannot be cast to androidx.navigation.fragment.NavHostFragment
                                                                                                    	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3449)
```

https://user-images.githubusercontent.com/2663464/196935409-928035ad-a02c-47e7-9a69-d4249d16d5b1.mp4

In the video we are trying to navigate back to `WooLoginEmailFragment` but `LoginActivity` is being recreated. At this point trying to invoke the following
```kotlin
        navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_login) as NavHostFragment
        navController = navHostFragment.navController
```
Because the fragment currently attached is `WooLoginEmailFragment`

The simplest solution to this is use lazy initialization so that we only instantiate `nacController` when we are sure is safe to use it. 

### Testing instructions

- Enable "Don't keep activities" from developer settings
- Click on login with WordPress email
- Click on "What is WordPress.com?"
- Navigate back to login prologue
- Click on "Get Started" 
- Navigate back twice and check the app is dismissed.  

