### PR TITLE
Fixed the Today & Yesterday date ranges

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
@@ -84,11 +84,9 @@ class AnalyticsDateRangeCalculator @Inject constructor(
 
     private fun getDateOfLastDayTwoQuartersAgo() = dateUtils.getDateForLastDayOfPreviousQuarter(TWO)
 
-    private fun getYesterdayRange() = SimpleDateRange(getDateForTwoDaysAgo(), getDateForYesterday())
+    private fun getYesterdayRange() = SimpleDateRange(getDateForYesterday(), getDateForYesterday())
 
-    private fun getDateForTwoDaysAgo() = Date(dateUtils.getCurrentDateTimeMinusDays(TWO))
-
-    private fun getTodayRange() = SimpleDateRange(getDateForYesterday(), dateUtils.getCurrentDate())
+    private fun getTodayRange() = SimpleDateRange(dateUtils.getCurrentDate(), dateUtils.getCurrentDate())
 
     private fun getDateForYesterday() = Date(dateUtils.getCurrentDateTimeMinusDays(ONE))
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
@@ -43,7 +43,6 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
     @Test
     fun `when the current date is given then get the date range for today is the expected`() {
         // Given
-        whenever(dateUtils.getCurrentDateTimeMinusDays(1)).thenReturn(DATE_ZERO)
         whenever(dateUtils.getCurrentDate()).thenReturn(date)
 
         // When


### PR DESCRIPTION
This PR fixes the Today and Yesterday date ranges in the analytics hub. Previously these ranges each included an extra day, which inflated the results.

To test:

* Choose an active store
* Verify the Today & Yesterday in the analytics hub match the results in `wp-admin`.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
