### PR TITLE
Extract JITM analytics into a separate class

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -105,8 +105,8 @@ class JitmTracker @Inject constructor(
         source: String,
         jitmId: String,
         featureClass: String,
-        errorType: WooErrorType,
-        errorDescription: String
+        errorType: WooErrorType?,
+        errorDescription: String?
     ) {
         track(
             stat = AnalyticsEvent.JITM_DISMISS_FAILURE,
@@ -114,9 +114,9 @@ class JitmTracker @Inject constructor(
                 KEY_SOURCE to source,
                 JITM_ID to jitmId,
                 JITM_FEATURE_CLASS to featureClass,
-                KEY_ERROR_TYPE to errorType.name,
-                KEY_ERROR_DESC to errorDescription
-            )
+            ),
+            errorType = errorType?.name,
+            errorDescription = errorDescription
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui
 
 import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
@@ -37,6 +39,17 @@ class JitmTracker @Inject constructor(
             properties = mapOf(KEY_SOURCE to source),
             errorType = type.name,
             errorDescription = message
+        )
+    }
+
+    fun trackJitmFetchSuccess(source: String, jitmId: String?, jitmCount: Int?) {
+        track(
+            stat = AnalyticsEvent.JITM_FETCH_SUCCESS,
+            properties = mutableMapOf(
+                KEY_SOURCE to source,
+                KEY_JITM to (jitmId ?: "null"),
+                KEY_JITM_COUNT to (jitmCount ?: 0)
+            )
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -65,4 +65,15 @@ class JitmTracker @Inject constructor(
             )
         )
     }
