### PR TITLE
[HotFix] Fix crash when launching magic link screen on API < 23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
     mediapickerVersion = '0.1.1'
-    wordPressLoginVersion = '0.20.0'
+    wordPressLoginVersion = '0.21.0'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7608 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes a crash that occurred on devices with API < 24 in the Magic Link screen.

### Testing instructions
1. Please use a device with API < 24 (Lollipop or Marshmallow).
2. Open the app.
3. Enter your WordPress.com email (shouldn't be an Automattic email).
4. Click on "Log in with magic link"
5. Confirm the app doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
