### PR TITLE
Fix crash when scanning non WooCommerce Qr codes

### DIFF
--- a/libs/barcode/src/main/java/com/woocommerce/android/barcode/QrCodeScanningFragment.kt
+++ b/libs/barcode/src/main/java/com/woocommerce/android/barcode/QrCodeScanningFragment.kt
@@ -173,7 +173,7 @@ class QrCodeScanningFragment : Fragment(), OnClickListener {
     }
 
     private fun isValidScannedRawValue(scannedRawValue: String?): Boolean =
-        scannedRawValue != null
-            && scannedRawValue.contains(MAGIC_LOGIN_ACTION)
-            && scannedRawValue.contains(MAGIC_LOGIN_SCHEME)
+        scannedRawValue != null &&
+            scannedRawValue.contains(MAGIC_LOGIN_ACTION) &&
+            scannedRawValue.contains(MAGIC_LOGIN_SCHEME)
 }

--- a/libs/barcode/src/main/res/values/strings.xml
+++ b/libs/barcode/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="prompt_point_at_a_barcode">Point your camera at the code</string>
     <string name="prompt_move_camera_closer">Move closer to search</string>
     <string name="prompt_searching">Scanning&#8230;</string>
+    <string name="not_a_valid_qr_code">Scanned Qr code is not a WooCommerce code</string>
 
     <!-- Strings for camera settings. -->
     <string name="pref_key_rear_camera_preview_size" translatable="false">rcpvs</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7713 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Fixes crash when scanning non WooCommerce Qr codes. 

The crash can be easily reproduced following the steps from the issue: #7713 

### Testing instructions
Test this flow and check the app does not crash:

1. Click on "Continue with WordPress.com" login button
2. Click on "Scan QR code" button 
3. Try to scan Jetpack Qr code from `wp-admin`. This one: 

![Screenshot 2022-11-01 at 16 18 41](https://user-images.githubusercontent.com/2663464/199278914-c38b8458-8d15-4ee3-9dba-120707ee7263.png)

4. A toast with the following message should be displayed: "Scanned Qr code is not a WooCommerce code"
5. The Qr code scanner should be available to scan a new code. 
6. Check that scanning a QR code from a magic link email, works as expected and logs you into the app

### Images/gif


https://user-images.githubusercontent.com/2663464/199279970-b9c7c294-4a65-4e60-8f83-5d2339ef9252.mp4


