### PR TITLE
Issue/7753 track visitor stats

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -241,6 +241,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_REVENUE_CARD_SELECTED = "revenue"
         const val VALUE_ORDERS_CARD_SELECTED = "orders"
         const val VALUE_PRODUCTS_CARD_SELECTED = "products"
+        const val VALUE_VISITORS_CARD_SELECTED = "visitors"
 
         const val JITM_ID = "jitm_id"
         const val JITM_FEATURE_CLASS = "feature_class"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubTransactionLauncher.kt
@@ -10,7 +10,10 @@ import com.automattic.android.tracks.crashlogging.performance.TransactionStatus
 import com.woocommerce.android.analytics.AnalyticsEvent.ANALYTICS_HUB_WAITING_TIME_LOADED
 import com.woocommerce.android.analytics.WaitingTimeTracker
 import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.ORDERS_FETCHED
+import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.PRODUCTS_FETCHED
 import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.REVENUE_FETCHED
+import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.VISITORS_FETCHED
+
 import com.woocommerce.android.util.CoroutineDispatchers
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.CoroutineScope
@@ -49,12 +52,18 @@ class AnalyticsHubTransactionLauncher @Inject constructor(
 
     private enum class Conditions {
         REVENUE_FETCHED,
-        ORDERS_FETCHED
+        ORDERS_FETCHED,
+        PRODUCTS_FETCHED,
+        VISITORS_FETCHED
     }
 
     fun onRevenueFetched() = satisfyCondition(REVENUE_FETCHED)
 
     fun onOrdersFetched() = satisfyCondition(ORDERS_FETCHED)
+
+    fun onProductsFetched() = satisfyCondition(PRODUCTS_FETCHED)
+
+    fun onVisitorsFetched() = satisfyCondition(VISITORS_FETCHED)
 
     fun clear() {
         validatorScope.cancel()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubTransactionLauncher.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Cond
 import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.PRODUCTS_FETCHED
 import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.REVENUE_FETCHED
 import com.woocommerce.android.ui.analytics.AnalyticsHubTransactionLauncher.Conditions.VISITORS_FETCHED
-
 import com.woocommerce.android.util.CoroutineDispatchers
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.CoroutineScope

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -180,7 +180,7 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     fun onVisitorsSeeReportClick() {
-        // Add track visitors click
+        trackSeeReportClicked(AnalyticsTracker.VALUE_VISITORS_CARD_SELECTED)
         openReportsView(analyticsRepository.getJetpackStatsPanelUrl())
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -271,13 +271,16 @@ class AnalyticsViewModel @Inject constructor(
             analyticsRepository.fetchProductsData(dateRange, timePeriod, fetchStrategy)
                 .let {
                     when (it) {
-                        is ProductsData -> mutableState.value = state.value.copy(
-                            productsState = buildProductsDataState(
-                                it.productsStat.itemsSold,
-                                it.productsStat.itemsSoldDelta,
-                                it.productsStat.products
+                        is ProductsData -> {
+                            mutableState.value = state.value.copy(
+                                productsState = buildProductsDataState(
+                                    it.productsStat.itemsSold,
+                                    it.productsStat.itemsSoldDelta,
+                                    it.productsStat.products
+                                )
                             )
-                        )
+                            transactionLauncher.onProductsFetched()
+                        }
                         ProductsError -> mutableState.value = state.value.copy(
                             productsState = ProductsNoDataState(
                                 resourceProvider.getString(R.string.analytics_products_no_data)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModel.kt
@@ -303,6 +303,7 @@ class AnalyticsViewModel @Inject constructor(
 
             if (timePeriod == CUSTOM) {
                 mutableState.value = state.value.copy(visitorsState = AnalyticsInformationViewState.HiddenState)
+                transactionLauncher.onVisitorsFetched()
                 return@launch
             }
 
@@ -328,7 +329,7 @@ class AnalyticsViewModel @Inject constructor(
                         visitorsStat.viewsCount
                     )
                 )
-                // submit sentry monitor transaction finished event
+                transactionLauncher.onVisitorsFetched()
             }
             is VisitorsError -> mutableState.value = state.value.copy(
                 refreshIndicator = NotShowIndicator,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsViewModelTest.kt
@@ -7,12 +7,18 @@ import com.woocommerce.android.model.OrdersStat
 import com.woocommerce.android.model.ProductItem
 import com.woocommerce.android.model.ProductsStat
 import com.woocommerce.android.model.RevenueStat
+import com.woocommerce.android.model.VisitorsStat
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.FetchStrategy.ForceNew
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.FetchStrategy.Saved
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.OrdersResult.OrdersData
+import com.woocommerce.android.ui.analytics.AnalyticsRepository.OrdersResult.OrdersError
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.ProductsResult.ProductsData
+import com.woocommerce.android.ui.analytics.AnalyticsRepository.ProductsResult.ProductsError
 import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueData
+import com.woocommerce.android.ui.analytics.AnalyticsRepository.RevenueResult.RevenueError
+import com.woocommerce.android.ui.analytics.AnalyticsRepository.VisitorsResult.VisitorsData
+import com.woocommerce.android.ui.analytics.AnalyticsRepository.VisitorsResult.VisitorsError
 import com.woocommerce.android.ui.analytics.AnalyticsViewModel.Companion.DATE_RANGE_SELECTED_KEY
 import com.woocommerce.android.ui.analytics.AnalyticsViewModel.Companion.TIME_PERIOD_SELECTED_KEY
 import com.woocommerce.android.ui.analytics.RefreshIndicator.NotShowIndicator
@@ -43,6 +49,8 @@ import org.mockito.kotlin.doReturnConsecutively
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import java.text.SimpleDateFormat
@@ -88,6 +96,8 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         on { getIfExists() } doReturn siteModel
     }
     private val savedState = AnalyticsFragmentArgs(targetGranularity = TODAY).initSavedStateHandle()
+
+    private val transactionLauncher = mock<AnalyticsHubTransactionLauncher>()
 
     private lateinit var sut: AnalyticsViewModel
 
@@ -501,6 +511,91 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         assertThat(sut.event.value).isInstanceOf(AnalyticsViewEvent.OpenDatePicker::class.java)
     }
 
+    @Test
+    fun `when all data is fetched successfully then all Sentry conditions are satisfied`() = testBlocking {
+        analyticsRepository.stub {
+            onBlocking { fetchRevenueData(any(), any(), any()) }.doReturn(getRevenueStats())
+            onBlocking { fetchOrdersData(any(), any(), any()) }.doReturn(getOrdersStats())
+            onBlocking { fetchProductsData(any(), any(), any()) }.doReturn(getProductsStats())
+            onBlocking { fetchRecentVisitorsData(any(), any(), any()) }.doReturn(getVisitorStats())
+        }
+
+        sut = givenAViewModel()
+
+        verify(transactionLauncher, times(1)).onRevenueFetched()
+        verify(transactionLauncher, times(1)).onOrdersFetched()
+        verify(transactionLauncher, times(1)).onProductsFetched()
+        verify(transactionLauncher, times(1)).onVisitorsFetched()
+    }
+
+    @Test
+    fun `when fetch revenue fails then Sentry revenue condition is not satisfied`() = testBlocking {
+        analyticsRepository.stub {
+            onBlocking { fetchRevenueData(any(), any(), any()) }.doReturn(RevenueError)
+            onBlocking { fetchOrdersData(any(), any(), any()) }.doReturn(getOrdersStats())
+            onBlocking { fetchProductsData(any(), any(), any()) }.doReturn(getProductsStats())
+            onBlocking { fetchRecentVisitorsData(any(), any(), any()) }.doReturn(getVisitorStats())
+        }
+
+        sut = givenAViewModel()
+
+        verify(transactionLauncher, times(0)).onRevenueFetched()
+        verify(transactionLauncher, times(1)).onOrdersFetched()
+        verify(transactionLauncher, times(1)).onProductsFetched()
+        verify(transactionLauncher, times(1)).onVisitorsFetched()
+    }
+
+    @Test
+    fun `when fetch orders fails then Sentry order condition is not satisfied`() = testBlocking {
+        analyticsRepository.stub {
+            onBlocking { fetchRevenueData(any(), any(), any()) }.doReturn(getRevenueStats())
+            onBlocking { fetchOrdersData(any(), any(), any()) }.doReturn(OrdersError)
+            onBlocking { fetchProductsData(any(), any(), any()) }.doReturn(getProductsStats())
+            onBlocking { fetchRecentVisitorsData(any(), any(), any()) }.doReturn(getVisitorStats())
+        }
+
+        sut = givenAViewModel()
+
+        verify(transactionLauncher, times(1)).onRevenueFetched()
+        verify(transactionLauncher, times(0)).onOrdersFetched()
+        verify(transactionLauncher, times(1)).onProductsFetched()
+        verify(transactionLauncher, times(1)).onVisitorsFetched()
+    }
+
+    @Test
+    fun `when fetch products fails then Sentry products condition is not satisfied`() = testBlocking {
+        analyticsRepository.stub {
+            onBlocking { fetchRevenueData(any(), any(), any()) }.doReturn(getRevenueStats())
+            onBlocking { fetchOrdersData(any(), any(), any()) }.doReturn(getOrdersStats())
+            onBlocking { fetchProductsData(any(), any(), any()) }.doReturn(ProductsError)
+            onBlocking { fetchRecentVisitorsData(any(), any(), any()) }.doReturn(getVisitorStats())
+        }
+
+        sut = givenAViewModel()
+
+        verify(transactionLauncher, times(1)).onRevenueFetched()
+        verify(transactionLauncher, times(1)).onOrdersFetched()
+        verify(transactionLauncher, times(0)).onProductsFetched()
+        verify(transactionLauncher, times(1)).onVisitorsFetched()
+    }
+
+    @Test
+    fun `when fetch visitors fails then Sentry visitors condition is not satisfied`() = testBlocking {
+        analyticsRepository.stub {
+            onBlocking { fetchRevenueData(any(), any(), any()) }.doReturn(getRevenueStats())
+            onBlocking { fetchOrdersData(any(), any(), any()) }.doReturn(getOrdersStats())
+            onBlocking { fetchProductsData(any(), any(), any()) }.doReturn(getProductsStats())
+            onBlocking { fetchRecentVisitorsData(any(), any(), any()) }.doReturn(VisitorsError)
+        }
+
+        sut = givenAViewModel()
+
+        verify(transactionLauncher, times(1)).onRevenueFetched()
+        verify(transactionLauncher, times(1)).onOrdersFetched()
+        verify(transactionLauncher, times(1)).onProductsFetched()
+        verify(transactionLauncher, times(0)).onVisitorsFetched()
+    }
+
     private fun givenAResourceProvider(): ResourceProvider = mock {
         on { getString(any()) } doAnswer { invocationOnMock -> invocationOnMock.arguments[0].toString() }
         on { getString(any(), any()) } doAnswer { invMock -> invMock.arguments[0].toString() }
@@ -515,7 +610,7 @@ class AnalyticsViewModelTest : BaseUnitTest() {
             currencyFormatter,
             analyticsRepository,
             selectedSite,
-            mock(),
+            transactionLauncher,
             mock(),
             analyticsDateRangeFormatter,
             savedState
@@ -563,6 +658,13 @@ class AnalyticsViewModelTest : BaseUnitTest() {
         itemsSoldDelta: Int = PRODUCT_ITEMS_SOLD_DELTA,
         productList: List<ProductItem> = PRODUCT_LIST
     ) = ProductsData(ProductsStat(itemsSold, DeltaPercentage.Value(itemsSoldDelta), productList))
+
+    private fun getVisitorStats(
+        visitorsCount: Int = DEFAULT_VISITORS_COUNT,
+        viewsCount: Int = DEFAULT_VIEWS_COUNT,
+        avgVisitorsDelta: DeltaPercentage = DeltaPercentage.Value(DEFAULT_AVG_VISITORS_DELTA),
+        avgViewsDelta: DeltaPercentage = DeltaPercentage.Value(DEFAULT_AVG_VIEWS_DELTA)
+    ) = VisitorsData(VisitorsStat(visitorsCount, viewsCount, avgVisitorsDelta, avgViewsDelta))
 
     companion object {
         private const val ANY_DATE_TIME_VALUE = "2021-11-21 00:00:00"
@@ -643,6 +745,11 @@ class AnalyticsViewModelTest : BaseUnitTest() {
                 PRODUCT_CURRENCY_CODE
             )
         ).sortedByDescending { it.quantity }
+
+        private const val DEFAULT_VISITORS_COUNT = 100
+        private const val DEFAULT_VIEWS_COUNT = 100
+        private const val DEFAULT_AVG_VISITORS_DELTA = 10
+        private const val DEFAULT_AVG_VIEWS_DELTA = 34
 
         const val ANY_URL = "https://a8c.com"
         const val ORDERS_COUNT = 5


### PR DESCRIPTION
Closes: #7753

### Why
The Visitors and Views card interactions and requests were not triggering anything related to Tracks or Sentry performance monitoring.

### Description
This PR adds tracks and sentry performance to the Visitors and Views card interactions and requests. It also adds sentry performance to the Product card. Monitoring user behavior with Sentry / Tracks will give us better information about the adoption and performance of the feature.

### Testing instructions
TC 1
1. Apply PATCH
2. Run app, select "See more" button on My Store
3. Go to Sentry > `Performance` > `AnalyticsHub` > Filter by `Recent Transactions`
4. **Assert that your transaction has been recorder**

<details>
<summary>
PATCH
</summary>

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt	(revision 56c883a088fee468b057c77e9db5c8d62a3c4502)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt	(date 1666789443401)
@@ -10,6 +10,7 @@
     private val analyticsWrapper: AnalyticsTrackerWrapper
 ) {
     operator fun invoke(): PerformanceMonitoringConfig {
+        return PerformanceMonitoringConfig.Enabled(1.0)
         val sampleRate = remoteConfigRepository.getPerformanceMonitoringSampleRate()
         val userEnabled = analyticsWrapper.sendUsageStats
 
```

</details>

TC 2

1. Open MyStore Screen
2. Tap on the `See more` button
3. Select `Today` on the date selection control of Analytic Hub
4. Scroll to the `Visitors and Views` card
5. Tap on `See report`
6. Check that the `analytics_hub_see_report_tapped` event is sent with the property `"card"` with value `"visitors"`


### Images/gif
```
🔵 Tracked: analytics_hub_see_report_tapped, Properties {"card":"visitors","blog_id":202934350,"is_wpcom_store":true,"is_debug":true}
```

#### Sentry
<img width="1115" alt="gxDl1X" src="https://user-images.githubusercontent.com/18119390/201149081-b9701ae1-a5da-4311-b4b3-7b691329870c.png">

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->