### PR TITLE
Adjust quarter date range selection options to work with Visitor stats

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -82,3 +82,9 @@ val Date.pastTimeDeltaFromNowInDays
         .takeIf { it >= 0 }
         ?.let { TimeUnit.DAYS.convert(it, MILLISECONDS) }
         ?.toInt()
+
+fun Date.theDayBeforeIt() =
+    Calendar.getInstance()
+        .apply { time = this@theDayBeforeIt }
+        .apply { add(Calendar.DATE, -1) }
+        .time

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -97,10 +97,11 @@ class AnalyticsFragment :
             key = KEY_DATE_RANGE_SELECTOR_RESULT,
             entryId = R.id.analytics
         ) { dateSelection ->
-            if (dateSelection == AnalyticTimePeriod.CUSTOM.description) {
-                viewModel.onCustomDateRangeClicked()
-            } else {
-                viewModel.onSelectedTimePeriodChanged(dateSelection)
+            when (AnalyticTimePeriod.from(dateSelection)) {
+                AnalyticTimePeriod.CUSTOM -> viewModel.onCustomDateRangeClicked()
+                AnalyticTimePeriod.QUARTER_TO_DATE,
+                AnalyticTimePeriod.LAST_QUARTER -> viewModel.onQuarterDateRangeClicked()
+                else -> viewModel.onSelectedTimePeriodChanged(dateSelection)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -97,11 +97,11 @@ class AnalyticsFragment :
             key = KEY_DATE_RANGE_SELECTOR_RESULT,
             entryId = R.id.analytics
         ) { dateSelection ->
-            when (AnalyticTimePeriod.from(dateSelection)) {
+            when (val timePeriod = AnalyticTimePeriod.from(dateSelection)) {
                 AnalyticTimePeriod.CUSTOM -> viewModel.onCustomDateRangeClicked()
                 AnalyticTimePeriod.QUARTER_TO_DATE,
                 AnalyticTimePeriod.LAST_QUARTER -> viewModel.onQuarterDateRangeClicked()
-                else -> viewModel.onSelectedTimePeriodChanged(dateSelection)
+                else -> viewModel.onSelectedTimePeriodChanged(timePeriod)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsFragment.kt
@@ -99,8 +99,6 @@ class AnalyticsFragment :
         ) { dateSelection ->
             when (val timePeriod = AnalyticTimePeriod.from(dateSelection)) {
                 AnalyticTimePeriod.CUSTOM -> viewModel.onCustomDateRangeClicked()
-                AnalyticTimePeriod.QUARTER_TO_DATE,
-                AnalyticTimePeriod.LAST_QUARTER -> viewModel.onQuarterDateRangeClicked()
                 else -> viewModel.onSelectedTimePeriodChanged(timePeriod)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -186,7 +186,7 @@ class AnalyticsRepository @Inject constructor(
         )
     }
 
-    suspend fun fetchVisitorsData(
+    suspend fun fetchRecentVisitorsData(
         dateRange: AnalyticsDateRange,
         selectedRange: AnalyticTimePeriod,
         fetchStrategy: FetchStrategy
@@ -278,7 +278,8 @@ class AnalyticsRepository @Inject constructor(
     private suspend fun getVisitorsStats(
         dateRange: AnalyticsDateRange,
         granularity: StatsGranularity,
-        fetchStrategy: FetchStrategy
+        fetchStrategy: FetchStrategy,
+        fetchingAmountLimit: Int = VISITORS_AND_VIEW_DEFAULT_FETCH_LIMIT
     ): WooResult<VisitsAndViewsModel> = coroutineScope {
         val site = selectedSite.get()
 
@@ -288,7 +289,8 @@ class AnalyticsRepository @Inject constructor(
             endDate = endDate,
             granularity = granularity.asJetpackGranularity(),
             forced = fetchStrategy is FetchStrategy.ForceNew,
-            site = site
+            site = site,
+            fetchingAmountLimit
         )
     }
 
@@ -350,6 +352,8 @@ class AnalyticsRepository @Inject constructor(
         const val ONE_H_PERCENT = 100
 
         const val TOP_PRODUCTS_LIST_SIZE = 5
+
+        const val VISITORS_AND_VIEW_DEFAULT_FETCH_LIMIT = 15
     }
 
     sealed class RevenueResult {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -35,8 +35,6 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.DateUtils
-import java.text.SimpleDateFormat
-import java.util.Locale
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -191,7 +191,7 @@ class AnalyticsRepository @Inject constructor(
         selectedRange: AnalyticTimePeriod,
         fetchStrategy: FetchStrategy
     ): VisitorsResult {
-        return getVisitorsStats(dateRange, getGranularity(selectedRange), fetchStrategy)
+        return getVisitorsStats(dateRange, getGranularity(selectedRange), fetchStrategy, MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT)
             .model?.dates?.last()
             ?.let {
                 VisitorsResult.VisitorsData(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.analytics
 
 import com.woocommerce.android.extensions.formatToYYYYmmDD
+import com.woocommerce.android.extensions.theDayBeforeIt
 import com.woocommerce.android.model.DeltaPercentage
 import com.woocommerce.android.model.OrdersStat
 import com.woocommerce.android.model.ProductItem
@@ -210,11 +211,7 @@ class AnalyticsRepository @Inject constructor(
         selectedRange: AnalyticTimePeriod,
         fetchStrategy: FetchStrategy
     ): VisitorsResult {
-        val startDate = Calendar.getInstance()
-            .apply { time = dateRange.getSelectedPeriod().from }
-            .apply { add(Calendar.DATE, -1) }
-            .time
-        
+        val startDate = dateRange.getSelectedPeriod().from.theDayBeforeIt()
         val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
 
         return getVisitorsStats(dateRange, getGranularity(selectedRange), fetchStrategy, QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -36,7 +36,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
@@ -194,8 +194,12 @@ class AnalyticsRepository @Inject constructor(
         selectedRange: AnalyticTimePeriod,
         fetchStrategy: FetchStrategy
     ): VisitorsResult {
-        return getVisitorsStats(dateRange, getGranularity(selectedRange), fetchStrategy, MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT)
-            .model?.dates?.last()
+        return getVisitorsStats(
+            dateRange,
+            getGranularity(selectedRange),
+            fetchStrategy,
+            MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT
+        ).model?.dates?.last()
             ?.let {
                 VisitorsResult.VisitorsData(
                     VisitorsStat(
@@ -214,8 +218,12 @@ class AnalyticsRepository @Inject constructor(
         val startDate = dateRange.getSelectedPeriod().from.theDayBeforeIt()
         val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
 
-        return getVisitorsStats(dateRange, getGranularity(selectedRange), fetchStrategy, QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT)
-            .model?.dates?.asSequence()
+        return getVisitorsStats(
+            dateRange,
+            getGranularity(selectedRange),
+            fetchStrategy,
+            QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT
+        ).model?.dates?.asSequence()
             ?.filter { startDate.before(simpleDateFormat.parse(it.period)) }
             ?.map { Pair(it.visitors, it.views) }
             ?.fold(Pair(0L, 0L)) { acc, pair -> Pair(acc.first + pair.first, acc.second + pair.second) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -354,6 +354,8 @@ class AnalyticsRepository @Inject constructor(
         const val TOP_PRODUCTS_LIST_SIZE = 5
 
         const val VISITORS_AND_VIEW_DEFAULT_FETCH_LIMIT = 15
+        const val MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT = 1
+        const val QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT = 3
     }
 
     sealed class RevenueResult {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -216,7 +216,6 @@ class AnalyticsRepository @Inject constructor(
         fetchStrategy: FetchStrategy
     ): VisitorsResult {
         val startDate = dateRange.getSelectedPeriod().from.theDayBeforeIt()
-        val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
 
         return getVisitorsStats(
             dateRange,
@@ -224,7 +223,7 @@ class AnalyticsRepository @Inject constructor(
             fetchStrategy,
             QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT
         ).model?.dates?.asSequence()
-            ?.filter { startDate.before(simpleDateFormat.parse(it.period)) }
+            ?.filter { startDate.before(DateUtils.getDateFromString(it.period)) }
             ?.map { Pair(it.visitors, it.views) }
             ?.fold(Pair(0L, 0L)) { acc, pair -> Pair(acc.first + pair.first, acc.second + pair.second) }
             ?.let { (visitors, views) ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -24,6 +24,8 @@ import com.woocommerce.android.ui.analytics.AnalyticsViewEvent.OpenWPComWebView
 import com.woocommerce.android.ui.analytics.RefreshIndicator.NotShowIndicator
 import com.woocommerce.android.ui.analytics.RefreshIndicator.ShowIndicator
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.LAST_QUARTER
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.QUARTER_TO_DATE
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeCalculator
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeFormatter
@@ -135,18 +137,15 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     fun onSelectedTimePeriodChanged(selectedTimePeriod: AnalyticTimePeriod) {
+        val isQuarterSelection = (selectedTimePeriod == QUARTER_TO_DATE) || (selectedTimePeriod == LAST_QUARTER)
         val dateRange = analyticsDateRange.getAnalyticsDateRangeFrom(selectedTimePeriod)
         saveSelectedTimePeriod(selectedTimePeriod)
         saveSelectedDateRange(dateRange)
         updateDateSelector()
         trackSelectedDateRange(selectedTimePeriod)
         viewModelScope.launch {
-            refreshAllAnalyticsAtOnce(isRefreshing = false, showSkeleton = true)
+            refreshAllAnalyticsAtOnce(isRefreshing = false, showSkeleton = true, isQuarterSelection = isQuarterSelection)
         }
-    }
-
-    fun onQuarterDateRangeClicked() {
-
     }
 
     fun onDateRangeSelectorClick() {
@@ -348,11 +347,11 @@ class AnalyticsViewModel @Inject constructor(
             AnalyticTimePeriod.YESTERDAY -> resourceProvider.getString(R.string.date_timeframe_yesterday)
             AnalyticTimePeriod.LAST_WEEK -> resourceProvider.getString(R.string.date_timeframe_last_week)
             AnalyticTimePeriod.LAST_MONTH -> resourceProvider.getString(R.string.date_timeframe_last_month)
-            AnalyticTimePeriod.LAST_QUARTER -> resourceProvider.getString(R.string.date_timeframe_last_quarter)
+            LAST_QUARTER -> resourceProvider.getString(R.string.date_timeframe_last_quarter)
             AnalyticTimePeriod.LAST_YEAR -> resourceProvider.getString(R.string.date_timeframe_last_year)
             AnalyticTimePeriod.WEEK_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_week_to_date)
             AnalyticTimePeriod.MONTH_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_month_to_date)
-            AnalyticTimePeriod.QUARTER_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_quarter_to_date)
+            QUARTER_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_quarter_to_date)
             AnalyticTimePeriod.YEAR_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_year_to_date)
             AnalyticTimePeriod.CUSTOM -> resourceProvider.getString(R.string.date_timeframe_custom)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -189,10 +189,10 @@ class AnalyticsViewModel @Inject constructor(
             .let { AnalyticTimePeriod.from(it) }
             .let { (it == QUARTER_TO_DATE) || (it == LAST_QUARTER) }
 
-        updateRevenue(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
-        updateOrders(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
-        updateProducts(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
-        updateVisitors(isRefreshing = isRefreshing, showSkeleton = showSkeleton, isQuarterSelection = isQuarterSelection)
+        updateRevenue(isRefreshing, showSkeleton)
+        updateOrders(isRefreshing, showSkeleton)
+        updateProducts(isRefreshing, showSkeleton)
+        updateVisitors(isRefreshing, showSkeleton, isQuarterSelection)
     }
 
     private fun updateRevenue(isRefreshing: Boolean, showSkeleton: Boolean) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -134,8 +134,7 @@ class AnalyticsViewModel @Inject constructor(
         }
     }
 
-    fun onSelectedTimePeriodChanged(newSelection: String) {
-        val selectedTimePeriod: AnalyticTimePeriod = AnalyticTimePeriod.from(newSelection)
+    fun onSelectedTimePeriodChanged(selectedTimePeriod: AnalyticTimePeriod) {
         val dateRange = analyticsDateRange.getAnalyticsDateRangeFrom(selectedTimePeriod)
         saveSelectedTimePeriod(selectedTimePeriod)
         saveSelectedDateRange(dateRange)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -185,14 +185,10 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     private fun refreshAllAnalyticsAtOnce(isRefreshing: Boolean, showSkeleton: Boolean) {
-        val isQuarterSelection = state.value.analyticsDateRangeSelectorState.selectedPeriod
-            .let { AnalyticTimePeriod.from(it) }
-            .let { (it == QUARTER_TO_DATE) || (it == LAST_QUARTER) }
-
         updateRevenue(isRefreshing, showSkeleton)
         updateOrders(isRefreshing, showSkeleton)
         updateProducts(isRefreshing, showSkeleton)
-        updateVisitors(isRefreshing, showSkeleton, isQuarterSelection)
+        updateVisitors(isRefreshing, showSkeleton)
     }
 
     private fun updateRevenue(isRefreshing: Boolean, showSkeleton: Boolean) =
@@ -281,11 +277,15 @@ class AnalyticsViewModel @Inject constructor(
                 }
         }
 
-    private fun updateVisitors(isRefreshing: Boolean, showSkeleton: Boolean, isQuarterSelection: Boolean) =
+    private fun updateVisitors(isRefreshing: Boolean, showSkeleton: Boolean) =
         launch {
             if (!FeatureFlag.ANALYTICS_HUB_PRODUCTS_AND_REPORTS.isEnabled()) {
                 return@launch
             }
+
+            val isQuarterSelection = state.value.analyticsDateRangeSelectorState.selectedPeriod
+                .let { AnalyticTimePeriod.from(it) }
+                .let { (it == QUARTER_TO_DATE) || (it == LAST_QUARTER) }
 
             val timePeriod = getSavedTimePeriod()
             val dateRange = getSavedDateRange()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -146,6 +146,10 @@ class AnalyticsViewModel @Inject constructor(
         }
     }
 
+    fun onQuarterDateRangeClicked() {
+
+    }
+
     fun onDateRangeSelectorClick() {
         onTrackableUIInteraction()
         AnalyticsTracker.track(AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -25,8 +25,17 @@ import com.woocommerce.android.ui.analytics.AnalyticsViewEvent.OpenWPComWebView
 import com.woocommerce.android.ui.analytics.RefreshIndicator.NotShowIndicator
 import com.woocommerce.android.ui.analytics.RefreshIndicator.ShowIndicator
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.CUSTOM
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.LAST_MONTH
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.LAST_QUARTER
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.LAST_WEEK
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.LAST_YEAR
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.MONTH_TO_DATE
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.QUARTER_TO_DATE
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.TODAY
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.WEEK_TO_DATE
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.YEAR_TO_DATE
+import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod.YESTERDAY
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeCalculator
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeFormatter
@@ -117,14 +126,14 @@ class AnalyticsViewModel @Inject constructor(
                     toDateStr
                 ),
                 toDatePeriod = resourceProvider.getString(R.string.date_timeframe_custom_date_range_title),
-                selectedPeriod = getTimePeriodDescription(AnalyticTimePeriod.CUSTOM)
+                selectedPeriod = getTimePeriodDescription(CUSTOM)
             )
         )
 
         val dateRange = analyticsDateRange.getAnalyticsDateRangeFromCustom(fromDateUtc, toDateUtc)
         saveSelectedDateRange(dateRange)
-        saveSelectedTimePeriod(AnalyticTimePeriod.CUSTOM)
-        trackSelectedDateRange(AnalyticTimePeriod.CUSTOM)
+        saveSelectedTimePeriod(CUSTOM)
+        trackSelectedDateRange(CUSTOM)
 
         viewModelScope.launch {
             refreshAllAnalyticsAtOnce(isRefreshing = false, showSkeleton = true)
@@ -344,17 +353,17 @@ class AnalyticsViewModel @Inject constructor(
 
     private fun getTimePeriodDescription(analyticTimeRange: AnalyticTimePeriod): String =
         when (analyticTimeRange) {
-            AnalyticTimePeriod.TODAY -> resourceProvider.getString(R.string.date_timeframe_today)
-            AnalyticTimePeriod.YESTERDAY -> resourceProvider.getString(R.string.date_timeframe_yesterday)
-            AnalyticTimePeriod.LAST_WEEK -> resourceProvider.getString(R.string.date_timeframe_last_week)
-            AnalyticTimePeriod.LAST_MONTH -> resourceProvider.getString(R.string.date_timeframe_last_month)
+            TODAY -> resourceProvider.getString(R.string.date_timeframe_today)
+            YESTERDAY -> resourceProvider.getString(R.string.date_timeframe_yesterday)
+            LAST_WEEK -> resourceProvider.getString(R.string.date_timeframe_last_week)
+            LAST_MONTH -> resourceProvider.getString(R.string.date_timeframe_last_month)
             LAST_QUARTER -> resourceProvider.getString(R.string.date_timeframe_last_quarter)
-            AnalyticTimePeriod.LAST_YEAR -> resourceProvider.getString(R.string.date_timeframe_last_year)
-            AnalyticTimePeriod.WEEK_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_week_to_date)
-            AnalyticTimePeriod.MONTH_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_month_to_date)
+            LAST_YEAR -> resourceProvider.getString(R.string.date_timeframe_last_year)
+            WEEK_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_week_to_date)
+            MONTH_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_month_to_date)
             QUARTER_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_quarter_to_date)
-            AnalyticTimePeriod.YEAR_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_year_to_date)
-            AnalyticTimePeriod.CUSTOM -> resourceProvider.getString(R.string.date_timeframe_custom)
+            YEAR_TO_DATE -> resourceProvider.getString(R.string.date_timeframe_year_to_date)
+            CUSTOM -> resourceProvider.getString(R.string.date_timeframe_custom)
         }
 
     private fun formatValue(value: String, currencyCode: String?) = currencyCode

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -185,11 +185,11 @@ class AnalyticsViewModel @Inject constructor(
         }
     }
 
-    private fun refreshAllAnalyticsAtOnce(isRefreshing: Boolean, showSkeleton: Boolean) {
+    private fun refreshAllAnalyticsAtOnce(isRefreshing: Boolean, showSkeleton: Boolean, isQuarterSelection: Boolean = false) {
         updateRevenue(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
         updateOrders(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
         updateProducts(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
-        updateVisitors(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
+        updateVisitors(isRefreshing = isRefreshing, showSkeleton = showSkeleton, isQuarterSelection = isQuarterSelection)
     }
 
     private fun updateRevenue(isRefreshing: Boolean, showSkeleton: Boolean) =
@@ -278,7 +278,7 @@ class AnalyticsViewModel @Inject constructor(
                 }
         }
 
-    private fun updateVisitors(isRefreshing: Boolean, showSkeleton: Boolean) =
+    private fun updateVisitors(isRefreshing: Boolean, showSkeleton: Boolean, isQuarterSelection: Boolean) =
         launch {
             if (!FeatureFlag.ANALYTICS_HUB_PRODUCTS_AND_REPORTS.isEnabled()) {
                 return@launch

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -292,13 +292,10 @@ class AnalyticsViewModel @Inject constructor(
                 return@launch
             }
 
-            val isQuarterSelection = state.value.analyticsDateRangeSelectorState.selectedPeriod
-                .let { AnalyticTimePeriod.from(it) }
-                .let { (it == QUARTER_TO_DATE) || (it == LAST_QUARTER) }
-
             val timePeriod = getSavedTimePeriod()
             val dateRange = getSavedDateRange()
             val fetchStrategy = getFetchStrategy(isRefreshing)
+            val isQuarterSelection = (timePeriod == QUARTER_TO_DATE) || (timePeriod == LAST_QUARTER)
 
             if (showSkeleton) mutableState.value = state.value.copy(visitorsState = LoadingViewState)
             mutableState.value = state.value.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -137,14 +137,13 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     fun onSelectedTimePeriodChanged(selectedTimePeriod: AnalyticTimePeriod) {
-        val isQuarterSelection = (selectedTimePeriod == QUARTER_TO_DATE) || (selectedTimePeriod == LAST_QUARTER)
         val dateRange = analyticsDateRange.getAnalyticsDateRangeFrom(selectedTimePeriod)
         saveSelectedTimePeriod(selectedTimePeriod)
         saveSelectedDateRange(dateRange)
         updateDateSelector()
         trackSelectedDateRange(selectedTimePeriod)
         viewModelScope.launch {
-            refreshAllAnalyticsAtOnce(isRefreshing = false, showSkeleton = true, isQuarterSelection = isQuarterSelection)
+            refreshAllAnalyticsAtOnce(isRefreshing = false, showSkeleton = true)
         }
     }
 
@@ -184,7 +183,11 @@ class AnalyticsViewModel @Inject constructor(
         }
     }
 
-    private fun refreshAllAnalyticsAtOnce(isRefreshing: Boolean, showSkeleton: Boolean, isQuarterSelection: Boolean = false) {
+    private fun refreshAllAnalyticsAtOnce(isRefreshing: Boolean, showSkeleton: Boolean) {
+        val isQuarterSelection = state.value.analyticsDateRangeSelectorState.selectedPeriod
+            .let { AnalyticTimePeriod.from(it) }
+            .let { (it == QUARTER_TO_DATE) || (it == LAST_QUARTER) }
+
         updateRevenue(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
         updateOrders(isRefreshing = isRefreshing, showSkeleton = showSkeleton)
         updateProducts(isRefreshing = isRefreshing, showSkeleton = showSkeleton)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -298,7 +298,7 @@ class AnalyticsViewModel @Inject constructor(
         timePeriod: AnalyticTimePeriod,
         fetchStrategy: AnalyticsRepository.FetchStrategy
     ) {
-        analyticsRepository.fetchVisitorsData(dateRange, timePeriod, fetchStrategy)
+        analyticsRepository.fetchRecentVisitorsData(dateRange, timePeriod, fetchStrategy)
             .let {
                 when (it) {
                     is VisitorsData -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
@@ -53,7 +53,6 @@ class StatsRepository @Inject constructor(
         // /wc-analytics/leaderboards. More info https://github.com/woocommerce/woocommerce-android/issues/6688
         private const val PRODUCT_ONLY_LEADERBOARD_MIN_WC_VERSION = "6.7.0"
         private const val AN_HOUR_IN_MILLIS = 3600000
-        private const val VISITORS_AND_VIEW_FETCH_LIMIT = 15
     }
 
     suspend fun fetchRevenueStats(
@@ -269,12 +268,13 @@ class StatsRepository @Inject constructor(
         endDate: Date,
         granularity: org.wordpress.android.fluxc.network.utils.StatsGranularity,
         forced: Boolean,
-        site: SiteModel = selectedSite.get()
+        site: SiteModel = selectedSite.get(),
+        fetchingAmountLimit: Int
     ): WooResult<VisitsAndViewsModel> {
         val result = visitsAndViewsStore.fetchVisits(
             site,
             granularity,
-            LimitMode.Top(VISITORS_AND_VIEW_FETCH_LIMIT),
+            LimitMode.Top(fetchingAmountLimit),
             endDate,
             forced
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
@@ -176,7 +176,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             }
 
             sut = givenAViewModel(resourceProvider)
-            sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
+            sut.onSelectedTimePeriodChanged(LAST_YEAR)
 
             with(sut.state.value.analyticsDateRangeSelectorState) {
                 assertEquals(LAST_YEAR.description, selectedPeriod)
@@ -195,7 +195,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
 
             sut = givenAViewModel()
 
-            sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
+            sut.onSelectedTimePeriodChanged(LAST_YEAR)
 
             val resourceProvider = givenAResourceProvider()
             with(sut.state.value.revenueState) {
@@ -222,7 +222,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
                 )
 
             sut = givenAViewModel()
-            sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
+            sut.onSelectedTimePeriodChanged(LAST_YEAR)
 
             with(sut.state.value.revenueState) {
                 assertTrue(this is AnalyticsInformationViewState.DataViewState)
@@ -240,7 +240,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
 
             sut = givenAViewModel()
 
-            sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
+            sut.onSelectedTimePeriodChanged(LAST_YEAR)
 
             with(sut.state.value.refreshIndicator) {
                 assertTrue(this is NotShowIndicator)
@@ -268,7 +268,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         }
 
         sut = givenAViewModel()
-        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE.description)
+        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE)
         sut.onRefreshRequested()
 
         val resourceProvider = givenAResourceProvider()
@@ -292,7 +292,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             }
 
             sut = givenAViewModel()
-            sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
+            sut.onSelectedTimePeriodChanged(LAST_YEAR)
 
             val resourceProvider = givenAResourceProvider()
             with(sut.state.value.ordersState) {
@@ -315,7 +315,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             }
 
             sut = givenAViewModel()
-            sut.onSelectedTimePeriodChanged(LAST_YEAR.description)
+            sut.onSelectedTimePeriodChanged(LAST_YEAR)
 
             val resourceProvider = givenAResourceProvider()
             with(sut.state.value.productsState) {
@@ -354,7 +354,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         }
 
         sut = givenAViewModel()
-        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE.description)
+        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE)
         sut.onRefreshRequested()
 
         val resourceProvider = givenAResourceProvider()
@@ -391,7 +391,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         }
 
         sut = givenAViewModel()
-        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE.description)
+        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE)
         sut.onRefreshRequested()
 
         with(sut.state.value.revenueState) {
@@ -422,7 +422,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         }
 
         sut = givenAViewModel()
-        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE.description)
+        sut.onSelectedTimePeriodChanged(WEEK_TO_DATE)
         sut.onRefreshRequested()
 
         val resourceProvider = givenAResourceProvider()


### PR DESCRIPTION
Summary
==========
Fix issue #7750 by introducing a proper way to request the `Last quarter` and `quarter to date` date range selections for the `Visitors and Views` data. This is done by doing a dedicated request to Quarter-related range selections.

How to Test
==========
1. Go to your store jetpack stats (URL should be /wp-admin/admin.php?page=stats)
2. Verify the Month views and visitors data chart
3. Go to the Analytics Hub and select `Last Quarter` or `Quarter to Date` date range options
4. Check if the data displayed in the Visitors and Views card in the Analytics Hub corresponds to the data sum of the respective three months of the quarter displayed in your store stats.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.