### PR TITLE
Enhancement/date card selectable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -95,7 +95,7 @@ class AnalyticsFragment :
 
     private fun bind(view: View) {
         _binding = FragmentAnalyticsBinding.bind(view)
-        binding.analyticsDateSelectorCard.setCalendarClickListener { viewModel.onDateRangeSelectorClick() }
+        binding.analyticsDateSelectorCard.setOnClickListener { viewModel.onDateRangeSelectorClick() }
         binding.analyticsRevenueCard.setSeeReportClickListener { viewModel.onRevenueSeeReportClick() }
         binding.analyticsOrdersCard.setSeeReportClickListener { viewModel.onOrdersSeeReportClick() }
         binding.analyticsProductsCard.setSeeReportClickListener { viewModel.onProductsSeeReportClick() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCardView.kt
@@ -14,7 +14,7 @@ class AnalyticsDateRangeCardView @JvmOverloads constructor(
 ) : MaterialCardView(ctx, attrs, defStyleAttr) {
     val binding = AnalyticsDateRangeCardViewBinding.inflate(LayoutInflater.from(ctx), this)
 
-    fun setCalendarClickListener(onClickListener: ((view: View) -> Unit)) {
+    fun setOnClickListener(onClickListener: ((view: View) -> Unit)) {
         binding.root.setOnClickListener(onClickListener)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCardView.kt
@@ -15,7 +15,7 @@ class AnalyticsDateRangeCardView @JvmOverloads constructor(
     val binding = AnalyticsDateRangeCardViewBinding.inflate(LayoutInflater.from(ctx), this)
 
     fun setCalendarClickListener(onClickListener: ((view: View) -> Unit)) {
-        binding.btnDateRangeSelector.setOnClickListener(onClickListener)
+        binding.root.setOnClickListener(onClickListener)
     }
 
     fun updateFromText(fromDatePeriod: String) {

--- a/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
@@ -35,12 +35,11 @@
             app:layout_constraintTop_toBottomOf="@+id/tv_toDate"
             tools:text="vs Previous Period (10 Sept 2021)" />
 
-        <ImageButton
+        <ImageView
             android:id="@+id/btn_dateRangeSelector"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="@dimen/major_100"
-            android:background="?selectableItemBackgroundBorderless"
             android:contentDescription="@string/analytics_date_range_selector_description"
             app:layout_constraintBottom_toBottomOf="@+id/tv_fromDate"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
@@ -40,12 +40,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="@dimen/major_100"
-            android:contentDescription="@string/analytics_date_range_selector_description"
+            android:importantForAccessibility="no"
             app:layout_constraintBottom_toBottomOf="@+id/tv_fromDate"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/tv_toDate"
-            app:srcCompat="@drawable/ic_analytics_calendar"
-            tools:ignore="TouchTargetSizeCheck" />
+            app:srcCompat="@drawable/ic_analytics_calendar" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>


### PR DESCRIPTION
### Description
This small PR makes the whole DateRangeCardView selectable and not only the image button.
p1666895225751919-slack-C02KUCFCSFP

### Testing instructions

1. Open My Store screen
2. Press the See more button under the store stats chart
3. Check that the whole Date Range view is selectable and that if you press the view, the date selection dialog is displayed.

### Images/gif

https://user-images.githubusercontent.com/18119390/198371741-b1bdd9cd-df8a-4f7b-b25f-4a0b7cab1d93.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->