### PR TITLE
Fix JITM Banner UI issue on the My Store screen when the store has no stats

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -31,19 +31,19 @@
                     android:descendantFocusability="blocksDescendants"
                     android:orientation="vertical">
 
-                    <com.woocommerce.android.widgets.WCEmptyView
-                        android:id="@+id/empty_view"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_marginTop="@dimen/major_350"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
-
                     <androidx.compose.ui.platform.ComposeView
                         android:id="@+id/jitmView"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/minor_100"/>
+
+                    <com.woocommerce.android.widgets.WCEmptyView
+                        android:id="@+id/empty_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="@dimen/major_100"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
                     <!-- Order stats -->
                     <com.woocommerce.android.ui.mystore.MyStoreStatsView


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7722 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a UI issue in the JITM banner that occurs when the store has no stats in the `MyStore` screen.

The JITM banner was getting displayed below the empty stats view before this PR. Now, the JITM banner will be shown at the top regardless of the state of the `MyStore` screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Pre-requisite
As mentioned in this post (pdfdoF-1vt-p2) make sure you have installed any one of the mentioned barcode plugin installed on your store. For example - you can install [A4 Barcode Generator](https://wordpress.org/plugins/a4-barcode-generator/)

Your store must be set up in the US. JITM is not supported in any other country.

### No Stats in My Store
1. Ensure your store has no stats OR in the code go to `MyStoreFragment` and set `OrderState.AtLeastOne -> showEmptyView(true)` to `OrderState.AtLeastOne -> showEmptyView(false)`
2. Visit `MyStore` screen
3. Ensure you see the JITM banner above the empty view.

### Stats in My Store
1. Ensure your store has stats
2. Visit `MyStore` screen
3. Ensure you see the JITM banner above the stats view as usual.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<p float="left">
  <img src="https://user-images.githubusercontent.com/1331230/199649567-4e7dd9b3-69d5-4302-b5c9-6c4d7a3cda0b.png" width="200" height="400"/>
Before
<br />


  <img src="https://user-images.githubusercontent.com/1331230/199649720-6e1af271-7f62-4a82-90ed-0ca2539d2489.png" width="200" height="400" /> 
After
</p>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
