### PR TITLE
Number crash on bulk update variations

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
@@ -42,11 +42,11 @@ class VariationsBulkUpdateInventoryFragment :
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentVariationsBulkUpdateInventoryBinding.bind(view)
-        binding.stockQuantityEditText.editText?.showKeyboardWithDelay()
-        binding.stockQuantityEditText.setOnTextChangedListener {
-            val text = it.toString()
-            val quantity = if (text.isNotBlank()) text.toDouble() else 0.0
-            viewModel.onStockQuantityChanged(quantity)
+        binding.stockQuantityEditText.run {
+            editText?.showKeyboardWithDelay()
+            setOnTextChangedListener { rawQuantity ->
+                viewModel.onStockQuantityChanged(rawQuantity.toString())
+            }
         }
 
         observeViewStateChanges()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
@@ -38,6 +38,8 @@ class VariationsBulkUpdateInventoryFragment :
 
     private var progressDialog: CustomProgressDialog? = null
 
+    private var doneMenuItem: MenuItem? = null
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -64,6 +66,7 @@ class VariationsBulkUpdateInventoryFragment :
             object : MenuProvider {
                 override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
                     menuInflater.inflate(R.menu.menu_variations_bulk_update, menu)
+                    doneMenuItem = menu.findItem(R.id.done)
                 }
 
                 override fun onMenuItemSelected(item: MenuItem): Boolean {
@@ -108,6 +111,9 @@ class VariationsBulkUpdateInventoryFragment :
             }
             new.isProgressDialogShown.takeIfNotEqualTo(old?.isProgressDialogShown) { isVisible ->
                 updateProgressbarDialogVisibility(isVisible)
+            }
+            new.isDoneEnabled.takeIfNotEqualTo(old?.isDoneEnabled){ isEnabled ->
+                doneMenuItem?.isEnabled = isEnabled
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
@@ -112,7 +112,7 @@ class VariationsBulkUpdateInventoryFragment :
             new.isProgressDialogShown.takeIfNotEqualTo(old?.isProgressDialogShown) { isVisible ->
                 updateProgressbarDialogVisibility(isVisible)
             }
-            new.isDoneEnabled.takeIfNotEqualTo(old?.isDoneEnabled){ isEnabled ->
+            new.isDoneEnabled.takeIfNotEqualTo(old?.isDoneEnabled) { isEnabled ->
                 doneMenuItem?.isEnabled = isEnabled
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
@@ -65,11 +65,8 @@ class VariationsBulkUpdateInventoryViewModel @Inject constructor(
     }
 
     fun onStockQuantityChanged(rawQuantity: String) {
-        val quantity = rawQuantity.toDoubleOrNull()
-        viewState = if (quantity == null) {
-            viewState.copy(stockQuantity = null, isDoneEnabled = false)
-        } else {
-            viewState.copy(stockQuantity = quantity, isDoneEnabled = true)
+        viewState = rawQuantity.toDoubleOrNull().let { quantity ->
+            viewState.copy(stockQuantity = quantity, isDoneEnabled = quantity != null)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
@@ -64,8 +64,13 @@ class VariationsBulkUpdateInventoryViewModel @Inject constructor(
         }
     }
 
-    fun onStockQuantityChanged(quantity: Double) {
-        viewState = viewState.copy(stockQuantity = quantity)
+    fun onStockQuantityChanged(rawQuantity: String) {
+        val quantity = rawQuantity.toDoubleOrNull()
+        viewState = if (quantity == null) {
+            viewState.copy(stockQuantity = null, isDoneEnabled = false)
+        } else {
+            viewState.copy(stockQuantity = quantity, isDoneEnabled = true)
+        }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
@@ -79,6 +79,7 @@ class VariationsBulkUpdateInventoryViewModel @Inject constructor(
         val stockQuantity: Double? = null,
         val stockQuantityGroupType: ValuesGroupType? = null,
         val isProgressDialogShown: Boolean = false,
+        val isDoneEnabled: Boolean = true
     ) : Parcelable
 
     @Parcelize


### PR DESCRIPTION
Closes: #7760

### Why
Detected on the call for testing (p5T066-3J8-p2#comment-13959), this issue will cause the app to crash when a negative value is introduced when bulk updating products stock quantities.

### Description
This PR fixes a crash when trying to bulk update the stock quantity of variation products with a negative value. The changes introduced on this PR favor the use of `toDoubleOrNull()` that will not crash when the value input is not a valid `Double`. In this particular case, when the value is either `null` or `-`. This PR also adds a new check to disable the `DONE` button when the user input is not a valid `Double` value, preventing an unnecessary call to the API.

### Testing instructions

1. Open the products screen
2. Tap on a Variable product with some variations
3. Tap on Variations
4. Tap on More menu (3 dots) -> Bulk update...
5. Select Stock quantity
6. Empty the EditText control
7. Check that if the value is empty the DONE button is disabled
8. Enter "-"
9. Check that the app don't crash
10. Check that if the value is invalid the DONE button is disabled
11. Enter "2", the value should be now "-2"
12. Check that the DONE button is enabled and the quantity can be updated successfully

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/200627288-08902ae8-4c67-4427-a0a4-49dfff8edebd.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->