### PR TITLE
Feature/7720 domain selection fetch api logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerScreen.kt
@@ -51,6 +51,8 @@ import com.woocommerce.android.ui.compose.component.WCSearchField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerViewModel.DomainPickerState
 import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerViewModel.DomainSuggestionUi
+import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerViewModel.LoadingState.Idle
+import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerViewModel.LoadingState.Loading
 
 @Composable
 fun DomainPickerScreen(viewModel: DomainPickerViewModel) {
@@ -144,7 +146,7 @@ private fun DomainSearchForm(
                 .weight(1f)
                 .fillMaxWidth()
         ) {
-            if (state.isLoading) {
+            if (state.loadingState == Loading) {
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             } else if (state.domainSuggestionsUi.isNotEmpty()) {
                 DomainSuggestionList(
@@ -248,7 +250,7 @@ fun DomainPickerPreview() {
     WooThemeWithBackground {
         DomainSearchForm(
             state = DomainPickerState(
-                isLoading = false,
+                loadingState = Idle,
                 domain = "White Christmas Tress",
                 domainSuggestionsUi = listOf(
                     DomainSuggestionUi("whitechristmastrees.mywc.mysite"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerScreen.kt
@@ -105,7 +105,7 @@ private fun Toolbar(
 private fun DomainSearchForm(
     state: DomainPickerState,
     onDomainQueryChanged: (String) -> Unit,
-    onDomainSuggestionSelected: (Int) -> Unit,
+    onDomainSuggestionSelected: (String) -> Unit,
     onContinueClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -167,7 +167,7 @@ private fun DomainSearchForm(
 @Composable
 private fun DomainSuggestionList(
     suggestions: List<DomainSuggestionUi>,
-    onDomainSuggestionSelected: (Int) -> Unit,
+    onDomainSuggestionSelected: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -185,7 +185,7 @@ private fun DomainSuggestionList(
                     domainSuggestion = suggestion,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { onDomainSuggestionSelected(index) }
+                        .clickable { onDomainSuggestionSelected(suggestion.domain) }
                 )
                 if (index < suggestions.lastIndex)
                     Divider(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerViewModel.kt
@@ -2,51 +2,70 @@ package com.woocommerce.android.ui.login.storecreation.domainpicker
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppConstants
+import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerViewModel.LoadingState.Idle
+import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerViewModel.LoadingState.Loading
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class DomainPickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    domainSuggestionsRepository: DomainSuggestionsRepository
 ) : ScopedViewModel(savedStateHandle) {
     private val domainQuery = savedState.getStateFlow(this, "")
-    private val domainSuggestionsUi = savedState.getStateFlow(
-        this,
-        listOf(
-            DomainSuggestionUi("whitechristmastrees.mywc.mysite"),
-            DomainSuggestionUi("whitechristmastrees.business.mywc.mysite"),
-            DomainSuggestionUi("whitechristmastrees.business.scroll"),
-            DomainSuggestionUi("whitechristmastrees.business.more"),
-            DomainSuggestionUi("whitechristmastrees.business.another"),
-            DomainSuggestionUi("whitechristmastrees.business.any"),
-            DomainSuggestionUi("whitechristmastrees.business.domain"),
-            DomainSuggestionUi("whitechristmastrees.business.site"),
-            DomainSuggestionUi("whitechristmastrees.business.other"),
-            DomainSuggestionUi("whitechristmastrees.business.more"),
-            DomainSuggestionUi("whitechristmastrees.business.more"),
-            DomainSuggestionUi("whitechristmastrees.business.more"),
-            DomainSuggestionUi("whitechristmastrees.business.more"),
-            DomainSuggestionUi("whitechristmastrees.business.more"),
-            DomainSuggestionUi("whitechristmastrees.business.more"),
-            DomainSuggestionUi("whitechristmastrees.business.last"),
-        )
-    )
+    private val loadingState = MutableStateFlow(Idle)
+    private val domainSuggestionsUi = domainSuggestionsRepository.domainSuggestions
+    private val selectedDomain = MutableStateFlow("")
 
     val viewState = combine(
         domainQuery,
-        domainSuggestionsUi
-    ) { domainQuery, domainSuggestions ->
+        domainSuggestionsUi,
+        loadingState,
+        selectedDomain
+    ) { domainQuery, domainSuggestions, loadingState, selectedDomain ->
         DomainPickerState(
-            isLoading = false,
+            loadingState = loadingState,
             domain = domainQuery,
-            domainSuggestionsUi = domainSuggestions
+            domainSuggestionsUi = domainSuggestions.map { domain ->
+                DomainSuggestionUi(
+                    isSelected = domain == selectedDomain,
+                    domain = domain
+                )
+            }
         )
     }.asLiveData()
+
+    init {
+        viewModelScope.launch {
+            domainQuery
+                .filter { it.isNotBlank() }
+                .onEach { loadingState.value = Loading }
+                .debounce { AppConstants.SEARCH_TYPING_DELAY_MS }
+                .collectLatest {
+                    // Make sure the loading state is correctly set after debounce too
+                    loadingState.value = Loading
+                    domainSuggestionsRepository.fetchDomainSuggestions(domainQuery.value)
+                        .onFailure {
+                            // TODO handle error cases
+                        }
+                    loadingState.value = Idle
+                }
+        }
+    }
 
     fun onBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)
@@ -60,15 +79,8 @@ class DomainPickerViewModel @Inject constructor(
         // TODO
     }
 
-    fun onDomainSuggestionSelected(selectedIndex: Int) {
-        domainSuggestionsUi.update {
-            domainSuggestionsUi.value
-                .mapIndexed { index, domain ->
-                    if (index == selectedIndex) {
-                        domain.copy(isSelected = true)
-                    } else domain.copy(isSelected = false)
-                }
-        }
+    fun onDomainSuggestionSelected(clickedDomain: String) {
+        selectedDomain.value = clickedDomain
     }
 
     fun onDomainChanged(query: String) {
@@ -76,7 +88,7 @@ class DomainPickerViewModel @Inject constructor(
     }
 
     data class DomainPickerState(
-        val isLoading: Boolean = false,
+        val loadingState: LoadingState = Idle,
         val domain: String = "",
         val domainSuggestionsUi: List<DomainSuggestionUi> = emptyList()
     )
@@ -85,4 +97,8 @@ class DomainPickerViewModel @Inject constructor(
         val domain: String = "",
         val isSelected: Boolean = false
     )
+
+    enum class LoadingState {
+        Idle, Loading
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerViewModel.kt
@@ -40,11 +40,16 @@ class DomainPickerViewModel @Inject constructor(
         DomainPickerState(
             loadingState = loadingState,
             domain = domainQuery,
-            domainSuggestionsUi = domainSuggestions.map { domain ->
-                DomainSuggestionUi(
-                    isSelected = domain == selectedDomain,
-                    domain = domain
-                )
+            domainSuggestionsUi =
+            if (domainQuery.isBlank()) {
+                emptyList()
+            } else {
+                domainSuggestions.map { domain ->
+                    DomainSuggestionUi(
+                        isSelected = domain == selectedDomain,
+                        domain = domain
+                    )
+                }
             }
         )
     }.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainSuggestionsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainSuggestionsRepository.kt
@@ -25,9 +25,9 @@ class DomainSuggestionsRepository @Inject constructor(
     suspend fun fetchDomainSuggestions(domainQuery: String): Result<Unit> {
         val domainSuggestionsPayload = SiteStore.SuggestDomainsPayload(
             domainQuery,
-            onlyWordpressCom = false,
+            onlyWordpressCom = true,
             includeWordpressCom = false,
-            includeDotBlogSubdomain = true,
+            includeDotBlogSubdomain = false,
             SUGGESTIONS_REQUEST_COUNT,
             includeVendorDot = false
         )
@@ -52,7 +52,9 @@ class DomainSuggestionsRepository @Inject constructor(
                 } else {
                     WooLog.w(WooLog.T.LOGIN, "Domain suggestions loaded successfully")
                     domainSuggestions.update {
-                        domainSuggestionsEvent.suggestions.map { it.domain_name }
+                        domainSuggestionsEvent.suggestions
+                            .filter { it.is_free }
+                            .map { it.domain_name }
                     }
                     Result.success(Unit)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainSuggestionsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainSuggestionsRepository.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.login.storecreation.domainpicker
+
+import com.woocommerce.android.WooException
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.dispatchAndAwait
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.store.SiteStore
+import javax.inject.Inject
+
+class DomainSuggestionsRepository @Inject constructor(
+    private val dispatcher: Dispatcher,
+) {
+    companion object {
+        private const val SUGGESTIONS_REQUEST_COUNT = 20
+    }
+
+    val domainSuggestions: MutableStateFlow<List<String>> = MutableStateFlow(emptyList())
+
+    suspend fun fetchDomainSuggestions(domainQuery: String): Result<Unit> {
+        val domainSuggestionsPayload = SiteStore.SuggestDomainsPayload(
+            domainQuery,
+            onlyWordpressCom = false,
+            includeWordpressCom = false,
+            includeDotBlogSubdomain = true,
+            SUGGESTIONS_REQUEST_COUNT,
+            includeVendorDot = false
+        )
+        dispatcher.dispatchAndAwait<SiteStore.SuggestDomainsPayload, SiteStore.OnSuggestedDomains>(
+            SiteActionBuilder.newSuggestDomainsAction(domainSuggestionsPayload)
+        )
+            .let { domainSuggestionsEvent ->
+                return if (domainSuggestionsEvent.isError) {
+                    WooLog.w(
+                        WooLog.T.LOGIN,
+                        "Error fetching domain suggestions: ${domainSuggestionsEvent.error.message}"
+                    )
+                    Result.failure(
+                        WooException(
+                            WooError(
+                                WooErrorType.API_ERROR,
+                                GenericErrorType.UNKNOWN,
+                                domainSuggestionsEvent.error.message
+                            )
+                        )
+                    )
+                } else {
+                    WooLog.w(WooLog.T.LOGIN, "Domain suggestions loaded successfully")
+                    domainSuggestions.update {
+                        domainSuggestionsEvent.suggestions.map { it.domain_name }
+                    }
+                    Result.success(Unit)
+                }
+            }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7720
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR implements the search functionality for domain suggestions 

### Testing instructions
- Trigger the store creation flow from site picker
- Navigate to domain picker step
- Enter any text input and check that domain suggestions are refreshed accordingly
- Check that clicking on the `X` button from search input field clears the list. 
- Check that only `*.wordpress.com` domains are displayed

### Images/gif


https://user-images.githubusercontent.com/2663464/200618404-4a1b523b-437d-4867-a648-80e155806ed5.mp4

