### PR TITLE
[10.9-rc2] Fix crash on getting `UserAgent` from background thread. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.1.0'
+    fluxCVersion = '2.1.1'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Twin PR of https://github.com/woocommerce/woocommerce-android/pull/7631, but targeting 10.9 release.

FluxC points to this: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2550