### PR TITLE
Apply active filters to orders search request

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 -----
 - [*] [Internal] Simplified login: update prologue screen layout [https://github.com/woocommerce/woocommerce-android/pull/7634]
 - [*] We improved products search behavior. In case there are filters set on Products page, the search results will be filtered accordingly. [https://github.com/woocommerce/woocommerce-android/pull/7696]
+- [*] We improved orders search behavior. In case there are filters set on Orders page, the search results will be filtered accordingly. [https://github.com/woocommerce/woocommerce-android/pull/7728]
 
 11.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetWCOrderListDescriptorWithFiltersAndSearchQuery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetWCOrderListDescriptorWithFiltersAndSearchQuery.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.ui.orders.filters.domain
+
+import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import javax.inject.Inject
+
+class GetWCOrderListDescriptorWithFiltersAndSearchQuery @Inject constructor(
+    private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters
+) {
+    operator fun invoke(searchQuery: String): WCOrderListDescriptor {
+        val listDescriptorWithFilters = getWCOrderListDescriptorWithFilters.invoke()
+
+        return WCOrderListDescriptor(
+            site = listDescriptorWithFilters.site,
+            statusFilter = listDescriptorWithFilters.statusFilter,
+            beforeFilter = listDescriptorWithFilters.beforeFilter,
+            afterFilter = listDescriptorWithFilters.afterFilter,
+            searchQuery = searchQuery
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -150,7 +150,15 @@ class OrderListFragment :
         orderListMenu = menu
         searchMenuItem = menu.findItem(R.id.menu_search)
         searchView = searchMenuItem?.actionView as SearchView?
-        searchView?.queryHint = getString(R.string.orderlist_search_hint)
+        searchView?.queryHint = getSearchQueryHint()
+    }
+
+    private fun getSearchQueryHint(): String {
+        return if (viewModel.viewState.isFilteringActive) {
+            getString(R.string.orderlist_search_hint_active_filters)
+        } else {
+            getString(R.string.orderlist_search_hint)
+        }
     }
 
     override fun onPrepareMenu(menu: Menu) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -385,6 +385,7 @@
     <string name="orderlist_filter_by">Filter orders by</string>
     <string name="orderlist_filter">Filter</string>
     <string name="orderlist_search_hint">Search orders</string>
+    <string name="orderlist_search_hint_active_filters">Search filtered orders</string>
     <string name="orderlist_filtered" translatable="false">: %1$s</string>
     <string name="orderlist_loading">Looking up your orders…</string>
     <string name="orderlist_no_filters_title">All Orders</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("MaxLineLength")
 package com.woocommerce.android.ui.orders
 
 import androidx.lifecycle.SavedStateHandle
@@ -17,6 +18,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.filters.domain.GetSelectedOrderFiltersCount
 import com.woocommerce.android.ui.orders.filters.domain.GetWCOrderListDescriptorWithFilters
+import com.woocommerce.android.ui.orders.filters.domain.GetWCOrderListDescriptorWithFiltersAndSearchQuery
 import com.woocommerce.android.ui.orders.list.OrderListItemIdentifier
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType
 import com.woocommerce.android.ui.orders.list.OrderListRepository
@@ -51,6 +53,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.clearInvocations
@@ -61,7 +64,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.list.PagedListWrapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
@@ -92,6 +94,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val pagedListWrapper: PagedListWrapper<OrderListItemUIType> = mock()
     private val orderFetcher: WCOrderFetcher = mock()
     private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters = mock()
+    private val getWCOrderListDescriptorWithFiltersAndSearchQuery: GetWCOrderListDescriptorWithFiltersAndSearchQuery = mock()
     private val getSelectedOrderFiltersCount: GetSelectedOrderFiltersCount = mock()
     private val bannerDisplayEligibilityChecker: BannerDisplayEligibilityChecker = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
@@ -101,6 +104,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     @Before
     fun setup() = testBlocking {
         whenever(getWCOrderListDescriptorWithFilters.invoke()).thenReturn(WCOrderListDescriptor(site = mock()))
+        whenever(getWCOrderListDescriptorWithFiltersAndSearchQuery.invoke(anyString())).thenReturn(WCOrderListDescriptor(site = mock()))
         whenever(pagedListWrapper.listError).doReturn(mock())
         whenever(pagedListWrapper.isEmpty).doReturn(mock())
         whenever(pagedListWrapper.isFetchingFirstPage).doReturn(mock())
@@ -114,7 +118,6 @@ class OrderListViewModelTest : BaseUnitTest() {
             )
         ).doReturn(pagedListWrapper)
         doReturn(true).whenever(networkStatus).isConnected()
-        doReturn(SiteModel()).whenever(selectedSite).get()
 
         viewModel = OrderListViewModel(
             savedState = savedStateHandle,
@@ -129,6 +132,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             fetcher = orderFetcher,
             resourceProvider = resourceProvider,
             getWCOrderListDescriptorWithFilters = getWCOrderListDescriptorWithFilters,
+            getWCOrderListDescriptorWithFiltersAndSearchQuery = getWCOrderListDescriptorWithFiltersAndSearchQuery,
             getSelectedOrderFiltersCount = getSelectedOrderFiltersCount,
             bannerDisplayEligibilityChecker = bannerDisplayEligibilityChecker,
             orderListTransactionLauncher = mock(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-android/issues/7663

### Description
This PR improves order search behavior. In the Orders page, in case there are filters set, when we perform a search operation, it now returns search results filtered accordingly.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to the Orders page
2. Apply filters
3. Open the search box and search for something
4. Observe search results are filtered according to filters selected in step 2.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
