### PR TITLE
Use `sp` for the TagView so it handles large fonts

### DIFF
--- a/WooCommerce/src/main/res/layout/analytics_information_section_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_information_section_view.xml
@@ -38,7 +38,7 @@
         <com.woocommerce.android.widgets.tags.TagView
             android:id="@+id/cardInformationSectionDeltaTag"
             android:layout_width="wrap_content"
-            android:layout_height="@dimen/major_150"
+            android:layout_height="@dimen/text_major_50"
             android:textSize="@dimen/text_minor_80"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="@+id/cardInformationSectionValue"


### PR DESCRIPTION
This small PR adjusts the percentage `TagViews` in the analytics hub so they better handle when the device is set to a larger font size. Here's how they look now

![before](https://user-images.githubusercontent.com/3903757/198128025-ce627909-e14b-41bd-a948-32e536e5f711.png)

And here's how they look in this PR:

![after](https://user-images.githubusercontent.com/3903757/198128073-5e1d1241-221a-4c8b-8352-aa6d8f56b4ae.png)

To test, switch between the various device font sizes and verify the tags look fine.

**Note:** It would also like to better handle the revenue values with larger font sizes so they don't wrap to two lines.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
