### PR TITLE
Feature/7510 error handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.signup.SignUpViewModel.NavigateToNextStep
 import com.woocommerce.android.ui.login.signup.SignUpViewModel.OnTermsOfServiceClicked
@@ -17,6 +18,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UrlUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -24,6 +26,7 @@ import javax.inject.Inject
 class SignUpFragment : BaseFragment() {
 
     @Inject internal lateinit var urlUtils: UrlUtils
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
     private val viewModel: SignUpViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
@@ -50,6 +53,7 @@ class SignUpFragment : BaseFragment() {
             when (event) {
                 is NavigateToNextStep -> navigateToNextStep()
                 is OnTermsOfServiceClicked -> openTermsOfServiceUrl()
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> findNavController().navigateUp()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
@@ -1,10 +1,18 @@
 package com.woocommerce.android.ui.login.signup
 
+import android.util.Patterns
+import androidx.core.text.isDigitsOnly
+import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.EMAIL_EXIST
+import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.EMAIL_INVALID
+import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.PASSWORD_INVALID
+import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.PASSWORD_TOO_SHORT
+import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.UNKNOWN_ERROR
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
 import org.wordpress.android.fluxc.store.signup.SignUpStore
+import org.wordpress.android.login.LoginEmailFragment
 import javax.inject.Inject
 
 class SignUpRepository @Inject constructor(
@@ -15,16 +23,22 @@ class SignUpRepository @Inject constructor(
         const val EMAIL_EXIST_API_ERROR = "email_exists"
         const val EMAIL_INVALID_API_ERROR = "email_invalid"
         const val PASSWORD_INVALID_API_ERROR = "password_invalid"
+        const val PASSWORD_MIN_LENGTH = 7
     }
 
     suspend fun createAccount(email: String, password: String): AccountCreationResult {
-        // 1. Get suggestions for username based on email
+        val invalidCredentialsError = validateCredentials(email, password)
+        if (invalidCredentialsError != null) {
+            return AccountCreationError(invalidCredentialsError)
+        }
+
         WooLog.d(WooLog.T.LOGIN, "Fetching suggestions for username")
         val userNameSuggestionsResult = signUpStore.fetchUserNameSuggestions(email)
         val username = when {
             userNameSuggestionsResult.isError -> email
             else -> userNameSuggestionsResult.suggestions.first()
         }
+
         WooLog.d(WooLog.T.LOGIN, "Creating new WP account for: $email, $username")
         val accountCreatedResult = signUpStore.createWpAccount(email, password, username)
         return when {
@@ -44,6 +58,25 @@ class SignUpRepository @Inject constructor(
         }
     }
 
+    private fun validateCredentials(
+        email: String,
+        password: String
+    ): SignUpError? {
+        val invalidCredentialsError = when {
+            !isValidEmail(email) -> EMAIL_INVALID
+            password.length < PASSWORD_MIN_LENGTH -> PASSWORD_TOO_SHORT
+            password.isDigitsOnly() -> PASSWORD_INVALID
+            else -> null
+        }
+        return invalidCredentialsError
+    }
+
+    private fun isValidEmail(email: String): Boolean {
+        val emailRegExPattern = Patterns.EMAIL_ADDRESS
+        val matcher = emailRegExPattern.matcher(email)
+        return matcher.find() && email.length <= LoginEmailFragment.MAX_EMAIL_LENGTH
+    }
+
     sealed class AccountCreationResult
     object AccountCreationSuccess : AccountCreationResult()
     data class AccountCreationError(
@@ -52,16 +85,17 @@ class SignUpRepository @Inject constructor(
 
     private fun String?.toSignUpError() =
         when {
-            this == EMAIL_EXIST_API_ERROR -> SignUpError.EMAIL_EXIST
-            this == EMAIL_INVALID_API_ERROR -> SignUpError.EMAIL_INVALID
-            this == PASSWORD_INVALID_API_ERROR -> SignUpError.PASSWORD_INVALID
-            else -> SignUpError.UNKNOWN_ERROR
+            this == EMAIL_EXIST_API_ERROR -> EMAIL_EXIST
+            this == EMAIL_INVALID_API_ERROR -> EMAIL_INVALID
+            this == PASSWORD_INVALID_API_ERROR -> PASSWORD_INVALID
+            else -> UNKNOWN_ERROR
         }
 
     enum class SignUpError {
         EMAIL_EXIST,
         EMAIL_INVALID,
         PASSWORD_INVALID,
+        PASSWORD_TOO_SHORT,
         UNKNOWN_ERROR
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -132,7 +132,7 @@ private fun SignUpForm(
             value = password,
             onValueChange = { password = it },
             label = stringResource(id = R.string.signup_password_hint),
-            isError = signUpState.error?.type == ErrorType.PASSWORD,
+            isError = isPasswordError,
             helperText = if (isPasswordError) signUpState.error?.stringId?.let { stringResource(id = it) } else null
         )
         TermsOfServiceText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -138,7 +138,8 @@ private fun SignUpForm(
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         WCColoredButton(
             modifier = Modifier.fillMaxWidth(),
-            onClick = { onPrimaryButtonClicked(email, password) }
+            onClick = { onPrimaryButtonClicked(email, password) },
+            enabled = email.isNotBlank() && password.isNotBlank()
         ) {
             Text(text = stringResource(id = R.string.signup_get_started_button))
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -117,19 +117,23 @@ private fun SignUpForm(
             style = MaterialTheme.typography.body1,
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+
+        val isEmailError = signUpState.error?.type == ErrorType.EMAIL
         WCOutlinedTextField(
             value = email,
             onValueChange = { email = it },
             label = stringResource(id = R.string.signup_email_address_hint),
-            isError = signUpState.error?.type == ErrorType.EMAIL,
-            helperText = signUpState.error?.stringId?.let { stringResource(id = it) }
+            isError = isEmailError,
+            helperText = if (isEmailError) signUpState.error?.stringId?.let { stringResource(id = it) } else null
         )
+
+        val isPasswordError = signUpState.error?.type == ErrorType.PASSWORD
         WCPasswordField(
             value = password,
             onValueChange = { password = it },
             label = stringResource(id = R.string.signup_password_hint),
             isError = signUpState.error?.type == ErrorType.PASSWORD,
-            helperText = signUpState.error?.stringId?.let { stringResource(id = it) }
+            helperText = if (isPasswordError) signUpState.error?.stringId?.let { stringResource(id = it) } else null
         )
         TermsOfServiceText(
             modifier = Modifier.clickable { termsOfServiceClicked() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.login.signup
 
 import android.content.res.Configuration
-import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -30,7 +29,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -45,6 +43,8 @@ import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
+import com.woocommerce.android.ui.login.signup.SignUpViewModel.InputFieldError.EMAIL
+import com.woocommerce.android.ui.login.signup.SignUpViewModel.InputFieldError.PASSWORD
 import com.woocommerce.android.ui.login.signup.SignUpViewModel.SignUpState
 
 @Composable
@@ -61,10 +61,10 @@ fun SignUpScreen(viewModel: SignUpViewModel) {
                     title = "",
                     subtitle = stringResource(id = R.string.signup_creating_account_loading_message)
                 )
-            state.isError -> Toast.makeText(LocalContext.current, state.errorMessage, Toast.LENGTH_LONG).show()
             else -> SignUpForm(
                 termsOfServiceClicked = viewModel::onTermsOfServiceClicked,
                 onPrimaryButtonClicked = viewModel::onGetStartedCLicked,
+                signUpState = state
             )
         }
     }
@@ -95,10 +95,11 @@ private fun Toolbar(
 private fun SignUpForm(
     modifier: Modifier = Modifier,
     termsOfServiceClicked: () -> Unit,
-    onPrimaryButtonClicked: (String, String) -> Unit
+    onPrimaryButtonClicked: (String, String) -> Unit,
+    signUpState: SignUpState
 ) {
-    var email by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf(signUpState.email ?: "") }
+    var password by remember { mutableStateOf(signUpState.password ?: "") }
 
     Column(
         modifier = modifier
@@ -122,11 +123,15 @@ private fun SignUpForm(
             value = email,
             onValueChange = { email = it },
             label = stringResource(id = R.string.signup_email_address_hint),
+            isError = signUpState.error?.type == EMAIL,
+            helperText = signUpState.error?.stringId?.let { stringResource(id = it) }
         )
         WCPasswordField(
             value = password,
             onValueChange = { password = it },
             label = stringResource(id = R.string.signup_password_hint),
+            isError = signUpState.error?.type == PASSWORD,
+            helperText = signUpState.error?.stringId?.let { stringResource(id = it) }
         )
         TermsOfServiceText(
             modifier = Modifier.clickable { termsOfServiceClicked() }
@@ -167,5 +172,6 @@ fun SignUpFormPreview() {
     SignUpForm(
         termsOfServiceClicked = {},
         onPrimaryButtonClicked = { _, _ -> },
+        signUpState = SignUpState()
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -42,8 +42,7 @@ import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
-import com.woocommerce.android.ui.login.signup.SignUpViewModel.InputFieldError.EMAIL
-import com.woocommerce.android.ui.login.signup.SignUpViewModel.InputFieldError.PASSWORD
+import com.woocommerce.android.ui.login.signup.SignUpViewModel.ErrorType
 import com.woocommerce.android.ui.login.signup.SignUpViewModel.SignUpState
 
 @Composable
@@ -122,14 +121,14 @@ private fun SignUpForm(
             value = email,
             onValueChange = { email = it },
             label = stringResource(id = R.string.signup_email_address_hint),
-            isError = signUpState.error?.type == EMAIL,
+            isError = signUpState.error?.type == ErrorType.EMAIL,
             helperText = signUpState.error?.stringId?.let { stringResource(id = it) }
         )
         WCPasswordField(
             value = password,
             onValueChange = { password = it },
             label = stringResource(id = R.string.signup_password_hint),
-            isError = signUpState.error?.type == PASSWORD,
+            isError = signUpState.error?.type == ErrorType.PASSWORD,
             helperText = signUpState.error?.stringId?.let { stringResource(id = it) }
         )
         TermsOfServiceText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -1,9 +1,17 @@
 package com.woocommerce.android.ui.login.signup
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.login.signup.SignUpRepository.AccountCreationError
+import com.woocommerce.android.ui.login.signup.SignUpRepository.AccountCreationSuccess
+import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError
+import com.woocommerce.android.ui.login.signup.SignUpViewModel.InputFieldError.EMAIL
+import com.woocommerce.android.ui.login.signup.SignUpViewModel.InputFieldError.OTHER
+import com.woocommerce.android.ui.login.signup.SignUpViewModel.InputFieldError.PASSWORD
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,6 +23,10 @@ class SignUpViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val signUpRepository: SignUpRepository
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        private const val PASSWORD_MIN_LENGTH = 7
+    }
+
     private val _viewState = MutableLiveData<SignUpState>()
     val viewState: LiveData<SignUpState> = _viewState
 
@@ -27,24 +39,72 @@ class SignUpViewModel @Inject constructor(
     }
 
     fun onGetStartedCLicked(email: String, password: String) {
+        if (!areCredentialsValid(email, password)) return
+        _viewState.value = SignUpState(email = email, password = password)
+
         viewModelScope.launch {
-            _viewState.value = SignUpState(isLoading = true)
-            signUpRepository.createAccount(email, password)
-                .fold(
-                    onFailure = { _viewState.value = SignUpState(isError = true, errorMessage = it.message) },
-                    onSuccess = {
-                        _viewState.value = SignUpState(isLoading = false)
-                        triggerEvent(NavigateToNextStep)
-                    }
-                )
+            _viewState.value = _viewState.value?.copy(isLoading = true)
+            when (val result = signUpRepository.createAccount(email, password)) {
+                is AccountCreationError ->
+                    _viewState.value = _viewState.value?.copy(
+                        isLoading = false,
+                        error = result.error.toSignUpErrorUI()
+                    )
+                AccountCreationSuccess -> {
+                    _viewState.value = _viewState.value?.copy(isLoading = false)
+                    triggerEvent(NavigateToNextStep)
+                }
+            }
         }
     }
 
+    private fun areCredentialsValid(email: String, password: String): Boolean {
+        // TODO
+        return true
+    }
+
+    private fun SignUpError.toSignUpErrorUI() =
+        when (this) {
+            SignUpError.EMAIL_EXIST ->
+                SignUpErrorUi(
+                    type = EMAIL,
+                    stringId = R.string.signup_email_exist_input
+                )
+            SignUpError.EMAIL_INVALID -> SignUpErrorUi(
+                type = EMAIL,
+                stringId = R.string.signup_email_invalid_input
+            )
+            SignUpError.PASSWORD_INVALID -> SignUpErrorUi(
+                type = PASSWORD,
+                stringId = when {
+                    viewState.value?.password.isNullOrEmpty() -> R.string.signup_password_not_secure_enough
+                    viewState.value!!.password!!.length < PASSWORD_MIN_LENGTH -> R.string.signup_password_too_short
+                    else -> R.string.signup_password_not_secure_enough
+                }
+            )
+            SignUpError.UNKNOWN_ERROR -> SignUpErrorUi(
+                type = OTHER,
+                stringId = R.string.signup_get_started_button
+            )
+        }
+
     data class SignUpState(
+        val email: String? = null,
+        val password: String? = null,
         val isLoading: Boolean = false,
-        val isError: Boolean = false,
-        val errorMessage: String? = null
+        val error: SignUpErrorUi? = null,
     )
+
+    data class SignUpErrorUi(
+        val type: InputFieldError,
+        @StringRes val stringId: Int
+    )
+
+    enum class InputFieldError {
+        EMAIL,
+        PASSWORD,
+        OTHER
+    }
 
     object OnTermsOfServiceClicked : MultiLiveEvent.Event()
     object NavigateToNextStep : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -38,9 +38,13 @@ class SignUpViewModel @Inject constructor(
     }
 
     fun onGetStartedCLicked(email: String, password: String) {
+        if (!networkStatus.isConnected()) {
+            triggerEvent(ShowSnackbar(R.string.no_network_message))
+            return
+        }
+
         val trimmedEmail = email.trim()
         _viewState.value = SignUpState(email = trimmedEmail, password = password)
-
         viewModelScope.launch {
             _viewState.value = _viewState.value?.copy(isLoading = true)
             when (val result = signUpRepository.createAccount(trimmedEmail, password)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationQuestionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationQuestionsFragment.kt
@@ -19,9 +19,7 @@ class StoreCreationQuestionsFragment : BaseFragment() {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                WooThemeWithBackground {
-
-                }
+                WooThemeWithBackground {}
             }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -324,7 +324,7 @@
     <string name="signup_terms_of_service">By continuing, you agree to our &lt;u&gt;Terms of Service.&lt;/u&gt;</string>
     <string name="signup_creating_account_loading_message">Creating new account</string>
     <string name="signup_email_exist_input">An account with this email already exists.</string>
-    <string name="signup_email_invalid_input">The email is invalid.</string>
+    <string name="signup_email_invalid_input">Please enter a valid email address.</string>
     <string name="signup_password_too_short">Your password is too short. Please pick a password that has at least 6 characters.</string>
     <string name="signup_password_not_secure_enough">Your password does not meet our security guidelines. Please try a more complex password.</string>
     <string name="signup_api_generic_error">Sorry, we couldn\'t create an account for the provided credentials. Please try with a different email.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -327,6 +327,7 @@
     <string name="signup_email_invalid_input">The email is invalid.</string>
     <string name="signup_password_too_short">Your password is too short. Please pick a password that has at least 6 characters.</string>
     <string name="signup_password_not_secure_enough">Your password does not meet our security guidelines. Please try a more complex password.</string>
+    <string name="signup_api_generic_error">Sorry, we couldn\'t create an account for the provided credentials. Please try with a different email.</string>
 
     <!--
         Analytics View

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -324,6 +324,10 @@
     <string name="signup_terms_of_service_description">By continuing, you agree to our</string>
     <string name="signup_terms_of_service_linked_text">Terms of Service.</string>
     <string name="signup_creating_account_loading_message">Creating new account</string>
+    <string name="signup_email_exist_input">An account with this email already exists.</string>
+    <string name="signup_email_invalid_input">The email is invalid.</string>
+    <string name="signup_password_too_short">Your password is too short. Please pick a password that has at least 6 characters.</string>
+    <string name="signup_password_not_secure_enough">Your password does not meet our security guidelines. Please try a more complex password.</string>
 
     <!--
         Analytics View

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2544-df64b47467026fe7434bb27fdcaaf8287947513b'
+    fluxCVersion = 'trunk-3fd4e5984630c78c2ffcf1cb93e88947bc77b69e'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Do not merge until #7565 is merged. 

Closes: #7510 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This adds needed changes to deal with all the possible errors from account creation. 

### Testing instructions
- Click on "Get Started" 
- Check button to proceed with account creation is disabled until email and password are not empty
- Type "dafsgdgs@gmail" as email and check -> Invalid email error is displayed
- Type "123" as password and check -> Password too short error
- Type "1234567" as password -> Check password not secure enough error
- Type "Jorgemucientes@gmail.com" as email and check -> email already exist
- Finally type a valid email and password and check account is created successfully. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2663464/197164371-484df3ba-66d1-435c-ae77-a66f2b5d7874.mp4

