### PR TITLE
Fetch newly created account

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
@@ -50,7 +50,6 @@ class SignUpRepository @Inject constructor(
                 AccountCreationError(accountCreatedResult.error.apiError.toSignUpError())
             }
             else -> {
-                WooLog.w(WooLog.T.LOGIN, "Success creating new account")
                 dispatcher.dispatchAndAwait<UpdateTokenPayload, OnAuthenticationChanged>(
                     AccountActionBuilder.newUpdateAccessTokenAction(UpdateTokenPayload(accountCreatedResult.token))
                 ).let { updateTokenResult ->
@@ -68,6 +67,7 @@ class SignUpRepository @Inject constructor(
                                 )
                                 AccountCreationError(UNKNOWN_ERROR)
                             } else {
+                                WooLog.w(WooLog.T.LOGIN, "Success creating new account")
                                 AccountCreationSuccess
                             }
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
@@ -5,6 +5,7 @@ import androidx.core.text.isDigitsOnly
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.EMAIL_EXIST
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.EMAIL_INVALID
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.PASSWORD_INVALID
+import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.PASSWORD_TOO_SHORT
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.UNKNOWN_ERROR
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.dispatchAndAwait
@@ -85,7 +86,7 @@ class SignUpRepository @Inject constructor(
     ): SignUpError? {
         val invalidCredentialsError = when {
             !isValidEmail(email) -> EMAIL_INVALID
-            password.length < PASSWORD_MIN_LENGTH -> SignUpError.PASSWORD_TOO_SHORT
+            password.length < PASSWORD_MIN_LENGTH -> PASSWORD_TOO_SHORT
             password.isDigitsOnly() -> PASSWORD_INVALID
             else -> null
         }


### PR DESCRIPTION
Fixes: #2551

Adds missing logic to fetch the account right after creating it. This way the account token and username are available to the app. 