### PR TITLE
Issue/analytics large font revenue

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionView.kt
@@ -1,16 +1,20 @@
 package com.woocommerce.android.ui.analytics.informationcard
 
 import android.content.Context
+import android.os.Build
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.core.widget.TextViewCompat
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsInformationSectionViewBinding
 import com.woocommerce.android.widgets.tags.ITag
 import com.woocommerce.android.widgets.tags.TagConfig
+import org.wordpress.android.util.DisplayUtils
 import kotlin.math.absoluteValue
 
 internal class AnalyticsInformationSectionView @JvmOverloads constructor(
@@ -21,6 +25,22 @@ internal class AnalyticsInformationSectionView @JvmOverloads constructor(
     val binding = AnalyticsInformationSectionViewBinding.inflate(LayoutInflater.from(ctx), this)
 
     internal fun setViewState(sectionViewState: AnalyticsInformationSectionViewState) {
+        // on devices with a larger font size the revenue value may wrap to multiple lines, so we set the
+        // auto sizing programmatically on API levels that support it
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            val minSize = resources.getDimensionPixelSize(R.dimen.text_minor_100)
+            val maxSize = resources.getDimensionPixelSize(R.dimen.text_major_50)
+            val granularity = DisplayUtils.spToPx(context, 1F).toInt()
+            binding.cardInformationSectionValue.maxLines = 1
+            TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+                binding.cardInformationSectionValue,
+                minSize,
+                maxSize,
+                granularity,
+                TypedValue.COMPLEX_UNIT_PX
+            )
+        }
+
         visibility = View.VISIBLE
         binding.cardInformationSectionTitle.text = sectionViewState.title
         binding.cardInformationSectionValue.text = sectionViewState.value

--- a/WooCommerce/src/main/res/layout/analytics_information_section_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_information_section_view.xml
@@ -24,16 +24,16 @@
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/cardInformationSectionValue"
             style="@style/Woo.Card.Title"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_00"
             android:layout_marginTop="@dimen/major_100"
             android:layout_marginBottom="@dimen/major_100"
-            android:layout_marginStart="@dimen/minor_00"
             android:textSize="@dimen/text_major_50"
             app:layout_constraintBottom_toTopOf="@+id/cardInformationSectionDeltaTag"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/cardInformationSectionTitle"
-            tools:text="$359687" />
+            tools:text="$359,687.50" />
 
         <com.woocommerce.android.widgets.tags.TagView
             android:id="@+id/cardInformationSectionDeltaTag"


### PR DESCRIPTION
This PR adjusts the analytics revenue values so they don't wrap on devices with larger fonts. To test, simply view revenue with the various device font sizes and verify they look good.

**BEFORE**

![before](https://user-images.githubusercontent.com/3903757/198351978-e3cb0171-9c8d-487a-bde8-42e0ea354ff9.png)


**AFTER**

![after](https://user-images.githubusercontent.com/3903757/198352018-2b84f7dc-adda-4876-82ea-30e32d63bdff.png)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
