### PR TITLE
Update MediaPicker to 0.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ ext {
     materialVersion = '1.6.1'
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
-    mediapickerVersion = 'trunk-6d9cbe0b1a0f0f2163b6ab6e0e5b2aadc6511ddd'
+    mediapickerVersion = '0.1.1'
     wordPressLoginVersion = '0.20.0'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'


### PR DESCRIPTION
### Description
This PR updates the MediaPicker library to version `0.1.1` instead of a `trunk` commit. There should be no functional change since the `0.1.1` release contains the same code as the `trunk` commit that's been used for the last several versions of WCAndroid. 

### Testing instructions
From https://github.com/woocommerce/woocommerce-android/pull/7459
1. Open the app on a device that has Android 11 or later.
2. Open a product.
3. Click on Add images.
4. Select multiple images.
5. Confirm all images are uploaded successfully.
6. Repeat multiple times to confirm no duplication happens now.

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.