### PR TITLE
Test: Fix build issues related to jCenter

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,14 +6,10 @@ pluginManagement {
     gradle.ext.navigationVersion = '2.4.1'
 
     repositories {
-        maven {
-            url 'https://a8c-libs.s3.amazonaws.com/android'
-            content {
-                includeGroup "com.automattic.android"
-            }
-        }
+        mavenCentral()
         gradlePluginPortal()
         google()
+
     }
 
     plugins {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,12 @@ pluginManagement {
     gradle.ext.navigationVersion = '2.4.1'
 
     repositories {
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+            content {
+                includeGroup "com.automattic.android"
+            }
+        }
         gradlePluginPortal()
         google()
     }


### PR DESCRIPTION
### Description
This PR adds `mavenCentral` to the list of plugin repositories, this is needed because `gradlePluginPortal` simply mirrors to `jCenter` according to the official documentation https://blog.gradle.org/jcenter-shutdown:
> The Gradle Plugin Portal implicitly mirrors JCenter currently. If you’re using the Plugin Portal (via gradlePluginPortal() or the URL [plugins.gradle.org/m2](http://plugins.gradle.org/m2)) to resolve your application’s dependencies, you may be relying on JCenter. You should avoid using the Plugin Portal as a repository, except for Gradle plugin projects.

I kept the same order of repositories as the default project template from Android Studio, but I wonder if we shouldn't move `gradlePluginPortal` to the last place to avoid long build times when `jCenter` is not working.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
