### PR TITLE
Feature/7510 tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -111,6 +111,12 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     LOGIN_WITH_QR_CODE_BUTTON_TAPPED(siteless = true),
     LOGIN_WITH_QR_CODE_SCANNED(siteless = true),
 
+    LOGIN_PROLOGUE_CREATE_SITE_TAPPED(siteless = true),
+    SIGNUP_LOGIN_BUTTON_TAPPED(siteless = true),
+    SIGNUP_SUBMITTED(siteless = true),
+    SIGNUP_SUCCESS(siteless = true),
+    SIGNUP_ERROR(siteless = true),
+
     // -- Site Picker
     SITE_PICKER_STORES_SHOWN(siteless = true),
     SITE_PICKER_CONTINUE_TAPPED(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -58,6 +58,7 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
 
         binding.buttonGetStarted.isVisible = FeatureFlag.ACCOUNT_CREATION_FLOW.isEnabled()
         binding.buttonGetStarted.setOnClickListener {
+            AnalyticsTracker.track(stat = AnalyticsEvent.LOGIN_PROLOGUE_CREATE_SITE_TAPPED)
             prologueFinishedListener?.onGetStartedClicked()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
@@ -28,6 +28,7 @@ class SignUpRepository @Inject constructor(
         const val EMAIL_EXIST_API_ERROR = "email_exists"
         const val EMAIL_INVALID_API_ERROR = "email_invalid"
         const val PASSWORD_INVALID_API_ERROR = "password_invalid"
+        const val USERNAME_INVALID_API_ERROR = "username_invalid"
         const val PASSWORD_MIN_LENGTH = 7
     }
 
@@ -113,6 +114,7 @@ class SignUpRepository @Inject constructor(
             this == EMAIL_EXIST_API_ERROR -> EMAIL_EXIST
             this == EMAIL_INVALID_API_ERROR -> EMAIL_INVALID
             this == PASSWORD_INVALID_API_ERROR -> PASSWORD_INVALID
+            this == USERNAME_INVALID_API_ERROR -> SignUpError.USERNAME_INVALID
             else -> UNKNOWN_ERROR
         }
 
@@ -121,6 +123,7 @@ class SignUpRepository @Inject constructor(
         EMAIL_INVALID,
         PASSWORD_INVALID,
         PASSWORD_TOO_SHORT,
+        USERNAME_INVALID,
         UNKNOWN_ERROR
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -98,7 +98,8 @@ class SignUpViewModel @Inject constructor(
                 type = PASSWORD,
                 stringId = R.string.signup_password_too_short
             )
-            SignUpError.UNKNOWN_ERROR -> SignUpErrorUi(
+            SignUpError.UNKNOWN_ERROR,
+            SignUpError.USERNAME_INVALID -> SignUpErrorUi(
                 type = UNKNOWN,
                 stringId = R.string.signup_api_generic_error
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7510
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Add tracking for signup

### Testing instructions
Check the following in the logcat: 
- When clicking on "Get started" from prologue: `Tracked: login_prologue_create_site_tapped, Properties: {"is_debug":true}`
- When clicking on "Log in" from sign up screen: `Tracked: signup_login_button_tapped, Properties: {"is_debug":true}`
- When clicking on "Get started" from sign up screen: `Tracked: signup_submitted, Properties: {"is_debug":true}`
- When getting an error on sign up. The error type property must match the error from the screen: `signup_error, Properties: {"error_type":"EMAIL_INVALID","is_debug":true}`
- When signing up successfully: `Tracked: signup_success, Properties: {"is_debug":true}`


