### PR TITLE
Dynamic UTM params from api response

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 11.1
 -----
 - [***] We added a new Analytics Hub inside the My Store area of the app. Simply click on the See More button under the store stats to check more detailed information on Revenue and Orders. (https://github.com/woocommerce/woocommerce-android/pull/7556)
+- [*][Internal] Removes the hardcoded UTM params and instead uses the fields from the JITM fetch API response as UTM params [https://github.com/woocommerce/woocommerce-android/pull/7718]
 
 11.0
 -----

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceComUTMProviderTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceComUTMProviderTest.kt
@@ -96,8 +96,8 @@ class WooCommerceComUTMProviderTest {
         val defaultUTMMedium = "woo_android"
         val url = "https://www.woocommerce.com/us/hw?utm_campaign=$existingUtmCampaign" +
             "&utm_source=$existingUtmSource"
-        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$jitmPrefixUtmCampaign&utm_source=$utmSource" +
-            "&utm_content=$jitmPrefixUtmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
+        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$jitmPrefixUtmCampaign" +
+            "&utm_source=$utmSource&utm_content=$jitmPrefixUtmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
 
         val urlWithUTM = provideUTMProvider(
             campaign = utmCampaign,

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceComUTMProviderTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceComUTMProviderTest.kt
@@ -38,11 +38,13 @@ class WooCommerceComUTMProviderTest {
     @Test
     fun `testUtmQueryParamsAreAddedToTheUrlProperly`() {
         val utmCampaign = "feature_announcement_card"
+        val jitmPrefixUtmCampaign = "jitm_group_feature_announcement_card"
         val utmSource = "orders_list"
         val utmContent = "upsell_card_readers"
+        val jitmPrefixUtmContent = "jitm_upsell_card_readers"
         val url = "https://www.woocommerce.com?utm_campaign=$utmCampaign&utm_source=$utmSource"
-        val expectedUrl = "https://www.woocommerce.com?utm_campaign=$utmCampaign&utm_source=$utmSource" +
-            "&utm_content=$utmContent&utm_term=1234&utm_medium=woo_android"
+        val expectedUrl = "https://www.woocommerce.com?utm_campaign=$jitmPrefixUtmCampaign&utm_source=$utmSource" +
+            "&utm_content=$jitmPrefixUtmContent&utm_term=1234&utm_medium=woo_android"
         val defaultUTMMedium = "woo_android"
 
         val urlWithUTM = provideUTMProvider(
@@ -53,18 +55,19 @@ class WooCommerceComUTMProviderTest {
         ).getUrlWithUtmParams(url)
 
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_medium")).isEqualTo(defaultUTMMedium)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(utmCampaign)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(jitmPrefixUtmCampaign)
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_source")).isEqualTo(utmSource)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(utmContent)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(jitmPrefixUtmContent)
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
     }
 
     @Test
     fun `testUtmQueriesAreExcludedInTheUrlIfTheyAreNullOrEmpty`() {
         val utmCampaign = "feature_announcement_card"
+        val jitmPrefixUtmCampaign = "jitm_group_feature_announcement_card"
         val defaultUTMMedium = "woo_android"
         val url = "https://www.woocommerce.com/us/hw"
-        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$utmCampaign" +
+        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$jitmPrefixUtmCampaign" +
             "&utm_term=1234&utm_medium=$defaultUTMMedium"
 
         val urlWithUTM = provideUTMProvider(
@@ -75,7 +78,7 @@ class WooCommerceComUTMProviderTest {
         ).getUrlWithUtmParams(url)
 
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_medium")).isEqualTo(defaultUTMMedium)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(utmCampaign)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(jitmPrefixUtmCampaign)
         assertFalse(urlWithUTM.contains("utm_source"))
         assertFalse(urlWithUTM.contains("utm_content"))
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
@@ -86,13 +89,15 @@ class WooCommerceComUTMProviderTest {
         val existingUtmCampaign = "payments_menu_item"
         val existingUtmSource = "payments_menu"
         val utmCampaign = "feature_announcement_card"
+        val jitmPrefixUtmCampaign = "jitm_group_feature_announcement_card"
         val utmSource = "orders_list"
         val utmContent = "upsell_card_readers"
+        val jitmPrefixUtmContent = "jitm_upsell_card_readers"
         val defaultUTMMedium = "woo_android"
         val url = "https://www.woocommerce.com/us/hw?utm_campaign=$existingUtmCampaign" +
             "&utm_source=$existingUtmSource"
-        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$utmCampaign&utm_source=$utmSource" +
-            "&utm_content=$utmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
+        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$jitmPrefixUtmCampaign&utm_source=$utmSource" +
+            "&utm_content=$jitmPrefixUtmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
 
         val urlWithUTM = provideUTMProvider(
             campaign = utmCampaign,
@@ -102,9 +107,9 @@ class WooCommerceComUTMProviderTest {
         ).getUrlWithUtmParams(url)
 
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_medium")).isEqualTo(defaultUTMMedium)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(utmCampaign)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(jitmPrefixUtmCampaign)
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_source")).isEqualTo(utmSource)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(utmContent)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(jitmPrefixUtmContent)
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
     }
 
@@ -171,6 +176,46 @@ class WooCommerceComUTMProviderTest {
         ).getUrlWithUtmParams(url)
 
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(utmCampaign)
+        assertThat(urlWithUTM).isEqualTo(expectedUrl)
+    }
+
+    @Test
+    fun `testCampaignPrefixIsAddedWhileAddingUtmParams`() {
+        val utmCampaign = "feature_announcement_card"
+        val jitmPrefixUtmCampaign = "jitm_group_$utmCampaign"
+        val defaultUTMMedium = "woo_android"
+        val url = "https://www.woocommerce.com/us/hw"
+        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$jitmPrefixUtmCampaign" +
+            "&utm_term=1234&utm_medium=$defaultUTMMedium"
+
+        val urlWithUTM = provideUTMProvider(
+            campaign = utmCampaign,
+            source = "",
+            content = null,
+            siteId = 1234L
+        ).getUrlWithUtmParams(url)
+
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(jitmPrefixUtmCampaign)
+        assertThat(urlWithUTM).isEqualTo(expectedUrl)
+    }
+
+    @Test
+    fun `testContentPrefixIsAddedWhileAddingUtmParams`() {
+        val utmContent = "test_content"
+        val jitmPrefixedUtmContent = "jitm_$utmContent"
+        val defaultUTMMedium = "woo_android"
+        val url = "https://www.woocommerce.com/us/hw"
+        val expectedUrl = "https://www.woocommerce.com/us/hw?" +
+            "utm_content=$jitmPrefixedUtmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
+
+        val urlWithUTM = provideUTMProvider(
+            campaign = "",
+            source = "",
+            content = utmContent,
+            siteId = 1234L
+        ).getUrlWithUtmParams(url)
+
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(jitmPrefixedUtmContent)
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooCommerceComUTMProviderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooCommerceComUTMProviderModule.kt
@@ -51,16 +51,4 @@ class WooCommerceComUTMProviderModule {
         content = null,
         siteId = selectedSite.getIfExists()?.siteId
     )
-
-    @Provides
-    @Singleton
-    @Named("my-store")
-    fun provideMyStoreUtm(
-        selectedSite: SelectedSite
-    ) = UtmProvider(
-        campaign = MyStoreViewModel.UTM_CAMPAIGN,
-        source = MyStoreViewModel.UTM_SOURCE,
-        content = MyStoreViewModel.UTM_CONTENT,
-        siteId = selectedSite.getIfExists()?.siteId
-    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooCommerceComUTMProviderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooCommerceComUTMProviderModule.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.di
 
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.mystore.MyStoreViewModel
 import com.woocommerce.android.ui.orders.list.OrderListViewModel
 import com.woocommerce.android.ui.payments.SelectPaymentMethodViewModel
 import com.woocommerce.android.ui.payments.cardreader.hub.CardReaderHubViewModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreUtmProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreUtmProvider.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.mystore
+
+import com.woocommerce.android.util.UtmProvider
+import dagger.Reusable
+import javax.inject.Inject
+
+/**
+ * This is just a wrapper around the UtmProvider to allow mocking the implementation in tests
+ */
+@Reusable
+class MyStoreUtmProvider @Inject constructor() {
+    fun getUrlWithUtmParams(
+        source: String,
+        id: String,
+        featureClass: String,
+        siteId: Long?,
+        url: String
+    ): String {
+        return UtmProvider(
+            campaign = featureClass,
+            source = source,
+            content = id,
+            siteId = siteId
+        ).getUrlWithUtmParams(url)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -86,9 +86,7 @@ class MyStoreViewModel @Inject constructor(
     companion object {
         private const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
         private const val JITM_MESSAGE_PATH = "woomobile:my_store:admin_notices"
-        const val UTM_CAMPAIGN = "jitm_group_woomobile_ipp"
         const val UTM_SOURCE = "my_store"
-        const val UTM_CONTENT = "jitm_woomobile_ipp_barcode_users"
     }
 
     val performanceObserver: LifecycleObserver = myStoreTransactionLauncher

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers.TopPerformerProduct
 import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.UtmProvider
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -65,7 +64,6 @@ import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import javax.inject.Named
 
 @HiltViewModel
 class MyStoreViewModel @Inject constructor(
@@ -83,7 +81,7 @@ class MyStoreViewModel @Inject constructor(
     private val myStoreTransactionLauncher: MyStoreTransactionLauncher,
     private val jitmStore: JitmStore,
     private val jitmTracker: JitmTracker,
-    @Named("my-store") private val utmProvider: UtmProvider,
+    private val myStoreUtmProvider: MyStoreUtmProvider,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
@@ -201,7 +199,13 @@ class MyStoreViewModel @Inject constructor(
         )
         triggerEvent(
             MyStoreEvent.OnJitmCtaClicked(
-                utmProvider.getUrlWithUtmParams(url)
+                myStoreUtmProvider.getUrlWithUtmParams(
+                    source = UTM_SOURCE,
+                    id = id,
+                    featureClass = featureClass,
+                    siteId = selectedSite.getIfExists()?.siteId,
+                    url = url
+                )
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UtmProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UtmProvider.kt
@@ -18,9 +18,17 @@ class UtmProvider(
     val parameters: Map<String, Any?>
         get() {
             return mapOf<String, Any?>(
-                "utm_campaign" to campaign,
+                "utm_campaign" to if (campaign.isNotEmpty()) {
+                    "jitm_group_$campaign"
+                } else {
+                    campaign
+                },
                 "utm_source" to source,
-                "utm_content" to content,
+                "utm_content" to if (!content.isNullOrEmpty()) {
+                    "jitm_$content"
+                } else {
+                    content
+                },
                 "utm_term" to siteId,
                 "utm_medium" to defaultUTMMedium
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -19,7 +19,6 @@ import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers.TopPerformerProduct
 import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.UtmProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -66,7 +65,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val jitmStore: JitmStore = mock()
     private val jitmTracker: JitmTracker = mock()
-    private val utmProvider: UtmProvider = mock()
+    private val utmProvider: MyStoreUtmProvider = mock()
 
     private lateinit var sut: MyStoreViewModel
 
@@ -578,6 +577,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
         testBlocking {
             givenNetworkConnectivity(connected = true)
             whenever(selectedSite.get()).thenReturn(SiteModel())
+            whenever(selectedSite.getIfExists()).thenReturn(SiteModel())
             whenever(
                 jitmStore.fetchJitmMessage(any(), any())
             ).thenReturn(
@@ -585,7 +585,15 @@ class MyStoreViewModelTest : BaseUnitTest() {
                     model = arrayOf(provideJitmApiResponse())
                 )
             )
-            whenever(utmProvider.getUrlWithUtmParams(any())).thenReturn("")
+            whenever(
+                utmProvider.getUrlWithUtmParams(
+                    anyString(),
+                    anyString(),
+                    anyString(),
+                    any(),
+                    anyString(),
+                )
+            ).thenReturn("")
 
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onPrimaryActionClicked.invoke()
@@ -603,6 +611,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
         testBlocking {
             givenNetworkConnectivity(connected = true)
             whenever(selectedSite.get()).thenReturn(SiteModel())
+            whenever(selectedSite.getIfExists()).thenReturn(SiteModel())
             whenever(
                 jitmStore.fetchJitmMessage(any(), any())
             ).thenReturn(
@@ -616,7 +625,15 @@ class MyStoreViewModelTest : BaseUnitTest() {
                     )
                 )
             )
-            whenever(utmProvider.getUrlWithUtmParams(any())).thenReturn(
+            whenever(
+                utmProvider.getUrlWithUtmParams(
+                    anyString(),
+                    anyString(),
+                    anyString(),
+                    any(),
+                    anyString(),
+                )
+            ).thenReturn(
                 "${AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY}US"
             )
 
@@ -636,6 +653,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
         testBlocking {
             givenNetworkConnectivity(connected = true)
             whenever(selectedSite.get()).thenReturn(SiteModel())
+            whenever(selectedSite.getIfExists()).thenReturn(SiteModel())
             whenever(
                 jitmStore.fetchJitmMessage(any(), any())
             ).thenReturn(
@@ -643,7 +661,15 @@ class MyStoreViewModelTest : BaseUnitTest() {
                     model = arrayOf(provideJitmApiResponse())
                 )
             )
-            whenever(utmProvider.getUrlWithUtmParams(any())).thenReturn(
+            whenever(
+                utmProvider.getUrlWithUtmParams(
+                    anyString(),
+                    anyString(),
+                    anyString(),
+                    any(),
+                    anyString(),
+                )
+            ).thenReturn(
                 ""
             )
 
@@ -905,6 +931,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
         testBlocking {
             givenNetworkConnectivity(connected = true)
             whenever(selectedSite.get()).thenReturn(SiteModel())
+            whenever(selectedSite.getIfExists()).thenReturn(SiteModel())
             whenever(
                 jitmStore.fetchJitmMessage(any(), any())
             ).thenReturn(
@@ -912,7 +939,15 @@ class MyStoreViewModelTest : BaseUnitTest() {
                     model = arrayOf(provideJitmApiResponse())
                 )
             )
-            whenever(utmProvider.getUrlWithUtmParams(any())).thenReturn("")
+            whenever(
+                utmProvider.getUrlWithUtmParams(
+                    anyString(),
+                    anyString(),
+                    anyString(),
+                    any(),
+                    anyString(),
+                )
+            ).thenReturn("")
 
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onPrimaryActionClicked.invoke()
@@ -930,6 +965,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
         testBlocking {
             givenNetworkConnectivity(connected = true)
             whenever(selectedSite.get()).thenReturn(SiteModel())
+            whenever(selectedSite.getIfExists()).thenReturn(SiteModel())
             whenever(
                 jitmStore.fetchJitmMessage(any(), any())
             ).thenReturn(
@@ -942,7 +978,15 @@ class MyStoreViewModelTest : BaseUnitTest() {
                     )
                 )
             )
-            whenever(utmProvider.getUrlWithUtmParams(any())).thenReturn("")
+            whenever(
+                utmProvider.getUrlWithUtmParams(
+                    anyString(),
+                    anyString(),
+                    anyString(),
+                    any(),
+                    anyString(),
+                )
+            ).thenReturn("")
 
             whenViewModelIsCreated()
             (sut.bannerState.value as BannerState).onPrimaryActionClicked.invoke()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7717 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the hardcoded UTM params and instead uses the fields from the JITM fetch API response to use as UTM params.

There were 2 UTM params that were hardcoded and those 2 are made dynamic now.

### All UTM Params
1. `utm_medium` – woo_android
2. `utm_campaign` – jitm_group_{JITM_FEATURE_CLASS}: identifies that this is a JITM, and the group for the message. In our IPP related messages, it will be jitm_group_woomobile_ipp
3. `utm_source` – my_store: we will display this JITM on the My Store screen.
4. `utm_term` – {BLOG_ID}
5. `utm_content` – jitm_{JITM_ID}: identifies the specific JITM which the click came from. In our first message, to Barcode extension users, it will be jitm_woomobile_ipp_barcode_users.

### Dynamic UTM Params
1. `utm_campaign` – jitm_group_{JITM_FEATURE_CLASS}
2. `utm_content` – jitm_{JITM_ID}

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Pre-requisite
As mentioned in this post (pdfdoF-1vt-p2) make sure you have installed any one of the mentioned barcode plugin installed on your store. For example - you can install [A4 Barcode Generator](https://wordpress.org/plugins/a4-barcode-generator/)

Your store must be set up in the US. JITM is not supported in any other country.

1. Visit `MyStore` screen
2. Ensure you see JITM banner.
3. Click on the banner CTA.
4. Ensure you see `utm_campaign` and `utm_content`  value in logs is the same as the JITM fetch GET API response field (This request happens when the MyStore screen is loaded when the app is opened) `feature_class` and `id` with `jitm_group_` and `jitm_` prefix correspondingly.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
