### PR TITLE
Introduce delta percentage to Visitors stats card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/VisitorsStat.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/VisitorsStat.kt
@@ -2,5 +2,7 @@ package com.woocommerce.android.model
 
 data class VisitorsStat(
     val visitorsCount: Int,
-    val viewsCount: Int
+    val viewsCount: Int,
+    val avgVisitorsDelta: DeltaPercentage,
+    val avgViewsDelta: DeltaPercentage
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -195,12 +195,21 @@ class AnalyticsRepository @Inject constructor(
         selectedRange: AnalyticTimePeriod,
         fetchStrategy: FetchStrategy
     ): VisitorsResult {
-        return getVisitorsStats(
+        val previousPeriodStats = getVisitorsStats(
+            dateRange.getComparisonPeriod().to,
+            getGranularity(selectedRange),
+            fetchStrategy,
+            MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT
+        )
+
+        val currentPeriodStats = getVisitorsStats(
             dateRange.getSelectedPeriod().to,
             getGranularity(selectedRange),
             fetchStrategy,
             MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT
-        ).model?.dates?.last()
+        )
+
+        return currentPeriodStats.model?.dates?.last()
             ?.let {
                 VisitorsResult.VisitorsData(
                     VisitorsStat(
@@ -218,6 +227,20 @@ class AnalyticsRepository @Inject constructor(
     ): VisitorsResult {
         val startDate = dateRange.getSelectedPeriod().from.theDayBeforeIt()
         val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+        val previousPeriodStats = getVisitorsStats(
+            dateRange.getComparisonPeriod().to,
+            getGranularity(selectedRange),
+            fetchStrategy,
+            QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT
+        )
+
+        val currentPeriodStats = getVisitorsStats(
+            dateRange.getSelectedPeriod().to,
+            getGranularity(selectedRange),
+            fetchStrategy,
+            QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT
+        )
 
         return getVisitorsStats(
             dateRange.getSelectedPeriod().to,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -203,24 +203,23 @@ class AnalyticsRepository @Inject constructor(
             getGranularity(selectedRange),
             fetchStrategy,
             MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT
-        )
+        ).model?.dates?.lastOrNull()
 
         val currentPeriodStats = getVisitorsStats(
             dateRange.getSelectedPeriod().to,
             getGranularity(selectedRange),
             fetchStrategy,
             MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT
-        )
+        ).model?.dates?.lastOrNull()
 
-        return currentPeriodStats.model?.dates?.last()
-            ?.let {
-                VisitorsResult.VisitorsData(
-                    VisitorsStat(
-                        it.visitors.toInt(),
-                        it.views.toInt()
-                    )
+        return currentPeriodStats?.let {
+            VisitorsResult.VisitorsData(
+                VisitorsStat(
+                    it.visitors.toInt(),
+                    it.views.toInt()
                 )
-            } ?: VisitorsResult.VisitorsError
+            )
+        } ?: VisitorsResult.VisitorsError
     }
 
     suspend fun fetchQuarterVisitorsData(
@@ -228,12 +227,13 @@ class AnalyticsRepository @Inject constructor(
         selectedRange: AnalyticTimePeriod,
         fetchStrategy: FetchStrategy
     ): VisitorsResult {
-        val previousPeriodStats = getVisitorsStats(
+        val (previousVisitors, previousViews) = getVisitorsStats(
             dateRange.getComparisonPeriod().to,
             getGranularity(selectedRange),
             fetchStrategy,
             QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT
         ).model?.dates?.foldStatsWithin(dateRange.getComparisonPeriod())
+            ?: Pair(0, 0)
 
         val currentPeriodStats = getVisitorsStats(
             dateRange.getSelectedPeriod().to,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.Date
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
@@ -195,7 +196,7 @@ class AnalyticsRepository @Inject constructor(
         fetchStrategy: FetchStrategy
     ): VisitorsResult {
         return getVisitorsStats(
-            dateRange,
+            dateRange.getSelectedPeriod().to,
             getGranularity(selectedRange),
             fetchStrategy,
             MOST_RECENT_VISITORS_AND_VIEW_FETCH_LIMIT
@@ -219,7 +220,7 @@ class AnalyticsRepository @Inject constructor(
         val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
 
         return getVisitorsStats(
-            dateRange,
+            dateRange.getSelectedPeriod().to,
             getGranularity(selectedRange),
             fetchStrategy,
             QUARTER_VISITORS_AND_VIEW_FETCH_LIMIT
@@ -310,14 +311,12 @@ class AnalyticsRepository @Inject constructor(
     }
 
     private suspend fun getVisitorsStats(
-        dateRange: AnalyticsDateRange,
+        endDate: Date,
         granularity: StatsGranularity,
         fetchStrategy: FetchStrategy,
         fetchingAmountLimit: Int = VISITORS_AND_VIEW_DEFAULT_FETCH_LIMIT
     ): WooResult<VisitsAndViewsModel> = coroutineScope {
         val site = selectedSite.get()
-
-        val endDate = dateRange.getAnalyzedPeriod().to
 
         statsRepository.fetchViewAndVisitorsStatsWithinRange(
             endDate = endDate,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -37,8 +37,8 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.text.SimpleDateFormat
-import java.util.Locale
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -390,6 +390,10 @@ class AnalyticsRepository @Inject constructor(
     private fun getCurrencyCode() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode
     private fun getAdminPanelUrl() = selectedSite.getIfExists()?.adminUrl
 
+    /***
+     * This method will select all Visitors and Views data within a given date range interval
+     * and fold all this data into a Pair containing the total visitors and total views of that period
+     */
     private fun List<VisitsAndViewsModel.PeriodData>.foldStatsWithin(dateRange: DateRange): Pair<Long, Long> {
         val startDate = dateRange.from.theDayBeforeIt()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.DeltaPercentage
 import com.woocommerce.android.model.ProductItem
+import com.woocommerce.android.model.VisitorsStat
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.FetchStrategy.ForceNew
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.FetchStrategy.Saved
@@ -317,10 +318,7 @@ class AnalyticsViewModel @Inject constructor(
             is VisitorsData -> {
                 mutableState.value = state.value.copy(
                     refreshIndicator = NotShowIndicator,
-                    visitorsState = buildVisitorsDataViewState(
-                        visitorsStat.visitorsCount,
-                        visitorsStat.viewsCount
-                    )
+                    visitorsState = buildVisitorsDataViewState(visitorsStat)
                 )
                 // submit sentry monitor transaction finished event
             }
@@ -384,20 +382,19 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     private fun buildVisitorsDataViewState(
-        visitorsCount: Int,
-        viewsCount: Int
+        stats: VisitorsStat
     ) = DataViewState(
         title = resourceProvider.getString(R.string.analytics_visitors_and_views_card_title),
         leftSection = AnalyticsInformationSectionViewState(
             title = resourceProvider.getString(R.string.analytics_visitors_subtitle),
-            visitorsCount.toString(),
-            null, /** Add delta calculation to Visitors and Views stats **/
+            stats.visitorsCount.toString(),
+            if (stats.avgVisitorsDelta is DeltaPercentage.Value) stats.avgVisitorsDelta.value else null,
             listOf() /** Add charts calculation to Visitors and Views stats **/
         ),
         rightSection = AnalyticsInformationSectionViewState(
             resourceProvider.getString(R.string.analytics_views_subtitle),
-            viewsCount.toString(),
-            null, /** Add delta calculation to Visitors and Views stats **/
+            stats.viewsCount.toString(),
+            if (stats.avgViewsDelta is DeltaPercentage.Value) stats.avgViewsDelta.value else null,
             listOf() /** Add charts calculation to Visitors and Views stats **/
         )
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -385,13 +385,13 @@ class AnalyticsViewModel @Inject constructor(
         leftSection = AnalyticsInformationSectionViewState(
             title = resourceProvider.getString(R.string.analytics_visitors_subtitle),
             stats.visitorsCount.toString(),
-            if (stats.avgVisitorsDelta is DeltaPercentage.Value) stats.avgVisitorsDelta.value else null,
+            stats.avgVisitorsDelta.run { this as? DeltaPercentage.Value }?.value,
             listOf() /** Add charts calculation to Visitors and Views stats **/
         ),
         rightSection = AnalyticsInformationSectionViewState(
             resourceProvider.getString(R.string.analytics_views_subtitle),
             stats.viewsCount.toString(),
-            if (stats.avgViewsDelta is DeltaPercentage.Value) stats.avgViewsDelta.value else null,
+            stats.avgViewsDelta.run { this as? DeltaPercentage.Value}?.value,
             listOf() /** Add charts calculation to Visitors and Views stats **/
         )
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -391,7 +391,7 @@ class AnalyticsViewModel @Inject constructor(
         rightSection = AnalyticsInformationSectionViewState(
             resourceProvider.getString(R.string.analytics_views_subtitle),
             stats.viewsCount.toString(),
-            stats.avgViewsDelta.run { this as? DeltaPercentage.Value}?.value,
+            stats.avgViewsDelta.run { this as? DeltaPercentage.Value }?.value,
             listOf() /** Add charts calculation to Visitors and Views stats **/
         )
     )


### PR DESCRIPTION
Summary
==========
Fix issue #7751 by acquiring the previous date range of the selected one and comparing them for visitor data and Site views data.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20221110_010045](https://user-images.githubusercontent.com/5920403/200997588-e013f8c5-4a2b-4626-ad85-2d45266951d2.png) | ![Screenshot_20221110_005744](https://user-images.githubusercontent.com/5920403/200997302-3d29e721-03a1-486d-ada7-ca96d6aa2f99.png) |

How to Test
==========
1. Go to your store jetpack stats (URL should be /wp-admin/admin.php?page=stats)
2. Verify the Month views and visitors data chart
3. Go to the Analytics Hub and select any possible date range except the custom one
4. Check if the data displayed in the Visitors and Views card in the Analytics Hub corresponds to the percentage value based on the displayed stats in your store stats.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
