### PR TITLE
IAP: Handle VM death during IAP in progress

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseActivity.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseActivity.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.iapshowcase
 import android.os.Bundle
 import android.util.Log
 import android.widget.Button
-import android.widget.EditText
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
@@ -15,6 +14,7 @@ import com.woocommerce.android.iap.pub.IAPActivityWrapper
 import com.woocommerce.android.iap.pub.IAPSitePurchasePlanFactory
 
 private const val MILLION = 1_000_000.0
+private const val REMOTE_SITE_ID = 1L
 
 class IAPShowcaseActivity : AppCompatActivity() {
     private val viewModel: IAPShowcaseViewModel by viewModels(null) {
@@ -23,7 +23,8 @@ class IAPShowcaseActivity : AppCompatActivity() {
                 IAPShowcaseViewModel(
                     IAPSitePurchasePlanFactory.createIAPSitePurchasePlan(
                         this@IAPShowcaseActivity.application,
-                        IAPDebugLogWrapper()
+                        REMOTE_SITE_ID,
+                        IAPDebugLogWrapper(),
                     )
                 ) as T
         }
@@ -39,10 +40,7 @@ class IAPShowcaseActivity : AppCompatActivity() {
             viewModel.fetchWPComPlanProduct()
         }
         findViewById<Button>(R.id.btnStartPurchase).setOnClickListener {
-            viewModel.purchasePlan(
-                IAPActivityWrapper(this),
-                findViewById<EditText>(R.id.etRemoteBlogId).text?.toString()?.toLong() ?: 1L
-            )
+            viewModel.purchasePlan(IAPActivityWrapper(this))
         }
         findViewById<Button>(R.id.btnCheckIfPlanPurchased).setOnClickListener {
             viewModel.checkIfWPComPlanPurchased()

--- a/WooCommerce/src/debug/res/layout/activity_iapshowcase.xml
+++ b/WooCommerce/src/debug/res/layout/activity_iapshowcase.xml
@@ -65,16 +65,6 @@
             android:layout_marginTop="16dp"
             android:text="@string/showcase_iap_check_if_plan_purchased" />
 
-        <EditText
-            android:id="@+id/etRemoteBlogId"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
-            android:hint="@string/showcase_iap_remote_blog_id"
-            android:inputType="number"
-            android:text="1"
-            tools:ignore="HardcodedText" />
-
         <Button
             android:id="@+id/btnStartPurchase"
             android:layout_width="match_parent"

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPExt.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPExt.kt
@@ -11,6 +11,7 @@ val ProductDetails.priceOfTheFirstPurchasedOfferInMicros
 val ProductDetails.currencyOfTheFirstPurchasedOffer
     get() = subscriptionOfferDetails?.get(0)!!.pricingPhases.pricingPhaseList[0]!!.priceCurrencyCode
 
+// TODO support for multiple offers?
 val ProductDetails.firstOfferToken
     get() = subscriptionOfferDetails!!.first().offerToken
 

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPExt.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPExt.kt
@@ -4,14 +4,12 @@ import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
 
-// TODO support for multiple plans?
 val ProductDetails.priceOfTheFirstPurchasedOfferInMicros
     get() = subscriptionOfferDetails?.get(0)!!.pricingPhases.pricingPhaseList[0]!!.priceAmountMicros
 
 val ProductDetails.currencyOfTheFirstPurchasedOffer
     get() = subscriptionOfferDetails?.get(0)!!.pricingPhases.pricingPhaseList[0]!!.priceCurrencyCode
 
-// TODO support for multiple offers?
 val ProductDetails.firstOfferToken
     get() = subscriptionOfferDetails!!.first().offerToken
 

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManager.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManager.kt
@@ -40,7 +40,7 @@ internal class IAPManager(
 
     private var purchaseStatusCheckerJob: Job? = null
 
-    val purchaseWpComPlanResult: Flow<IAPPurchaseResult> = iapPurchasesUpdatedListener.purchaseWpComPlanResult.map {
+    val iapPurchaseResult: Flow<IAPPurchaseResult> = iapPurchasesUpdatedListener.purchaseResult.map {
         purchaseStatusCheckerJob?.cancel()
         mapPurchaseResultToIAPPurchaseResult(it)
     }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManagerFactory.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManagerFactory.kt
@@ -19,8 +19,8 @@ internal object IAPManagerFactory {
             iapBillingClientStateHandler,
             iapOutMapper,
             iapInMapper,
-            iapPurchasesUpdatedListener,
             logWrapper,
+            iapPurchasesUpdatedListener,
         )
     }
 }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManagerFactory.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPManagerFactory.kt
@@ -19,8 +19,8 @@ internal object IAPManagerFactory {
             iapBillingClientStateHandler,
             iapOutMapper,
             iapInMapper,
-            logWrapper,
             iapPurchasesUpdatedListener,
+            logWrapper,
         )
     }
 }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPPurchasesUpdatedListener.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPPurchasesUpdatedListener.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.flow.mapNotNull
 internal class IAPPurchasesUpdatedListener(
     private val logWrapper: IAPLogWrapper,
 ) : PurchasesUpdatedListener {
-    private val _purchaseWpComPlanResult = MutableStateFlow<PurchasesResult?>(null)
-    val purchaseWpComPlanResult: Flow<PurchasesResult> = _purchaseWpComPlanResult.mapNotNull { it }
+    private val _purchaseResult = MutableStateFlow<PurchasesResult?>(null)
+    val purchaseResult: Flow<PurchasesResult> = _purchaseResult.mapNotNull { it }
 
     override fun onPurchasesUpdated(billingResult: BillingResult, purchases: List<Purchase>?) {
         logWrapper.d(IAP_LOG_TAG, "onPurchasesUpdated $billingResult $purchases")
@@ -25,6 +25,6 @@ internal class IAPPurchasesUpdatedListener(
     }
 
     fun onPurchaseAvailable(purchasesResult: PurchasesResult) {
-        _purchaseWpComPlanResult.value = purchasesResult
+        _purchaseResult.value = purchasesResult
     }
 }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPPurchasesUpdatedListener.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/core/IAPPurchasesUpdatedListener.kt
@@ -21,6 +21,10 @@ internal class IAPPurchasesUpdatedListener(
         val responseCode = billingResult.responseCode
         val debugMessage = billingResult.debugMessage
         logWrapper.d(IAP_LOG_TAG, "onPurchasesUpdated: $responseCode $debugMessage")
-        _purchaseWpComPlanResult.value = PurchasesResult(billingResult, purchases.orEmpty())
+        onPurchaseAvailable(PurchasesResult(billingResult, purchases.orEmpty()))
+    }
+
+    fun onPurchaseAvailable(purchasesResult: PurchasesResult) {
+        _purchaseWpComPlanResult.value = purchasesResult
     }
 }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/model/IAPPurchaseResult.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/model/IAPPurchaseResult.kt
@@ -2,9 +2,9 @@ package com.woocommerce.android.iap.internal.model
 
 import com.woocommerce.android.iap.pub.model.IAPError
 
-internal sealed class IAPPurchaseResponse {
-    data class Success(val purchases: List<IAPPurchase>?) : IAPPurchaseResponse()
-    data class Error(val error: IAPError.Billing) : IAPPurchaseResponse()
+internal sealed class IAPPurchaseResult {
+    data class Success(val purchases: List<IAPPurchase>?) : IAPPurchaseResult()
+    data class Error(val error: IAPError.Billing) : IAPPurchaseResult()
 }
 
 internal data class IAPPurchase(

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
@@ -43,7 +43,7 @@ internal class IAPPurchaseWPComPlanActionsImpl(
 
     override val purchaseWpComPlanResult: Flow<WPComPurchaseResult> = merge(
         purchaseWpComPlanFetchingProductsError.mapNotNull { it },
-        iapManager.iapPurchaseResult.map { mapPurchaseResultToWPComPurchaseResult(it) },
+        iapManager.iapPurchaseResult.map { handleNewPurchaseResultEvent(it) },
     )
 
     override suspend fun isWPComPlanPurchased(): WPComIsPurchasedResult {
@@ -92,7 +92,7 @@ internal class IAPPurchaseWPComPlanActionsImpl(
         iapManager.disconnect()
     }
 
-    private suspend fun mapPurchaseResultToWPComPurchaseResult(response: IAPPurchaseResult) = when (response) {
+    private suspend fun handleNewPurchaseResultEvent(response: IAPPurchaseResult) = when (response) {
         is IAPPurchaseResult.Success -> {
             val purchase = response.purchases!!.first()
             confirmPurchaseOnBackend(remoteSiteId, purchase)

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
@@ -43,7 +43,7 @@ internal class IAPPurchaseWPComPlanActionsImpl(
 
     override val purchaseWpComPlanResult: Flow<WPComPurchaseResult> = merge(
         purchaseWpComPlanFetchingProductsError.mapNotNull { it },
-        iapManager.purchaseWpComPlanResult.map { mapPurchaseResultToWPComPurchaseResult(it) },
+        iapManager.iapPurchaseResult.map { mapPurchaseResultToWPComPurchaseResult(it) },
     )
 
     override suspend fun isWPComPlanPurchased(): WPComIsPurchasedResult {

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/pub/IAPSitePurchasePlanFactory.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/pub/IAPSitePurchasePlanFactory.kt
@@ -9,10 +9,11 @@ import com.woocommerce.android.iap.internal.planpurchase.IAPPurchaseWPComPlanAct
 object IAPSitePurchasePlanFactory {
     fun createIAPSitePurchasePlan(
         context: Application,
+        remoteSiteId: Long,
         logWrapper: IAPLogWrapper,
     ): PurchaseWPComPlanActions {
         val iapMobilePayAPI: IAPMobilePayAPI = IAPMobilePayAPIStub(logWrapper)
         val iapManager = IAPManagerFactory.createIAPManager(context, logWrapper)
-        return IAPPurchaseWPComPlanActionsImpl(iapMobilePayAPI, iapManager)
+        return IAPPurchaseWPComPlanActionsImpl(iapMobilePayAPI, iapManager, remoteSiteId)
     }
 }

--- a/libs/iap/src/main/java/com/woocommerce/android/iap/pub/PurchaseWPComPlanActions.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/pub/PurchaseWPComPlanActions.kt
@@ -4,11 +4,14 @@ import com.woocommerce.android.iap.internal.model.IAPSupportedResult
 import com.woocommerce.android.iap.pub.model.WPComIsPurchasedResult
 import com.woocommerce.android.iap.pub.model.WPComProductResult
 import com.woocommerce.android.iap.pub.model.WPComPurchaseResult
+import kotlinx.coroutines.flow.Flow
 import java.io.Closeable
 
 interface PurchaseWPComPlanActions : Closeable {
+    val purchaseWpComPlanResult: Flow<WPComPurchaseResult>
+
     suspend fun isWPComPlanPurchased(): WPComIsPurchasedResult
-    suspend fun purchaseWPComPlan(activityWrapper: IAPActivityWrapper, remoteSiteId: Long): WPComPurchaseResult
+    suspend fun purchaseWPComPlan(activityWrapper: IAPActivityWrapper)
     suspend fun fetchWPComPlanProduct(): WPComProductResult
     suspend fun isIAPSupported(): IAPSupportedResult
 }

--- a/libs/iap/src/test/kotlin/com/woocommerce/android/iap/pub/IAPPurchaseWPComPlanActionsTest.kt
+++ b/libs/iap/src/test/kotlin/com/woocommerce/android/iap/pub/IAPPurchaseWPComPlanActionsTest.kt
@@ -24,6 +24,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+private const val REMOTE_SITE_ID = 1L
+
 @ExperimentalCoroutinesApi
 class IAPPurchaseWPComPlanActionsTest {
     private val logWrapperMock: IAPLogWrapper = mock()
@@ -46,7 +48,8 @@ class IAPPurchaseWPComPlanActionsTest {
         setupBillingClientToBeConnected()
         sut = IAPPurchaseWPComPlanActionsImpl(
             iapMobilePayAPI = mobilePayAPIMock,
-            iapManager = buildIapManager(iapBillingClientStateHandler, purchasesUpdatedListener)
+            iapManager = buildIapManager(iapBillingClientStateHandler, purchasesUpdatedListener),
+            REMOTE_SITE_ID,
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7592 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes the bug when we were losing the result of the purchase in cases when the ViewModel is killed by the system, IAP is restored and the purchase process continued

### Main changes
* Added `val purchaseWpComPlanResult: Flow<WPComPurchaseResult>` to the API
* `remoteSiteId` is passed via the constructor now to the `IAPPurchaseWPComPlanActionsImpl`
The reason behind this is that we anyway do not support purchases for multiple sites at the moment, and having it passed as a parameter makes it mandatory to store it as a state in the Manager which opens different potential issues
* `IAPPurchaseWPComPlanActionsImpl` fetches product details before starting the purchase. Before it was done on the layer below. In case of an error, it pushes the error back via `purchaseWpComPlanResult` flow
* `IAPManager` just starts the purchase and doesn't wait for the result. The result is returned via flow which is pushes events back from `IAPPurchasesUpdatedListener`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Enabled the "don't keep activities option"
* Start the purchase flow
* Hide/Show the Activity
* Notice that the VM has been recreated
* Continue the Purchase flow
* Notice that the result is delivered back to the activity and the stubbed network called was performed as well

### Images/gif
<!-- Include  before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/198990166-b805b017-de5d-49f4-a49e-fa79c9fef25e.mp4