+
+    fun trackJitmCtaTapped(source: String, jitmId: String, featureClass: String) {
+        track(
+            stat = AnalyticsEvent.JITM_CTA_TAPPED,
+            properties = mapOf(
+                KEY_SOURCE to source,
+                JITM_ID to jitmId,
+                JITM_FEATURE_CLASS to featureClass
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -4,6 +4,8 @@ import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
@@ -95,6 +97,25 @@ class JitmTracker @Inject constructor(
                 KEY_SOURCE to source,
                 JITM_ID to jitmId,
                 JITM_FEATURE_CLASS to featureClass
+            )
+        )
+    }
+
+    fun trackJitmDismissFailure(
+        source: String,
+        jitmId: String,
+        featureClass: String,
+        errorType: WooErrorType,
+        errorDescription: String
+    ) {
+        track(
+            stat = AnalyticsEvent.JITM_DISMISS_FAILURE,
+            properties = mapOf(
+                KEY_SOURCE to source,
+                JITM_ID to jitmId,
+                JITM_FEATURE_CLASS to featureClass,
+                KEY_ERROR_TYPE to errorType.name,
+                KEY_ERROR_DESC to errorDescription
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -76,4 +76,15 @@ class JitmTracker @Inject constructor(
             )
         )
     }
+
+    fun trackJitmDismissTapped(source: String, jitmId: String, featureClass: String) {
+        track(
+            stat = AnalyticsEvent.JITM_DISMISS_TAPPED,
+            properties = mapOf(
+                KEY_SOURCE to source,
+                JITM_ID to jitmId,
+                JITM_FEATURE_CLASS to featureClass
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -87,4 +87,15 @@ class JitmTracker @Inject constructor(
             )
         )
     }
+
+    fun trackJitmDismissSuccess(source: String, jitmId: String, featureClass: String) {
+        track(
+            stat = AnalyticsEvent.JITM_DISMISS_SUCCESS,
+            properties = mapOf(
+                KEY_SOURCE to source,
+                JITM_ID to jitmId,
+                JITM_FEATURE_CLASS to featureClass
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui
 
 import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
@@ -45,10 +47,21 @@ class JitmTracker @Inject constructor(
     fun trackJitmFetchSuccess(source: String, jitmId: String?, jitmCount: Int?) {
         track(
             stat = AnalyticsEvent.JITM_FETCH_SUCCESS,
-            properties = mutableMapOf(
+            properties = mapOf(
                 KEY_SOURCE to source,
                 KEY_JITM to (jitmId ?: "null"),
                 KEY_JITM_COUNT to (jitmCount ?: 0)
+            )
+        )
+    }
+
+    fun trackJitmDisplayed(source: String, jitmId: String, featureClass: String) {
+        track(
+            stat = AnalyticsEvent.JITM_DISPLAYED,
+            properties = mapOf(
+                KEY_SOURCE to source,
+                JITM_ID to jitmId,
+                JITM_FEATURE_CLASS to featureClass
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -4,8 +4,6 @@ import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/JitmTracker.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui
+
+import androidx.annotation.VisibleForTesting
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import javax.inject.Inject
+
+class JitmTracker @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+) {
+    @VisibleForTesting
+    fun track(
+        stat: AnalyticsEvent,
+        properties: Map<String, Any> = mapOf(),
+        errorType: String? = null,
+        errorDescription: String? = null,
+    ) {
+        val isError = !errorType.isNullOrBlank() || !errorDescription.isNullOrEmpty()
+        if (isError) {
+            analyticsTrackerWrapper.track(
+                stat,
+                properties,
+                this@JitmTracker.javaClass.simpleName,
+                errorType,
+                errorDescription
+            )
+        } else {
+            analyticsTrackerWrapper.track(stat, properties)
+        }
+    }
+
+    fun trackJitmFetchFailure(source: String, type: WooErrorType, message: String?) {
+        track(
+            stat = AnalyticsEvent.JITM_FETCH_FAILURE,
+            properties = mapOf(KEY_SOURCE to source),
+            errorType = type.name,
+            errorDescription = message
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmTracker.kt
@@ -111,7 +111,7 @@ class JitmTracker @Inject constructor(
                 JITM_ID to jitmId,
                 JITM_FEATURE_CLASS to featureClass,
             ),
-            errorType = errorType?.name,
+            errorType = errorType?.name ?: WooErrorType.GENERIC_ERROR.name,
             errorDescription = errorDescription
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmTracker.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui
+package com.woocommerce.android.ui.jitm
 
 import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.analytics.AnalyticsEvent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmTracker.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.jitm
 
-import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
@@ -14,8 +13,7 @@ import javax.inject.Inject
 class JitmTracker @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
-    @VisibleForTesting
-    fun track(
+    private fun track(
         stat: AnalyticsEvent,
         properties: Map<String, Any> = mapOf(),
         errorType: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -18,7 +18,7 @@ import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.JitmTracker
+import com.woocommerce.android.ui.jitm.JitmTracker
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -162,7 +162,11 @@ class MyStoreViewModel @Inject constructor(
             return
         }
 
-        trackJitmFetchSuccessEvent(response.model?.getOrNull(0)?.id, response.model?.size)
+        jitmTracker.trackJitmFetchSuccess(
+            UTM_SOURCE,
+            response.model?.getOrNull(0)?.id,
+            response.model?.size
+        )
         response.model?.getOrNull(0)?.let { model: JITMApiResponse ->
             trackJitmDisplayedEvent(
                 model.id,
@@ -209,17 +213,6 @@ class MyStoreViewModel @Inject constructor(
                 KEY_SOURCE to UTM_SOURCE,
                 JITM_ID to id,
                 JITM_FEATURE_CLASS to featureClass
-            )
-        )
-    }
-
-    private fun trackJitmFetchFailureEvent(type: WooErrorType, message: String?) {
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.JITM_FETCH_FAILURE,
-            mapOf(
-                KEY_SOURCE to UTM_SOURCE,
-                KEY_ERROR_TYPE to type.name,
-                KEY_ERROR_DESC to message
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -168,7 +168,8 @@ class MyStoreViewModel @Inject constructor(
             response.model?.size
         )
         response.model?.getOrNull(0)?.let { model: JITMApiResponse ->
-            trackJitmDisplayedEvent(
+            jitmTracker.trackJitmDisplayed(
+                UTM_SOURCE,
                 model.id,
                 model.featureClass
             )
@@ -198,17 +199,6 @@ class MyStoreViewModel @Inject constructor(
     private fun trackJitmCtaTappedEvent(id: String, featureClass: String) {
         analyticsTrackerWrapper.track(
             AnalyticsEvent.JITM_CTA_TAPPED,
-            mapOf(
-                KEY_SOURCE to UTM_SOURCE,
-                JITM_ID to id,
-                JITM_FEATURE_CLASS to featureClass
-            )
-        )
-    }
-
-    private fun trackJitmDisplayedEvent(id: String, featureClass: String) {
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.JITM_DISPLAYED,
             mapOf(
                 KEY_SOURCE to UTM_SOURCE,
                 JITM_ID to id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -18,8 +18,8 @@ import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.jitm.JitmTracker
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
+import com.woocommerce.android.ui.jitm.JitmTracker
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.IsJetPackCPEnabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -220,7 +220,11 @@ class MyStoreViewModel @Inject constructor(
             jitmStore.dismissJitmMessage(selectedSite.get(), jitmId, featureClass).also { response ->
                 when {
                     response.model != null && response.model!! -> {
-                        trackJitmDismissSuccessEvent(jitmId, featureClass)
+                        jitmTracker.trackJitmDismissSuccess(
+                            UTM_SOURCE,
+                            jitmId,
+                            featureClass
+                        )
                     }
                     else -> trackJitmDismissFailureEvent(
                         jitmId,
@@ -247,17 +251,6 @@ class MyStoreViewModel @Inject constructor(
                 JITM_FEATURE_CLASS to featureClass,
                 KEY_ERROR_TYPE to errorType,
                 KEY_ERROR_DESC to errorDescription
-            )
-        )
-    }
-
-    private fun trackJitmDismissSuccessEvent(id: String, featureClass: String) {
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.JITM_DISMISS_SUCCESS,
-            mapOf(
-                KEY_SOURCE to UTM_SOURCE,
-                JITM_ID to id,
-                JITM_FEATURE_CLASS to featureClass
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -196,23 +196,16 @@ class MyStoreViewModel @Inject constructor(
         } ?: WooLog.i(WooLog.T.JITM, "No JITM Campaign in progress")
     }
 
-    private fun trackJitmCtaTappedEvent(id: String, featureClass: String) {
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.JITM_CTA_TAPPED,
-            mapOf(
-                KEY_SOURCE to UTM_SOURCE,
-                JITM_ID to id,
-                JITM_FEATURE_CLASS to featureClass
-            )
-        )
-    }
-
     private fun onJitmCtaClicked(
         id: String,
         featureClass: String,
         url: String
     ) {
-        trackJitmCtaTappedEvent(id, featureClass)
+        jitmTracker.trackJitmCtaTapped(
+            UTM_SOURCE,
+            id,
+            featureClass
+        )
         triggerEvent(
             MyStoreEvent.OnJitmCtaClicked(
                 utmProvider.getUrlWithUtmParams(url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.JitmTracker
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders
@@ -89,6 +90,7 @@ class MyStoreViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val myStoreTransactionLauncher: MyStoreTransactionLauncher,
     private val jitmStore: JitmStore,
+    private val jitmTracker: JitmTracker,
     @Named("my-store") private val utmProvider: UtmProvider,
 ) : ScopedViewModel(savedState) {
     companion object {
@@ -155,7 +157,7 @@ class MyStoreViewModel @Inject constructor(
 
     private fun populateResultToUI(response: WooResult<Array<JITMApiResponse>>) {
         if (response.isError) {
-            trackJitmFetchFailureEvent(response.error.type, response.error.message)
+            jitmTracker.trackJitmFetchFailure(UTM_SOURCE, response.error.type, response.error.message)
             WooLog.e(WooLog.T.JITM, "Failed to fetch JITM for the message path $JITM_MESSAGE_PATH")
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -215,7 +215,7 @@ class MyStoreViewModel @Inject constructor(
 
     private fun onJitmDismissClicked(jitmId: String, featureClass: String) {
         _bannerState.value = _bannerState.value?.copy(shouldDisplayBanner = false)
-        trackJitmDismissTappedEvent(jitmId, featureClass)
+        jitmTracker.trackJitmDismissTapped(UTM_SOURCE, jitmId, featureClass)
         viewModelScope.launch {
             jitmStore.dismissJitmMessage(selectedSite.get(), jitmId, featureClass).also { response ->
                 when {
@@ -254,17 +254,6 @@ class MyStoreViewModel @Inject constructor(
     private fun trackJitmDismissSuccessEvent(id: String, featureClass: String) {
         analyticsTrackerWrapper.track(
             AnalyticsEvent.JITM_DISMISS_SUCCESS,
-            mapOf(
-                KEY_SOURCE to UTM_SOURCE,
-                JITM_ID to id,
-                JITM_FEATURE_CLASS to featureClass
-            )
-        )
-    }
-
-    private fun trackJitmDismissTappedEvent(id: String, featureClass: String) {
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.JITM_DISMISS_TAPPED,
             mapOf(
                 KEY_SOURCE to UTM_SOURCE,
                 JITM_ID to id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -125,6 +125,7 @@ class MyStoreViewModel @Inject constructor(
 
     @VisibleForTesting
     val refreshStoreStats = BooleanArray(StatsGranularity.values().size) { true }
+
     @VisibleForTesting
     val refreshTopPerformerStats = BooleanArray(StatsGranularity.values().size) { true }
 
@@ -226,33 +227,16 @@ class MyStoreViewModel @Inject constructor(
                             featureClass
                         )
                     }
-                    else -> trackJitmDismissFailureEvent(
+                    else -> jitmTracker.trackJitmDismissFailure(
+                        UTM_SOURCE,
                         jitmId,
                         featureClass,
-                        response.error?.type?.name,
+                        response.error?.type,
                         response.error?.message
                     )
                 }
             }
         }
-    }
-
-    private fun trackJitmDismissFailureEvent(
-        id: String,
-        featureClass: String,
-        errorType: String?,
-        errorDescription: String?
-    ) {
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.JITM_DISMISS_FAILURE,
-            mapOf(
-                KEY_SOURCE to UTM_SOURCE,
-                JITM_ID to id,
-                JITM_FEATURE_CLASS to featureClass,
-                KEY_ERROR_TYPE to errorType,
-                KEY_ERROR_DESC to errorDescription
-            )
-        )
     }
 
     override fun onCleared() {
@@ -528,6 +512,7 @@ class MyStoreViewModel @Inject constructor(
         data class OpenTopPerformer(
             val productId: Long
         ) : MyStoreEvent()
+
         data class OpenAnalytics(val analyticsPeriod: AnalyticTimePeriod) : MyStoreEvent()
         data class OnJitmCtaClicked(
             val url: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -12,13 +12,6 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.network.ConnectionChangeReceiver
@@ -62,7 +55,6 @@ import org.apache.commons.text.StringEscapeUtils
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMApiResponse
 import org.wordpress.android.fluxc.store.JitmStore

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -217,17 +217,6 @@ class MyStoreViewModel @Inject constructor(
         )
     }
 
-    private fun trackJitmFetchSuccessEvent(jitmId: String? = null, jitmCount: Int? = null) {
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.JITM_FETCH_SUCCESS,
-            mapOf(
-                KEY_SOURCE to UTM_SOURCE,
-                KEY_JITM to jitmId,
-                KEY_JITM_COUNT to jitmCount
-            )
-        )
-    }
-
     private fun onJitmCtaClicked(
         id: String,
         featureClass: String,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -258,6 +258,9 @@ class JitmTrackerTest : BaseUnitTest() {
             verify(trackerWrapper).track(
                 eq(JITM_DISMISS_FAILURE),
                 any(),
+                any(),
+                any(),
+                any(),
             )
         }
     }
@@ -279,9 +282,10 @@ class JitmTrackerTest : BaseUnitTest() {
                     KEY_SOURCE to UTM_SOURCE,
                     JITM_ID to "12345",
                     JITM_FEATURE_CLASS to "test_feature_class",
-                    KEY_ERROR_TYPE to WooErrorType.GENERIC_ERROR.name,
-                    KEY_ERROR_DESC to "test error"
-                )
+                ),
+                errorContext = "JitmTracker",
+                errorType = WooErrorType.GENERIC_ERROR.name,
+                errorDescription = "test error",
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -1,7 +1,12 @@
 package com.woocommerce.android.ui.jitm
 
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
@@ -87,6 +92,42 @@ class JitmTrackerTest : BaseUnitTest() {
                     KEY_SOURCE to UTM_SOURCE,
                     KEY_JITM to "12345",
                     KEY_JITM_COUNT to 1
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm displayed invoked, then JITM_FETCH_DISPLAYED tracked`() {
+        testBlocking {
+            jitmTracker.trackJitmDisplayed(
+                UTM_SOURCE,
+                "12345",
+                ""
+            )
+
+            verify(trackerWrapper).track(
+                eq(JITM_DISPLAYED),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm displayed invoked, then JITM_FETCH_DISPLAYED tracked with correct properties`() {
+        testBlocking {
+            jitmTracker.trackJitmDisplayed(
+                UTM_SOURCE,
+                "12345",
+                "test_feature_class"
+            )
+
+            verify(trackerWrapper).track(
+                JITM_DISPLAYED,
+                mapOf(
+                    KEY_SOURCE to UTM_SOURCE,
+                    JITM_ID to "12345",
+                    JITM_FEATURE_CLASS to "test_feature_class"
                 ),
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.jitm
 
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_CTA_TAPPED
+import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_SUCCESS
@@ -166,6 +167,42 @@ class JitmTrackerTest : BaseUnitTest() {
                     JITM_ID to "12345",
                     JITM_FEATURE_CLASS to "test_feature_class"
                 ),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm dismiss clicked invoked, then JITM_DISMISS_TAPPED tracked`() {
+        testBlocking {
+            jitmTracker.trackJitmDismissTapped(
+                UTM_SOURCE,
+                "12345",
+                ""
+            )
+
+            verify(trackerWrapper).track(
+                eq(JITM_DISMISS_TAPPED),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm dismiss clicked invoked, then JITM_DISMISS_TAPPED tracked with correct properties`() {
+        testBlocking {
+            jitmTracker.trackJitmDismissTapped(
+                UTM_SOURCE,
+                "12345",
+                "test_feature_class"
+            )
+
+            verify(trackerWrapper).track(
+                JITM_DISMISS_TAPPED,
+                mapOf(
+                    KEY_SOURCE to UTM_SOURCE,
+                    JITM_ID to "12345",
+                    JITM_FEATURE_CLASS to "test_feature_class"
+                )
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.jitm
 
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_CTA_TAPPED
+import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_FAILURE
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISPLAYED
@@ -10,6 +11,8 @@ import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
@@ -239,6 +242,48 @@ class JitmTrackerTest : BaseUnitTest() {
                     KEY_SOURCE to UTM_SOURCE,
                     JITM_ID to "12345",
                     JITM_FEATURE_CLASS to "test_feature_class"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm dismiss failure invoked, then JITM_DISMISS_FAILURE tracked`() {
+        testBlocking {
+            jitmTracker.trackJitmDismissFailure(
+                UTM_SOURCE,
+                "12345",
+                "",
+                WooErrorType.GENERIC_ERROR,
+                "test error"
+            )
+
+            verify(trackerWrapper).track(
+                eq(JITM_DISMISS_FAILURE),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm dismiss failure invoked, then JITM_DISMISS_FAILURE tracked with correct properties`() {
+        testBlocking {
+            jitmTracker.trackJitmDismissFailure(
+                UTM_SOURCE,
+                "12345",
+                "test_feature_class",
+                WooErrorType.GENERIC_ERROR,
+                "test error"
+            )
+
+            verify(trackerWrapper).track(
+                JITM_DISMISS_FAILURE,
+                mapOf(
+                    KEY_SOURCE to UTM_SOURCE,
+                    JITM_ID to "12345",
+                    JITM_FEATURE_CLASS to "test_feature_class",
+                    KEY_ERROR_TYPE to WooErrorType.GENERIC_ERROR.name,
+                    KEY_ERROR_DESC to "test error"
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -225,7 +225,7 @@ class JitmTrackerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when track jitm dismiss success invoked, then JITM_DISMISS_SUCCESS tracked wit hcorrect properties`() {
+    fun `when track jitm dismiss success invoked, then JITM_DISMISS_SUCCESS tracked with correct properties`() {
         testBlocking {
             jitmTracker.trackJitmDismissSuccess(
                 UTM_SOURCE,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.jitm
 
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.JitmTracker
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.Companion.UTM_SOURCE
@@ -31,6 +32,23 @@ class JitmTrackerTest : BaseUnitTest() {
                 anyString(),
                 anyString(),
                 anyString(),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm failure invoked, then JITM_FETCH_FAILURE tracked with correct properties`() {
+        testBlocking {
+            jitmTracker.trackJitmFetchFailure(UTM_SOURCE, WooErrorType.GENERIC_ERROR, "debug message")
+
+            verify(trackerWrapper).track(
+                JITM_FETCH_FAILURE,
+                mapOf(
+                    KEY_SOURCE to UTM_SOURCE
+                ),
+                "JitmTracker",
+                WooErrorType.GENERIC_ERROR.name,
+                "debug message",
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -1,0 +1,37 @@
+package com.woocommerce.android.ui.jitm
+
+import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.JitmTracker
+import com.woocommerce.android.ui.mystore.MyStoreViewModel.Companion.UTM_SOURCE
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+
+@ExperimentalCoroutinesApi
+class JitmTrackerTest : BaseUnitTest() {
+    private val trackerWrapper: AnalyticsTrackerWrapper = mock()
+
+    private val jitmTracker = JitmTracker(trackerWrapper)
+
+    @Test
+    fun `when track jitm failure invoked, then JITM_FETCH_FAILURE tracked`() {
+        testBlocking {
+            jitmTracker.trackJitmFetchFailure(UTM_SOURCE, WooErrorType.GENERIC_ERROR, "debug message")
+
+            verify(trackerWrapper).track(
+                eq(JITM_FETCH_FAILURE),
+                any(),
+                anyString(),
+                anyString(),
+                anyString(),
+            )
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.jitm
 
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
+import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.JitmTracker
@@ -49,6 +52,42 @@ class JitmTrackerTest : BaseUnitTest() {
                 "JitmTracker",
                 WooErrorType.GENERIC_ERROR.name,
                 "debug message",
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm success invoked, then JITM_FETCH_SUCCESS tracked`() {
+        testBlocking {
+            jitmTracker.trackJitmFetchSuccess(
+                UTM_SOURCE,
+                "12345",
+                1
+            )
+
+            verify(trackerWrapper).track(
+                eq(JITM_FETCH_SUCCESS),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm success invoked, then JITM_FETCH_SUCCESS tracked with correct properties`() {
+        testBlocking {
+            jitmTracker.trackJitmFetchSuccess(
+                UTM_SOURCE,
+                "12345",
+                1
+            )
+
+            verify(trackerWrapper).track(
+                JITM_FETCH_SUCCESS,
+                mapOf(
+                    KEY_SOURCE to UTM_SOURCE,
+                    KEY_JITM to "12345",
+                    KEY_JITM_COUNT to 1
+                ),
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.jitm
 
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.JITM_CTA_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_SUCCESS
@@ -124,6 +125,42 @@ class JitmTrackerTest : BaseUnitTest() {
 
             verify(trackerWrapper).track(
                 JITM_DISPLAYED,
+                mapOf(
+                    KEY_SOURCE to UTM_SOURCE,
+                    JITM_ID to "12345",
+                    JITM_FEATURE_CLASS to "test_feature_class"
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm cta clicked invoked, then JITM_CTA_TAPPED tracked`() {
+        testBlocking {
+            jitmTracker.trackJitmCtaTapped(
+                UTM_SOURCE,
+                "12345",
+                ""
+            )
+
+            verify(trackerWrapper).track(
+                eq(JITM_CTA_TAPPED),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm cta clicked invoked, then JITM_CTA_TAPPED tracked with correct properties`() {
+        testBlocking {
+            jitmTracker.trackJitmCtaTapped(
+                UTM_SOURCE,
+                "12345",
+                "test_feature_class"
+            )
+
+            verify(trackerWrapper).track(
+                JITM_CTA_TAPPED,
                 mapOf(
                     KEY_SOURCE to UTM_SOURCE,
                     JITM_ID to "12345",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ui.JitmTracker
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.Companion.UTM_SOURCE
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -9,8 +9,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.jitm
 
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_CTA_TAPPED
+import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
@@ -198,6 +199,42 @@ class JitmTrackerTest : BaseUnitTest() {
 
             verify(trackerWrapper).track(
                 JITM_DISMISS_TAPPED,
+                mapOf(
+                    KEY_SOURCE to UTM_SOURCE,
+                    JITM_ID to "12345",
+                    JITM_FEATURE_CLASS to "test_feature_class"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm dismiss success invoked, then JITM_DISMISS_SUCCESS tracked`() {
+        testBlocking {
+            jitmTracker.trackJitmDismissSuccess(
+                UTM_SOURCE,
+                "12345",
+                ""
+            )
+
+            verify(trackerWrapper).track(
+                eq(JITM_DISMISS_SUCCESS),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `when track jitm dismiss success invoked, then JITM_DISMISS_SUCCESS tracked wit hcorrect properties`() {
+        testBlocking {
+            jitmTracker.trackJitmDismissSuccess(
+                UTM_SOURCE,
+                "12345",
+                "test_feature_class"
+            )
+
+            verify(trackerWrapper).track(
+                JITM_DISMISS_SUCCESS,
                 mapOf(
                     KEY_SOURCE to UTM_SOURCE,
                     JITM_ID to "12345",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmTrackerTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.jitm
 
-import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_CTA_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_FAILURE
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_SUCCESS
@@ -8,7 +7,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISMISS_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_FAILURE
 import com.woocommerce.android.analytics.AnalyticsEvent.JITM_FETCH_SUCCESS
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_FEATURE_CLASS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.JITM_ID
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -771,8 +771,9 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_DISPLAYED),
+            verify(jitmTracker).trackJitmDisplayed(
+                any(),
+                any(),
                 any()
             )
         }
@@ -798,13 +799,10 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_DISPLAYED,
-                mapOf(
-                    AnalyticsTracker.KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    AnalyticsTracker.JITM_ID to "12345",
-                    AnalyticsTracker.JITM_FEATURE_CLASS to "woomobile_ipp"
-                )
+            verify(jitmTracker).trackJitmDisplayed(
+                UTM_SOURCE,
+                "12345",
+                "woomobile_ipp"
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -920,8 +920,9 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onPrimaryActionClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_CTA_TAPPED),
+            verify(jitmTracker).trackJitmCtaTapped(
+                any(),
+                any(),
                 any()
             )
         }
@@ -949,13 +950,11 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onPrimaryActionClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_CTA_TAPPED,
-                mapOf(
-                    AnalyticsTracker.KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    AnalyticsTracker.JITM_ID to "12345",
-                    AnalyticsTracker.JITM_FEATURE_CLASS to "woomobile_ipp"
-                )
+
+            verify(jitmTracker).trackJitmCtaTapped(
+                UTM_SOURCE,
+                "12345",
+                "woomobile_ipp"
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -698,8 +698,9 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_FETCH_SUCCESS),
+            verify(jitmTracker).trackJitmFetchSuccess(
+                any(),
+                any(),
                 any()
             )
         }
@@ -720,13 +721,10 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_FETCH_SUCCESS,
-                mapOf(
-                    KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    KEY_JITM to "12345",
-                    KEY_JITM_COUNT to 1
-                )
+            verify(jitmTracker).trackJitmFetchSuccess(
+                UTM_SOURCE,
+                "12345",
+                1
             )
         }
     }
@@ -750,13 +748,10 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_FETCH_SUCCESS,
-                mapOf(
-                    KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    KEY_JITM to "12345",
-                    KEY_JITM_COUNT to 3
-                )
+            verify(jitmTracker).trackJitmFetchSuccess(
+                UTM_SOURCE,
+                "12345",
+                3
             )
         }
     }
@@ -829,9 +824,10 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_FETCH_SUCCESS),
-                any()
+            verify(jitmTracker).trackJitmFetchSuccess(
+                anyString(),
+                eq(null),
+                anyInt()
             )
         }
     }
@@ -851,13 +847,10 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_FETCH_SUCCESS,
-                mapOf(
-                    KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    KEY_JITM to null,
-                    KEY_JITM_COUNT to 0
-                )
+            verify(jitmTracker).trackJitmFetchSuccess(
+                UTM_SOURCE,
+                null,
+                0
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -14,6 +14,8 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.JitmTracker
+import com.woocommerce.android.ui.mystore.MyStoreViewModel.Companion.UTM_SOURCE
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.MyStoreEvent.OnJitmCtaClicked
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
@@ -31,6 +33,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
@@ -65,6 +68,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
     private val usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val jitmStore: JitmStore = mock()
+    private val jitmTracker: JitmTracker = mock()
     private val utmProvider: UtmProvider = mock()
 
     private lateinit var sut: MyStoreViewModel
@@ -869,17 +873,15 @@ class MyStoreViewModelTest : BaseUnitTest() {
                 WooResult(
                     WooError(
                         type = WooErrorType.GENERIC_ERROR,
-                        original = BaseRequest.GenericErrorType.NETWORK_ERROR
+                        original = BaseRequest.GenericErrorType.NETWORK_ERROR,
+                        message = ""
                     )
                 )
             )
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_FETCH_FAILURE),
-                any()
-            )
+            verify(jitmTracker).trackJitmFetchFailure(anyString(), any(), anyString())
         }
     }
 
@@ -902,13 +904,10 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_FETCH_FAILURE,
-                mapOf(
-                    AnalyticsTracker.KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    AnalyticsTracker.KEY_ERROR_TYPE to WooErrorType.GENERIC_ERROR.name,
-                    AnalyticsTracker.KEY_ERROR_DESC to "Generic error"
-                )
+            verify(jitmTracker).trackJitmFetchFailure(
+                UTM_SOURCE,
+                WooErrorType.GENERIC_ERROR,
+                "Generic error"
             )
         }
     }
@@ -1278,6 +1277,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
             analyticsTrackerWrapper,
             myStoreTransactionLauncher = mock(),
             jitmStore,
+            jitmTracker,
             utmProvider,
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -1031,8 +1031,9 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onDismissClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_DISMISS_SUCCESS),
+            verify(jitmTracker).trackJitmDismissSuccess(
+                any(),
+                any(),
                 any()
             )
         }
@@ -1062,13 +1063,10 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onDismissClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_DISMISS_SUCCESS,
-                mapOf(
-                    AnalyticsTracker.KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    AnalyticsTracker.JITM_ID to "12345",
-                    AnalyticsTracker.JITM_FEATURE_CLASS to "woomobile_ipp"
-                )
+            verify(jitmTracker).trackJitmDismissSuccess(
+                UTM_SOURCE,
+                "12345",
+                "woomobile_ipp"
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -975,8 +975,9 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onDismissClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_DISMISS_TAPPED),
+            verify(jitmTracker).trackJitmDismissTapped(
+                any(),
+                any(),
                 any()
             )
         }
@@ -1003,13 +1004,10 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onDismissClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_DISMISS_TAPPED,
-                mapOf(
-                    AnalyticsTracker.KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    AnalyticsTracker.JITM_ID to "12345",
-                    AnalyticsTracker.JITM_FEATURE_CLASS to "woomobile_ipp"
-                )
+            verify(jitmTracker).trackJitmDismissTapped(
+                UTM_SOURCE,
+                "12345",
+                "woomobile_ipp"
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -7,9 +7,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_JITM_COUNT
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.NetworkStatus
@@ -949,7 +946,6 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onPrimaryActionClicked.invoke()
-
 
             verify(jitmTracker).trackJitmCtaTapped(
                 UTM_SOURCE,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -1090,9 +1090,12 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onDismissClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_DISMISS_FAILURE),
-                any()
+            verify(jitmTracker).trackJitmDismissFailure(
+                anyString(),
+                anyString(),
+                anyString(),
+                eq(null),
+                eq(null)
             )
         }
     }
@@ -1121,9 +1124,12 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onDismissClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                eq(AnalyticsEvent.JITM_DISMISS_FAILURE),
-                any()
+            verify(jitmTracker).trackJitmDismissFailure(
+                anyString(),
+                anyString(),
+                anyString(),
+                any(),
+                eq(null)
             )
         }
     }
@@ -1158,15 +1164,12 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onDismissClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_DISMISS_FAILURE,
-                mapOf(
-                    AnalyticsTracker.KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    AnalyticsTracker.JITM_ID to "12345",
-                    AnalyticsTracker.JITM_FEATURE_CLASS to "woomobile_ipp",
-                    AnalyticsTracker.KEY_ERROR_TYPE to WooErrorType.GENERIC_ERROR.name,
-                    AnalyticsTracker.KEY_ERROR_DESC to "Generic error",
-                )
+            verify(jitmTracker).trackJitmDismissFailure(
+                UTM_SOURCE,
+                "12345",
+                "woomobile_ipp",
+                WooErrorType.GENERIC_ERROR,
+                "Generic error"
             )
         }
     }
@@ -1195,15 +1198,12 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onDismissClicked.invoke()
 
-            verify(analyticsTrackerWrapper).track(
-                AnalyticsEvent.JITM_DISMISS_FAILURE,
-                mapOf(
-                    AnalyticsTracker.KEY_SOURCE to MyStoreViewModel.UTM_SOURCE,
-                    AnalyticsTracker.JITM_ID to "12345",
-                    AnalyticsTracker.JITM_FEATURE_CLASS to "woomobile_ipp",
-                    AnalyticsTracker.KEY_ERROR_TYPE to null,
-                    AnalyticsTracker.KEY_ERROR_DESC to null,
-                )
+            verify(jitmTracker).trackJitmDismissFailure(
+                UTM_SOURCE,
+                "12345",
+                "woomobile_ipp",
+                null,
+                null
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.JitmTracker
+import com.woocommerce.android.ui.jitm.JitmTracker
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.Companion.UTM_SOURCE
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.MyStoreEvent.OnJitmCtaClicked
 import com.woocommerce.android.ui.mystore.domain.GetStats


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7668 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR extracts all the analytics related JITM into a separate class `JitmTracker`.

The reason behind this refactoring is not to clutter `MyStoreViewModel` with too much JITM-related analytics logic.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Ensure CI is happy

Smoke test JITM and ensure tracks are being logged as expected.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
