### PR TITLE
Update Apache Commons Text to 1.10.0

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -342,8 +342,7 @@ dependencies {
 
     testImplementation 'app.cash.turbine:turbine:0.8.0'
 
-    // Use caution when updating this, as commons-text 1.9 caused the reviews tab to crash on API 21
-    implementation "org.apache.commons:commons-text:1.8"
+    implementation "org.apache.commons:commons-text:1.9"
     implementation "commons-io:commons-io:2.11.0"
 
     implementation "com.tinder.statemachine:statemachine:$stateMachineVersion"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -319,7 +319,7 @@ dependencies {
         exclude group: 'asm', module: 'asm'
         exclude group: 'org.json', module: 'json'
     }
-    androidTestImplementation 'org.apache.httpcomponents:httpclient-android:4.3.5.1'
+    androidTestImplementation "org.apache.httpcomponents:httpclient-android:$httpClientAndroidVersion"
 
     // Resolve conflicts between main and test APK
     androidTestImplementation "androidx.annotation:annotation:1.3.0"
@@ -342,8 +342,8 @@ dependencies {
 
     testImplementation 'app.cash.turbine:turbine:0.8.0'
 
-    implementation "org.apache.commons:commons-text:1.9"
-    implementation "commons-io:commons-io:2.11.0"
+    implementation "org.apache.commons:commons-text:$commonsText"
+    implementation "commons-io:commons-io:$commonsIO"
 
     implementation "com.tinder.statemachine:statemachine:$stateMachineVersion"
 

--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,11 @@ ext {
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'
 
+    // Apache
+    commonsText = '1.9'
+    commonsIO = '2.11.0'
+    httpClientAndroidVersion = '4.3.5.1'
+
     // Compose and its module versions need to be consistent with each other (for example 'compose-theme-adapter')
     composeVersion = "1.1.1"
     composeAccompanistVersion = "0.23.1"

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ ext {
     workManagerVersion = '2.7.1'
 
     // Apache
-    commonsText = '1.9'
+    commonsText = '1.10.0'
     commonsIO = '2.11.0'
     httpClientAndroidVersion = '4.3.5.1'
 


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After an internal discussion (see `peaMlT-2f-p2` and `peaMlT-2f-p2#comment-77`) and the fact that `minSdkVersion` is already upgraded to `24` (see [merged PR](https://github.com/woocommerce/woocommerce-android/pull/7643)), this PR upgrades Apache's `Commons Text` library to [1.10.0](https://commons.apache.org/proper/commons-text/changes-report.html#a1.10.0) in order fix the possible `StringSubstitutor` related vulnerability in the library.

For more details see: https://commons.apache.org/proper/commons-text/changes-report.html#a1.10.0

And more specifically see release notes entry below:

```
Make default string lookups configurable via system property. Remove
dns, url, and script lookups from defaults. If these lookups are
required for use in StringSubstitutor.createInterpolator(), they must be
enabled via system property. See StringLookupFactory for details.
```

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This `Commons Text` library is only being used via its `StringEscapeUtils.unescapeHtml4(...)` utility method, which is only being used by the below two files:
- `StringExt.kt` and
- `MyStoreViewModel`.

The `StringExt.kt` file uses the `StringEscapeUtils.unescapeHtml4(...)` utility method only via its `String.fastStripHtml()` function, which in turn is being used by the below files:
- `model` package:
    - `OrderMapper.kt`
    - `Product.kt`
    - `ProductVariation.kt`
- `ui` package:
    - `products` package:
        - `ProductDetailCardBuilder.kt`
        - `ProductDetailFragment.kt`
        - `ProductDetailViewModel.kt`
        - `settings` package:
            - ProductSettingsFragment.kt`
    - `reviews` package:
        - `ReviewDetailFragment.kt`
        - `ReviewListAdapter.kt`

As such, and in order to test this change one could:
- First, quickly smoke test the `WooCommerce` app and see if it works as expected.
- Then, try and be more specific by taking a look at the below screens and make sure everything is working as expected:
    - `Product Detail`
    - `Product Settings`
    - `Review Detail`
    - `My Store`
- Finally, try and install the `WooCommerce` app on Android 7 (`API 24/25`) device and verify that it works as expected on the lower band devices (see [API Levels](https://ap)). This is done in order to verify that the newest version of the `Commons Text` library is working as expected on devices with the minimum supported SDK by the app. Note that last time a crash was discovered on the reviews tab screen on Android 5 (`API 21/22`), see [fix PR](https://github.com/woocommerce/woocommerce-android/pull/3719) and its related `Commons Lang3` implicit crash.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
