### PR TITLE
Date range selection UI adjustments

### DIFF
--- a/WooCommerce/src/main/res/drawable/bg_calendar_gray_circle.xml
+++ b/WooCommerce/src/main/res/drawable/bg_calendar_gray_circle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/analytics_calendar_bg_color" />
+</shape>

--- a/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
@@ -10,6 +10,20 @@
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/major_100">
 
+        <ImageView
+            android:id="@+id/calendar_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/major_85"
+            android:background="@drawable/bg_calendar_gray_circle"
+            android:importantForAccessibility="no"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_fromDate"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/tv_toDate"
+            app:srcCompat="@drawable/ic_analytics_calendar"
+            app:tint="@color/color_on_surface"
+            android:layout_marginStart="@dimen/major_100"/>
+
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/tv_toDate"
             style="@style/Woo.Card.Title"
@@ -19,7 +33,7 @@
             android:maxLines="1"
             android:textSize="@dimen/text_minor_125"
             app:layout_constraintBottom_toTopOf="@+id/tv_fromDate"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/calendar_icon"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="Today (11 Sept 2021)" />
 
@@ -31,7 +45,7 @@
             android:layout_marginTop="@dimen/minor_100"
             android:maxLines="1"
             android:textSize="@dimen/text_minor_80"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/calendar_icon"
             app:layout_constraintTop_toBottomOf="@+id/tv_toDate"
             tools:text="vs Previous Period (10 Sept 2021)" />
 
@@ -39,12 +53,12 @@
             android:id="@+id/btn_dateRangeSelector"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="@dimen/major_100"
             android:importantForAccessibility="no"
+            android:layout_marginEnd="@dimen/major_100"
             app:layout_constraintBottom_toBottomOf="@+id/tv_fromDate"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/tv_toDate"
-            app:srcCompat="@drawable/ic_analytics_calendar" />
+            app:srcCompat="@drawable/ic_arrow_drop_down" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -151,5 +151,5 @@
     <color name="analytics_background">@color/woo_black_90</color>
     <color name="analytics_delta_positive_color">#B8E6BF</color>
     <color name="analytics_delta_text_color">@color/woo_black_90</color>
-    <color name="analytics_calendar_bg_color">@color/woo_black_80</color>
+    <color name="analytics_calendar_bg_color">@color/woo_white_alpha_008</color>
 </resources>

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -151,4 +151,5 @@
     <color name="analytics_background">@color/woo_black_90</color>
     <color name="analytics_delta_positive_color">#B8E6BF</color>
     <color name="analytics_delta_text_color">@color/woo_black_90</color>
+    <color name="analytics_calendar_bg_color">@color/woo_black_80</color>
 </resources>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -216,5 +216,5 @@
     <color name="analytics_delta_positive_color">#69B56E</color>
     <color name="analytics_delta_tag_negative_color">#C95854</color>
     <color name="analytics_delta_text_color">@color/white</color>
-    <color name="analytics_calendar_bg_color">@color/gray_5</color>
+    <color name="analytics_calendar_bg_color">@color/woo_black_alpha_008</color>
 </resources>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -216,4 +216,5 @@
     <color name="analytics_delta_positive_color">#69B56E</color>
     <color name="analytics_delta_tag_negative_color">#C95854</color>
     <color name="analytics_delta_text_color">@color/white</color>
+    <color name="analytics_calendar_bg_color">@color/gray_5</color>
 </resources>

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -39,6 +39,7 @@
 
     <color name="woo_white">@android:color/white</color>
     <color name="woo_white_alpha_005">#0DFFFFFF</color>
+    <color name="woo_white_alpha_008">#08FFFFFF</color>
     <color name="woo_white_alpha_009">#17FFFFFF</color>
     <color name="woo_white_alpha_012">#1FFFFFFF</color>
     <color name="woo_white_alpha_038">#61FFFFFF</color>
@@ -61,6 +62,7 @@
     <color name="woo_black_90_alpha_087">#DE121212</color>
     <color name="woo_black_900">#272727</color>
     <color name="woo_black_80">#363636</color>
+    <color name="woo_black_alpha_008">#08212121</color>
 
     <color name="jetpack_green_40">#069e08</color>
     <color name="jetpack_black">#0B2621</color>

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -39,7 +39,7 @@
 
     <color name="woo_white">@android:color/white</color>
     <color name="woo_white_alpha_005">#0DFFFFFF</color>
-    <color name="woo_white_alpha_008">#08FFFFFF</color>
+    <color name="woo_white_alpha_008">#14FFFFFF</color>
     <color name="woo_white_alpha_009">#17FFFFFF</color>
     <color name="woo_white_alpha_012">#1FFFFFFF</color>
     <color name="woo_white_alpha_038">#61FFFFFF</color>
@@ -62,7 +62,7 @@
     <color name="woo_black_90_alpha_087">#DE121212</color>
     <color name="woo_black_900">#272727</color>
     <color name="woo_black_80">#363636</color>
-    <color name="woo_black_alpha_008">#08212121</color>
+    <color name="woo_black_alpha_008">#14212121</color>
 
     <color name="jetpack_green_40">#069e08</color>
     <color name="jetpack_black">#0B2621</color>


### PR DESCRIPTION
Closes: #7695

### Description
This PR adjusts the Date range selection UI to make the control feel more tappable. 

p1666993323533909/1666901898.743199-slack-C0354HSNUJH

### Testing instructions

1. Go to MyStore screen
2. Tap on see more under the store stats
3. Check that the date range selection matches exploration number 2. 

![kwwuqcVCwtgy6EIzJ1atbL3oMCbDa6R3DOY6KReH.jpg](https://user-images.githubusercontent.com/18119390/199104185-541ff631-d834-4c4a-b7c8-9e9b6a7c6a99.jpg)

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Dark Mode **Off**  | Dark Mode On |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/18119390/199106612-6dd66f86-3a87-427c-9927-ed5740500b0a.png" /> | <img width="300" src="https://user-images.githubusercontent.com/18119390/199104722-517f662d-5246-4d31-a1b2-5eb21cc73ec4.png" />|

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->