### PR TITLE
build: declare A8C repository for Gradle Plugins

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,12 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+            content {
+                includeGroup "com.automattic.android"
+            }
+        }
     }
 
     plugins {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

CI and local builds started to fail because of `com.automattic.android:fetchstyle:1.1'] was not found in any of the following sources:` :

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/5845095/200553957-17832c3a-5b56-4070-82f1-16dc3a85bf1b.png">
Sample build: https://buildkite.com/automattic/woocommerce-android/builds/7474#01845691-dd8d-400f-8d7f-f559ed9c0fb6

### Reproduction

Checkout current `trunk` (31dc5a8) and run:

```
./gradlew assembleWasabiDebug --refresh-dependencies
```

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Checkout this branch
2. Run `./gradlew assembleWasabiDebug --refresh-dependencies`
3. Assert that build is passing


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
