### PR TITLE
Issue-6968 Consolidate `Intent.ACTION_SENDTO` and `ACTION_DIAL` calls

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.util.ActivityUtils
 import org.wordpress.android.util.ToastUtils
 import java.util.Locale
 
@@ -61,17 +62,12 @@ object OrderCustomerHelper {
             )
         )
 
-        val intent = Intent(Intent.ACTION_DIAL)
-        intent.data = Uri.parse("tel:$phone")
-        try {
-            context.startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
+        ActivityUtils.dialPhoneNumber(context, phone) { error ->
             AnalyticsTracker.track(
                 AnalyticsEvent.ORDER_CONTACT_ACTION_FAILED,
                 this.javaClass.simpleName,
-                e.javaClass.simpleName, "No phone app was found"
+                error.javaClass.simpleName, "No phone app was found"
             )
-
             ToastUtils.showToast(context, R.string.error_no_phone_app)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.util.ActivityUtils
-import com.woocommerce.android.util.ActivityUtils.sendEmail
 import org.wordpress.android.util.ToastUtils
 import java.util.Locale
 
@@ -34,7 +33,7 @@ object OrderCustomerHelper {
             )
         )
 
-        sendEmail(context, email) { error ->
+        ActivityUtils.sendEmail(context, email) { error ->
             AnalyticsTracker.track(
                 AnalyticsEvent.ORDER_CONTACT_ACTION_FAILED,
                 this.javaClass.simpleName,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ActivityUtils.sendEmail
 import org.wordpress.android.util.ToastUtils
 import java.util.Locale
 
@@ -22,7 +23,7 @@ object OrderCustomerHelper {
     fun createEmail(
         context: Context,
         order: Order,
-        emailAddr: String
+        email: String
     ) {
         AnalyticsTracker.track(
             AnalyticsEvent.ORDER_CONTACT_ACTION,
@@ -33,17 +34,12 @@ object OrderCustomerHelper {
             )
         )
 
-        val intent = Intent(Intent.ACTION_SENDTO)
-        intent.data = Uri.parse("mailto:$emailAddr") // only email apps should handle this
-        try {
-            context.startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
+        sendEmail(context, email) { error ->
             AnalyticsTracker.track(
                 AnalyticsEvent.ORDER_CONTACT_ACTION_FAILED,
                 this.javaClass.simpleName,
-                e.javaClass.simpleName, "No e-mail app was found"
+                error.javaClass.simpleName, "No e-mail app was found"
             )
-
             ToastUtils.showToast(context, R.string.error_no_email_app)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsHelper.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.webkit.URLUtil
 import com.woocommerce.android.R
+import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.util.ToastUtils
@@ -37,7 +38,7 @@ object CustomOrderFieldsHelper {
         when (CustomOrderFieldType.fromMetadataValue(value)) {
             CustomOrderFieldType.EMAIL -> sendEmail(context, value)
             CustomOrderFieldType.URL -> showUrl(context, value)
-            CustomOrderFieldType.PHONE -> dialPhone(context, value)
+            CustomOrderFieldType.PHONE -> ActivityUtils.dialPhoneNumber(context, value)
             CustomOrderFieldType.TEXT -> {
                 // no action
             }
@@ -56,17 +57,6 @@ object CustomOrderFieldsHelper {
             context.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             ToastUtils.showToast(context, R.string.error_no_email_app)
-        }
-    }
-
-    @Suppress("SwallowedException")
-    private fun dialPhone(context: Context, phone: String) {
-        val intent = Intent(Intent.ACTION_DIAL)
-        intent.data = Uri.parse("tel:$phone")
-        try {
-            context.startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
-            ToastUtils.showToast(context, R.string.error_no_phone_app)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsHelper.kt
@@ -1,15 +1,11 @@
 package com.woocommerce.android.ui.orders.details.customfields
 
-import android.content.ActivityNotFoundException
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import android.webkit.URLUtil
-import com.woocommerce.android.R
 import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ActivityUtils.sendEmail
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.StringUtils
-import org.wordpress.android.util.ToastUtils
 
 object CustomOrderFieldsHelper {
     interface CustomOrderFieldClickListener {
@@ -47,16 +43,5 @@ object CustomOrderFieldsHelper {
 
     private fun showUrl(context: Context, url: String) {
         ChromeCustomTabUtils.launchUrl(context, url)
-    }
-
-    @Suppress("SwallowedException")
-    private fun sendEmail(context: Context, emailAddr: String) {
-        val intent = Intent(Intent.ACTION_SENDTO)
-        intent.data = Uri.parse("mailto:$emailAddr")
-        try {
-            context.startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
-            ToastUtils.showToast(context, R.string.error_no_email_app)
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -39,6 +39,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLab
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
+import com.woocommerce.android.util.ActivityUtils.dialPhoneNumber
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -264,7 +265,7 @@ class EditShippingLabelAddressFragment :
                     findNavController().navigateSafely(action)
                 }
                 is OpenMapWithAddress -> launchMapsWithAddress(event.address)
-                is DialPhoneNumber -> dialPhoneNumber(event.phoneNumber)
+                is DialPhoneNumber -> dialPhoneNumber(requireContext(), event.phoneNumber)
                 else -> event.isHandled = false
             }
         }
@@ -304,16 +305,6 @@ class EditShippingLabelAddressFragment :
             startActivity(mapIntent)
         } catch (e: ActivityNotFoundException) {
             ToastUtils.showToast(context, R.string.error_no_gmaps_app)
-        }
-    }
-
-    private fun dialPhoneNumber(phone: String) {
-        val intent = Intent(Intent.ACTION_DIAL)
-        intent.data = Uri.parse("tel:$phone")
-        try {
-            startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
-            ToastUtils.showToast(context, R.string.error_no_phone_app)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -155,8 +155,9 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
     }
 
     private fun composeEmail(address: String, subject: UiString, content: UiString) {
-        val success = ActivityUtils.composeEmail(requireActivity(), address, subject, content)
-        if (!success) viewModel.onEmailActivityNotFound()
+        ActivityUtils.sendEmail(requireActivity(), address, subject, content) {
+            viewModel.onEmailActivityNotFound()
+        }
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/receipt/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/receipt/ReceiptPreviewFragment.kt
@@ -111,7 +111,8 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview) {
     }
 
     private fun composeEmail(event: SendReceipt) {
-        val success = ActivityUtils.composeEmail(requireActivity(), event.address, event.subject, event.content)
-        if (!success) viewModel.onEmailActivityNotFound()
+        ActivityUtils.sendEmail(requireActivity(), event.address, event.subject, event.content) {
+            viewModel.onEmailActivityNotFound()
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -36,12 +36,14 @@ object ActivityUtils {
         context.startActivity(intent)
     }
 
+    @Suppress("SwallowedException")
     fun dialPhoneNumber(context: Context, phoneNumber: String) {
         dialPhoneNumber(context, phoneNumber) {
             ToastUtils.showToast(context, R.string.error_no_phone_app)
         }
     }
 
+    @Suppress("SwallowedException")
     fun dialPhoneNumber(context: Context, phoneNumber: String, onError: (e: ActivityNotFoundException) -> Unit) {
         val intent = Intent(Intent.ACTION_DIAL)
         intent.data = Uri.parse("tel:$phoneNumber")
@@ -98,18 +100,35 @@ object ActivityUtils {
         }
     }
 
-    fun composeEmail(activity: Activity, billingEmail: String, subject: UiString, content: UiString): Boolean {
+    @Suppress("SwallowedException")
+    fun sendEmail(context: Context, email: String) {
+        sendEmail(context, email) {
+            ToastUtils.showToast(context, R.string.error_no_email_app)
+        }
+    }
+
+    @Suppress("SwallowedException")
+    fun sendEmail(
+        context: Context,
+        email: String,
+        subject: UiString? = null,
+        content: UiString? = null,
+        onError: (e: ActivityNotFoundException) -> Unit = {}
+    ) {
         val intent = Intent(Intent.ACTION_SENDTO).apply {
             data = Uri.parse("mailto:") // only email apps should handle this
-            putExtra(Intent.EXTRA_EMAIL, arrayOf(billingEmail))
-            putExtra(Intent.EXTRA_SUBJECT, UiHelpers.getTextOfUiString(activity, subject))
-            putExtra(Intent.EXTRA_TEXT, UiHelpers.getTextOfUiString(activity, content))
+            putExtra(Intent.EXTRA_EMAIL, arrayOf(email))
+            if (subject != null) {
+                putExtra(Intent.EXTRA_SUBJECT, UiHelpers.getTextOfUiString(context, subject))
+            }
+            if (content != null) {
+                putExtra(Intent.EXTRA_TEXT, UiHelpers.getTextOfUiString(context, content))
+            }
         }
-        return try {
-            activity.startActivity(intent)
-            true
+        try {
+            context.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
-            false
+            onError(e)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -36,6 +36,23 @@ object ActivityUtils {
         context.startActivity(intent)
     }
 
+    fun dialPhoneNumber(context: Context, phoneNumber: String) {
+        dialPhoneNumber(context, phoneNumber) {
+            ToastUtils.showToast(context, R.string.error_no_phone_app)
+        }
+    }
+
+    fun dialPhoneNumber(context: Context, phoneNumber: String, onError: (e: ActivityNotFoundException) -> Unit) {
+        val intent = Intent(Intent.ACTION_DIAL)
+        intent.data = Uri.parse("tel:$phoneNumber")
+
+        try {
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            onError(e)
+        }
+    }
+
     /**
      * Use this only when you want to open the external browser - otherwise use
      * [ChromeCustomTabUtils.launchUrl] to provide a better in-app experience


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
This PR consolidates code responsible for redirecting from the app to dial a phone number and send email with an email client.

Closes: #6968
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The original issue: #6968.
There were code duplicates in places responsible for opening phone and email client apps. This PR extracts the common code into `ActivityUtils` class and modifies all the places where `ACTION_SENDTO` and `ACTION_DIAL` are found in the project to use the extracted code.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
There should not be any visual / behavioral changes in the app. Dialing phone numbers and sending emails should work the same.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
