### PR TITLE
Issue/7709 simplified login password

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - [*] [Internal] Simplified login: update prologue screen layout [https://github.com/woocommerce/woocommerce-android/pull/7634]
 - [*] We improved products search behavior. In case there are filters set on Products page, the search results will be filtered accordingly. [https://github.com/woocommerce/woocommerce-android/pull/7696]
 - [*] [Internal] Simplified login: update the site picker design [https://github.com/woocommerce/woocommerce-android/pull/7677]
+- [*] [Internal] Simplified login: update the password sceen [https://github.com/woocommerce/woocommerce-android/pull/7711]
 
 11.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailPasswordFragment.kt
@@ -4,23 +4,16 @@ import android.content.Context
 import android.os.Bundle
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.core.view.isVisible
 import com.bumptech.glide.Registry.MissingComponentException
 import com.woocommerce.android.R
-import com.woocommerce.android.experiment.SimplifiedLoginExperiment
-import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.CONTROL
-import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.SIMPLIFIED_LOGIN_WPCOM
-import com.woocommerce.android.extensions.hide
-import com.woocommerce.android.extensions.show
 import dagger.android.support.AndroidSupportInjection
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.login.LoginEmailPasswordFragment
 import org.wordpress.android.login.LoginListener
 import org.wordpress.android.login.LoginWpcomService
-import javax.inject.Inject
 
 class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
     companion object {
@@ -56,9 +49,6 @@ class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
     private var email: String? = null
     private var isSocialLogin: Boolean = false
 
-    @Inject
-    lateinit var simplifiedLoginExperiment: SimplifiedLoginExperiment
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -87,22 +77,6 @@ class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
 
     @LayoutRes
     override fun getContentLayout(): Int = R.layout.fragment_login_email_password
-
-    override fun setupLabel(label: TextView) {
-        val text = if (isSocialLogin) {
-            R.string.enter_wpcom_password_google
-        } else when (simplifiedLoginExperiment.getCurrentVariant()) {
-            SIMPLIFIED_LOGIN_WPCOM -> R.string.enter_wpcom_password
-            CONTROL -> null
-        }
-
-        if (text != null) {
-            label.show()
-            label.setText(text)
-        } else {
-            label.hide()
-        }
-    }
 
     override fun setupContent(rootView: ViewGroup) {
         super.setupContent(rootView)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailPasswordFragment.kt
@@ -4,16 +4,23 @@ import android.content.Context
 import android.os.Bundle
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.core.view.isVisible
 import com.bumptech.glide.Registry.MissingComponentException
 import com.woocommerce.android.R
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.CONTROL
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant.SIMPLIFIED_LOGIN_WPCOM
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.show
 import dagger.android.support.AndroidSupportInjection
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.login.LoginEmailPasswordFragment
 import org.wordpress.android.login.LoginListener
 import org.wordpress.android.login.LoginWpcomService
+import javax.inject.Inject
 
 class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
     companion object {
@@ -47,11 +54,16 @@ class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
     private lateinit var onPassWordErrorListener: Listener
     private var loginListener: LoginListener? = null
     private var email: String? = null
+    private var isSocialLogin: Boolean = false
+
+    @Inject
+    lateinit var simplifiedLoginExperiment: SimplifiedLoginExperiment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        email = arguments?.getString(ARG_EMAIL_ADDRESS)
+        email = requireArguments().getString(ARG_EMAIL_ADDRESS)
+        isSocialLogin = requireArguments().getBoolean(ARG_SOCIAL_LOGIN)
     }
 
     override fun onAttach(context: Context) {
@@ -75,6 +87,22 @@ class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
 
     @LayoutRes
     override fun getContentLayout(): Int = R.layout.fragment_login_email_password
+
+    override fun setupLabel(label: TextView) {
+        val text = if (isSocialLogin) {
+            R.string.enter_wpcom_password_google
+        } else when (simplifiedLoginExperiment.getCurrentVariant()) {
+            SIMPLIFIED_LOGIN_WPCOM -> R.string.enter_wpcom_password
+            CONTROL -> null
+        }
+
+        if (text != null) {
+            label.show()
+            label.setText(text)
+        } else {
+            label.hide()
+        }
+    }
 
     override fun setupContent(rootView: ViewGroup) {
         super.setupContent(rootView)

--- a/WooCommerce/src/main/res/layout/fragment_login_email_password.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_email_password.xml
@@ -5,14 +5,23 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingEnd="@dimen/margin_extra_large"
-    android:paddingStart="@dimen/margin_extra_large">
+    android:paddingStart="@dimen/margin_extra_large"
+    android:paddingEnd="@dimen/margin_extra_large">
 
-    <include
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_medium"
-        layout="@layout/login_include_email_header" />
+        android:layout_gravity="center"
+        android:layout_marginVertical="@dimen/minor_100"
+        android:background="@drawable/bg_rounded_box"
+        android:paddingHorizontal="@dimen/major_100"
+        android:paddingVertical="@dimen/minor_100">
+
+        <include
+            layout="@layout/login_include_email_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </FrameLayout>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/label"
@@ -20,9 +29,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
-        android:visibility="gone"
-        tools:text="@string/enter_wpcom_password"
-        />
+        android:text="@string/enter_wpcom_password" />
 
     <org.wordpress.android.login.widgets.WPLoginInputRow
         android:id="@+id/login_password_row"
@@ -41,8 +48,8 @@
         style="@style/Widget.LoginFlow.Button.Tertiary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingEnd="@dimen/margin_none"
         android:paddingStart="@dimen/margin_none"
+        android:paddingEnd="@dimen/margin_none"
         android:text="@string/reset_your_password" />
 
     <View
@@ -60,8 +67,8 @@
         style="@style/Widget.LoginFlow.Button.Tertiary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingEnd="@dimen/margin_none"
         android:paddingStart="@dimen/margin_none"
+        android:paddingEnd="@dimen/margin_none"
         android:text="@string/login_get_link_by_email"
         android:visibility="gone"
         tools:visibility="visible" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1845,7 +1845,7 @@
     <string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>
     <string name="magic_link_update_error">An error has occurred. Please login to continue</string>
     <string name="magic_link_fetch_account_error">There was some trouble fetching your account. You can retry now or close and try again later.</string>
-    <string name="enter_wpcom_password">Enter your WordPress.com password.</string>
+    <string name="enter_wpcom_password">Enter the password for your account.</string>
     <string name="enter_wpcom_password_google">To proceed with this Google account, please provide the matching WordPress.com password. This will be asked only once.</string>
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7709 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR just adds the required changes to the password screen for simplified login.

As discussed in p1667189100766619-slack-C046HDZL87J, we will be showing the same label for both variants. 

### Testing instructions
Test the following on the two variants:
1. Open the app.
2. Click on "Login with WordPress.com"
3. Enter your Email.
4. Confirm the password screen is looking as expected.

### Images/gif
| Normal Login | Social Login |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1657201/199242933-67036ad2-227f-48c6-914a-e03946563850.png) | ![image](https://user-images.githubusercontent.com/1657201/199243740-c56f2aad-cb2e-457c-8418-c13f89d84ca5.png) |

If the email doesn't fit, it'll wrap as discussed in Figma:
<img width=360 src="https://user-images.githubusercontent.com/1657201/199242668-7feda1d6-de64-4613-8702-63f67817959f.png" />

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->