### PR TITLE
Fix percentage labels in Analytics Hub

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -34,7 +34,6 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
-import kotlin.math.round
 
 class AnalyticsRepository @Inject constructor(
     private val statsRepository: StatsRepository,
@@ -239,7 +238,7 @@ class AnalyticsRepository @Inject constructor(
     private fun calculateDeltaPercentage(previousVal: Double, currentVal: Double): DeltaPercentage = when {
         previousVal <= ZERO_VALUE -> DeltaPercentage.NotExist
         currentVal <= ZERO_VALUE -> DeltaPercentage.Value((MINUS_ONE * ONE_H_PERCENT))
-        else -> DeltaPercentage.Value((round((currentVal - previousVal) / previousVal) * ONE_H_PERCENT).toInt())
+        else -> DeltaPercentage.Value(((currentVal - previousVal) / previousVal * ONE_H_PERCENT).toInt())
     }
 
     private fun shouldUpdatePreviousStats(startDate: String, endDate: String, forceUpdate: Boolean) =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7638 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes percentage calculations in Analytics Hub.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
I think there are no testing instructions.

I've added unit tests for the proposed change. I believe this is sufficient.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | Now |
| --- | --- |
| <img width="" alt="Screenshot 2022-10-26 at 15 48 26" src="https://user-images.githubusercontent.com/5845095/198057743-c4ad785d-8103-4602-a16a-54daab58b363.png"> | ![image](https://user-images.githubusercontent.com/5845095/198057779-93d7fb18-7939-46ac-9810-626148f049ea.png) |




- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
