### PR TITLE
A8C Libs S3 and Fetch Style Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ import io.github.wzieba.tracks.plugin.TracksExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id 'com.automattic.android.fetchstyle'
     id 'io.gitlab.arturbosch.detekt'
     id 'io.github.wzieba.tracks.plugin'
     id 'com.android.application' apply false

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,6 @@ pluginManagement {
             filter {
                 includeGroup "com.automattic.android"
                 includeGroup "com.automattic.android.configure"
-                includeGroup "com.automattic.android.fetchstyle"
                 includeGroup "com.automattic.android.publish-to-s3"
             }
         }
@@ -27,7 +26,6 @@ pluginManagement {
         id 'androidx.navigation.safeargs.kotlin' version gradle.ext.navigationVersion
         id 'com.android.application' version gradle.ext.agpVersion
         id 'com.android.library' version gradle.ext.agpVersion
-        id 'com.automattic.android.fetchstyle'
         id 'com.google.gms.google-services' version '4.3.10'
         id 'io.github.wzieba.tracks.plugin' version '1.0.0'
         id 'io.gitlab.arturbosch.detekt' version gradle.ext.detektVersion
@@ -38,15 +36,6 @@ pluginManagement {
         id 'org.jetbrains.kotlin.plugin.parcelize' version gradle.ext.kotlinVersion
         id 'se.bjurr.violations.violation-comments-to-github-gradle-plugin' version '1.69.0'
         id 'com.google.dagger.hilt.android' version gradle.ext.daggerVersion
-    }
-
-    resolutionStrategy {
-        eachPlugin {
-            // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.fetchstyle") {
-                useModule("com.automattic.android:fetchstyle:1.1")
-            }
-        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ pluginManagement {
     gradle.ext.navigationVersion = '2.4.1'
 
     repositories {
+
         gradlePluginPortal()
         google()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,19 @@ pluginManagement {
     gradle.ext.navigationVersion = '2.4.1'
 
     repositories {
-
+        exclusiveContent {
+            forRepository {
+                maven {
+                    url = uri("https://a8c-libs.s3.amazonaws.com/android")
+                }
+            }
+            filter {
+                includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.configure"
+                includeGroup "com.automattic.android.fetchstyle"
+                includeGroup "com.automattic.android.publish-to-s3"
+            }
+        }
         gradlePluginPortal()
         google()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,6 @@ pluginManagement {
             }
             filter {
                 includeGroup "com.automattic.android"
-                includeGroup "com.automattic.android.configure"
-                includeGroup "com.automattic.android.publish-to-s3"
             }
         }
         gradlePluginPortal()


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR is twofold:

1. It adds the missing `A8C Libs S3` settings related repositories configuration. (2c381c68bf8da41e3f273c6ce193243b5404d264)
2. It removes the [fetchstyle](https://github.com/Automattic/style-config-android) plugin from the project. (cb57d7c9a7299cccc197a2a65b77e4f03fde3510)

PS: For more info please refer to this internal discussion here: `CC7L49W13/p1667892065193709`

-----

This [style-config-android](https://github.com/Automattic/style-config-android) plugin is mostly unused and very outdated.

To the @woocommerce/apps-infrastructure's knowledge and checking GE stats no-one is using the `./gradlew downloadConfigs` task to fetch/update the style config files. For years now, almost all Android engineers depend on the default AS style and such like `.idea` configuration.

In addition to that, this plugin has recently created a build related issue where it couldn't be found in any of the configured sources (see [here](https://buildkite.com/automattic/woocommerce-android/builds/7477) and [here](https://buildkite.com/automattic/woocommerce-android/builds/7478#018456c6-4b17-4413-b2f0-c5c80b366622)). Keeping and maintaining such an unused/outdated plugin is counter productive.

```
* What went wrong:
[2022-11-08T07:04:47Z] Plugin [id: 'com.automattic.android.fetchstyle',
artifact: 'com.automattic.android:fetchstyle:1.1'] was not found in any
of the following sources:
```

As such, this [plugin](https://github.com/Automattic/style-config-android) is now removed and will be (most probably) also removed on all other repos (sooner or later). Then, the [plugin's repo](https://github.com/Automattic/style-config-android) will be then marked as deprecated and archived.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could try and run the `./gradlew downloadConfigs` task and verify that it is no longer found in the root project for `WCAndroid`.

Note that the [dependency-tree-diff](https://buildkite.com/automattic/woocommerce-android/builds/7481#018456e0-d322-4c02-977d-e9482e785a99) CI check that is failing is expected since this `fetchstyle` and its configuration is still available on `trunk` and as such the dependency tree diff cannot be completed as it also failing on that branch (as expected).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
