### PR TITLE
Fix duplicate year to date in date range selector

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.datepicker.CalendarConstraints
 import com.google.android.material.datepicker.MaterialDatePicker
@@ -73,15 +72,15 @@ class AnalyticsFragment :
 
     private fun openDateRangeSelector() = findNavController().navigateSafely(buildDialogDateRangeSelectorArguments())
 
-    private fun buildDialogDateRangeSelectorArguments(): NavDirections {
-        val ranges = getDateRangeSelectorViewState().availableRangeDates.toTypedArray()
-        return AnalyticsFragmentDirections.actionAnalyticsFragmentToDateRangeSelector(
-            requestKey = KEY_DATE_RANGE_SELECTOR_RESULT,
-            keys = ranges,
-            values = ranges,
-            selectedItem = getDateRangeSelectorViewState().selectedPeriod
-        )
-    }
+    private fun buildDialogDateRangeSelectorArguments() =
+        getDateRangeSelectorViewState().availableRangeDates.toTypedArray().let { ranges ->
+            AnalyticsFragmentDirections.actionAnalyticsFragmentToDateRangeSelector(
+                requestKey = KEY_DATE_RANGE_SELECTOR_RESULT,
+                keys = ranges,
+                values = ranges,
+                selectedItem = getDateRangeSelectorViewState().selectedPeriod
+            )
+        }
 
     private fun setupResultHandlers(viewModel: AnalyticsViewModel) {
         handleDialogResult<String>(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.datepicker.CalendarConstraints
 import com.google.android.material.datepicker.MaterialDatePicker
@@ -72,13 +73,15 @@ class AnalyticsFragment :
 
     private fun openDateRangeSelector() = findNavController().navigateSafely(buildDialogDateRangeSelectorArguments())
 
-    private fun buildDialogDateRangeSelectorArguments() =
-        AnalyticsFragmentDirections.actionAnalyticsFragmentToDateRangeSelector(
+    private fun buildDialogDateRangeSelectorArguments(): NavDirections {
+        val ranges = getDateRangeSelectorViewState().availableRangeDates.distinct().toTypedArray()
+        return AnalyticsFragmentDirections.actionAnalyticsFragmentToDateRangeSelector(
             requestKey = KEY_DATE_RANGE_SELECTOR_RESULT,
-            keys = getDateRangeSelectorViewState().availableRangeDates.toTypedArray(),
-            values = getDateRangeSelectorViewState().availableRangeDates.toTypedArray(),
+            keys = ranges,
+            values = ranges,
             selectedItem = getDateRangeSelectorViewState().selectedPeriod
         )
+    }
 
     private fun setupResultHandlers(viewModel: AnalyticsViewModel) {
         handleDialogResult<String>(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -74,7 +74,7 @@ class AnalyticsFragment :
     private fun openDateRangeSelector() = findNavController().navigateSafely(buildDialogDateRangeSelectorArguments())
 
     private fun buildDialogDateRangeSelectorArguments(): NavDirections {
-        val ranges = getDateRangeSelectorViewState().availableRangeDates.distinct().toTypedArray()
+        val ranges = getDateRangeSelectorViewState().availableRangeDates.toTypedArray()
         return AnalyticsFragmentDirections.actionAnalyticsFragmentToDateRangeSelector(
             requestKey = KEY_DATE_RANGE_SELECTOR_RESULT,
             keys = ranges,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -356,7 +356,6 @@
         <item translatable="false">@string/date_timeframe_month_to_date</item>
         <item translatable="false">@string/date_timeframe_quarter_to_date</item>
         <item translatable="false">@string/date_timeframe_year_to_date</item>
-        <item translatable="false">@string/date_timeframe_year_to_date</item>
     </string-array>
     <string name="analytics_see_report_button_text">See report</string>e
     <string name="analytics_see_report_button_content_description">See more report details</string>


### PR DESCRIPTION
Summary
==========
Fix issue #7680 by removing the duplicate resource of the `Year to Date` text inside the Date Range selection.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20221028_140131](https://user-images.githubusercontent.com/5920403/198719705-a50af069-ccb7-4f0f-9b8f-0698bd5f838a.png) | ![Screenshot_20221028_164501](https://user-images.githubusercontent.com/5920403/198719717-53ce3f59-b478-4067-ba23-23252fb8ed1b.png) |

How to Test
==========
1. Simply verify if the duplication of the Year to date is gone

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.