### PR TITLE
Fix AB setup for simplified login

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -44,7 +44,8 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     private val defaultValues by lazy {
         mapOf(
             PROLOGUE_VARIANT_KEY to PrologueVariant.CONTROL.name,
-            JETPACK_TIMEOUT_POLICY_VARIANT_KEY to JetpackTimeoutPolicyVariant.CONTROL.name
+            JETPACK_TIMEOUT_POLICY_VARIANT_KEY to JetpackTimeoutPolicyVariant.CONTROL.name,
+            SIMPLIFIED_LOGIN_VARIANT_KEY to LoginVariant.CONTROL.name
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -93,8 +93,14 @@ class FirebaseRemoteConfigRepository @Inject constructor(
                 emit(JetpackTimeoutPolicyVariant.valueOf(defaultValues[JETPACK_TIMEOUT_POLICY_VARIANT_KEY]!!))
             }
 
-    override fun getSimplifiedLoginVariant(): LoginVariant =
-        LoginVariant.valueOf(remoteConfig.getString(SIMPLIFIED_LOGIN_VARIANT_KEY).uppercase())
+    override fun getSimplifiedLoginVariant(): LoginVariant {
+        return try {
+            LoginVariant.valueOf(remoteConfig.getString(SIMPLIFIED_LOGIN_VARIANT_KEY).uppercase())
+        } catch (e: IllegalArgumentException) {
+            crashLogging.get().recordException(e)
+            LoginVariant.valueOf(defaultValues[SIMPLIFIED_LOGIN_VARIANT_KEY]!!)
+        }
+    }
 
     private fun observeStringRemoteValue(key: String) = changesTrigger
         .map { remoteConfig.getString(key) }


### PR DESCRIPTION
### Description
@hafizrahman after merging #7623, I remembered a case about when Remote Config is unable to fetch values, then it would switch to the default values, which are either user-defined, or default values by the SDK.

So for our case, we are using a String, the default value for this is an empty String, which means if Firebase Remote Config fails to fetch it, it will try to convert the empty to String to the enum `LoginVariant`, which would throw this exception:
```
java.lang.IllegalArgumentException: No enum constant com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.
```

I updated the implementation to supply our own default value, and I also added a try/catch clause to handle any errors when converting the value to Enum, it follows the same pattern as the other experiments in the Repository.

Sorry for missing this on my PR review.

### Testing instructions
1. Clear the app's data.
2. Enable airplane mode.
3. Launch the app.
4. Click on "Continue with WordPress.com"
5. Confirm the app doesn't crash.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
