### PR TITLE
issue-3554 Product search results filtering

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 11.1
 -----
-
+[*] We improved products search behavior. In case there are filters set on Products page, the search results will be filtered accordingly. [https://github.com/woocommerce/woocommerce-android/pull/7696]
 
 11.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -193,11 +193,21 @@ class ProductListFragment :
                 if (isSearchActive) {
                     menuItem.expandActionView()
                     searchView?.setQuery(viewModel.viewStateLiveData.liveData.value?.query, false)
+                    val queryHint = getSearchQueryHint()
+                    searchView?.queryHint = queryHint
                 } else {
                     menuItem.collapseActionView()
                 }
                 enableSearchListeners()
             }
+        }
+    }
+
+    private fun getSearchQueryHint(): String {
+        return if (viewModel.viewStateLiveData.liveData.value?.isFilteringActive == true) {
+            getString(R.string.product_search_hint_active_filters)
+        } else {
+            getString(R.string.product_search_hint)
         }
     }
 
@@ -311,6 +321,9 @@ class ProductListFragment :
             }
             new.isBottomNavBarVisible.takeIfNotEqualTo(old?.isBottomNavBarVisible) { isBottomNavBarVisible ->
                 showBottomNavBar(isVisible = isBottomNavBarVisible)
+            }
+            new.isSearchActive.takeIfNotEqualTo(old?.isSearchActive) {
+                refreshOptionsMenu()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -104,7 +104,8 @@ class ProductListRepository @Inject constructor(
         searchQuery: String,
         isSkuSearch: Boolean = false,
         loadMore: Boolean = false,
-        excludedProductIds: List<Long>? = null
+        excludedProductIds: List<Long>? = null,
+        productFilterOptions: Map<ProductFilterOption, String> = emptyMap(),
     ): List<Product>? {
         // cancel any existing load
         loadContinuation.cancel()
@@ -120,7 +121,8 @@ class ProductListRepository @Inject constructor(
                 pageSize = PRODUCT_PAGE_SIZE,
                 offset = offset,
                 sorting = productSortingChoice,
-                excludedProductIds = excludedProductIds
+                excludedProductIds = excludedProductIds,
+                filterOptions = productFilterOptions
             )
             dispatcher.dispatch(WCProductActionBuilder.newSearchProductsAction(payload))
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -270,7 +270,7 @@ class ProductListViewModel @Inject constructor(
                         isSkeletonShown = !loadMore,
                         isEmptyViewVisible = false,
                         displaySortAndFilterCard = false,
-                        isAddProductButtonVisible = false
+                        isAddProductButtonVisible = false,
                     )
                     fetchProductList(
                         viewState.query,
@@ -395,7 +395,8 @@ class ProductListViewModel @Inject constructor(
             productRepository.searchProductList(
                 searchQuery = searchQuery,
                 isSkuSearch = isSkuSearch,
-                loadMore = loadMore
+                loadMore = loadMore,
+                productFilterOptions = productFilterOptions
             )?.let { products ->
                 // make sure the search query hasn't changed while the fetch was processing
                 if (searchQuery == productRepository.lastSearchQuery &&
@@ -479,6 +480,8 @@ class ProductListViewModel @Inject constructor(
     ) : Parcelable {
         @IgnoredOnParcel
         val isBottomNavBarVisible = isSearchActive != true
+        @IgnoredOnParcel
+        val isFilteringActive = filterCount != null && filterCount > 0
     }
 
     sealed class ProductListEvent : Event() {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1448,6 +1448,7 @@
     <string name="product_list_filters_show_products">Show products</string>
     <string name="product_list_filters_list_item">Selected filter option</string>
     <string name="product_search_hint">Search products</string>
+    <string name="product_search_hint_active_filters">Search filtered products</string>
     <string name="product_search_all">All products</string>
     <string name="product_search_sku">SKU</string>
     <string name="product_list_sorting_list_item">Selected sorting option</string>

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2556-4929b762bd2edfb8975d6cd27bf8a69fe97c0ad0'
+    fluxCVersion = 'trunk-de1e4ebe20d33a39dad3aecb6debb4f40830e958'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.2.0'
+    fluxCVersion = '2556-4929b762bd2edfb8975d6cd27bf8a69fe97c0ad0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3554

### Description
This PR applies [changes](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2556) in FluxC adding optional `filterOptions` parameter to `ProductRestClient::searchProducts function`:
1. Adds optional `productFilterOptions ` to `ProductsListRepository::searchProductList` function and uses it in `ProductListViewModel`.
2. Updates search query hint in case the filters are active.

### Testing instructions
1. Go to Products page
3. Apply filters
4. Open the search box and search for something
5. Observe search results are filtered according to filters selected in step 2. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
