### PR TITLE
Ignore fetch account errors during signup

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.dispatchAndAwait
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
@@ -51,11 +52,12 @@ class SignUpRepository @Inject constructor(
                 WooLog.w(WooLog.T.LOGIN, "Error creating new WP account: ${accountCreatedResult.error.apiError}")
                 AccountCreationError(accountCreatedResult.error.apiError.toSignUpError())
             }
-            else -> onAccountCreationSuccess(accountCreatedResult)
+            else -> onAccountCreationSuccess(username, accountCreatedResult)
         }
     }
 
     private suspend fun onAccountCreationSuccess(
+        username: String,
         accountCreatedResult: SignUpStore.CreateWpAccountResult
     ): AccountCreationResult {
         dispatcher.dispatchAndAwait<UpdateTokenPayload, OnAuthenticationChanged>(
@@ -64,22 +66,28 @@ class SignUpRepository @Inject constructor(
             return if (updateTokenResult.isError) {
                 WooLog.w(WooLog.T.LOGIN, "Error updating token: ${updateTokenResult.error.message}")
                 AccountCreationError(UNKNOWN_ERROR)
-            } else onTokenUpdatedSuccessfully()
+            } else onTokenUpdatedSuccessfully(username)
         }
     }
 
-    private suspend fun onTokenUpdatedSuccessfully(): AccountCreationResult {
-        dispatcher.dispatchAndAwait<Void, OnAccountChanged>(
+    private suspend fun onTokenUpdatedSuccessfully(username: String): AccountCreationResult {
+        return dispatcher.dispatchAndAwait<Void, OnAccountChanged>(
             AccountActionBuilder.newFetchAccountAction()
         ).let { accountFetchResult ->
-            return if (accountFetchResult.isError) {
+            if (accountFetchResult.isError) {
                 WooLog.w(WooLog.T.LOGIN, message = "Error fetching the user: ${accountFetchResult.error.message}")
-                AccountCreationError(UNKNOWN_ERROR)
-            } else {
-                WooLog.w(WooLog.T.LOGIN, "Success creating new account")
-                prefsWrapper.markAsNewSignUp(true)
-                AccountCreationSuccess
+                // Persist the username manually and ignore the error
+                val account = AccountModel().apply {
+                    userName = username
+                }
+                dispatcher.dispatchAndAwait<AccountModel, OnAccountChanged>(
+                    AccountActionBuilder.newUpdateAccountAction(account)
+                )
             }
+
+            WooLog.w(WooLog.T.LOGIN, "Success creating new account")
+            prefsWrapper.markAsNewSignUp(true)
+            AccountCreationSuccess
         }
     }
 


### PR DESCRIPTION
### Description
This PR adds handling of account fetching errors, if an error occurs, we will ignore it, then we will persist the username manually to make it ready for the next steps.

### Testing instructions
Use this patch:
```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt	(revision 01cfe480b9a701d2260af343aef4eb539c20a84b)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt	(date 1667296196081)
@@ -71,24 +71,17 @@
     }
 
     private suspend fun onTokenUpdatedSuccessfully(username: String): AccountCreationResult {
-        return dispatcher.dispatchAndAwait<Void, OnAccountChanged>(
-            AccountActionBuilder.newFetchAccountAction()
-        ).let { accountFetchResult ->
-            if (accountFetchResult.isError) {
-                WooLog.w(WooLog.T.LOGIN, message = "Error fetching the user: ${accountFetchResult.error.message}")
-                // Persist the username manually and ignore the error
-                val account = AccountModel().apply {
-                    userName = username
-                }
-                dispatcher.dispatchAndAwait<AccountModel, OnAccountChanged>(
-                    AccountActionBuilder.newUpdateAccountAction(account)
-                )
-            }
+        // Persist the username manually and ignore the error
+        val account = AccountModel().apply {
+            userName = username
+        }
+        dispatcher.dispatchAndAwait<AccountModel, OnAccountChanged>(
+            AccountActionBuilder.newUpdateAccountAction(account)
+        )
 
             WooLog.w(WooLog.T.LOGIN, "Success creating new account")
             prefsWrapper.markAsNewSignUp(true)
-            AccountCreationSuccess
-        }
+        return AccountCreationSuccess
     }
 
     private fun validateCredentials(
```
to disable account fetching completely, then confirm the store creation's webview is correctly loaded and authenticated.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
