### PR TITLE
Refactor account fetching during sign-up

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.dispatchAndAwait
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
-import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
 import org.wordpress.android.fluxc.store.signup.SignUpStore
@@ -63,17 +62,6 @@ class SignUpRepository @Inject constructor(
         ).let { updateTokenResult ->
             return if (updateTokenResult.isError) {
                 WooLog.w(WooLog.T.LOGIN, "Error updating token: ${updateTokenResult.error.message}")
-                AccountCreationError(UNKNOWN_ERROR)
-            } else onTokenUpdatedSuccessfully()
-        }
-    }
-
-    private suspend fun onTokenUpdatedSuccessfully(): AccountCreationResult {
-        dispatcher.dispatchAndAwait<Void, OnAccountChanged>(
-            AccountActionBuilder.newFetchAccountAction()
-        ).let { accountFetchResult ->
-            return if (accountFetchResult.isError) {
-                WooLog.w(WooLog.T.LOGIN, message = "Error fetching the user: ${accountFetchResult.error.message}")
                 AccountCreationError(UNKNOWN_ERROR)
             } else {
                 WooLog.w(WooLog.T.LOGIN, "Success creating new account")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -116,9 +116,6 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
             new.isSecondaryBtnVisible.takeIfNotEqualTo(old?.isSecondaryBtnVisible) {
                 binding.loginEpilogueButtonBar.buttonSecondary.isVisible = it
             }
-            new.isTertiaryBtnEnabled.takeIfNotEqualTo(old?.isTertiaryBtnEnabled) {
-                binding.loginEpilogueButtonBar.buttonTertiary.isEnabled = it
-            }
             new.isNoStoresViewVisible.takeIfNotEqualTo(old?.isNoStoresViewVisible) {
                 binding.sitesRecycler.isVisible = !it
                 binding.noStoresView.isVisible = it

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -116,6 +116,9 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
             new.isSecondaryBtnVisible.takeIfNotEqualTo(old?.isSecondaryBtnVisible) {
                 binding.loginEpilogueButtonBar.buttonSecondary.isVisible = it
             }
+            new.isTertiaryBtnEnabled.takeIfNotEqualTo(old?.isTertiaryBtnEnabled) {
+                binding.loginEpilogueButtonBar.buttonTertiary.isEnabled = it
+            }
             new.isNoStoresViewVisible.takeIfNotEqualTo(old?.isNoStoresViewVisible) {
                 binding.sitesRecycler.isVisible = !it
                 binding.noStoresView.isVisible = it

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -109,21 +109,20 @@ class SitePickerViewModel @Inject constructor(
                 triggerEvent(NavigateToStoreCreationEvent)
             }
         }
-        
+
         appPrefsWrapper.markAsNewSignUp(false)
     }
 
     private suspend fun getOrFetchAccount(): AccountModel? {
-        return accountRepository.getUserAccount() ?:
-            accountRepository.fetchUserAccount().fold(
-                onSuccess = {
-                    return accountRepository.getUserAccount()
-                },
-                onFailure = {
-                    triggerEvent(ShowSnackbar(string.error_fetch_my_profile))
-                    return null
-                }
-            )
+        return accountRepository.getUserAccount() ?: accountRepository.fetchUserAccount().fold(
+            onSuccess = {
+                accountRepository.getUserAccount()
+            },
+            onFailure = {
+                triggerEvent(ShowSnackbar(string.error_fetch_my_profile))
+                null
+            }
+        )
     }
 
     private fun updateSiteViewDetails() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -632,13 +632,9 @@ class SitePickerViewModel @Inject constructor(
     }
 
     private fun checkAccountAndLaunchStoreCreationWebFlow() = launch {
-        sitePickerViewState = sitePickerViewState.copy(isTertiaryBtnEnabled = false)
-
         getOrFetchAccount()?.let {
             triggerEvent(NavigateToStoreCreationEvent)
         }
-
-        sitePickerViewState = sitePickerViewState.copy(isTertiaryBtnEnabled = true)
     }
 
     private fun trackLoginEvent(
@@ -673,7 +669,6 @@ class SitePickerViewModel @Inject constructor(
         val isProgressDiaLogVisible: Boolean = false,
         val isPrimaryBtnVisible: Boolean = false,
         val isSecondaryBtnVisible: Boolean = false,
-        val isTertiaryBtnEnabled: Boolean = true,
         val isNoStoresBtnVisible: Boolean = false,
         val currentSitePickerState: SitePickerState = SitePickerState.StoreListState
     ) : Parcelable


### PR DESCRIPTION
This PR moves the account-fetching from the sign-up flow to the site picker to avoid users getting stuck if their account can't be fetched after sign up.