### PR TITLE
Fix analytics Today and Yesterday previous date range comparison

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
@@ -66,11 +66,9 @@ class AnalyticsDateRangeCalculator @Inject constructor(
 
     private fun getDateOfLastDayTwoQuartersAgo() = dateUtils.getDateForLastDayOfPreviousQuarter(2)
 
-    private fun getYesterdayRange() = SimpleDateRange(Date(dateUtils.getCurrentDateTimeMinusDays(2)), getDateForYesterday())
+    private fun getYesterdayRange() = SimpleDateRange(getCurrentDateTimeMinusDays(2), getDateForYesterday())
 
     private fun getTodayRange() = SimpleDateRange(getDateForYesterday(), dateUtils.getCurrentDate())
-
-    private fun getDateForYesterday() = Date(dateUtils.getCurrentDateTimeMinusDays(1))
 
     private fun getLastMonthRange() =
         MultipleDateRange(
@@ -112,6 +110,10 @@ class AnalyticsDateRangeCalculator @Inject constructor(
         dateUtils.getDateTimeAppliedOperation(dateUtils.getCurrentDate(), Calendar.MONTH, -1)
 
     private fun getDateForLastDayOfTwoYearsAgo() = dateUtils.getDateForLastDayOfPreviousYear(2)
+
+    private fun getDateForYesterday() = getCurrentDateTimeMinusDays(1)
+
+    private fun getCurrentDateTimeMinusDays(days: Int) = Date(dateUtils.getCurrentDateTimeMinusDays(days))
 
     companion object {
         const val DAYS_IN_WEEK = 7

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculator.kt
@@ -66,9 +66,9 @@ class AnalyticsDateRangeCalculator @Inject constructor(
 
     private fun getDateOfLastDayTwoQuartersAgo() = dateUtils.getDateForLastDayOfPreviousQuarter(2)
 
-    private fun getYesterdayRange() = SimpleDateRange(getDateForYesterday(), getDateForYesterday())
+    private fun getYesterdayRange() = SimpleDateRange(Date(dateUtils.getCurrentDateTimeMinusDays(2)), getDateForYesterday())
 
-    private fun getTodayRange() = SimpleDateRange(dateUtils.getCurrentDate(), dateUtils.getCurrentDate())
+    private fun getTodayRange() = SimpleDateRange(getDateForYesterday(), dateUtils.getCurrentDate())
 
     private fun getDateForYesterday() = Date(dateUtils.getCurrentDateTimeMinusDays(1))
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
@@ -43,15 +43,17 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
     fun `when a any previous days date is given then get the date range for yesterday is the expected`() {
         // Given
         val yesterday = getDateFromString("2022-10-27")
+        val theDayBeforeYesterday = getDateFromString("2022-10-26")
 
-        whenever(dateUtils.getCurrentDateTimeMinusDays(any())).thenReturn(yesterday.time)
+        whenever(dateUtils.getCurrentDateTimeMinusDays(1)).thenReturn(yesterday.time)
+        whenever(dateUtils.getCurrentDateTimeMinusDays(2)).thenReturn(theDayBeforeYesterday.time)
 
         // When
         val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.YESTERDAY)
 
         // Then
         assertTrue(result is SimpleDateRange)
-        assertEquals(yesterday, result.from)
+        assertEquals(theDayBeforeYesterday, result.from)
         assertEquals(yesterday, result.to)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/daterangeselector/AnalyticsDateRangeCalculatorTest.kt
@@ -25,15 +25,17 @@ class AnalyticsDateRangeCalculatorTest : BaseUnitTest() {
     fun `when the current date is given then get the date range for today is the expected`() {
         // Given
         val today = getDateFromString("2022-10-28")
+        val yesterday = getDateFromString("2022-10-27")
 
         whenever(dateUtils.getCurrentDate()).thenReturn(today)
+        whenever(dateUtils.getCurrentDateTimeMinusDays(1)).thenReturn(yesterday.time)
 
         // When
         val result = sut.getAnalyticsDateRangeFrom(AnalyticTimePeriod.TODAY)
 
         // Then
         assertTrue(result is SimpleDateRange)
-        assertEquals(today, result.from)
+        assertEquals(yesterday, result.from)
         assertEquals(today, result.to)
     }
 


### PR DESCRIPTION
Summary
==========
Fix issue #7775 by adjusting Today's and Yesterday's date range selection comparison.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20221110_130308](https://user-images.githubusercontent.com/5920403/201145197-b41fe2c1-5c52-4cc5-bd34-ae9c159bb392.png) | ![Screenshot_20221110_130150](https://user-images.githubusercontent.com/5920403/201145119-2f11f64d-c4c0-446f-9c47-b79f7cea2071.png) |

How to Test
==========
1. Go to the Analytics Hub, select Today and Yesterday date range
2. Verify that the `previous date` is describing the day before the main selected one

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
