### PR TITLE
Fix logic of navigation after account creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -66,6 +66,7 @@ class SignUpFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
 
         nextStep = requireArguments().serializable(NEXT_STEP_KEY) ?: error("Screen requires passing a NextStep")
+        viewModel.nextStep = nextStep
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepository.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.login.signup
 
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.EMAIL_EXIST
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.EMAIL_INVALID
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError.PASSWORD_INVALID
@@ -19,7 +18,6 @@ import javax.inject.Inject
 class SignUpRepository @Inject constructor(
     private val signUpStore: SignUpStore,
     private val dispatcher: Dispatcher,
-    private val prefsWrapper: AppPrefsWrapper,
     private val signUpCredentialsValidator: SignUpCredentialsValidator
 ) {
     private companion object {
@@ -86,7 +84,6 @@ class SignUpRepository @Inject constructor(
             }
 
             WooLog.w(WooLog.T.LOGIN, "Success creating new account")
-            prefsWrapper.markAsNewSignUp(true)
             AccountCreationSuccess
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -5,10 +5,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.login.signup.SignUpFragment.NextStep
 import com.woocommerce.android.ui.login.signup.SignUpRepository.AccountCreationError
 import com.woocommerce.android.ui.login.signup.SignUpRepository.AccountCreationSuccess
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError
@@ -27,7 +29,10 @@ class SignUpViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val signUpRepository: SignUpRepository,
     private val networkStatus: NetworkStatus,
+    private val appPrefs: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
+    lateinit var nextStep: NextStep
+
     private val _viewState = MutableLiveData<SignUpState>()
     val viewState: LiveData<SignUpState> = _viewState
 
@@ -74,6 +79,9 @@ class SignUpViewModel @Inject constructor(
                 AccountCreationSuccess -> {
                     AnalyticsTracker.track(stat = AnalyticsEvent.SIGNUP_SUCCESS)
                     _viewState.value = _viewState.value?.copy(isLoading = false)
+                    if (nextStep == NextStep.STORE_CREATION) {
+                        appPrefs.markAsNewSignUp(true)
+                    }
                     triggerEvent(OnAccountCreated)
                 }
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/signup/SignUpRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.login.signup
 
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.FakeDispatcher
 import com.woocommerce.android.ui.login.signup.SignUpRepository.SignUpError
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -38,13 +37,11 @@ class SignUpRepositoryTest : BaseUnitTest() {
 
     private val signUpStore: SignUpStore = mock()
     private val dispatcher: Dispatcher = FakeDispatcher()
-    private val prefsWrapper: AppPrefsWrapper = mock()
     private val signUpCredentialsValidator: SignUpCredentialsValidator = mock()
 
     private val sut: SignUpRepository = SignUpRepository(
         signUpStore,
         dispatcher,
-        prefsWrapper,
         signUpCredentialsValidator
     )
 


### PR DESCRIPTION
Closes: #7813 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR just fixes the logic of navigation after creating an account:
1. It would start store creation if it's using the "Get Started" button of the prologue.
2. It would go to an empty site picker if it was started from the "Wrong Email" screen.

### Testing instructions
Test account creation for the above two flows and confirm it works as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
