### PR TITLE
fix: crash on updating widgets with app no running

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-3fd4e5984630c78c2ffcf1cb93e88947bc77b69e'
+    fluxCVersion = 'trunk-1003c5c729f033d83fbefb9317584b65729c41ab'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7596
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
See details in FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2546