### PR TITLE
[Simplified Login] experiment for Jetpack Installation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
@@ -8,7 +8,7 @@ interface ExperimentTracker {
         const val LOGIN_SUCCESSFUL_EVENT = "login_successful"
         const val SITE_VERIFICATION_SUCCESSFUL_EVENT = "site_verification_successful"
         const val SIMPLIFIED_LOGIN_ELIGIBLE_EVENT = "simplified_login_experiment_eligible"
-        const val NATIVE_JETPACK_INSTALLATION_ELIGIBLE_EVENT = "wcandroid_jetpack_installation_eligible"
+        const val JETPACK_INSTALLATION_ELIGIBLE_EVENT = "wcandroid_jetpack_installation_eligible"
         const val SIMPLIFIED_LOGIN_SUCCESSFUL_EVENT = "my_store_displayed"
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
@@ -8,6 +8,7 @@ interface ExperimentTracker {
         const val LOGIN_SUCCESSFUL_EVENT = "login_successful"
         const val SITE_VERIFICATION_SUCCESSFUL_EVENT = "site_verification_successful"
         const val SIMPLIFIED_LOGIN_ELIGIBLE_EVENT = "simplified_login_experiment_eligible"
+        const val NATIVE_JETPACK_INSTALLATION_ELIGIBLE_EVENT = "wcandroid_jetpack_installation_eligible"
         const val SIMPLIFIED_LOGIN_SUCCESSFUL_EVENT = "my_store_displayed"
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
+import com.woocommerce.android.experiment.JetpackInstallationExperiment.JetpackInstallationVariant
 import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooLog
@@ -22,6 +23,7 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     companion object {
         private const val PERFORMANCE_MONITORING_SAMPLE_RATE_KEY = "wc_android_performance_monitoring_sample_rate"
         private const val SIMPLIFIED_LOGIN_VARIANT_KEY = "simplified_login_variant"
+        private const val JETPACK_INSTALLATION_VARIANT_KEY = "wcandroid_jetpack_installation_variant"
         private const val DEBUG_INTERVAL = 10L
         private const val RELEASE_INTERVAL = 31200L
     }
@@ -77,6 +79,15 @@ class FirebaseRemoteConfigRepository @Inject constructor(
         } catch (e: IllegalArgumentException) {
             crashLogging.get().recordException(e)
             LoginVariant.valueOf(defaultValues[SIMPLIFIED_LOGIN_VARIANT_KEY]!!)
+        }
+    }
+
+    override fun getJetpackInstallationVariant(): JetpackInstallationVariant {
+        return try {
+            JetpackInstallationVariant.valueOf(remoteConfig.getString(JETPACK_INSTALLATION_VARIANT_KEY).uppercase())
+        } catch (e: IllegalArgumentException) {
+            crashLogging.get().recordException(e)
+            JetpackInstallationVariant.valueOf(defaultValues[JETPACK_INSTALLATION_VARIANT_KEY]!!)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -38,7 +38,8 @@ class FirebaseRemoteConfigRepository @Inject constructor(
 
     private val defaultValues by lazy {
         mapOf(
-            SIMPLIFIED_LOGIN_VARIANT_KEY to LoginVariant.CONTROL.name
+            SIMPLIFIED_LOGIN_VARIANT_KEY to LoginVariant.CONTROL.name,
+            JETPACK_INSTALLATION_VARIANT_KEY to JetpackInstallationVariant.CONTROL.name
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.config
 
+import com.woocommerce.android.experiment.JetpackInstallationExperiment.JetpackInstallationVariant
 import com.woocommerce.android.experiment.SimplifiedLoginExperiment.LoginVariant
 
 interface RemoteConfigRepository {
     fun fetchRemoteConfig()
     fun getPerformanceMonitoringSampleRate(): Double
     fun getSimplifiedLoginVariant(): LoginVariant
+    fun getJetpackInstallationVariant(): JetpackInstallationVariant
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/JetpackInstallationExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/JetpackInstallationExperiment.kt
@@ -15,7 +15,7 @@ class JetpackInstallationExperiment @Inject constructor(
 
     fun activate() {
         // Track Firebase's activation event for the A/B testing.
-        experimentTracker.log(ExperimentTracker.NATIVE_JETPACK_INSTALLATION_ELIGIBLE_EVENT)
+        experimentTracker.log(ExperimentTracker.JETPACK_INSTALLATION_ELIGIBLE_EVENT)
 
         // Track used variant
         val variant = getCurrentVariant()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/JetpackInstallationExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/JetpackInstallationExperiment.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.experiment
+
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.analytics.ExperimentTracker
+import com.woocommerce.android.config.RemoteConfigRepository
+import javax.inject.Inject
+
+class JetpackInstallationExperiment @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val experimentTracker: ExperimentTracker,
+    private val remoteConfigRepository: RemoteConfigRepository,
+) {
+
+    fun activate() {
+        // Track Firebase's activation event for the A/B testing.
+        experimentTracker.log(ExperimentTracker.NATIVE_JETPACK_INSTALLATION_ELIGIBLE_EVENT)
+
+        // Track used variant
+        val variant = getCurrentVariant()
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SIMPLIFIED_LOGIN_EXPERIMENT,
+            mapOf(Pair(AnalyticsTracker.KEY_EXPERIMENT_VARIANT, variant.name))
+        )
+    }
+
+    fun getCurrentVariant() = remoteConfigRepository.getJetpackInstallationVariant()
+
+    enum class JetpackInstallationVariant {
+        CONTROL,
+        NATIVE
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.experiment.JetpackInstallationExperiment
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -42,7 +43,8 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
     private val sitePickRepository: SitePickerRepository,
     private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val jetpackInstallationExperiment: JetpackInstallationExperiment
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val FETCHED_URL_KEY = "fetched_url"
@@ -179,8 +181,10 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
                 when {
                     !it.exists -> inlineErrorFlow.value = R.string.invalid_site_url_message
                     !it.isWordPress -> stepFlow.value = Step.NotWordpress
-                    !it.isWPCom && !it.isJetpackActive ->
+                    !it.isWPCom && !it.isJetpackActive -> {
+                        jetpackInstallationExperiment.activate()
                         stepFlow.value = Step.JetpackUnavailable
+                    }
                     !it.isWPCom && !it.isJetpackConnected -> navigateToJetpackConnectionError()
                     else -> navigateBackToSitePicker()
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7773 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR creates an experiment for the Jetpack installation flow, it follows the same approach we've done for the first simplified login experiment.

### Testing instructions
I don't think there is anything to test right now, so just reviewing the code and checking the AB test definition in Firebase Console.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
