### PR TITLE
Updating navigation library version 2.41 -> 2.5.3

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
     gradle.ext.daggerVersion = '2.42'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.6.10'
-    gradle.ext.navigationVersion = '2.4.1'
+    gradle.ext.navigationVersion = '2.5.3'
 
     repositories {
         exclusiveContent {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7210
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Version 2.4.1 generates code that causes kotlin compiler to complain. It's been fixed in version 2.5.1. The PR updates navigation library from 2.4.1 to 2.5.3 (the latest)

[The change list](https://developer.android.com/jetpack/androidx/releases/navigation)  looks safe. I tested all the major flows and they look fine. It would be great to test deep links because there are some changes related to this (@wzieba could you please verify that it's all ok?)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Probably checking navigation in different flows is the only way we can test something here

