### PR TITLE
Hide visitor stats on custom range

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRange
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeFormatter
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticsDateRangeSelectorViewState
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationSectionViewState
+import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.DataViewState
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.LoadingViewState
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.NoDataState
@@ -299,6 +300,11 @@ class AnalyticsViewModel @Inject constructor(
             val timePeriod = getSavedTimePeriod()
             val dateRange = getSavedDateRange()
             val fetchStrategy = getFetchStrategy(isRefreshing)
+
+            if (timePeriod == CUSTOM) {
+                mutableState.value = state.value.copy(visitorsState = AnalyticsInformationViewState.HiddenState)
+                return@launch
+            }
 
             if (showSkeleton) mutableState.value = state.value.copy(visitorsState = LoadingViewState)
             mutableState.value = state.value.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationCardView.kt
@@ -9,6 +9,7 @@ import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsInformationCardViewBinding
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.DataViewState
+import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.HiddenState
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.LoadingViewState
 import com.woocommerce.android.ui.analytics.informationcard.AnalyticsInformationViewState.NoDataState
 import com.woocommerce.android.util.FeatureFlag
@@ -27,10 +28,12 @@ class AnalyticsInformationCardView @JvmOverloads constructor(
     }
 
     internal fun updateInformation(viewState: AnalyticsInformationViewState) {
+        visibility = if (viewState is HiddenState) View.GONE else View.VISIBLE
         when (viewState) {
             is LoadingViewState -> setSkeleton()
             is DataViewState -> setDataViewState(viewState)
             is NoDataState -> setNoDataViewState(viewState)
+            is HiddenState -> {}
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/informationcard/AnalyticsInformationViewState.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.analytics.informationcard
 
 sealed class AnalyticsInformationViewState {
+    object HiddenState : AnalyticsInformationViewState()
     object LoadingViewState : AnalyticsInformationViewState()
     data class NoDataState(val message: String) : AnalyticsInformationViewState()
     data class DataViewState(


### PR DESCRIPTION
⚠️ This PR depends on this [other PR](https://github.com/woocommerce/woocommerce-android/pull/7776)

Closes: #7780

### Why
The custom range selection support for the Visitors and Views stats card is still pending and won't be delivered in Milestone 2, to avoid misleading data, we should hide that card when a custom date range is selected. This can be reverted once issue https://github.com/woocommerce/woocommerce-android/issues/7749 is addressed.

### Description
This PR adds a new state to the `AnalyticsInformationViewState`, the HiddenState that is going to be used when the user selects the custom date range option. This new HiddenState will hide the stat card and is used to prevent the Visitors and Views stats card from being shown when the custom range selection is selected.

### Testing instructions
1. Open MyStore screen
2. Tap on See more
3. Check that when the selected option is different than a custom date range, the Visitors and Views stats card is visible
4. Check that when the selected option is a custom date range, the Visitors and Views stats card is hidden

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/201119120-8dba9caf-20b8-470a-8f58-1900b7aa8cfd.mp4


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
