### PR TITLE
[10.8.1] Fix crash on getting `UserAgent` from background thread.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.56.0'
+    fluxCVersion = '1.56.1'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
This PR updates FluxC to version `1.56.1` which contains the fix https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2546 for getting `UserAgent` from a background thread. For details please see FluxC PR.