### PR TITLE
feat: add performance monitoring for analytics hub

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -701,4 +701,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     // App links
     UNIVERSAL_LINK_OPENED,
     UNIVERSAL_LINK_FAILED,
+
+    // Analytics Hub
+    ANALYTICS_HUB_WAITING_TIME_LOADED
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -30,6 +30,11 @@ class AnalyticsFragment :
 
     override fun getFragmentTitle() = getString(R.string.analytics)
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        lifecycle.addObserver(viewModel.performanceObserver)
+        super.onCreate(savedInstanceState)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubTransactionLauncher.kt
@@ -1,0 +1,86 @@
+package com.woocommerce.android.ui.analytics
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.automattic.android.tracks.crashlogging.performance.PerformanceTransactionRepository
+import com.automattic.android.tracks.crashlogging.performance.TransactionId
+import com.automattic.android.tracks.crashlogging.performance.TransactionOperation
+import com.automattic.android.tracks.crashlogging.performance.TransactionStatus
+import com.woocommerce.android.analytics.AnalyticsEvent.ANALYTICS_HUB_WAITING_TIME_LOADED
+import com.woocommerce.android.analytics.WaitingTimeTracker
+import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.ORDERS_FETCHED
+import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.REVENUE_FETCHED
+import com.woocommerce.android.util.CoroutineDispatchers
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ViewModelScoped
+class AnalyticsHubTransactionLauncher @Inject constructor(
+    private val performanceTransactionRepository: PerformanceTransactionRepository,
+    dispatchers: CoroutineDispatchers,
+) : LifecycleEventObserver {
+    private companion object {
+        const val TRANSACTION_NAME = "AnalyticsHub"
+    }
+
+    private var performanceTransactionId: TransactionId? = null
+    private val conditionsToSatisfy = MutableStateFlow(Conditions.values().toList())
+    private val validatorScope = CoroutineScope(dispatchers.main + Job())
+    private val waitingTimeTracker = WaitingTimeTracker(ANALYTICS_HUB_WAITING_TIME_LOADED)
+
+    init {
+        validatorScope.launch {
+            conditionsToSatisfy.collect { toSatisfy ->
+                if (toSatisfy.isEmpty()) {
+                    performanceTransactionId?.let {
+                        performanceTransactionRepository.finishTransaction(it, TransactionStatus.SUCCESSFUL)
+                    }
+                    waitingTimeTracker.end()
+                }
+            }
+        }
+    }
+
+    private enum class Conditions {
+        REVENUE_FETCHED,
+        ORDERS_FETCHED
+    }
+
+    fun onRevenueFetched() = satisfyCondition(REVENUE_FETCHED)
+
+    fun onOrdersFetched() = satisfyCondition(ORDERS_FETCHED)
+
+    fun clear() {
+        validatorScope.cancel()
+    }
+
+    private fun satisfyCondition(condition: Conditions) {
+        conditionsToSatisfy.value = (conditionsToSatisfy.value - condition)
+    }
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        when (event) {
+            Lifecycle.Event.ON_CREATE -> {
+                performanceTransactionId =
+                    performanceTransactionRepository.startTransaction(TRANSACTION_NAME, TransactionOperation.UI_LOAD)
+                waitingTimeTracker.start()
+            }
+            Lifecycle.Event.ON_STOP -> {
+                performanceTransactionId?.let {
+                    performanceTransactionRepository.finishTransaction(it, TransactionStatus.ABORTED)
+                }
+                performanceTransactionId = null
+                waitingTimeTracker.abort()
+            }
+            else -> {
+                // no-op
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.analytics
 
+import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
@@ -53,10 +54,13 @@ class AnalyticsViewModel @Inject constructor(
     private val currencyFormatter: CurrencyFormatter,
     private val analyticsRepository: AnalyticsRepository,
     private val selectedSite: SelectedSite,
+    private val transactionLauncher: AnalyticsHubTransactionLauncher,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
 
     private val navArgs: AnalyticsFragmentArgs by savedState.navArgs()
+
+    val performanceObserver: LifecycleObserver = transactionLauncher
 
     private val mutableState = MutableStateFlow(
         AnalyticsViewState(
@@ -137,15 +141,18 @@ class AnalyticsViewModel @Inject constructor(
             analyticsRepository.fetchRevenueData(dateRange, timePeriod, fetchStrategy)
                 .let {
                     when (it) {
-                        is RevenueData -> mutableState.value = state.value.copy(
-                            refreshIndicator = NotShowIndicator,
-                            revenueState = buildRevenueDataViewState(
-                                formatValue(it.revenueStat.totalValue.toString(), it.revenueStat.currencyCode),
-                                it.revenueStat.totalDelta,
-                                formatValue(it.revenueStat.netValue.toString(), it.revenueStat.currencyCode),
-                                it.revenueStat.netDelta
+                        is RevenueData -> {
+                            mutableState.value = state.value.copy(
+                                refreshIndicator = NotShowIndicator,
+                                revenueState = buildRevenueDataViewState(
+                                    formatValue(it.revenueStat.totalValue.toString(), it.revenueStat.currencyCode),
+                                    it.revenueStat.totalDelta,
+                                    formatValue(it.revenueStat.netValue.toString(), it.revenueStat.currencyCode),
+                                    it.revenueStat.netDelta
+                                )
                             )
-                        )
+                            transactionLauncher.onRevenueFetched()
+                        }
                         is RevenueError -> mutableState.value = state.value.copy(
                             refreshIndicator = NotShowIndicator,
                             revenueState = NoDataState(resourceProvider.getString(R.string.analytics_revenue_no_data))
@@ -167,14 +174,17 @@ class AnalyticsViewModel @Inject constructor(
             analyticsRepository.fetchOrdersData(dateRange, timePeriod, fetchStrategy)
                 .let {
                     when (it) {
-                        is OrdersData -> mutableState.value = state.value.copy(
-                            ordersState = buildOrdersDataViewState(
-                                it.ordersStat.ordersCount.toString(),
-                                it.ordersStat.ordersCountDelta,
-                                formatValue(it.ordersStat.avgOrderValue.toString(), it.ordersStat.currencyCode),
-                                it.ordersStat.avgOrderDelta
+                        is OrdersData -> {
+                            mutableState.value = state.value.copy(
+                                ordersState = buildOrdersDataViewState(
+                                    it.ordersStat.ordersCount.toString(),
+                                    it.ordersStat.ordersCountDelta,
+                                    formatValue(it.ordersStat.avgOrderValue.toString(), it.ordersStat.currencyCode),
+                                    it.ordersStat.avgOrderDelta
+                                )
                             )
-                        )
+                            transactionLauncher.onOrdersFetched()
+                        }
                         is OrdersError -> mutableState.value = state.value.copy(
                             ordersState = NoDataState(resourceProvider.getString(R.string.analytics_orders_no_data))
                         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
@@ -502,7 +502,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         AnalyticsViewModel(
             resourceProvider, dateUtil, calculator,
             currencyFormatter, analyticsRepository,
-            selectedSite, savedState
+            selectedSite, mock(), savedState
         )
 
     private fun getRevenueStats(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7636 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds performance monitoring for the Analytics Hub feature. We'll record a valid performance transaction as soon as Milestone 1 features load, that is:
- Revenue
- Orders

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Apply PATCH
2. Run app, select "See more" button on My Store
3. Go to Sentry > `Performance` > `AnalyticsHub` > Filter by `Recent Transactions`
4. **Assert that your transaction has been recorder**

<details>
<summary>
PATCH
</summary>

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt	(revision 56c883a088fee468b057c77e9db5c8d62a3c4502)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt	(date 1666789443401)
@@ -10,6 +10,7 @@
     private val analyticsWrapper: AnalyticsTrackerWrapper
 ) {
     operator fun invoke(): PerformanceMonitoringConfig {
+        return PerformanceMonitoringConfig.Enabled(1.0)
         val sampleRate = remoteConfigRepository.getPerformanceMonitoringSampleRate()
         val userEnabled = analyticsWrapper.sendUsageStats
 
```

</details>

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/5845095/198032609-fc046938-96e5-475f-a3f9-9f51f8053d88.png">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
