### PR TITLE
[Simplified login] Fix the wording of the button "try another account" in the control variant

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoWPcomAccountFoundFragment.kt
@@ -15,6 +15,8 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentLoginNoWpcomAccountFoundBinding
 import com.woocommerce.android.databinding.ViewLoginEpilogueButtonBarBinding
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment
+import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.zendesk.util.StringUtils
@@ -50,6 +52,9 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
 
     @Inject
     internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
+
+    @Inject
+    internal lateinit var simplifiedLoginExperiment: SimplifiedLoginExperiment
 
     private lateinit var listener: Listener
 
@@ -94,15 +99,20 @@ class LoginNoWPcomAccountFoundFragment : Fragment(R.layout.fragment_login_no_wpc
 
                 listener.onCreateAccountClicked()
             }
+        }
 
-            with(btnBinding.buttonSecondary) {
-                visibility = View.VISIBLE
-                text = getString(R.string.login_try_another_email)
-                setOnClickListener {
-                    unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_ACCOUNT)
-
-                    loginListener?.startOver()
+        with(btnBinding.buttonSecondary) {
+            visibility = View.VISIBLE
+            text = getString(
+                when (simplifiedLoginExperiment.getCurrentVariant()) {
+                    LoginVariant.CONTROL -> R.string.login_try_another_account
+                    LoginVariant.SIMPLIFIED_LOGIN_WPCOM -> R.string.login_try_another_email
                 }
+            )
+            setOnClickListener {
+                unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_ACCOUNT)
+
+                loginListener?.startOver()
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
In the PR https://github.com/woocommerce/woocommerce-android/pull/7724, I missed the wording of the "try another account" button, this button would still need to keep its old wording for the control variant. This PR fixes this.

### Testing instructions
1. Make sure your device is using the control variant (either by setting a test device, or by hardcoding it).
2. Open the app.
3. Tap on "continue with wordpress.com"
4. Type a wrong email.
5. Confirm the wording says: "Log in with another account" in the error screen.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
