### PR TITLE
IAP: handle the case when new purchase is not delivered to the call back

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseViewModel.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseViewModel.kt
@@ -73,7 +73,7 @@ class IAPShowcaseViewModel : ViewModel() {
 
     private fun handleError(error: IAPError) {
         _iapEvent.value = when (error) {
-            is IAPError.Billing -> "Billing error: ${error.debugMessage}"
+            is IAPError.Billing -> "Billing error: ${error::class.java.simpleName} ${error.debugMessage}"
             IAPError.RemoteCommunication.Network -> "Network error"
             is IAPError.RemoteCommunication.Server -> "Server error: ${error.reason}"
         }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManager.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManager.kt
@@ -22,13 +22,11 @@ import com.woocommerce.android.iap.pub.IAP_LOG_TAG
 import com.woocommerce.android.iap.pub.model.IAPError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.Continuation
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 internal class IAPManager(
     private val activity: AppCompatActivity,
@@ -66,13 +64,8 @@ internal class IAPManager(
                 val flowParams = buildBillingFlowParams(iapProductDetailsResponse.productDetails)
                 billingClient.launchBillingFlow(activity, flowParams)
 
-                var continuation: Continuation<PurchasesResult>? = null
-                val job = startPeriodicPurchasesCheckJob(iapProduct) { continuation }
-                val purchasesResult = suspendCoroutine<PurchasesResult> {
-                    continuation = it
-                    iapPurchasesUpdatedListener.waitTillNextPurchaseEvent(it)
-                }
-                job.cancel()
+                startPeriodicPurchasesCheckJob(iapProduct) { iapPurchasesUpdatedListener.onPurchaseAvailable(it) }
+                val purchasesResult = iapPurchasesUpdatedListener.getPurchaseResult()
                 if (purchasesResult.billingResult.isSuccess) {
                     IAPPurchaseResponse.Success(
                         purchasesResult.purchasesList.map {
@@ -183,26 +176,29 @@ internal class IAPManager(
 
     private fun startPeriodicPurchasesCheckJob(
         iapProduct: IAPProduct,
-        continuationProvider: () -> Continuation<PurchasesResult>?,
-    ) = CoroutineScope(Dispatchers.IO).launch {
-        repeat(PURCHASE_STATE_CHECK_TIMES) {
-            if (isActive) {
-                delay(PURCHASE_STATE_CHECK_INTERVAL)
-                val purchasesResult = queryPurchases(iapProduct.productType)
-                logWrapper.d(IAP_LOG_TAG, "Fetching purchases. Result ${purchasesResult.billingResult}")
-                if (purchasesResult.billingResult.isSuccess &&
-                    purchasesResult.purchasesList.firstOrNull {
-                        it.products.contains(iapProduct.productId)
-                    }?.purchaseState == Purchase.PurchaseState.PURCHASED
-                ) {
-                    continuationProvider()?.resume(purchasesResult)
+        onPurchaseAvailable: (PurchasesResult) -> Unit,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            repeat(PURCHASE_STATE_CHECK_TIMES) {
+                if (isActive) {
+                    delay(PURCHASE_STATE_CHECK_INTERVAL)
+                    val purchasesResult = queryPurchases(iapProduct.productType)
+                    logWrapper.d(IAP_LOG_TAG, "Fetching purchases. Result ${purchasesResult.billingResult}")
+                    if (purchasesResult.billingResult.isSuccess &&
+                        purchasesResult.purchasesList.firstOrNull {
+                            it.products.contains(iapProduct.productId)
+                        }?.purchaseState == Purchase.PurchaseState.PURCHASED
+                    ) {
+                        onPurchaseAvailable(purchasesResult)
+                        cancel()
+                    }
                 }
             }
         }
     }
 
     companion object {
-        private const val PURCHASE_STATE_CHECK_INTERVAL = 20_000L
-        private const val PURCHASE_STATE_CHECK_TIMES = 20
+        private const val PURCHASE_STATE_CHECK_INTERVAL = 10_000L
+        private const val PURCHASE_STATE_CHECK_TIMES = 30
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7526
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
From [the documentation](https://developer.android.com/google/play/billing/integrate#process):

> Once a user completes a purchase, your app then needs to process that purchase. In most cases, your app is notified of purchases through your [PurchasesUpdatedListener](https://developer.android.com/reference/com/android/billingclient/api/PurchasesUpdatedListener). but there are cases where your app is made aware of calling [BillingClient.queryPurchasesAsync()](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchasesAsync(com.android.billingclient.api.QueryPurchasesParams,%20com.android.billingclient.api.PurchasesResponseListener)) as described in [Fetching purchases](https://developer.android.com/google/play/billing/integrate#fetch).

This PR adds background periodical task that checks purchase status 20 times every 20 seconds

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The easiest way to test is to simulate that the event was not delivered to `PurchasesResponseListener`:
* Remove/comment out `IAPPurchasesUpdatedListener::23` 
* Start the purchase flow
* Make a purchase
* Notice that in background the remote call (currently stub so check the logs) was still performed even with ignored events from `PurchasesResponseListener`
