### PR TITLE
[Simplified login] revert the `getCurrentVariant` change

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.experiment
 import javax.inject.Inject
 
 class SimplifiedLoginExperiment @Inject constructor() {
-    suspend fun getCurrentVariant() = LoginVariant.SIMPLIFIED
+    fun getCurrentVariant() = LoginVariant.SIMPLIFIED
 
     enum class LoginVariant {
         STANDARD,


### PR DESCRIPTION
### Description
@hafizrahman this PR just reverts my last change to your PR, I'm making `getCurrentVariant` a blocking function again 😄.
After trying to use it on one of my changes, I found out that having as suspendable would get in our way. To avoid this, we can follow a similar approach to what `FirebaseRemoteConfigRepository#getPerformanceMonitoringSampleRate` does, it's a synchronous function that just proxies the call to `FirebaseRemoteConfig`, and I don't think this will be any different from the previous experiments, since we never really observe the changes, we just call `first()` to get the first one.

Sorry for this going back and forth on this small change.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
