### PR TITLE
Replace deprecated menu usages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListFragment.kt
@@ -53,7 +53,6 @@ class ParentCategoryListFragment :
 
         _binding = FragmentProductCategoriesListBinding.bind(view)
 
-        setHasOptionsMenu(true)
         setupObservers(viewModel)
         viewModel.fetchParentCategories()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
@@ -5,8 +5,10 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -32,7 +34,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class ProductDownloadDetailsFragment :
-    BaseFragment(R.layout.fragment_product_download_details), BackPressListener {
+    BaseFragment(R.layout.fragment_product_download_details), BackPressListener, MenuProvider {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel: ProductDownloadDetailsViewModel by viewModels()
@@ -48,7 +50,7 @@ class ProductDownloadDetailsFragment :
 
         _binding = FragmentProductDownloadDetailsBinding.bind(view)
 
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         setupObservers(viewModel)
     }
 
@@ -57,7 +59,7 @@ class ProductDownloadDetailsFragment :
         _binding = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         if (navArgs.isEditing) {
             inflater.inflate(R.menu.menu_product_download_details, menu)
@@ -69,7 +71,7 @@ class ProductDownloadDetailsFragment :
         doneOrUpdateMenuItem.isVisible = viewModel.showDoneButton
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 viewModel.onDoneOrUpdateClicked()
@@ -86,7 +88,7 @@ class ProductDownloadDetailsFragment :
                 viewModel.onDeleteButtonClicked()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
@@ -5,6 +5,8 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.ItemTouchHelper.DOWN
 import androidx.recyclerview.widget.ItemTouchHelper.UP
@@ -21,7 +23,9 @@ import com.woocommerce.android.widgets.DraggableItemTouchHelper
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ProductDownloadsFragment : BaseProductFragment(R.layout.fragment_product_downloads_list) {
+class ProductDownloadsFragment :
+    BaseProductFragment(R.layout.fragment_product_downloads_list),
+    MenuProvider {
     private val itemTouchHelper by lazy {
         DraggableItemTouchHelper(
             dragDirs = UP or DOWN,
@@ -54,7 +58,7 @@ class ProductDownloadsFragment : BaseProductFragment(R.layout.fragment_product_d
 
         _binding = FragmentProductDownloadsListBinding.bind(view)
 
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         setupObservers(viewModel)
 
         with(binding.productDownloadsRecycler) {
@@ -69,19 +73,18 @@ class ProductDownloadsFragment : BaseProductFragment(R.layout.fragment_product_d
         _binding = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_product_downloads_list, menu)
-        super.onCreateOptionsMenu(menu, inflater)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_product_downloads_settings -> {
                 viewModel.onDownloadsSettingsClicked()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductCatalogVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductCatalogVisibilityFragment.kt
@@ -37,7 +37,6 @@ class ProductCatalogVisibilityFragment :
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentProductCatalogVisibilityBinding.bind(view)
-        setHasOptionsMenu(true)
 
         selectedCatalogVisibility = savedInstanceState?.getString(ARG_CATALOG_VISIBILITY) ?: navArgs.catalogVisibility
         binding.btnFeatured.isChecked = savedInstanceState?.getBoolean(ARG_IS_FEATURED) ?: navArgs.featured


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7815
Closes: #7816 
Closes: #7817 
Closes: #7819 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaces deprecated menu usages in:
* ParentCategoryListFragment
* ProductDownloadDetailsFragment
* ProductDownloadsFragment
*  ProductCatalogVisibilityFragment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open product details. Add details. Categories. Add category. Parent category. Notice that the menu still empty
* Open product details with downloadable content. Downloadable files. Click on a file. Notice that the menu the same
* Open product details with downloadable content. Downloadable files. Notice that the menu the same
* Open product details. Menu -> product settings. Catalog visibility. Notice that the menu is empty
