### PR TITLE
Make email text field single line and handle keyboard actions properly

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.ClickableText
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -24,16 +26,21 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -95,6 +102,7 @@ private fun Toolbar(
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun SignUpForm(
     modifier: Modifier = Modifier,
@@ -103,6 +111,7 @@ private fun SignUpForm(
     onLoginClicked: () -> Unit,
     signUpState: SignUpState
 ) {
+    val focusRequester = remember { FocusRequester() }
     var email by remember { mutableStateOf(signUpState.email ?: "") }
     var password by remember { mutableStateOf(signUpState.password ?: "") }
 
@@ -124,11 +133,14 @@ private fun SignUpForm(
 
         val isEmailError = signUpState.error?.type == ErrorType.EMAIL
         WCOutlinedTextField(
+            modifier = Modifier.focusRequester(focusRequester),
             value = email,
             onValueChange = { email = it },
             label = stringResource(id = R.string.signup_email_address_hint),
             isError = isEmailError,
-            helperText = if (isEmailError) signUpState.error?.stringId?.let { stringResource(id = it) } else null
+            helperText = if (isEmailError) signUpState.error?.stringId?.let { stringResource(id = it) } else null,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
         )
 
         val isPasswordError = signUpState.error?.type == ErrorType.PASSWORD
@@ -137,7 +149,8 @@ private fun SignUpForm(
             onValueChange = { password = it },
             label = stringResource(id = R.string.signup_password_hint),
             isError = isPasswordError,
-            helperText = if (isPasswordError) signUpState.error?.stringId?.let { stringResource(id = it) } else null
+            helperText = if (isPasswordError) signUpState.error?.stringId?.let { stringResource(id = it) } else null,
+            keyboardActions = KeyboardActions(onDone = { onPrimaryButtonClicked(email, password) })
         )
         TermsOfServiceText(
             modifier = Modifier.clickable { termsOfServiceClicked() }
@@ -151,6 +164,8 @@ private fun SignUpForm(
             Text(text = stringResource(id = R.string.signup_get_started_button))
         }
     }
+    // Request focus on email field when entering screen
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
 }
 
 @Composable


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7821
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Minor fixed and enhancements to sign up form: 

- The email field is now single line
- Keyboard action buttons are handled properly
- Email text field has focus when entering the screen

### Testing instructions
- Open Sign up screen
- Check email field gets focus automatically
- Enter any valid email and click on keyboard action button
- Enter password and click on keyboard action button
- Check account creation is submitted without clicking on "Continue" button

