### PR TITLE
Activate/simplified login experiment setup

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -694,6 +694,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     // Experiments (A/B test variants)
     PROLOGUE_EXPERIMENT,
     JETPACK_TIMEOUT_EXPERIMENT,
+    SIMPLIFIED_LOGIN_EXPERIMENT,
 
     // Widgets
     WIDGET_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
@@ -8,6 +8,8 @@ interface ExperimentTracker {
         const val LOGIN_SUCCESSFUL_EVENT = "login_successful"
         const val NEW_JETPACK_TIMEOUT_POLICY_ELIGIBLE_EVENT = "new_jetpack_timeout_experiment_eligible"
         const val SITE_VERIFICATION_SUCCESSFUL_EVENT = "site_verification_successful"
+        const val SIMPLIFIED_LOGIN_ELIGIBLE_EVENT = "simplified_login_experiment_eligible"
+        const val SIMPLIFIED_LOGIN_SUCCESSFUL_EVENT = "my_store_displayed"
     }
 
     fun log(event: String, block: (ParametersBuilder.() -> Unit)? = null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -27,6 +27,7 @@ class FirebaseRemoteConfigRepository @Inject constructor(
         const val PROLOGUE_VARIANT_KEY = "prologue_variant"
         private const val PERFORMANCE_MONITORING_SAMPLE_RATE_KEY = "wc_android_performance_monitoring_sample_rate"
         private const val JETPACK_TIMEOUT_POLICY_VARIANT_KEY = "jetpack_timeout_policy_variant"
+        private const val SIMPLIFIED_LOGIN_VARIANT_KEY = "simplified_login_variant"
         private const val DEBUG_INTERVAL = 10L
         private const val RELEASE_INTERVAL = 31200L
     }
@@ -89,6 +90,9 @@ class FirebaseRemoteConfigRepository @Inject constructor(
                 crashLogging.get().recordException(it)
                 emit(JetpackTimeoutPolicyVariant.valueOf(defaultValues[JETPACK_TIMEOUT_POLICY_VARIANT_KEY]!!))
             }
+
+    override fun getSimplifiedLoginVariant(): String =
+        remoteConfig.getString(SIMPLIFIED_LOGIN_VARIANT_KEY)
 
     private fun observeStringRemoteValue(key: String) = changesTrigger
         .map { remoteConfig.getString(key) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -6,6 +6,7 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
 import com.woocommerce.android.experiment.JetpackTimeoutExperiment.JetpackTimeoutPolicyVariant
 import com.woocommerce.android.experiment.PrologueExperiment.PrologueVariant
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -91,8 +92,8 @@ class FirebaseRemoteConfigRepository @Inject constructor(
                 emit(JetpackTimeoutPolicyVariant.valueOf(defaultValues[JETPACK_TIMEOUT_POLICY_VARIANT_KEY]!!))
             }
 
-    override fun getSimplifiedLoginVariant(): String =
-        remoteConfig.getString(SIMPLIFIED_LOGIN_VARIANT_KEY)
+    override fun getSimplifiedLoginVariant(): LoginVariant =
+        LoginVariant.valueOf(remoteConfig.getString(SIMPLIFIED_LOGIN_VARIANT_KEY).uppercase())
 
     private fun observeStringRemoteValue(key: String) = changesTrigger
         .map { remoteConfig.getString(key) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.config
 
 import com.woocommerce.android.experiment.JetpackTimeoutExperiment.JetpackTimeoutPolicyVariant
 import com.woocommerce.android.experiment.PrologueExperiment.PrologueVariant
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant
 import kotlinx.coroutines.flow.Flow
 
 interface RemoteConfigRepository {
@@ -9,5 +10,5 @@ interface RemoteConfigRepository {
     fun observePrologueVariant(): Flow<PrologueVariant>
     fun getPerformanceMonitoringSampleRate(): Double
     fun observeJetpackTimeoutPolicyVariantVariant(): Flow<JetpackTimeoutPolicyVariant>
-    fun getSimplifiedLoginVariant(): String
+    fun getSimplifiedLoginVariant(): LoginVariant
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -9,4 +9,5 @@ interface RemoteConfigRepository {
     fun observePrologueVariant(): Flow<PrologueVariant>
     fun getPerformanceMonitoringSampleRate(): Double
     fun observeJetpackTimeoutPolicyVariantVariant(): Flow<JetpackTimeoutPolicyVariant>
+    fun getSimplifiedLoginVariant(): String
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
@@ -1,9 +1,24 @@
 package com.woocommerce.android.experiment
 
+import com.woocommerce.android.analytics.ExperimentTracker
+import com.woocommerce.android.config.RemoteConfigRepository
 import javax.inject.Inject
 
-class SimplifiedLoginExperiment @Inject constructor() {
-    fun getCurrentVariant() = LoginVariant.SIMPLIFIED
+class SimplifiedLoginExperiment @Inject constructor(
+    private val remoteConfigRepository: RemoteConfigRepository,
+) {
+    companion object {
+        private const val VARIANT_CONTROL = "control"
+        private const val VARIANT_SIMPLIFIED = "simplified_login_i1"
+    }
+
+    fun getCurrentVariant(): LoginVariant {
+        return when (remoteConfigRepository.getSimplifiedLoginVariant()) {
+            VARIANT_CONTROL -> LoginVariant.STANDARD
+            VARIANT_SIMPLIFIED -> LoginVariant.SIMPLIFIED
+            else ->  LoginVariant.STANDARD
+        }
+    }
 
     enum class LoginVariant {
         STANDARD,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
@@ -13,18 +13,20 @@ class SimplifiedLoginExperiment @Inject constructor(
     private val remoteConfigRepository: RemoteConfigRepository,
 ) {
     companion object {
+        // The two values below are set in Firebase
         private const val VARIANT_CONTROL = "control"
         private const val VARIANT_SIMPLIFIED = "simplified_login_i1"
     }
 
     fun run() {
-        // Firebase's activation event for A/B testing. Make sure to only call it once!
+        // Track Firebase's activation event for the A/B testing. Make sure to only call it once!
         experimentTracker.log(ExperimentTracker.SIMPLIFIED_LOGIN_ELIGIBLE_EVENT)
 
         // Track used variant
+        val variant = getCurrentVariant()
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SIMPLIFIED_LOGIN_EXPERIMENT,
-            mapOf(Pair(AnalyticsTracker.KEY_EXPERIMENT_VARIANT, getCurrentVariant().name))
+            mapOf(Pair(AnalyticsTracker.KEY_EXPERIMENT_VARIANT, variant.name))
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
@@ -29,6 +29,6 @@ class SimplifiedLoginExperiment @Inject constructor(
 
     enum class LoginVariant {
         CONTROL,
-        SIMPLIFIED_LOGIN_I1
+        SIMPLIFIED_LOGIN_WPCOM
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
@@ -12,11 +12,6 @@ class SimplifiedLoginExperiment @Inject constructor(
     private val experimentTracker: ExperimentTracker,
     private val remoteConfigRepository: RemoteConfigRepository,
 ) {
-    companion object {
-        // The two values below are set in Firebase
-        private const val VARIANT_CONTROL = "control"
-        private const val VARIANT_SIMPLIFIED = "simplified_login_i1"
-    }
 
     fun activate() {
         // Track Firebase's activation event for the A/B testing. Make sure to only call it once!
@@ -30,16 +25,10 @@ class SimplifiedLoginExperiment @Inject constructor(
         )
     }
 
-    fun getCurrentVariant(): LoginVariant {
-        return when (remoteConfigRepository.getSimplifiedLoginVariant()) {
-            VARIANT_CONTROL -> LoginVariant.STANDARD
-            VARIANT_SIMPLIFIED -> LoginVariant.SIMPLIFIED
-            else -> LoginVariant.STANDARD
-        }
-    }
+    fun getCurrentVariant() = remoteConfigRepository.getSimplifiedLoginVariant()
 
     enum class LoginVariant {
-        STANDARD,
-        SIMPLIFIED
+        CONTROL,
+        SIMPLIFIED_LOGIN_I1
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
@@ -18,7 +18,7 @@ class SimplifiedLoginExperiment @Inject constructor(
         private const val VARIANT_SIMPLIFIED = "simplified_login_i1"
     }
 
-    fun run() {
+    fun activate() {
         // Track Firebase's activation event for the A/B testing. Make sure to only call it once!
         experimentTracker.log(ExperimentTracker.SIMPLIFIED_LOGIN_ELIGIBLE_EVENT)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
@@ -1,15 +1,30 @@
 package com.woocommerce.android.experiment
 
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.config.RemoteConfigRepository
 import javax.inject.Inject
 
 class SimplifiedLoginExperiment @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val experimentTracker: ExperimentTracker,
     private val remoteConfigRepository: RemoteConfigRepository,
 ) {
     companion object {
         private const val VARIANT_CONTROL = "control"
         private const val VARIANT_SIMPLIFIED = "simplified_login_i1"
+    }
+    fun run() {
+        // Firebase's activation event for A/B testing. Make sure to only call it once!
+        experimentTracker.log(ExperimentTracker.SIMPLIFIED_LOGIN_ELIGIBLE_EVENT)
+
+        // Track used variant
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SIMPLIFIED_LOGIN_EXPERIMENT,
+            mapOf(Pair(AnalyticsTracker.KEY_EXPERIMENT_VARIANT, getCurrentVariant().name))
+        )
     }
 
     fun getCurrentVariant(): LoginVariant {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/SimplifiedLoginExperiment.kt
@@ -16,6 +16,7 @@ class SimplifiedLoginExperiment @Inject constructor(
         private const val VARIANT_CONTROL = "control"
         private const val VARIANT_SIMPLIFIED = "simplified_login_i1"
     }
+
     fun run() {
         // Firebase's activation event for A/B testing. Make sure to only call it once!
         experimentTracker.log(ExperimentTracker.SIMPLIFIED_LOGIN_ELIGIBLE_EVENT)
@@ -31,7 +32,7 @@ class SimplifiedLoginExperiment @Inject constructor(
         return when (remoteConfigRepository.getSimplifiedLoginVariant()) {
             VARIANT_CONTROL -> LoginVariant.STANDARD
             VARIANT_SIMPLIFIED -> LoginVariant.SIMPLIFIED
-            else ->  LoginVariant.STANDARD
+            else -> LoginVariant.STANDARD
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -9,8 +9,8 @@ import androidx.annotation.LayoutRes
 import androidx.core.text.HtmlCompat
 import com.woocommerce.android.R
 import com.woocommerce.android.experiment.SimplifiedLoginExperiment
-import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.SIMPLIFIED
-import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.STANDARD
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.SIMPLIFIED_LOGIN_WPCOM
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.CONTROL
 import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.util.WooPermissionUtils
@@ -40,8 +40,8 @@ class WooLoginEmailFragment : LoginEmailFragment() {
 
     @LayoutRes
     override fun getContentLayout(): Int = when (simplifiedLoginExperiment.getCurrentVariant()) {
-        STANDARD -> R.layout.fragment_login_email_screen
-        SIMPLIFIED -> R.layout.fragment_simplified_login_email_screen
+        CONTROL -> R.layout.fragment_login_email_screen
+        SIMPLIFIED_LOGIN_WPCOM -> R.layout.fragment_simplified_login_email_screen
     }
 
     override fun setupContent(rootView: ViewGroup) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -9,8 +9,8 @@ import androidx.annotation.LayoutRes
 import androidx.core.text.HtmlCompat
 import com.woocommerce.android.R
 import com.woocommerce.android.experiment.SimplifiedLoginExperiment
-import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.SIMPLIFIED_LOGIN_WPCOM
 import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.CONTROL
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.SIMPLIFIED_LOGIN_WPCOM
 import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.util.WooPermissionUtils

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.attr
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.FragmentMyStoreBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.scrollStartEvents
@@ -80,6 +81,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store), MenuProvid
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var dateUtils: DateUtils
     @Inject lateinit var usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter
+    @Inject lateinit var experimentTracker: ExperimentTracker
 
     private var _binding: FragmentMyStoreBinding? = null
     private val binding get() = _binding!!
@@ -170,6 +172,9 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store), MenuProvid
         binding.statsScrollView.scrollStartEvents()
             .onEach { usageTracksEventEmitter.interacted() }
             .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        // Successful event for Simplified Login A/B testing.
+        experimentTracker.log(ExperimentTracker.SIMPLIFIED_LOGIN_SUCCESSFUL_EVENT)
 
         setupStateObservers()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7614
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the required wirings to let the A/B test experiment to be activated. It adds these functions:
- `activate()`: To start the testing
- `getCurrentVariant()`: To get the currently given variant.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Nothing to test now since the Firebase A/B test is not running yet.
