### PR TITLE
Algorithm for generating variation candidates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidates.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidates.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.ui.products.variations.domain
+
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductType
+
+data class TermAssignment(val attributeName: String, val termName: String)
+typealias VariationCandidate = List<TermAssignment>
+
+class GenerateVariationCandidates {
+
+    operator fun invoke(product: Product): List<VariationCandidate> {
+        if (product.type != ProductType.VARIABLE.value) {
+            return emptyList()
+        }
+
+        val termAssignmentsGroupedByAttribute: List<List<TermAssignment>> = product.attributes.map { productAttribute ->
+            productAttribute.terms.map { term ->
+                TermAssignment(
+                    attributeName = productAttribute.name, termName = term
+                )
+            }
+        }
+
+        val variationCandidates = cartesianProductForTermAssignments(termAssignmentsGroupedByAttribute)
+
+        return if (variationCandidates.first().isEmpty()) {
+            emptyList()
+        } else {
+            variationCandidates
+        }
+    }
+
+    private fun cartesianProductForTermAssignments(
+        termsGroupedByAttribute: List<List<TermAssignment>>
+    ): List<VariationCandidate> = termsGroupedByAttribute.fold(
+        listOf(emptyList())
+    ) { acc: List<VariationCandidate>, assignmentsGroupedByAttribute: List<TermAssignment> ->
+        acc.flatMap { variationCandidate ->
+            assignmentsGroupedByAttribute.map { termAssignment ->
+                variationCandidate + termAssignment
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidates.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidates.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.variations.domain
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.ui.products.ProductType
 
 data class TermAssignment(val attributeName: String, val termName: String)
@@ -13,13 +14,15 @@ class GenerateVariationCandidates {
             return emptyList()
         }
 
-        val termAssignmentsGroupedByAttribute: List<List<TermAssignment>> = product.attributes.map { productAttribute ->
-            productAttribute.terms.map { term ->
-                TermAssignment(
-                    attributeName = productAttribute.name, termName = term
-                )
+        val termAssignmentsGroupedByAttribute: List<List<TermAssignment>> = product.attributes
+            .filter(ProductAttribute::isVariation)
+            .map { productAttribute ->
+                productAttribute.terms.map { term ->
+                    TermAssignment(
+                        attributeName = productAttribute.name, termName = term
+                    )
+                }
             }
-        }
 
         val variationCandidates = cartesianProductForTermAssignments(termAssignmentsGroupedByAttribute)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidatesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidatesTest.kt
@@ -1,0 +1,77 @@
+package com.woocommerce.android.ui.products.variations.domain
+
+import com.woocommerce.android.model.ProductAttribute
+import com.woocommerce.android.ui.products.ProductHelper
+import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.ui.products.ProductType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class GenerateVariationCandidatesTest {
+
+    val sut = GenerateVariationCandidates()
+
+    @Test
+    fun `should generate all variation candidates for a product with 3 attributes each with 2 terms`() {
+        // given
+        val product = ProductHelper.getDefaultNewProduct(ProductType.VARIABLE, isVirtual = false).copy(
+            attributes = listOf(
+                ProductAttribute(id = 1, name = "Size", terms = listOf("S", "M")),
+                ProductAttribute(id = 2, name = "Color", terms = listOf("Red", "Blue")),
+                ProductAttribute(id = 2, name = "Type", terms = listOf("Sport", "Casual"))
+            )
+        )
+
+        val expectedVariationCandidates = listOf(
+            Triple("M", "Blue", "Sport"),
+            Triple("M", "Blue", "Casual"),
+            Triple("S", "Blue", "Sport"),
+            Triple("S", "Blue", "Casual"),
+            Triple("M", "Red", "Sport"),
+            Triple("M", "Red", "Casual"),
+            Triple("S", "Red", "Sport"),
+            Triple("S", "Red", "Casual"),
+        ).map { triple ->
+            listOf(
+                TermAssignment("Size", triple.first),
+                TermAssignment("Color", triple.second),
+                TermAssignment("Type", triple.third)
+            )
+        }
+
+        // when
+        val result = sut.invoke(product)
+
+        // then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(expectedVariationCandidates)
+    }
+
+    @Test
+    fun `should generate empty list of candidates if product has no attributes`() {
+        // given
+        val product =
+            ProductHelper.getDefaultNewProduct(ProductType.VARIABLE, isVirtual = false).copy(attributes = emptyList())
+
+        // when
+        val result = sut.invoke(product)
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should generate empty list of candidates if product is not type of variable`() {
+        // given
+        val product =
+            ProductHelper.getDefaultNewProduct(
+                ProductType.SIMPLE,
+                isVirtual = false
+            ).copy(attributes = ProductTestUtils.generateProductAttributeList())
+
+        // when
+        val result = sut.invoke(product)
+
+        // then
+        assertThat(result).isEmpty()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidatesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidatesTest.kt
@@ -16,9 +16,9 @@ class GenerateVariationCandidatesTest {
         // given
         val product = ProductHelper.getDefaultNewProduct(ProductType.VARIABLE, isVirtual = false).copy(
             attributes = listOf(
-                ProductAttribute(id = 1, name = "Size", terms = listOf("S", "M")),
-                ProductAttribute(id = 2, name = "Color", terms = listOf("Red", "Blue")),
-                ProductAttribute(id = 2, name = "Type", terms = listOf("Sport", "Casual"))
+                ProductAttribute(id = 1, name = "Size", terms = listOf("S", "M"), isVariation = true),
+                ProductAttribute(id = 2, name = "Color", terms = listOf("Red", "Blue"), isVariation = true),
+                ProductAttribute(id = 2, name = "Type", terms = listOf("Sport", "Casual"), isVariation = true)
             )
         )
 
@@ -73,5 +73,35 @@ class GenerateVariationCandidatesTest {
 
         // then
         assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should not generate all variation candidates with an attribute that is non variable one`() {
+        // given
+        val product = ProductHelper.getDefaultNewProduct(ProductType.VARIABLE, isVirtual = false).copy(
+            attributes = listOf(
+                ProductAttribute(id = 1, name = "Size", terms = listOf("S", "M"), isVariation = true),
+                ProductAttribute(id = 2, name = "Color", terms = listOf("Red", "Blue"), isVariation = true),
+                ProductAttribute(id = 2, name = "Type", terms = listOf("Sport", "Casual"), isVariation = false)
+            )
+        )
+
+        val expectedVariationCandidates = listOf(
+            Pair("M", "Blue"),
+            Pair("S", "Blue"),
+            Pair("M", "Red"),
+            Pair("S", "Red"),
+        ).map { triple ->
+            listOf(
+                TermAssignment("Size", triple.first),
+                TermAssignment("Color", triple.second),
+            )
+        }
+
+        // when
+        val result = sut.invoke(product)
+
+        // then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(expectedVariationCandidates)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7859 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds an algorithm for generating all possible variations for a given product based on its attributes. It's an n-ary cartesian product containing both the attribute _name_ and its _value_ (called "term").

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please see the algorithm and try to find a way to break it. The attached unit tests can help debug.



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
