### PR TITLE
Improve simulated reader toggle on dev options screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsFragment.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentDeveloperOptionsBinding
 import com.woocommerce.android.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.ToastUtils
 
 @AndroidEntryPoint
 class DeveloperOptionsFragment : BaseFragment(R.layout.fragment_developer_options) {
@@ -21,6 +22,7 @@ class DeveloperOptionsFragment : BaseFragment(R.layout.fragment_developer_option
 
         initViews(binding)
         observeViewState(binding)
+        observeEvents()
     }
 
     private fun initViews(binding: FragmentDeveloperOptionsBinding) {
@@ -29,6 +31,18 @@ class DeveloperOptionsFragment : BaseFragment(R.layout.fragment_developer_option
             DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL)
         )
         binding.developerOptionsRv.adapter = DeveloperOptionsAdapter()
+    }
+
+    private fun observeEvents() {
+        viewModel.event.observe(
+            viewLifecycleOwner
+        ) { event ->
+            when (event) {
+                is DeveloperOptionsViewModel.DeveloperOptionsEvents.ShowToastString -> {
+                    ToastUtils.showToast(context, event.message)
+                }
+            }
+        }
     }
 
     private fun observeViewState(binding: FragmentDeveloperOptionsBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsRepository.kt
@@ -1,15 +1,11 @@
 package com.woocommerce.android.ui.prefs
 
-import android.content.Context
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.payments.cardreader.ClearCardReaderDataAction
-import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 class DeveloperOptionsRepository @Inject constructor(
     private val appPrefs: AppPrefs,
-    private val context: Context,
     private val clearCardReaderDataAction: ClearCardReaderDataAction
 ) {
 
@@ -23,9 +19,5 @@ class DeveloperOptionsRepository @Inject constructor(
 
     suspend fun clearSelectedCardReader() {
         clearCardReaderDataAction.invoke()
-    }
-
-    fun showToast() {
-        ToastUtils.showToast(context, R.string.simulated_reader_toast)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsRepository.kt
@@ -1,12 +1,17 @@
 package com.woocommerce.android.ui.prefs
 
+import android.content.Context
+import android.widget.Toast
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
+import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 class DeveloperOptionsRepository @Inject constructor(
     private val appPrefs: AppPrefs,
-    private val cardReaderManager: CardReaderManager
+    private val cardReaderManager: CardReaderManager,
+    private val context: Context
 ) {
 
     fun isSimulatedCardReaderEnabled(): Boolean {
@@ -19,6 +24,9 @@ class DeveloperOptionsRepository @Inject constructor(
 
     suspend fun clearSelectedCardReader() {
         cardReaderManager.disconnectReader()
+    }
 
+    fun showToast() {
+        ToastUtils.showToast(context, R.string.simulated_reader_toast)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsRepository.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.prefs
 
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.cardreader.CardReaderManager
 import javax.inject.Inject
 
 class DeveloperOptionsRepository @Inject constructor(
-    private val appPrefs: AppPrefs
+    private val appPrefs: AppPrefs,
+    private val cardReaderManager: CardReaderManager
 ) {
 
     fun isSimulatedCardReaderEnabled(): Boolean {
@@ -13,5 +15,10 @@ class DeveloperOptionsRepository @Inject constructor(
 
     fun changeSimulatedReaderState(isChecked: Boolean) {
         appPrefs.isSimulatedReaderEnabled = isChecked
+    }
+
+    suspend fun clearSelectedCardReader() {
+        cardReaderManager.disconnectReader()
+
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsRepository.kt
@@ -1,17 +1,16 @@
 package com.woocommerce.android.ui.prefs
 
 import android.content.Context
-import android.widget.Toast
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
-import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.ui.payments.cardreader.ClearCardReaderDataAction
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 class DeveloperOptionsRepository @Inject constructor(
     private val appPrefs: AppPrefs,
-    private val cardReaderManager: CardReaderManager,
-    private val context: Context
+    private val context: Context,
+    private val clearCardReaderDataAction: ClearCardReaderDataAction
 ) {
 
     fun isSimulatedCardReaderEnabled(): Boolean {
@@ -23,7 +22,7 @@ class DeveloperOptionsRepository @Inject constructor(
     }
 
     suspend fun clearSelectedCardReader() {
-        cardReaderManager.disconnectReader()
+        clearCardReaderDataAction.invoke()
     }
 
     fun showToast() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -42,7 +42,6 @@ class DeveloperOptionsViewModel @Inject constructor(
         )
     )
 
-
     private fun onSimulatedReaderToggled(isChecked: Boolean) {
         if (!isChecked) {
             launch {
@@ -53,9 +52,11 @@ class DeveloperOptionsViewModel @Inject constructor(
 
         developerOptionsRepository.changeSimulatedReaderState(isChecked)
         val currentViewState = viewState.value
-        (currentViewState?.rows?.find {
-            it.devOptionsKey == UiStringRes(string.simulated_reader_key)
-        } as? ToggleableListItem)?.let { originalListItem ->
+        (
+            currentViewState?.rows?.find {
+                it.devOptionsKey == UiStringRes(string.simulated_reader_key)
+            } as? ToggleableListItem
+            )?.let { originalListItem ->
             val newState = originalListItem.copy(isChecked = isChecked)
             _viewState.value = currentViewState.copy(
                 rows = currentViewState.rows.map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -35,7 +35,7 @@ class DeveloperOptionsViewModel @Inject constructor(
         ToggleableListItem(
             icon = drawable.img_card_reader_connecting,
             label = UiStringRes(string.enable_card_reader),
-            devOptionsKey = UiStringRes(string.simulated_reader_key),
+            key = UiStringRes(string.simulated_reader_key),
             isEnabled = true,
             isChecked = developerOptionsRepository.isSimulatedCardReaderEnabled(),
             onToggled = ::onSimulatedReaderToggled
@@ -54,7 +54,7 @@ class DeveloperOptionsViewModel @Inject constructor(
         val currentViewState = viewState.value
         (
             currentViewState?.rows?.find {
-                it.devOptionsKey == UiStringRes(string.simulated_reader_key)
+                it.key == UiStringRes(string.simulated_reader_key)
             } as? ToggleableListItem
             )?.let { originalListItem ->
             val newState = originalListItem.copy(isChecked = isChecked)
@@ -75,13 +75,13 @@ class DeveloperOptionsViewModel @Inject constructor(
             abstract val label: UiString
             abstract val icon: Int?
             abstract var isEnabled: Boolean
-            abstract var devOptionsKey: UiString
+            abstract var key: UiString
 
             data class ToggleableListItem(
                 @DrawableRes override val icon: Int,
                 override val label: UiString,
                 override var isEnabled: Boolean = false,
-                override var devOptionsKey: UiString,
+                override var key: UiString,
                 val onToggled: (Boolean) -> Unit,
                 val isChecked: Boolean
             ) : ListItem()
@@ -90,7 +90,7 @@ class DeveloperOptionsViewModel @Inject constructor(
                 @DrawableRes override val icon: Int,
                 override val label: UiString,
                 override var isEnabled: Boolean = false,
-                override var devOptionsKey: UiString,
+                override var key: UiString,
                 val onClick: () -> Unit
             ) : ListItem()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.prefs.DeveloperOptionsViewModel.DeveloperOptio
 import com.woocommerce.android.ui.prefs.DeveloperOptionsViewModel.DeveloperOptionsViewState.ListItem.ToggleableListItem
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -44,10 +45,10 @@ class DeveloperOptionsViewModel @Inject constructor(
 
     private fun onSimulatedReaderToggled(isChecked: Boolean) {
         if (!isChecked) {
-//            launch {
-//                developerOptionsRepository.clearSelectedCardReader()
-//            }
-            developerOptionsRepository.showToast()
+            launch {
+                developerOptionsRepository.clearSelectedCardReader()
+                developerOptionsRepository.showToast()
+            }
         }
 
         developerOptionsRepository.changeSimulatedReaderState(isChecked)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.prefs
 
 import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -9,12 +8,10 @@ import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
-import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent
 import com.woocommerce.android.ui.prefs.DeveloperOptionsViewModel.DeveloperOptionsViewState.ListItem
 import com.woocommerce.android.ui.prefs.DeveloperOptionsViewModel.DeveloperOptionsViewState.ListItem.ToggleableListItem
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 @HiltViewModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -8,11 +9,12 @@ import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent
 import com.woocommerce.android.ui.prefs.DeveloperOptionsViewModel.DeveloperOptionsViewState.ListItem
 import com.woocommerce.android.ui.prefs.DeveloperOptionsViewModel.DeveloperOptionsViewState.ListItem.ToggleableListItem
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
+import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 @HiltViewModel
@@ -42,11 +44,13 @@ class DeveloperOptionsViewModel @Inject constructor(
         )
     )
 
+
     private fun onSimulatedReaderToggled(isChecked: Boolean) {
         if (!isChecked) {
-            launch {
-                developerOptionsRepository.clearSelectedCardReader()
-            }
+//            launch {
+//                developerOptionsRepository.clearSelectedCardReader()
+//            }
+            developerOptionsRepository.showToast()
         }
 
         developerOptionsRepository.changeSimulatedReaderState(isChecked)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1753,9 +1753,10 @@
     <string name="dev_options">Developer Options</string>
 
     <!--
-        Settings
+        Developer Options Screen
     -->
     <string name="enable_card_reader">Enable Simulated Card Reader</string>
+    <string name="simulated_reader_key">Simulated Reader Key</string>
 
     <!--
         WCToggleSingleOptionView

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1763,6 +1763,7 @@
     -->
     <string name="toggle_option_checked">option checked</string>
     <string name="toggle_option_not_checked">option not checked</string>
+    <string name="simulated_reader_toast">Simulated Card Reader has been disabled</string>
     <!--
         Help and support
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7670 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds the logic to disconnect the selected card reader once you toggle the simulated reader off. 
Also adds a toast message to indicate the reader was disconnected

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1 - in Debug build -> Go to the App Menu - Settings - Developer Options
2 - Toggle the Simulated Reader ON
3 - create a simple payment or an order
4 - take the payment via credit card
5 - make sure the simulated reader is activated (It might ask you to select which reader, select the one according to where your store is based - US or Canada)
6 - Go back to the settings screen - Developer Options
7 - Toggle the simulated reader OFF
8 - repeat the steps to collect a payment
9 - Make sure the simulated reader won't activate

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/30724184/198836485-a0db5762-1a1d-4634-b89b-1114dc4a0fd6.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
