### PR TITLE
[UI Tests] - Set InitializationRule only on first test case

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
@@ -43,7 +43,7 @@ class SingleOrderScreen : Screen {
 
     fun assertSingleOrderScreenWithProduct(order: OrderData): SingleOrderScreen {
         Espresso.onView(withId(TOOLBAR))
-            .check(ViewAssertions.matches(hasDescendant(withText("Order #${order.id}"))))
+            .check(ViewAssertions.matches(hasDescendant(withText("Orders #${order.id}"))))
             .check(ViewAssertions.matches(isDisplayed()))
 
         Espresso.onView(withText(order.productName))

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
@@ -43,7 +43,7 @@ class SingleOrderScreen : Screen {
 
     fun assertSingleOrderScreenWithProduct(order: OrderData): SingleOrderScreen {
         Espresso.onView(withId(TOOLBAR))
-            .check(ViewAssertions.matches(hasDescendant(withText("Orders #${order.id}"))))
+            .check(ViewAssertions.matches(hasDescendant(withText("Order #${order.id}"))))
             .check(ViewAssertions.matches(isDisplayed()))
 
         Espresso.onView(withText(order.productName))

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -25,6 +25,7 @@ class OrdersUITest : TestBase() {
     @get:Rule(order = 0)
     val rule = HiltAndroidRule(this)
 
+    // Only need to initialize once on the first test
     @get:Rule(order = 1)
     val initRule = InitializationRule()
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsUITest.kt
@@ -4,7 +4,6 @@ package com.woocommerce.android.e2e.tests.ui
 
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
-import com.woocommerce.android.e2e.helpers.InitializationRule
 import com.woocommerce.android.e2e.helpers.TestBase
 import com.woocommerce.android.e2e.helpers.util.MocksReader
 import com.woocommerce.android.e2e.helpers.util.ProductData
@@ -26,9 +25,6 @@ class ProductsUITest : TestBase() {
     val rule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val initRule = InitializationRule()
-
-    @get:Rule(order = 2)
     var activityRule = ActivityTestRule(LoginActivity::class.java)
 
     @Before

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ReviewsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ReviewsUITest.kt
@@ -5,7 +5,6 @@ package com.woocommerce.android.e2e.tests.ui
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
-import com.woocommerce.android.e2e.helpers.InitializationRule
 import com.woocommerce.android.e2e.helpers.TestBase
 import com.woocommerce.android.e2e.helpers.util.MocksReader
 import com.woocommerce.android.e2e.helpers.util.ReviewData
@@ -29,9 +28,6 @@ class ReviewsUITest : TestBase() {
     val composeTestRule = createComposeRule()
 
     @get:Rule(order = 2)
-    val initRule = InitializationRule()
-
-    @get:Rule(order = 3)
     var activityRule = ActivityTestRule(LoginActivity::class.java)
 
     @Before


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
Before this change, when the `Orders` test case fail, it will fail subsequent tests with this error: `java.lang.IllegalStateException: There are multiple DataStores active for the same file:` (examples: [1](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.edfd947f2636efe3/matrices/4866950476760092623/details?stepId=bs.36aca2432b8ca3f2&testCaseId=40), [2](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.edfd947f2636efe3/matrices/6443009397835311315/details?stepId=bs.283b1093afe7b9f5&testCaseId=50)). 

With this change, it should no longer happen. It looks like the `InitializationRule` only needs to run once per test suite run, so  I've removed that on other test cases except the first one.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Make any one of the test cases fail and ensure that other test cases will continue to run. [Example test run in CI](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.edfd947f2636efe3/matrices/4986640062645478713/details?stepId=bs.147bc5cb31abfe6b&tabId=&testCaseId=44) after change with one (intentionally) failing test.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
