### PR TITLE
Generate all variations entrypoint

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.products.variations.VariationListViewModel.Sho
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowBulkUpdateAttrPicker
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowBulkUpdateLimitExceededWarning
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowVariationDetail
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -107,6 +108,8 @@ class VariationListFragment :
     }
 
     private fun initializeViews(savedInstanceState: Bundle?) {
+        binding.addAllVariationsButton.isVisible = FeatureFlag.GENERATE_ALL_VARIATIONS.isEnabled()
+
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         this.layoutManager = layoutManager
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,7 +14,8 @@ enum class FeatureFlag {
     WC_SHIPPING_BANNER,
     UNIFIED_ORDER_EDITING,
     ORDER_CREATION_CUSTOMER_SEARCH,
-    NATIVE_STORE_CREATION_FLOW;
+    NATIVE_STORE_CREATION_FLOW,
+    GENERATE_ALL_VARIATIONS;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -28,7 +29,8 @@ enum class FeatureFlag {
             ANALYTICS_HUB_PRODUCTS_AND_REPORTS,
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            NATIVE_STORE_CREATION_FLOW -> PackageUtils.isDebugBuild()
+            NATIVE_STORE_CREATION_FLOW,
+            GENERATE_ALL_VARIATIONS -> PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_variation_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_variation_list.xml
@@ -33,6 +33,18 @@
                 android:text="@string/variation_list_generate_new_variation"
                 android:textAllCaps="true" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/addAllVariationsButton"
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:text="@string/variation_list_generate_all_variations"
+                android:textAllCaps="true"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/variationList"
                 android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1611,6 +1611,7 @@
     <string name="variation_detail_price_warning_title">Some variations do not have prices</string>
     <string name="variation_detail_image_add">Add a variation image</string>
     <string name="variation_list_generate_new_variation">Generate new variation</string>
+    <string name="variation_list_generate_all_variations">Generate all variations</string>
     <string name="variation_created_title">Variation Created</string>
     <string name="variation_create_dialog_title">Generating variation</string>
     <string name="variation_loading_dialog_title">Fetching variations…</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7856
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a UI entrypoint hidden behind a feature flag for "generate all variations" feature.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open any "variable product"
2. Go to `Variations`
3. **Assert there's "generate all variations" button**

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| wasabiDebug | vanillaRelease | 
| --- | --- |
| <img width="721" alt="Screenshot 2022-11-15 at 13 27 59" src="https://user-images.githubusercontent.com/5845095/201946850-a10189ed-8049-4ed7-a609-01193a8308f3.png"> | <img width="721" alt="Screenshot 2022-11-15 at 13 31 04" src="https://user-images.githubusercontent.com/5845095/201946899-02c84338-d46c-44e9-bff1-147d5252a6f9.png"> |




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
