### PR TITLE
IAP: Configuration change handling

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseViewModel.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseViewModel.kt
@@ -14,9 +14,7 @@ import com.woocommerce.android.iap.pub.model.WPComPurchaseResult
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import kotlinx.coroutines.launch
 
-class IAPShowcaseViewModel : ViewModel() {
-    lateinit var iapManager: PurchaseWPComPlanActions
-
+class IAPShowcaseViewModel(private val iapManager: PurchaseWPComPlanActions) : ViewModel() {
     private val _productInfo = MutableLiveData<WPComPlanProduct>()
     val productInfo: LiveData<WPComPlanProduct> = _productInfo
 

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPLifecycleObserver.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPLifecycleObserver.kt
@@ -82,9 +82,11 @@ internal class IAPLifecycleObserver(
     }
 
     private fun releaseWaiters() {
-        connectionEstablishingContinuations.forEach {
-            it.resume(Unit)
+        synchronized(connectionEstablishingContinuations) {
+            connectionEstablishingContinuations.forEach {
+                it.resume(Unit)
+            }
+            connectionEstablishingContinuations.clear()
         }
-        connectionEstablishingContinuations.clear()
     }
 }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManager.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManager.kt
@@ -32,7 +32,6 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 internal class IAPManager(
-    private val activity: AppCompatActivity,
     private val iapLifecycleObserver: IAPLifecycleObserver,
     private val iapOutMapper: IAPOutMapper,
     private val iapInMapper: IAPInMapper,
@@ -42,8 +41,11 @@ internal class IAPManager(
     private val billingClient: BillingClient
         get() = iapLifecycleObserver.billingClient
 
-    init {
-        activity.lifecycle.addObserver(iapLifecycleObserver)
+    private lateinit var activity: AppCompatActivity
+
+    fun initIAP(activity: AppCompatActivity) {
+        this.activity = activity
+        iapLifecycleObserver.initBillingClient(activity)
     }
 
     suspend fun fetchPurchases(iapProductType: IAPProductType): IAPPurchaseResponse =

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManagerFactory.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManagerFactory.kt
@@ -1,25 +1,19 @@
 package com.woocommerce.android.iap.internal.core
 
-import androidx.appcompat.app.AppCompatActivity
 import com.woocommerce.android.iap.pub.IAPLogWrapper
 
 internal object IAPManagerFactory {
-    fun createIAPManager(
-        activity: AppCompatActivity,
-        logWrapper: IAPLogWrapper
-    ): IAPManager {
+    fun createIAPManager(logWrapper: IAPLogWrapper): IAPManager {
         val iapOutMapper = IAPOutMapper()
         val iapPurchasesUpdatedListener = IAPPurchasesUpdatedListener(
             logWrapper,
         )
         val iapLifecycleObserver = IAPLifecycleObserver(
-            activity,
             iapPurchasesUpdatedListener,
             logWrapper
         )
         val iapInMapper = IAPInMapper()
         return IAPManager(
-            activity,
             iapLifecycleObserver,
             iapOutMapper,
             iapInMapper,

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
@@ -23,11 +23,14 @@ private val iapProduct = IAPProduct.WPPremiumPlanTesting
 private const val SUPPORTED_CURRENCY = "USD"
 
 internal class IAPPurchaseWPComPlanActionsImpl(
-    activity: AppCompatActivity,
     logWrapper: IAPLogWrapper,
     private val iapMobilePayAPI: IAPMobilePayAPI,
 ) : PurchaseWPComPlanActions {
-    private val iapManager = IAPManagerFactory.createIAPManager(activity, logWrapper)
+    private val iapManager = IAPManagerFactory.createIAPManager(logWrapper)
+
+    override fun initIAPWithNewActivity(activity: AppCompatActivity) {
+        iapManager.initIAP(activity)
+    }
 
     override suspend fun isWPComPlanPurchased(): WPComIsPurchasedResult {
         return when (val response = iapManager.fetchPurchases(iapProduct.productType)) {

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/pub/IAPSitePurchasePlanFactory.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/pub/IAPSitePurchasePlanFactory.kt
@@ -1,16 +1,12 @@
 package com.woocommerce.android.iap.pub
 
-import androidx.appcompat.app.AppCompatActivity
 import com.woocommerce.android.iap.internal.network.IAPMobilePayAPI
 import com.woocommerce.android.iap.internal.network.IAPMobilePayAPIStub
 import com.woocommerce.android.iap.internal.planpurchase.IAPPurchaseWPComPlanActionsImpl
 
 object IAPSitePurchasePlanFactory {
-    fun createIAPSitePurchasePlan(
-        activity: AppCompatActivity,
-        logWrapper: IAPLogWrapper,
-    ): PurchaseWPComPlanActions {
+    fun createIAPSitePurchasePlan(logWrapper: IAPLogWrapper): PurchaseWPComPlanActions {
         val iapMobilePayAPI: IAPMobilePayAPI = IAPMobilePayAPIStub(logWrapper)
-        return IAPPurchaseWPComPlanActionsImpl(activity, logWrapper, iapMobilePayAPI)
+        return IAPPurchaseWPComPlanActionsImpl(logWrapper, iapMobilePayAPI)
     }
 }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/pub/PurchaseWPComPlanActions.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/pub/PurchaseWPComPlanActions.kt
@@ -1,11 +1,17 @@
 package com.woocommerce.android.iap.pub
 
+import androidx.appcompat.app.AppCompatActivity
 import com.woocommerce.android.iap.internal.model.IAPSupportedResult
 import com.woocommerce.android.iap.pub.model.WPComIsPurchasedResult
 import com.woocommerce.android.iap.pub.model.WPComProductResult
 import com.woocommerce.android.iap.pub.model.WPComPurchaseResult
 
 interface PurchaseWPComPlanActions {
+    /**
+     * Has to be called for every instance of activity, e.g. from `onCreate` method
+     */
+    fun initIAPWithNewActivity(activity: AppCompatActivity)
+
     suspend fun isWPComPlanPurchased(): WPComIsPurchasedResult
     suspend fun purchaseWPComPlan(remoteSiteId: Long): WPComPurchaseResult
     suspend fun fetchWPComPlanProduct(): WPComProductResult


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7580 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Having `IAPManager` and all its dependencies activity scoped don't work well with a configuration change. We simply wait in suspend point on the object that doesn't have active `activity` anymore. This PR fixes this issue, by adding a method in the API that accepts a new activity. It has to be called every time when a new activity created

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Start purchase flow
* Invoke configuration change (e.g. screen rotation)
* Finish the flow
* Notice that purchase result has been delivered to the UI (toast message)

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/197545528-b8c1e229-6dce-4c53-ac5f-622955f2ad2e.mp4
