### PR TITLE
Add charts to stats sections

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrdersStat.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrdersStat.kt
@@ -5,5 +5,7 @@ data class OrdersStat(
     val ordersCountDelta: DeltaPercentage,
     val avgOrderValue: Double,
     val avgOrderDelta: DeltaPercentage,
-    val currencyCode: String?
+    val currencyCode: String?,
+    val ordersCountByInterval: List<Long>,
+    val avgOrderValueByInterval: List<Double>
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/RevenueStat.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/RevenueStat.kt
@@ -5,7 +5,9 @@ data class RevenueStat(
     val totalDelta: DeltaPercentage,
     val netValue: Double,
     val netDelta: DeltaPercentage,
-    val currencyCode: String?
+    val currencyCode: String?,
+    val totalRevenueByInterval: List<Double>,
+    val netRevenueByInterval: List<Double>
 )
 
 sealed class DeltaPercentage {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -54,8 +54,11 @@ class AnalyticsRepository @Inject constructor(
         fetchStrategy: FetchStrategy
     ): RevenueResult {
         val granularity = getGranularity(selectedRange)
-        val currentPeriodTotalRevenue = getCurrentPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
-        val previousPeriodTotalRevenue = getPreviousPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+        val currentPeriod = getCurrentPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+        val previousPeriod = getPreviousPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+
+        val currentPeriodTotalRevenue = currentPeriod?.parseTotal()
+        val previousPeriodTotalRevenue = previousPeriod?.parseTotal()
 
         if (listOf(currentPeriodTotalRevenue, previousPeriodTotalRevenue).any { it == null } ||
             currentPeriodTotalRevenue?.totalSales == null ||
@@ -69,13 +72,25 @@ class AnalyticsRepository @Inject constructor(
         val currentTotalSales = currentPeriodTotalRevenue.totalSales!!
         val currentNetRevenue = currentPeriodTotalRevenue.netRevenue!!
 
+        val intervals = currentPeriod.getIntervalList()
+
+        val totalRevenueByInterval = intervals.map {
+            it.subtotals?.totalSales ?: 0.0
+        }
+
+        val netRevenueByInterval = intervals.map {
+            it.subtotals?.netRevenue ?: 0.0
+        }
+
         return RevenueData(
             RevenueStat(
                 currentTotalSales,
                 calculateDeltaPercentage(previousTotalSales, currentTotalSales),
                 currentNetRevenue,
                 calculateDeltaPercentage(previousNetRevenue, currentNetRevenue),
-                getCurrencyCode()
+                getCurrencyCode(),
+                totalRevenueByInterval,
+                netRevenueByInterval
             )
         )
     }
@@ -86,8 +101,12 @@ class AnalyticsRepository @Inject constructor(
         fetchStrategy: FetchStrategy
     ): OrdersResult {
         val granularity = getGranularity(selectedRange)
-        val currentPeriodTotalRevenue = getCurrentPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
-        val previousPeriodTotalRevenue = getPreviousPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+
+        val currentPeriod = getCurrentPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+        val previousPeriod = getPreviousPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+
+        val currentPeriodTotalRevenue = currentPeriod?.parseTotal()
+        val previousPeriodTotalRevenue = previousPeriod?.parseTotal()
 
         if (listOf(currentPeriodTotalRevenue, previousPeriodTotalRevenue).any { it == null } ||
             currentPeriodTotalRevenue?.ordersCount == null ||
@@ -101,13 +120,25 @@ class AnalyticsRepository @Inject constructor(
         val currentOrdersCount = currentPeriodTotalRevenue.ordersCount!!
         val currentAvgOrderValue = currentPeriodTotalRevenue.avgOrderValue!!
 
+        val intervals = currentPeriod.getIntervalList()
+
+        val ordersCountByInterval = intervals.map {
+            it.subtotals?.ordersCount ?: 0
+        }
+
+        val avgOrderValueByInterval = intervals.map {
+            it.subtotals?.avgOrderValue ?: 0.0
+        }
+
         return OrdersResult.OrdersData(
             OrdersStat(
                 currentOrdersCount,
                 calculateDeltaPercentage(previousOrdersCount.toDouble(), currentOrdersCount.toDouble()),
                 currentAvgOrderValue,
                 calculateDeltaPercentage(previousOrderValue, currentAvgOrderValue),
-                getCurrencyCode()
+                getCurrencyCode(),
+                ordersCountByInterval,
+                avgOrderValueByInterval
             )
         )
     }
@@ -119,8 +150,11 @@ class AnalyticsRepository @Inject constructor(
     ): ProductsResult {
         val granularity = getGranularity(selectedRange)
 
-        val currentPeriodTotalRevenue = getCurrentPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
-        val previousPeriodTotalRevenue = getPreviousPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+        val currentPeriod = getCurrentPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+        val previousPeriod = getPreviousPeriodStats(dateRange, granularity, fetchStrategy).getOrNull()
+        val currentPeriodTotalRevenue = currentPeriod?.parseTotal()
+        val previousPeriodTotalRevenue = previousPeriod?.parseTotal()
+
         val productsStats = getProductStats(dateRange, fetchStrategy, TOP_PRODUCTS_LIST_SIZE).getOrNull()
 
         if (listOf(currentPeriodTotalRevenue, previousPeriodTotalRevenue, productsStats).any { it == null } ||
@@ -159,7 +193,7 @@ class AnalyticsRepository @Inject constructor(
         dateRange: AnalyticsDateRange,
         granularity: StatsGranularity,
         fetchStrategy: FetchStrategy
-    ): Result<WCRevenueStatsModel.Total> = coroutineScope {
+    ): Result<WCRevenueStatsModel?> = coroutineScope {
         val startDate = when (dateRange) {
             is SimpleDateRange -> dateRange.from.formatToYYYYmmDD()
             is MultipleDateRange -> dateRange.to.from.formatToYYYYmmDD()
@@ -186,7 +220,7 @@ class AnalyticsRepository @Inject constructor(
         dateRange: AnalyticsDateRange,
         granularity: StatsGranularity,
         fetchStrategy: FetchStrategy
-    ): Result<WCRevenueStatsModel.Total> = coroutineScope {
+    ): Result<WCRevenueStatsModel?> = coroutineScope {
         val startDate = when (dateRange) {
             is SimpleDateRange -> dateRange.from.formatToYYYYmmDD()
             is MultipleDateRange -> dateRange.from.from.formatToYYYYmmDD()
@@ -266,13 +300,13 @@ class AnalyticsRepository @Inject constructor(
         endDate: String,
         granularity: StatsGranularity,
         fetchStrategy: FetchStrategy
-    ): Result<WCRevenueStatsModel.Total> =
+    ): Result<WCRevenueStatsModel?> =
         statsRepository.fetchRevenueStats(
             granularity,
             fetchStrategy is FetchStrategy.ForceNew,
             startDate,
             endDate
-        ).flowOn(dispatchers.io).single().mapCatching { it!!.parseTotal()!! }
+        ).flowOn(dispatchers.io).single().mapCatching { it }
 
     private fun getCurrencyCode() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode
     private fun getAdminPanelUrl() = selectedSite.getIfExists()?.adminUrl
@@ -312,6 +346,6 @@ class AnalyticsRepository @Inject constructor(
     private data class AnalyticsStatsResultWrapper(
         val startDate: String,
         val endDate: String,
-        val result: Deferred<Result<WCRevenueStatsModel.Total>>
+        val result: Deferred<Result<WCRevenueStatsModel?>>
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -212,12 +212,7 @@ class AnalyticsViewModel @Inject constructor(
                         is RevenueData -> {
                             mutableState.value = state.value.copy(
                                 refreshIndicator = NotShowIndicator,
-                                revenueState = buildRevenueDataViewState(
-                                    formatValue(it.revenueStat.totalValue.toString(), it.revenueStat.currencyCode),
-                                    it.revenueStat.totalDelta,
-                                    formatValue(it.revenueStat.netValue.toString(), it.revenueStat.currencyCode),
-                                    it.revenueStat.netDelta
-                                )
+                                revenueState = buildRevenueDataViewState(it)
                             )
                             transactionLauncher.onRevenueFetched()
                         }
@@ -244,12 +239,7 @@ class AnalyticsViewModel @Inject constructor(
                     when (it) {
                         is OrdersData -> {
                             mutableState.value = state.value.copy(
-                                ordersState = buildOrdersDataViewState(
-                                    it.ordersStat.ordersCount.toString(),
-                                    it.ordersStat.ordersCountDelta,
-                                    formatValue(it.ordersStat.avgOrderValue.toString(), it.ordersStat.currencyCode),
-                                    it.ordersStat.avgOrderDelta
-                                )
+                                ordersState = buildOrdersDataViewState(it)
                             )
                             transactionLauncher.onOrdersFetched()
                         }
@@ -353,6 +343,7 @@ class AnalyticsViewModel @Inject constructor(
 
     private fun getAvailableDateRanges() =
         resourceProvider.getStringArray(R.array.analytics_date_range_selectors).asList()
+
     private fun getDefaultTimePeriod() = navArgs.targetGranularity
 
     private fun getDefaultDateRange() = analyticsDateRange.getAnalyticsDateRangeFrom(getDefaultTimePeriod())
@@ -383,43 +374,45 @@ class AnalyticsViewModel @Inject constructor(
         selectedPeriod = getTimePeriodDescription(getSavedTimePeriod())
     )
 
-    private fun buildRevenueDataViewState(
-        totalValue: String,
-        totalDelta: DeltaPercentage,
-        netValue: String,
-        netDelta: DeltaPercentage
-    ) =
+    private fun buildRevenueDataViewState(data: RevenueData) =
         DataViewState(
             title = resourceProvider.getString(R.string.analytics_revenue_card_title),
             leftSection = AnalyticsInformationSectionViewState(
                 resourceProvider.getString(R.string.analytics_total_sales_title),
-                totalValue,
-                if (totalDelta is DeltaPercentage.Value) totalDelta.value else null
+                formatValue(data.revenueStat.totalValue.toString(), data.revenueStat.currencyCode),
+                if (data.revenueStat.totalDelta is DeltaPercentage.Value) data.revenueStat.totalDelta.value else null,
+                data.revenueStat.totalRevenueByInterval.map { it.toFloat() }
             ),
             rightSection = AnalyticsInformationSectionViewState(
                 resourceProvider.getString(R.string.analytics_net_sales_title),
-                netValue,
-                if (netDelta is DeltaPercentage.Value) netDelta.value else null
-            )
+                formatValue(data.revenueStat.netValue.toString(), data.revenueStat.currencyCode),
+                if (data.revenueStat.netDelta is DeltaPercentage.Value) data.revenueStat.netDelta.value else null,
+                data.revenueStat.netRevenueByInterval.map { it.toFloat() }
+            ),
         )
 
-    private fun buildOrdersDataViewState(
-        totalOrders: String,
-        totalDelta: DeltaPercentage,
-        avgValue: String,
-        avgDelta: DeltaPercentage
-    ) =
+    private fun buildOrdersDataViewState(data: OrdersData) =
         DataViewState(
             title = resourceProvider.getString(R.string.analytics_orders_card_title),
             leftSection = AnalyticsInformationSectionViewState(
                 resourceProvider.getString(R.string.analytics_total_orders_title),
-                totalOrders,
-                if (totalDelta is DeltaPercentage.Value) totalDelta.value else null
+                data.ordersStat.ordersCount.toString(),
+                if (data.ordersStat.ordersCountDelta is DeltaPercentage.Value) {
+                    data.ordersStat.ordersCountDelta.value
+                } else {
+                    null
+                },
+                data.ordersStat.ordersCountByInterval.map { it.toFloat() }
             ),
             rightSection = AnalyticsInformationSectionViewState(
                 resourceProvider.getString(R.string.analytics_avg_orders_title),
-                avgValue,
-                if (avgDelta is DeltaPercentage.Value) avgDelta.value else null
+                formatValue(data.ordersStat.avgOrderValue.toString(), data.ordersStat.currencyCode),
+                if (data.ordersStat.avgOrderDelta is DeltaPercentage.Value) {
+                    data.ordersStat.avgOrderDelta.value
+                } else {
+                    null
+                },
+                data.ordersStat.avgOrderValueByInterval.map { it.toFloat() }
             )
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/LineChart.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/LineChart.kt
@@ -1,0 +1,145 @@
+package com.woocommerce.android.ui.analytics
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LineChart(
+    info: List<Float>,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Green,
+    strokeWidth: Dp = 2.dp
+) {
+    when (info.size) {
+        // We only draw the chart when info size is greater than 1
+        0, 1 -> {}
+        else -> {
+            MultipleValuesLineChart(
+                info = info,
+                color = color,
+                strokeWidth = strokeWidth,
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Composable
+internal fun MultipleValuesLineChart(
+    info: List<Float>,
+    color: Color,
+    strokeWidth: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val transparentGraphColor = remember {
+        color.copy(alpha = 0.5f)
+    }
+    val higherValue = remember(info) {
+        (info.maxOfOrNull { it }?.plus(1)) ?: 0f
+    }
+    val lowerValue = remember(info) {
+        info.minOfOrNull { it } ?: 0f
+    }
+    val ratio = remember(info) { higherValue - lowerValue }
+
+    val animation = remember(info) { Animatable(0f) }
+
+    LaunchedEffect(info) {
+        animation.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(
+                durationMillis = 300,
+                delayMillis = 100,
+                easing = LinearOutSlowInEasing
+            )
+        )
+    }
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val padding = size.width * 0.1f
+        val spaceBetweenValues = (size.width - padding) / info.size
+
+        val strokePath = Path().apply {
+            val height = size.height
+            for (i in info.indices) {
+                val currentValue = info[i]
+                val yRatio = (currentValue - lowerValue) / ratio
+
+                val x = padding + i * spaceBetweenValues
+                val chartTopDrawableArea = height - padding
+                val y = chartTopDrawableArea - (yRatio * chartTopDrawableArea) * animation.value
+
+                if (i == 0) moveTo(x, y) else lineTo(x, y)
+            }
+        }
+
+        val lastX = padding + info.size * spaceBetweenValues
+
+        val fillPath = Path()
+            .apply {
+                addPath(strokePath)
+                lineTo(lastX, size.height - padding)
+                lineTo(padding, size.height - padding)
+                close()
+            }
+
+        drawPath(
+            path = fillPath,
+            brush = Brush.verticalGradient(
+                colors = listOf(
+                    transparentGraphColor,
+                    Color.Transparent
+                ),
+                endY = size.height - padding
+            )
+        )
+
+        drawPath(
+            path = strokePath,
+            color = color,
+            style = Stroke(
+                width = strokeWidth.toPx(),
+                cap = StrokeCap.Round
+            )
+        )
+    }
+}
+
+@Preview(widthDp = 300, heightDp = 300)
+@Composable
+internal fun LineChartPreviewSquare() {
+    LineChart(info = listOf(10f, 5.5f, 12f, 12f, 8f, 18f))
+}
+
+@Preview(widthDp = 500, heightDp = 300)
+@Composable
+internal fun LineChartPreviewRectangle() {
+    LineChart(info = listOf(10f, 5.5f, 12f, 12f, 8f, 18f))
+}
+
+@Preview(widthDp = 300, heightDp = 300)
+@Composable
+internal fun LineChartPreviewEmpty() {
+    LineChart(info = emptyList())
+}
+
+@Preview(widthDp = 300, heightDp = 300)
+@Composable
+internal fun LineChartPreviewOneValue() {
+    LineChart(info = listOf(10f))
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/LineChart.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/LineChart.kt
@@ -56,7 +56,7 @@ internal fun SingleValueLineChart(
     strokeWidth: Dp,
     modifier: Modifier = Modifier,
 ) {
-    val transparentGraphColor = remember {
+    val transparentGraphColor = remember(color) {
         color.copy(alpha = 0.5f)
     }
 
@@ -111,7 +111,7 @@ internal fun MultipleValuesLineChart(
     strokeWidth: Dp,
     modifier: Modifier = Modifier,
 ) {
-    val transparentGraphColor = remember(info) {
+    val transparentGraphColor = remember(color) {
         color.copy(alpha = 0.5f)
     }
     val higherValue = remember(info) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionView.kt
@@ -6,12 +6,16 @@ import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.TextViewCompat
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsInformationSectionViewBinding
+import com.woocommerce.android.ui.analytics.LineChart
+import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.widgets.tags.ITag
 import com.woocommerce.android.widgets.tags.TagConfig
 import org.wordpress.android.util.DisplayUtils
@@ -54,6 +58,22 @@ internal class AnalyticsInformationSectionView @JvmOverloads constructor(
                 AnalyticsInformationSectionDeltaTag(it, getDeltaTagText(sectionViewState.sign, it))
         }
         binding.cardInformationSectionDeltaTag.isVisible = sectionViewState.delta != null
+        binding.cardInformationChart.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val color = if (sectionViewState.delta != null && sectionViewState.delta > 0) {
+                    colorResource(R.color.analytics_delta_positive_color)
+                } else {
+                    colorResource(R.color.analytics_delta_tag_negative_color)
+                }
+                WooTheme {
+                    LineChart(
+                        info = sectionViewState.chartInfo,
+                        color = color
+                    )
+                }
+            }
+        }
     }
 
     private fun getDeltaTagText(sign: String, value: Int) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionView.kt
@@ -58,19 +58,22 @@ internal class AnalyticsInformationSectionView @JvmOverloads constructor(
                 AnalyticsInformationSectionDeltaTag(it, getDeltaTagText(sectionViewState.sign, it))
         }
         binding.cardInformationSectionDeltaTag.isVisible = sectionViewState.delta != null
-        binding.cardInformationChart.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-            setContent {
-                val color = if (sectionViewState.delta != null && sectionViewState.delta > 0) {
-                    colorResource(R.color.analytics_delta_positive_color)
-                } else {
-                    colorResource(R.color.analytics_delta_tag_negative_color)
-                }
-                WooTheme {
-                    LineChart(
-                        info = sectionViewState.chartInfo,
-                        color = color
-                    )
+        // Display the Charts only when the tag is visible
+        if (sectionViewState.delta != null) {
+            binding.cardInformationChart.apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                setContent {
+                    val color = if (sectionViewState.delta > 0) {
+                        colorResource(R.color.analytics_delta_positive_color)
+                    } else {
+                        colorResource(R.color.analytics_delta_tag_negative_color)
+                    }
+                    WooTheme {
+                        LineChart(
+                            info = sectionViewState.chartInfo,
+                            color = color
+                        )
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionView.kt
@@ -14,6 +14,7 @@ import androidx.core.widget.TextViewCompat
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsInformationSectionViewBinding
+import com.woocommerce.android.extensions.greaterThan
 import com.woocommerce.android.ui.analytics.LineChart
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.widgets.tags.ITag
@@ -57,23 +58,22 @@ internal class AnalyticsInformationSectionView @JvmOverloads constructor(
             binding.cardInformationSectionDeltaTag.tag =
                 AnalyticsInformationSectionDeltaTag(it, getDeltaTagText(sectionViewState.sign, it))
         }
-        binding.cardInformationSectionDeltaTag.isVisible = sectionViewState.delta != null
-        // Display the Charts only when the tag is visible
-        if (sectionViewState.delta != null) {
-            binding.cardInformationChart.apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                setContent {
-                    val color = if (sectionViewState.delta > 0) {
-                        colorResource(R.color.analytics_delta_positive_color)
-                    } else {
-                        colorResource(R.color.analytics_delta_tag_negative_color)
-                    }
-                    WooTheme {
-                        LineChart(
-                            info = sectionViewState.chartInfo,
-                            color = color
-                        )
-                    }
+        val isDeltaNotNull = sectionViewState.delta != null
+        binding.cardInformationSectionDeltaTag.isVisible = isDeltaNotNull
+        binding.cardInformationChart.apply {
+            isVisible = isDeltaNotNull
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val color = if (sectionViewState.delta.greaterThan(0)) {
+                    colorResource(R.color.analytics_delta_positive_color)
+                } else {
+                    colorResource(R.color.analytics_delta_tag_negative_color)
+                }
+                WooTheme {
+                    LineChart(
+                        info = sectionViewState.chartInfo,
+                        color = color
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationSectionViewState.kt
@@ -3,7 +3,8 @@ package com.woocommerce.android.ui.analytics.informationcard
 data class AnalyticsInformationSectionViewState(
     val title: String,
     val value: String,
-    val delta: Int?
+    val delta: Int?,
+    val chartInfo: List<Float>
 ) {
     val sign: String
         get() = when {

--- a/WooCommerce/src/main/res/layout/analytics_information_section_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_information_section_view.xml
@@ -28,7 +28,6 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/minor_00"
             android:layout_marginTop="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
             android:textSize="@dimen/text_major_50"
             app:layout_constraintBottom_toTopOf="@+id/cardInformationSectionDeltaTag"
             app:layout_constraintStart_toStartOf="parent"
@@ -40,12 +39,26 @@
             android:layout_width="wrap_content"
             android:layout_height="@dimen/text_major_50"
             android:textSize="@dimen/text_minor_80"
+            android:layout_marginTop="@dimen/major_100"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="@+id/cardInformationSectionValue"
             app:layout_constraintTop_toBottomOf="@+id/cardInformationSectionValue"
             app:tagTextColor="@color/woo_white"
             tools:tagColor="#69B56E"
             tools:tagText="+1000%" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/cardInformationChart"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/analytics_chart_height"
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginStart="@dimen/minor_100"
+            app:layout_constraintWidth_max="@dimen/analytics_max_chart_width"
+            app:layout_constraintStart_toEndOf="@+id/cardInformationSectionDeltaTag"
+            app:layout_constraintTop_toBottomOf="@+id/cardInformationSectionValue"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintEnd_toEndOf="parent"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -111,6 +111,9 @@ so that's the baseline as defined in `major_100`.
     <dimen name="chart_axis_bottom_padding">10dp</dimen>
     <dimen name="chart_bar_radius">2dp</dimen>
 
+    <dimen name="analytics_chart_height">32dp</dimen>
+    <dimen name="analytics_max_chart_width">72dp</dimen>
+
     <!-- Other literal dimensions -->
     <dimen name="margin_app_title_aligned">72dp</dimen>
     <dimen name="min_tap_target">48dp</dimen>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepositoryTest.kt
@@ -175,7 +175,9 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                         netValue = 100.0,
                         totalDelta = DeltaPercentage.Value(20),
                         netDelta = DeltaPercentage.Value(25),
-                        currencyCode = null
+                        currencyCode = null,
+                        totalRevenueByInterval = listOf(120.0),
+                        netRevenueByInterval = listOf(100.0)
                     )
                 )
             )
@@ -845,11 +847,17 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
 
     private fun givenARevenue(totalSales: Double?, netValue: Double?, itemsSold: Int?): WCRevenueStatsModel {
         val stats: WCRevenueStatsModel = mock()
+        val interval: WCRevenueStatsModel.Interval = mock()
+        val subtotal: WCRevenueStatsModel.SubTotal = mock()
         val revenueStatsTotal: WCRevenueStatsModel.Total = mock()
         whenever(revenueStatsTotal.totalSales).thenReturn(totalSales)
         whenever(revenueStatsTotal.netRevenue).thenReturn(netValue)
         whenever(revenueStatsTotal.itemsSold).thenReturn(itemsSold)
         whenever(stats.parseTotal()).thenReturn(revenueStatsTotal)
+        whenever(subtotal.totalSales).thenReturn(totalSales)
+        whenever(subtotal.netRevenue).thenReturn(netValue)
+        whenever(interval.subtotals).thenReturn(subtotal)
+        whenever(stats.getIntervalList()).thenReturn(listOf(interval))
         return stats
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
@@ -519,7 +519,17 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         currencyCode: String = CURRENCY_CODE,
         totalDelta: DeltaPercentage = DeltaPercentage.Value(TOTAL_DELTA.toInt()),
         netDelta: DeltaPercentage = DeltaPercentage.Value(NET_DELTA.toInt()),
-    ) = RevenueData(RevenueStat(totalValue, totalDelta, netValue, netDelta, currencyCode))
+    ) = RevenueData(
+        RevenueStat(
+            totalValue,
+            totalDelta,
+            netValue,
+            netDelta,
+            currencyCode,
+            listOf(TOTAL_VALUE),
+            listOf(NET_VALUE)
+        )
+    )
 
     private fun getOrdersStats(
         ordersCount: Int = ORDERS_COUNT,
@@ -533,7 +543,9 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             DeltaPercentage.Value(ordersCountDelta),
             avgOrderValue,
             DeltaPercentage.Value(avgOrderValueDelta),
-            currencyCode
+            currencyCode,
+            listOf(ORDERS_COUNT.toLong()),
+            listOf(AVG_ORDER_VALUE)
         )
     )
 

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-de1e4ebe20d33a39dad3aecb6debb4f40830e958'
+    fluxCVersion = '2558-06e1fc7f8c6c514e919c7970c3196c95d7a8c0ed'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2558-06e1fc7f8c6c514e919c7970c3196c95d7a8c0ed'
+    fluxCVersion = 'trunk-247374275cf46d65eb59f89d3541b7cc1489b874'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ This PR depends on [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2558)

Closes: #7701

### Why
As part of the new Analytics Hub feature, we want to display charts representing the stats behavior by interval as shown in the image below, providing more info and a better experience for merchants.

<img width="300" src="https://user-images.githubusercontent.com/18119390/199751044-cb9c1d9f-f1cf-40e0-acf1-be225e662b67.png" />

### Description
The main goal of this PR is to add line charts to the Analytics Revenue and Orders stats cards. 
In order to add the charts, now the `AnalyticRepository` fetches the whole `WCRevenueStatsModel` and not only the totals. This way, we are able to get the period interval lists that we need to draw the charts. 
The `OrderStat` and `RevenueStat` classes were also updated to include the intervals that will be represented by the charts.

The charts are created using the LineChart composable function added in this PR. 
LineChart includes two cases:
1. There is only one value to represent. In this case, the chart is drawn has a single line from start to end.
2. There are multiple values to represent. The common line chart case that is represented as a line joining the different values.

### Testing instructions

1. Open MyStore Screen
2. Tap on See more below the store stats
3. Check that **when** the delta tag is visible, besides the tag, there is a chart matching the tag color (red | green) representing the stat value by interval

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Light Mode  | Dark Mode |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/18119390/199749255-74ec34df-1914-4a3c-98b7-f08a5f9488d5.png" /> | <img width="300" src="https://user-images.githubusercontent.com/18119390/199749267-2600f6f9-9a64-4efa-ae82-2d927bd6a27c.png" />  |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
