### PR TITLE
Replace deprecated menu usages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingFragment.kt
@@ -8,8 +8,10 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.MenuProvider
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
@@ -42,7 +44,9 @@ import org.wordpress.android.fluxc.utils.DateUtils as FluxCDateUtils
 
 @AndroidEntryPoint
 class AddOrderShipmentTrackingFragment :
-    BaseFragment(R.layout.fragment_add_shipment_tracking), BackPressListener {
+    BaseFragment(R.layout.fragment_add_shipment_tracking),
+    BackPressListener,
+    MenuProvider {
     companion object {
         const val KEY_ADD_SHIPMENT_TRACKING_RESULT = "key_add_shipment_tracking_result"
     }
@@ -62,11 +66,6 @@ class AddOrderShipmentTrackingFragment :
             navigationIcon = R.drawable.ic_gridicons_cross_24dp
         )
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_add_shipment_tracking, container, false)
     }
@@ -75,6 +74,8 @@ class AddOrderShipmentTrackingFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         val binding = FragmentAddShipmentTrackingBinding.bind(view)
         initUi(binding)
@@ -160,7 +161,7 @@ class AddOrderShipmentTrackingFragment :
             val calendar = FluxCDateUtils.getCalendarInstance(viewModel.currentSelectedDate)
             dateShippedPickerDialog = DatePickerDialog(
                 requireActivity(),
-                DatePickerDialog.OnDateSetListener { _, year, month, dayOfMonth ->
+                { _, year, month, dayOfMonth ->
                     viewModel.onDateChanged("$year-${month + 1}-$dayOfMonth")
                 },
                 calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)
@@ -198,12 +199,11 @@ class AddOrderShipmentTrackingFragment :
     /**
      * Reusing the same menu used for adding order notes
      */
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_add, menu)
-        super.onCreateOptionsMenu(menu, inflater)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_add -> {
                 activity?.let {
@@ -213,7 +213,7 @@ class AddOrderShipmentTrackingFragment :
                 viewModel.onAddButtonTapped()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListFragment.kt
@@ -3,11 +3,14 @@ package com.woocommerce.android.ui.orders.tracking
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.DialogOrderTrackingProviderListBinding
@@ -28,7 +31,8 @@ import javax.inject.Inject
 class AddOrderTrackingProviderListFragment :
     BaseFragment(R.layout.dialog_order_tracking_provider_list),
     OnQueryTextListener,
-    OnProviderClickListener {
+    OnProviderClickListener,
+    MenuProvider {
     companion object {
         const val TAG: String = "AddOrderTrackingProviderListFragment"
         const val SHIPMENT_TRACKING_PROVIDER_RESULT = "tracking-provider-result"
@@ -51,13 +55,10 @@ class AddOrderTrackingProviderListFragment :
 
     private val skeletonView = SkeletonView()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         val binding = DialogOrderTrackingProviderListBinding.bind(view)
 
@@ -65,7 +66,7 @@ class AddOrderTrackingProviderListFragment :
         setupObservers(binding)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_search, menu)
         val searchMenuItem = menu.findItem(R.id.menu_search)
         searchView = searchMenuItem!!.actionView as SearchView
@@ -76,8 +77,9 @@ class AddOrderTrackingProviderListFragment :
             it.imeOptions = it.imeOptions or EditorInfo.IME_FLAG_NO_EXTRACT_UI
             it.setOnQueryTextListener(this@AddOrderTrackingProviderListFragment)
         }
-        super.onCreateOptionsMenu(menu, inflater)
     }
+
+    override fun onMenuItemSelected(menuItem: MenuItem) = false
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/receipt/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/receipt/ReceiptPreviewFragment.kt
@@ -7,7 +7,9 @@ import android.view.MenuItem
 import android.view.View
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentReceiptPreviewBinding
@@ -24,7 +26,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview) {
+class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), MenuProvider {
     val viewModel: ReceiptPreviewViewModel by viewModels()
 
     @Inject lateinit var printHtmlHelper: PrintHtmlHelper
@@ -35,17 +37,19 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
+
         _binding = FragmentReceiptPreviewBinding.bind(view)
         initViews(binding, savedInstanceState)
         initObservers(binding)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_receipt_preview, menu)
-        super.onCreateOptionsMenu(menu, inflater)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_print -> {
                 viewModel.onPrintClicked()
@@ -55,7 +59,7 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview) {
                 viewModel.onSendEmailClicked()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/receipt/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/receipt/ReceiptPreviewFragment.kt
@@ -82,7 +82,6 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
     }
 
     private fun initViews(binding: FragmentReceiptPreviewBinding, savedInstanceState: Bundle?) {
-        setHasOptionsMenu(true)
         if (savedInstanceState != null) {
             binding.receiptPreviewPreviewWebview.restoreState(savedInstanceState)
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsCustomerNoteFragment.kt
@@ -5,7 +5,9 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.core.widget.doAfterTextChanged
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -15,7 +17,9 @@ import com.woocommerce.android.ui.base.BaseFragment
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.DisplayUtils
 
-class SimplePaymentsCustomerNoteFragment : BaseFragment(R.layout.fragment_order_create_edit_customer_note) {
+class SimplePaymentsCustomerNoteFragment :
+    BaseFragment(R.layout.fragment_order_create_edit_customer_note),
+    MenuProvider {
     private var _binding: FragmentOrderCreateEditCustomerNoteBinding? = null
     val binding
         get() = _binding!!
@@ -25,7 +29,7 @@ class SimplePaymentsCustomerNoteFragment : BaseFragment(R.layout.fragment_order_
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         _binding = FragmentOrderCreateEditCustomerNoteBinding.bind(view)
         if (savedInstanceState == null) {
@@ -56,15 +60,14 @@ class SimplePaymentsCustomerNoteFragment : BaseFragment(R.layout.fragment_order_
         _binding = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
         doneMenuItem.isEnabled = hasChanges()
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 navigateBackWithResult(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsCustomerNoteFragment.kt
@@ -76,7 +76,7 @@ class SimplePaymentsCustomerNoteFragment :
                 )
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7785
Closes: #7786
Closes: #7787
Closes: #7788
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaces deprecated menu usages in:
* AddOrderShipmentTrackingFragment
* AddOrderTrackingProviderListFragment
* AddOrderTrackingProviderListFragment
* SimplePaymentsCustomerNoteFragment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open an order. Click add tracking. Notice that the menu has a search and it works
* Open an order. Click add tracking. Click on the carrier. Notice that the menu has a search and it works
* Start simple payments. Click on "add a note". Notice that the menu has 1 button it works
* Make an IPP payment. Open an order. Click see receipt. Notice that the menu has 2 buttons and both of them work
