### PR TITLE
IAP: handle multiple invocation startpurchase

### DIFF
--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
@@ -26,6 +26,8 @@ internal class IAPPurchaseWPComPlanActionsImpl(
     private val remoteSiteId: Long,
     private val iapProduct: IAPProduct = IAPProduct.WPPremiumPlanTesting
 ) : PurchaseWPComPlanActions {
+    @Volatile
+    private var isPurchaseInProgress = false
 
     init {
         iapManager.connect()
@@ -46,7 +48,11 @@ internal class IAPPurchaseWPComPlanActionsImpl(
     }
 
     override suspend fun purchaseWPComPlan(activityWrapper: IAPActivityWrapper) {
+        if (isPurchaseInProgress) return
+
+        isPurchaseInProgress = true
         purchaseWpComPlanHandler.purchaseWPComPlan(activityWrapper, iapProduct, remoteSiteId)
+        isPurchaseInProgress = false
     }
 
     override suspend fun fetchWPComPlanProduct(): WPComProductResult {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7708
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Guard to cancel duplicated invocations of the "makePurchase" method

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Try quickly click on "make purchase" button
* Notice that before the change you can see 2 UIs at the same time
* Notice that after the change it's always 1 UI

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/200833925-ff6a7236-4a3a-4d78-a4a0-417550ce5c98.mp4

