### PR TITLE
Add missing analytics hub tracks triggers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,10 +3,6 @@
 -----
 
 
-11.1
------
-- [***] We added a new Analytics Hub inside the My Store area of the app. Simply click on the See More button under the store stats to check more detailed information on Revenue and Orders. (https://github.com/woocommerce/woocommerce-android/pull/7556)
-
 11.0
 -----
 - [*] Fixed a bug caused by statement descriptor value too long or containing illegal chars [https://github.com/woocommerce/woocommerce-android/pull/7595]
@@ -14,6 +10,7 @@
 - [*] [Internal] Simplified login: update the "WP Account not found" screen [https://github.com/woocommerce/woocommerce-android/pull/7639]
 - [**] Display Just In Time Message (JITM) related to card reader purchase on the MyStore screen [https://github.com/woocommerce/woocommerce-android/pull/7652]
 - [*] [Internal] IPP plugins statuses added as zendesk tags [https://github.com/woocommerce/woocommerce-android/pull/7624]
+- [***] We added a new Analytics Hub inside the My Store area of the app. Simply click on the See More button under the store stats to check more detailed information on Revenue and Orders. (https://github.com/woocommerce/woocommerce-android/pull/7556)
 
 10.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentAnalyticsBinding
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.scrollStartEvents
 import com.woocommerce.android.ui.analytics.RefreshIndicator.ShowIndicator
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
 import com.woocommerce.android.ui.base.BaseFragment
@@ -20,6 +21,8 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class AnalyticsFragment :
@@ -49,9 +52,13 @@ class AnalyticsFragment :
         viewModel.event.observe(viewLifecycleOwner) { event -> handleEvent(event) }
         binding.analyticsRefreshLayout.setOnRefreshListener {
             binding.analyticsRefreshLayout.scrollUpChild = binding.scrollView
+            viewModel.onTrackableUIInteraction()
             viewModel.onRefreshRequested()
         }
         binding.analyticsProductsCard.isVisible = FeatureFlag.ANALYTICS_HUB_PRODUCTS_AND_REPORTS.isEnabled()
+        binding.scrollView.scrollStartEvents()
+            .onEach { viewModel.onTrackableUIInteraction() }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -161,6 +161,7 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     fun onDateRangeSelectorClick() {
+        onTrackableUIInteraction()
         AnalyticsTracker.track(AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_BUTTON_TAPPED)
         triggerEvent(AnalyticsViewEvent.OpenDateRangeSelector)
     }
@@ -190,6 +191,10 @@ class AnalyticsViewModel @Inject constructor(
         } else {
             triggerEvent(OpenUrl(analyticsRepository.getProductsAdminPanelUrl()))
         }
+    }
+
+    fun onTrackableUIInteraction() {
+        usageTracksEventEmitter.interacted()
     }
 
     private fun updateRevenue(isRefreshing: Boolean, showSkeleton: Boolean) =
@@ -459,6 +464,7 @@ class AnalyticsViewModel @Inject constructor(
         ?: getDefaultTimePeriod()
 
     private fun trackSeeReportClicked(selectedCardType: String) {
+        onTrackableUIInteraction()
         AnalyticsTracker.track(
             AnalyticsEvent.ANALYTICS_HUB_SEE_REPORT_TAPPED,
             mapOf(
@@ -468,6 +474,7 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     private fun trackSelectedDateRange(selectedTimePeriod: AnalyticTimePeriod) {
+        onTrackableUIInteraction()
         AnalyticsTracker.track(
             AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_SELECTED,
             mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformation
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.LoadingViewState
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.NoDataState
 import com.woocommerce.android.ui.analytics.listcard.AnalyticsListCardItemViewState
+import com.woocommerce.android.ui.mystore.MyStoreStatsUsageTracksEventEmitter
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
@@ -62,6 +63,7 @@ class AnalyticsViewModel @Inject constructor(
     private val analyticsRepository: AnalyticsRepository,
     private val selectedSite: SelectedSite,
     private val transactionLauncher: AnalyticsHubTransactionLauncher,
+    private val usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -193,9 +193,7 @@ class AnalyticsViewModel @Inject constructor(
         }
     }
 
-    fun onTrackableUIInteraction() {
-        usageTracksEventEmitter.interacted()
-    }
+    fun onTrackableUIInteraction() = usageTracksEventEmitter.interacted()
 
     private fun updateRevenue(isRefreshing: Boolean, showSkeleton: Boolean) =
         launch {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
@@ -510,7 +510,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         AnalyticsViewModel(
             resourceProvider, dateUtil, calculator,
             currencyFormatter, analyticsRepository,
-            selectedSite, mock(), savedState
+            selectedSite, mock(), mock(), savedState
         )
 
     private fun getRevenueStats(


### PR DESCRIPTION
Summary
==========
This is a hotfix to add a missing piece of tracks to the Analytics Hub, it also adjusts the Analytics Hub release notes information to the correct version.

How to Test
==========
1. Open the Woo app with the Analytics Hub feature flag enabled
2. Click on the `See more` button inside the My Store stats
3. Verify that the Analytics Hub opens, click the date selector on the top right corner and change it
4. Click on the `See Report` button
6. Return from the browser back to the Analytics Hub
7. Execute a pull to refresh action
8. Verify that the `used_analytics` tracks are triggered as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.