### PR TITLE
Hotfix for store creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.ONBOARDING_CAROUSEL_DISPLAYED
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.extensions.packageInfo
 import com.woocommerce.android.tools.SelectedSite
@@ -97,7 +98,8 @@ object AppPrefs {
         CARD_READER_DO_NOT_SHOW_CASH_ON_DELIVERY_DISABLED_ONBOARDING_STATE,
         ACTIVE_STATS_GRANULARITY,
         USE_SIMULATED_READER,
-        NEW_SIGN_UP
+        NEW_SIGN_UP,
+        STORE_CREATION_SOURCE
     }
 
     /**
@@ -884,6 +886,12 @@ object AppPrefs {
     }
 
     fun getIsNewSignUp() = getBoolean(DeletablePrefKey.NEW_SIGN_UP, false)
+
+    fun setStoreCreationSource(source: String) {
+        setString(DeletablePrefKey.STORE_CREATION_SOURCE, source)
+    }
+
+    fun getStoreCreationSource() = getString(DeletablePrefKey.STORE_CREATION_SOURCE, AnalyticsTracker.VALUE_OTHER)
 
     private fun getActiveStatsGranularityFilterKey(currentSiteId: Int) =
         PrefKeyString("${DeletablePrefKey.ACTIVE_STATS_GRANULARITY}:$currentSiteId")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -216,6 +216,12 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getIsNewSignUp() = AppPrefs.getIsNewSignUp()
 
+    fun setStoreCreationSource(source: String) {
+        AppPrefs.setStoreCreationSource(source)
+    }
+
+    fun getStoreCreationSource() = AppPrefs.getStoreCreationSource()
+
     /**
      * Card Reader Upsell
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -421,6 +421,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_LOGIN_EMAIL_ERROR = "login_email_error"
         const val VALUE_SWITCHING_STORE = "switching_store"
         const val VALUE_PROLOGUE = "prologue"
+        const val VALUE_LOGIN = "login"
         const val VALUE_OTHER = "other"
 
         var sendUsageStats: Boolean = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -418,9 +418,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_PATH = "path"
 
         // -- Store creation
-        const val VALUE_LOGIN = "login"
+        const val VALUE_LOGIN_EMAIL_ERROR = "login_email_error"
         const val VALUE_SWITCHING_STORE = "switching_store"
         const val VALUE_PROLOGUE = "prologue"
+        const val VALUE_OTHER = "other"
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle.State
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentLoginNoWpcomAccountFoundBinding
 import com.woocommerce.android.databinding.ViewLoginEpilogueButtonBarBinding
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
@@ -90,6 +91,7 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
         with(btnBinding.buttonPrimary) {
             text = getString(R.string.login_create_an_account)
             setOnClickListener {
+                appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN_EMAIL_ERROR)
                 unifiedLoginTracker.trackClick(Click.CREATE_ACCOUNT)
 
                 listener.onCreateAccountClicked()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -44,22 +44,24 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
 
         binding.buttonLoginStore.setOnClickListener {
             // Login with site address
+            AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
             prologueFinishedListener?.onPrimaryButtonClicked()
         }
 
         binding.buttonLoginWpcom.setOnClickListener {
             // Login with WordPress.com account
+            AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
             prologueFinishedListener?.onSecondaryButtonClicked()
         }
 
         if (savedInstanceState == null) {
             unifiedLoginTracker.track(Flow.PROLOGUE, Step.PROLOGUE)
-            AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
 
             simplifiedLoginExperiment.activate()
         }
 
         binding.buttonGetStarted.setOnClickListener {
+            AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
             AnalyticsTracker.track(stat = AnalyticsEvent.LOGIN_PROLOGUE_CREATE_SITE_TAPPED)
             prologueFinishedListener?.onGetStartedClicked()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -54,12 +54,13 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
 
         if (savedInstanceState == null) {
             unifiedLoginTracker.track(Flow.PROLOGUE, Step.PROLOGUE)
+            AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
+
             simplifiedLoginExperiment.activate()
         }
 
         binding.buttonGetStarted.setOnClickListener {
             AnalyticsTracker.track(stat = AnalyticsEvent.LOGIN_PROLOGUE_CREATE_SITE_TAPPED)
-            AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
             prologueFinishedListener?.onGetStartedClicked()
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -58,6 +59,7 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
 
         binding.buttonGetStarted.setOnClickListener {
             AnalyticsTracker.track(stat = AnalyticsEvent.LOGIN_PROLOGUE_CREATE_SITE_TAPPED)
+            AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
             prologueFinishedListener?.onGetStartedClicked()
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
@@ -125,7 +125,7 @@ class WebViewStoreCreationViewModel @Inject constructor(
         step.value = Step.StoreLoading
         launch {
             // keep fetching the user's sites until the new site is properly configured or the retry limit is reached
-            for (retries in 1 .. STORE_LOAD_RETRIES_LIMIT) {
+            for (retries in 1..STORE_LOAD_RETRIES_LIMIT) {
                 val result = getOrFetchNewSite()
                 if (result == STORE_FOUND || result == ERROR) {
                     break

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
@@ -127,10 +127,10 @@ class WebViewStoreCreationViewModel @Inject constructor(
             // keep fetching the user's sites until the new site is properly configured or the retry limit is reached
             for (retries in 1 .. STORE_LOAD_RETRIES_LIMIT) {
                 val result = getOrFetchNewSite()
-                if (result == STORE_FOUND || result == ERROR || retries == STORE_LOAD_RETRIES_LIMIT) {
+                if (result == STORE_FOUND || result == ERROR) {
                     break
-                } else {
-                    WooLog.d(T.LOGIN, "Maximum retries reached...")
+                } else if (retries == STORE_LOAD_RETRIES_LIMIT) {
+                    WooLog.d(T.LOGIN, "Max number of store load retries reached...")
                     step.value = Step.StoreLoadingError
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.moremenu
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -33,6 +34,7 @@ class MoreMenuViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val moreMenuRepository: MoreMenuRepository,
     private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
+    private val appPrefsWrapper: AppPrefsWrapper,
     unseenReviewsCountHandler: UnseenReviewsCountHandler
 ) : ScopedViewModel(savedState) {
     val moreMenuViewState =
@@ -136,6 +138,7 @@ class MoreMenuViewModel @Inject constructor(
         AnalyticsTracker.track(
             AnalyticsEvent.HUB_MENU_SWITCH_STORE_TAPPED
         )
+        appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_SWITCHING_STORE)
         triggerEvent(MoreMenuEvent.StartSitePickerEvent)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/AddStoreBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/AddStoreBottomSheetFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -13,8 +13,6 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 
 class AddStoreBottomSheetFragment : WCBottomSheetDialogFragment(R.layout.dialog_site_picker_add_store_bottom_sheet) {
-    private val navArgs: AddStoreBottomSheetFragmentArgs by navArgs()
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = DialogSitePickerAddStoreBottomSheetBinding.bind(view)
@@ -22,12 +20,12 @@ class AddStoreBottomSheetFragment : WCBottomSheetDialogFragment(R.layout.dialog_
         binding.createNewStoreButton.setOnClickListener {
             AnalyticsTracker.track(
                 AnalyticsEvent.SITE_PICKER_CREATE_SITE_TAPPED,
-                mapOf(AnalyticsTracker.KEY_SOURCE to navArgs.source)
+                mapOf(AnalyticsTracker.KEY_SOURCE to AppPrefs.getStoreCreationSource())
             )
 
             findNavController().navigateSafely(
                 directions = AddStoreBottomSheetFragmentDirections
-                    .actionAddStoreBottomSheetFragmentToWebViewStoreCreationFragment(navArgs.source),
+                    .actionAddStoreBottomSheetFragmentToWebViewStoreCreationFragment(),
                 navOptions = NavOptions.Builder()
                     .setPopUpTo(R.id.sitePickerFragment, false)
                     .build()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -163,8 +163,8 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
                 is ShowWooUpgradeDialogEvent -> showWooUpgradeDialog()
                 is NavigateToHelpFragmentEvent -> navigateToHelpScreen(event.origin)
                 is NavigateToNewToWooEvent -> navigateToNewToWooScreen()
-                is NavigateToAddStoreEvent -> navigateToAddStoreScreen(event.source)
-                is NavigateToStoreCreationEvent -> navigateToStoreCreation(event.source)
+                is NavigateToAddStoreEvent -> navigateToAddStoreScreen()
+                is NavigateToStoreCreationEvent -> navigateToStoreCreation()
                 is NavigateToEmailHelpDialogEvent -> navigateToNeedHelpFindingEmailScreen()
                 is NavigateToWPComWebView -> navigateToWPComWebView(event)
                 is NavigateToAccountMismatchScreen -> navigateToAccountMismatchScreen(event)
@@ -263,14 +263,14 @@ class SitePickerFragment : BaseFragment(R.layout.fragment_site_picker), LoginEma
         ChromeCustomTabUtils.launchUrl(requireContext(), AppUrls.NEW_TO_WOO_DOC)
     }
 
-    private fun navigateToAddStoreScreen(source: String) {
+    private fun navigateToAddStoreScreen() {
         findNavController()
-            .navigateSafely(SitePickerFragmentDirections.actionSitePickerFragmentToAddStoreBottomSheetFragment(source))
+            .navigateSafely(SitePickerFragmentDirections.actionSitePickerFragmentToAddStoreBottomSheetFragment())
     }
 
-    private fun navigateToStoreCreation(source: String) {
+    private fun navigateToStoreCreation() {
         findNavController()
-            .navigateSafely(SitePickerFragmentDirections.actionSitePickerFragmentToWebViewStoreCreationFragment(source))
+            .navigateSafely(SitePickerFragmentDirections.actionSitePickerFragmentToWebViewStoreCreationFragment())
     }
 
     private fun navigateToHelpScreen(origin: HelpActivity.Origin) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -86,8 +86,6 @@ class SitePickerViewModel @Inject constructor(
     val shouldShowToolbar: Boolean
         get() = !navArgs.openedFromLogin
 
-    private val navSource = getNavigationSource()
-
     init {
         when (navArgs.openedFromLogin) {
             true -> loadLoginView()
@@ -423,19 +421,7 @@ class SitePickerViewModel @Inject constructor(
 
     fun onAddStoreClick() {
         analyticsTrackerWrapper.track(AnalyticsEvent.SITE_PICKER_ADD_A_STORE_TAPPED)
-        triggerEvent(NavigateToAddStoreEvent(navSource))
-    }
-
-    private fun getNavigationSource(): String {
-        return if (navArgs.openedFromLogin) {
-            if (appPrefsWrapper.getIsNewSignUp()) {
-                AnalyticsTracker.VALUE_PROLOGUE
-            } else {
-                AnalyticsTracker.VALUE_LOGIN
-            }
-        } else {
-            AnalyticsTracker.VALUE_SWITCHING_STORE
-        }
+        triggerEvent(NavigateToAddStoreEvent)
     }
 
     fun onTryAnotherAccountButtonClick() {
@@ -632,7 +618,7 @@ class SitePickerViewModel @Inject constructor(
 
     private fun startStoreCreationWebFlow() {
         appPrefsWrapper.markAsNewSignUp(false)
-        triggerEvent(NavigateToStoreCreationEvent(navSource))
+        triggerEvent(NavigateToStoreCreationEvent)
     }
 
     private fun trackLoginEvent(
@@ -695,8 +681,8 @@ class SitePickerViewModel @Inject constructor(
         object NavigateToMainActivityEvent : SitePickerEvent()
         object NavigateToEmailHelpDialogEvent : SitePickerEvent()
         object NavigateToNewToWooEvent : SitePickerEvent()
-        data class NavigateToAddStoreEvent(val source: String) : SitePickerEvent()
-        data class NavigateToStoreCreationEvent(val source: String) : SitePickerEvent()
+        object NavigateToAddStoreEvent : SitePickerEvent()
+        object NavigateToStoreCreationEvent : SitePickerEvent()
         data class NavigateToHelpFragmentEvent(val origin: HelpActivity.Origin) : SitePickerEvent()
         data class NavigateToWPComWebView(
             val url: String,

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -481,9 +481,7 @@
     <fragment
         android:id="@+id/webViewStoreCreationFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.webview.WebViewStoreCreationFragment"
-        android:label="WebViewStoreCreationFragment" >
-        <argument android:name="source" />
-    </fragment>
+        android:label="WebViewStoreCreationFragment" />
     <dialog
         android:id="@+id/addStoreBottomSheetFragment"
         android:name="com.woocommerce.android.ui.sitepicker.AddStoreBottomSheetFragment"
@@ -494,6 +492,5 @@
         <action
             android:id="@+id/action_addStoreBottomSheetFragment_to_webViewStoreCreationFragment"
             app:destination="@id/webViewStoreCreationFragment" />
-        <argument android:name="source" />
     </dialog>
 </navigation>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.moremenu
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
@@ -46,6 +47,8 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         on { moreMenuPaymentsFeatureWasClicked }.thenReturn(flowOf(true))
     }
 
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
+
     private lateinit var viewModel: MoreMenuViewModel
 
     suspend fun setup(setupMocks: suspend () -> Unit) {
@@ -57,6 +60,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             moreMenuRepository = moreMenuRepository,
             moreMenuNewFeatureHandler = moreMenuNewFeatureHandler,
             unseenReviewsCountHandler = unseenReviewsCountHandler,
+            appPrefsWrapper = appPrefsWrapper
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -524,7 +524,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
             verify(analyticsTrackerWrapper, times(1)).track(
                 AnalyticsEvent.SITE_PICKER_ADD_A_STORE_TAPPED
             )
-            assertThat(view).isEqualTo(NavigateToAddStoreEvent(source = "login"))
+            assertThat(view).isEqualTo(NavigateToAddStoreEvent)
         }
 
     @Test


### PR DESCRIPTION
This PR fixes 2 things:

- Flawed analytics to track store creation source
- Fixes the store-loading logic, which now breaks the retry loop as soon as the site is found

I've created this change as a hotfix because we need to properly measure the impact of the feature, which would otherwise be skewed.

**To test:**

#### Login prologue entry point

Make sure you set `NATIVE_STORE_CREATION_FLOW -> false` in the `FeatureFlag`.

1. Launch the app
2. Log out and skip onboarding if needed
3. Tap `Create a Store` —> in the console, you should see `🔵 Tracked: login_prologue_create_site_tapped, Properties: {"is_debug":true}`
4. When the store creation view is shown, tap the X button to dismiss the view —> in the console, you should fist see `🔵 Tracked: site_creation_dismissed, Properties: {"source": "prologue”, is_debug":true}`

#### Store picker entry point

1. Go to More menu -> Tap on Switch store
2. On the store picker, tap on `Add a store` to create a store —> `🔵 Tracked: site_picker_create_site_tapped, Properties: {"source": "switching_store”, is_debug":true}` should be tracked
3. When the store creation view is shown, tap the X button to dismiss the view —> in the console, you should fist see `🔵 Tracked: site_creation_dismissed, Properties: {"source": "switching_store”, is_debug":true}`

#### Login email error entry point - login

1. Go back to the prologue screen
2. Tap `Log in`
3. Enter an invalid email —> a no WP account error screen should be shown
4. Tap `Create An Account` —> account creation form should be shown
5. Tap `Log in` to log in —> `🔵 Tracked: signup_login_button_tapped, Properties: {is_debug":true}` should be tracked
6. Continue to log in with an existing account —> store creation view should be shown at the end
7. When the store creation view is shown, tap the X button to dismiss the view —> `🔵 Tracked: site_creation_dismissed, Properties: {"source": "login_email_error”, is_debug":true}` should be tracked