### PR TITLE
Update `compileSdkVersion` for `barcode` module (from `31` to `33`)

### DIFF
--- a/libs/barcode/build.gradle
+++ b/libs/barcode/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion gradle.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion gradle.ext.minSdkVersion

--- a/libs/barcode/build.gradle
+++ b/libs/barcode/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         minSdkVersion gradle.ext.minSdkVersion
-        targetSdkVersion 31
+        targetSdkVersion gradle.ext.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/libs/barcode/build.gradle
+++ b/libs/barcode/build.gradle
@@ -26,9 +26,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        freeCompilerArgs += [
-                "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
-        ]
     }
 }
 

--- a/libs/barcode/build.gradle
+++ b/libs/barcode/build.gradle
@@ -24,9 +24,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
 }
 
 dependencies {

--- a/libs/barcode/src/main/java/com/woocommerce/android/barcode/QrCodeScanningFragment.kt
+++ b/libs/barcode/src/main/java/com/woocommerce/android/barcode/QrCodeScanningFragment.kt
@@ -89,7 +89,7 @@ class QrCodeScanningFragment : Fragment(), OnClickListener {
 
     override fun onClick(view: View) {
         when (view.id) {
-            R.id.closeButton -> requireActivity().onBackPressed()
+            R.id.closeButton -> requireActivity().onBackPressedDispatcher.onBackPressed()
         }
     }
 

--- a/libs/barcode/src/main/java/com/woocommerce/android/barcode/ScopedExecutor.kt
+++ b/libs/barcode/src/main/java/com/woocommerce/android/barcode/ScopedExecutor.kt
@@ -30,10 +30,10 @@ class ScopedExecutor(private val executor: Executor) : Executor {
         if (shutdown.get()) {
             return
         }
-        executor.execute {
+        executor.execute executeAgain@{
             // Check again in case it has been shut down in the mean time.
             if (shutdown.get()) {
-                return@execute
+                return@executeAgain
             }
             command.run()
         }

--- a/libs/barcode/src/main/java/com/woocommerce/android/barcode/Utils.kt
+++ b/libs/barcode/src/main/java/com/woocommerce/android/barcode/Utils.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.woocommerce.android.barcode
 
 import android.content.ContentResolver
@@ -54,6 +56,7 @@ object Utils {
      * be set to a size that is the same aspect ratio as the preview size we choose. Otherwise, the
      * preview images may be distorted on some devices.
      */
+    @Suppress("DEPRECATION")
     fun generateValidPreviewSizeList(camera: Camera): List<CameraSizePair> {
         val parameters = camera.parameters
         val supportedPreviewSizes = parameters.supportedPreviewSizes

--- a/libs/barcode/src/main/java/com/woocommerce/android/barcode/camera/CameraSizePair.kt
+++ b/libs/barcode/src/main/java/com/woocommerce/android/barcode/camera/CameraSizePair.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.woocommerce.android.barcode.camera
 
 import android.hardware.Camera
@@ -29,6 +31,7 @@ class CameraSizePair {
     val preview: Size
     val picture: Size?
 
+    @Suppress("DEPRECATION")
     constructor(previewSize: Camera.Size, pictureSize: Camera.Size?) {
         preview = Size(previewSize.width, previewSize.height)
         picture = pictureSize?.let { Size(it.width, it.height) }

--- a/libs/barcode/src/main/java/com/woocommerce/android/barcode/camera/CameraSource.kt
+++ b/libs/barcode/src/main/java/com/woocommerce/android/barcode/camera/CameraSource.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.woocommerce.android.barcode.camera
 
 import android.content.Context

--- a/libs/barcode/src/main/java/com/woocommerce/android/barcode/camera/FrameProcessorBase.kt
+++ b/libs/barcode/src/main/java/com/woocommerce/android/barcode/camera/FrameProcessorBase.kt
@@ -78,7 +78,7 @@ abstract class FrameProcessorBase<T> : FrameProcessor {
                 this@FrameProcessorBase.onSuccess(results, graphicOverlay)
                 processLatestFrame(graphicOverlay)
             }
-            .addOnFailureListener(executor) { e -> OnFailureListener { this@FrameProcessorBase.onFailure(it) } }
+            .addOnFailureListener(executor) { OnFailureListener { this@FrameProcessorBase.onFailure(it) } }
     }
 
     override fun stop() {


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After [a discussion](https://github.com/woocommerce/woocommerce-android/pull/7643#issuecomment-1296866999) with @0nko, this PR upgrades `compileSdkVersion` to `33` for the `barcode` module. This was the only module that was still on `compileSdkVersion = 31`. With this update and that fact that `targetSdkVersion` got aligned too, all modules are now pointing to the exact same `minSdkVersion`, `compileSdkVersion` and `targetSdkVersions`.

-----

As part of this `compileSdkVersion = 31` upgrade the below changes were also applied in order to fix any additional warnings that this change brought-up:

Warnings Resolution List:
1. [Resolve on back pressed deprecated warning for barcode module.](https://github.com/woocommerce/woocommerce-android/pull/7741/commits/2c763f52ed567b2a96fc103f9c62cab44713c63f)
2. [Resolve more than one label with such a name in scope warning.](https://github.com/woocommerce/woocommerce-android/pull/7741/commits/1c943a62bd03a8d4cb3dba1a9513d8dd4eb4b213)
3. [Resolve parameter is never and could be renamed to _ warning.](https://github.com/woocommerce/woocommerce-android/pull/7741/commits/2b0076e401040053bfb440b5ef4e7fdfc369b2a1)

Warnings Suppression List:
1. [Suppress android hardware camera deprecated warnings.](https://github.com/woocommerce/woocommerce-android/pull/7741/commits/e8040cc982fc80cdebb85c87708aa00fce94a23d)

Build List:
1. [Use common target sdk version from settings for barcode module.](https://github.com/woocommerce/woocommerce-android/pull/7741/commits/540a95a8d816b70cc6edeff4ddae5e35ca1638ac)
4. [Remove unnecessary experimental coroutines api annotation.](https://github.com/woocommerce/woocommerce-android/pull/7741/commits/e060148275086ec5273576a25ffeda24fc2ad9b8)
5. [Remove unnecessary kotlin option configuration for barcode module.](https://github.com/woocommerce/woocommerce-android/pull/7741/commits/66d32412ac37a92ea6b96abb058acabdbaec69c6)

-----

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could quickly smoke test the `Barcode` related feature of the `WooCommerce` app and see if it works as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
