### PR TITLE
[Simplified login] Site credentials step for native jetpack installation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
@@ -60,6 +60,7 @@ class JetpackActivationSiteCredentialsFragment : BaseFragment() {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun navigateToJetpackActivationSteps(event: NavigateToJetpackActivationSteps) {
         Toast.makeText(requireContext(), "TODO", Toast.LENGTH_LONG).show()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.login.jetpack.sitecredentials
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class JetpackActivationSiteCredentialsFragment : BaseFragment() {
+    private val viewModel: JetpackActivationSiteCredentialsViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    JetpackActivationSiteCredentialsScreen(viewModel)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
@@ -13,7 +13,9 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.NavigateToJetpackActivationSteps
+import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.ResetPassword
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
@@ -22,6 +24,10 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class JetpackActivationSiteCredentialsFragment : BaseFragment() {
+    companion object {
+        private const val FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword"
+    }
+
     private val viewModel: JetpackActivationSiteCredentialsViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
@@ -46,6 +52,7 @@ class JetpackActivationSiteCredentialsFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is NavigateToJetpackActivationSteps -> navigateToJetpackActivationSteps(event)
+                is ResetPassword -> showResetPasswordWebPage(event.siteUrl)
                 Exit -> findNavController().navigateUp()
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowUiStringSnackbar -> uiMessageResolver.showSnack(event.message)
@@ -55,5 +62,9 @@ class JetpackActivationSiteCredentialsFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationSteps(event: NavigateToJetpackActivationSteps) {
         Toast.makeText(requireContext(), "TODO", Toast.LENGTH_LONG).show()
+    }
+
+    private fun showResetPasswordWebPage(siteUrl: String) {
+        ChromeCustomTabUtils.launchUrl(requireActivity(), "${siteUrl.trimEnd('/')}/$FORGOT_PASSWORD_URL_SUFFIX")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
@@ -4,13 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.NavigateToJetpackActivationSteps
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class JetpackActivationSiteCredentialsFragment : BaseFragment() {
@@ -18,6 +26,9 @@ class JetpackActivationSiteCredentialsFragment : BaseFragment() {
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return ComposeView(requireContext()).apply {
@@ -29,5 +40,20 @@ class JetpackActivationSiteCredentialsFragment : BaseFragment() {
                 }
             }
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is NavigateToJetpackActivationSteps -> navigateToJetpackActivationSteps(event)
+                Exit -> findNavController().navigateUp()
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is ShowUiStringSnackbar -> uiMessageResolver.showSnack(event.message)
+            }
+        }
+    }
+
+    private fun navigateToJetpackActivationSteps(event: NavigateToJetpackActivationSteps) {
+        Toast.makeText(requireContext(), "TODO", Toast.LENGTH_LONG).show()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -1,8 +1,134 @@
 package com.woocommerce.android.ui.login.jetpack.sitecredentials
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCPasswordField
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.JetpackActivationSiteCredentialsViewState
 
 @Composable
 fun JetpackActivationSiteCredentialsScreen(viewModel: JetpackActivationSiteCredentialsViewModel) {
-    TODO("Not yet implemented")
+    viewModel.viewState.observeAsState().value?.let {
+        JetpackActivationSiteCredentialsScreen(it)
+    }
+}
+
+@Composable
+fun JetpackActivationSiteCredentialsScreen(
+    viewState: JetpackActivationSiteCredentialsViewState,
+    onUsernameChanged: (String) -> Unit = {},
+    onPasswordChanged: (String) -> Unit = {},
+    onConnectClick: () -> Unit = {}
+) {
+    Column(
+        modifier = Modifier
+            .background(MaterialTheme.colors.surface)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+    ) {
+        Toolbar(onCloseClick = {})
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(dimensionResource(id = R.dimen.major_100)),
+        ) {
+            Text(text = stringResource(id = R.string.enter_credentials_for_site, viewState.siteUrl))
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            WCOutlinedTextField(
+                value = viewState.username,
+                onValueChange = onUsernameChanged,
+                label = stringResource(id = R.string.username),
+                isError = viewState.errorMessage != null,
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+            )
+            WCPasswordField(
+                value = viewState.password,
+                onValueChange = onPasswordChanged,
+                label = stringResource(id = R.string.password),
+                isError = viewState.errorMessage != null,
+                helperText = viewState.errorMessage?.let { stringResource(id = it) },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(
+                    onDone = { onConnectClick() }
+                )
+            )
+        }
+
+        WCColoredButton(
+            onClick = { /*TODO*/ },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        ) {
+            Text(
+                text = stringResource(
+                    id = if (viewState.isJetpackInstalled) R.string.login_jetpack_connect
+                    else R.string.login_jetpack_install
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun Toolbar(
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TopAppBar(
+        backgroundColor = MaterialTheme.colors.surface,
+        title = { Text(stringResource(id = R.string.login_jetpack_installation_screen_title)) },
+        navigationIcon = {
+            IconButton(onClick = onCloseClick) {
+                Icon(
+                    Icons.Filled.Clear,
+                    contentDescription = stringResource(id = R.string.back)
+                )
+            }
+        },
+        elevation = 0.dp,
+        modifier = modifier
+    )
+}
+
+
+@Preview
+@Composable
+private fun JetpackActivationSiteCredentialsScreenPreview() {
+    WooThemeWithBackground {
+        JetpackActivationSiteCredentialsScreen(
+            viewState = JetpackActivationSiteCredentialsViewState(
+                isJetpackInstalled = false,
+                siteUrl = "reallyniceshirts.com"
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -84,8 +84,11 @@ fun JetpackActivationSiteCredentialsScreen(
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
             Text(
                 text = annotatedStringRes(
-                    stringResId = if (viewState.isJetpackInstalled) R.string.login_jetpack_connection_enter_site_credentials
-                    else R.string.login_jetpack_installation_enter_site_credentials,
+                    stringResId = if (viewState.isJetpackInstalled) {
+                        R.string.login_jetpack_connection_enter_site_credentials
+                    } else {
+                        R.string.login_jetpack_installation_enter_site_credentials
+                    },
                     viewState.siteUrl
                 )
             )
@@ -192,7 +195,6 @@ private fun Toolbar(
         modifier = modifier
     )
 }
-
 
 @Preview
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.login.jetpack.sitecredentials
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun JetpackActivationSiteCredentialsScreen(viewModel: JetpackActivationSiteCredentialsViewModel) {
+    TODO("Not yet implemented")
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
@@ -117,7 +118,7 @@ fun JetpackActivationSiteCredentialsScreen(
         }
 
         WCColoredButton(
-            onClick = { /*TODO*/ },
+            onClick = onContinueClick,
             enabled = viewState.isValid,
             modifier = Modifier
                 .fillMaxWidth()
@@ -131,6 +132,10 @@ fun JetpackActivationSiteCredentialsScreen(
             )
         }
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+    }
+
+    if (viewState.isLoading) {
+        ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -11,8 +11,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -75,6 +77,7 @@ fun JetpackActivationSiteCredentialsScreen(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .padding(dimensionResource(id = R.dimen.major_100)),
         ) {
             JetpackToWoo()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -179,7 +179,7 @@ private fun Toolbar(
 ) {
     TopAppBar(
         backgroundColor = MaterialTheme.colors.surface,
-        title = { Text(stringResource(id = R.string.login_jetpack_installation_screen_title)) },
+        title = { Text(stringResource(id = R.string.login_jetpack_site_credentials_screen_title)) },
         navigationIcon = {
             IconButton(onClick = onCloseClick) {
                 Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -43,7 +43,12 @@ import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivatio
 @Composable
 fun JetpackActivationSiteCredentialsScreen(viewModel: JetpackActivationSiteCredentialsViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        JetpackActivationSiteCredentialsScreen(it)
+        JetpackActivationSiteCredentialsScreen(
+            viewState = it,
+            onUsernameChanged = viewModel::onUsernameChanged,
+            onPasswordChanged = viewModel::onPasswordChanged,
+            onContinueClick = viewModel::onContinueClick
+        )
     }
 }
 
@@ -52,7 +57,7 @@ fun JetpackActivationSiteCredentialsScreen(
     viewState: JetpackActivationSiteCredentialsViewState,
     onUsernameChanged: (String) -> Unit = {},
     onPasswordChanged: (String) -> Unit = {},
-    onConnectClick: () -> Unit = {}
+    onContinueClick: () -> Unit = {}
 ) {
     Column(
         modifier = Modifier
@@ -92,7 +97,7 @@ fun JetpackActivationSiteCredentialsScreen(
                 helperText = viewState.errorMessage?.let { stringResource(id = it) },
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(
-                    onDone = { onConnectClick() }
+                    onDone = { onContinueClick() }
                 )
             )
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
@@ -113,6 +118,7 @@ fun JetpackActivationSiteCredentialsScreen(
 
         WCColoredButton(
             onClick = { /*TODO*/ },
+            enabled = viewState.isValid,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -48,7 +48,8 @@ fun JetpackActivationSiteCredentialsScreen(viewModel: JetpackActivationSiteCrede
             viewState = it,
             onUsernameChanged = viewModel::onUsernameChanged,
             onPasswordChanged = viewModel::onPasswordChanged,
-            onContinueClick = viewModel::onContinueClick
+            onContinueClick = viewModel::onContinueClick,
+            onCloseClick = viewModel::onCloseClick
         )
     }
 }
@@ -58,14 +59,15 @@ fun JetpackActivationSiteCredentialsScreen(
     viewState: JetpackActivationSiteCredentialsViewState,
     onUsernameChanged: (String) -> Unit = {},
     onPasswordChanged: (String) -> Unit = {},
-    onContinueClick: () -> Unit = {}
+    onContinueClick: () -> Unit = {},
+    onCloseClick: () -> Unit = {}
 ) {
     Column(
         modifier = Modifier
             .background(MaterialTheme.colors.surface)
             .fillMaxSize(),
     ) {
-        Toolbar(onCloseClick = {})
+        Toolbar(onCloseClick = onCloseClick)
         Column(
             modifier = Modifier
                 .weight(1f)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -1,13 +1,16 @@
 package com.woocommerce.android.ui.login.jetpack.sitecredentials
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
@@ -17,15 +20,20 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
@@ -50,7 +58,6 @@ fun JetpackActivationSiteCredentialsScreen(
         modifier = Modifier
             .background(MaterialTheme.colors.surface)
             .fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
     ) {
         Toolbar(onCloseClick = {})
         Column(
@@ -59,7 +66,15 @@ fun JetpackActivationSiteCredentialsScreen(
                 .fillMaxWidth()
                 .padding(dimensionResource(id = R.dimen.major_100)),
         ) {
-            Text(text = stringResource(id = R.string.enter_credentials_for_site, viewState.siteUrl))
+            JetpackToWoo()
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            Text(
+                text = annotatedStringRes(
+                    stringResId = if (viewState.isJetpackInstalled) R.string.login_jetpack_connection_enter_site_credentials
+                    else R.string.login_jetpack_installation_enter_site_credentials,
+                    viewState.siteUrl
+                )
+            )
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
             WCOutlinedTextField(
                 value = viewState.username,
@@ -80,6 +95,20 @@ fun JetpackActivationSiteCredentialsScreen(
                     onDone = { onConnectClick() }
                 )
             )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = null,
+                    tint = colorResource(id = R.color.color_on_surface_medium),
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40))
+                )
+                Text(
+                    text = stringResource(id = R.string.login_jetpack_connection_approval_hint),
+                    style = MaterialTheme.typography.caption,
+                    color = colorResource(id = R.color.color_on_surface_medium)
+                )
+            }
         }
 
         WCColoredButton(
@@ -95,6 +124,29 @@ fun JetpackActivationSiteCredentialsScreen(
                 )
             )
         }
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+    }
+}
+
+@Composable
+private fun JetpackToWoo(modifier: Modifier = Modifier) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+    ) {
+        val logoModifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_100))
+        Image(
+            painter = painterResource(id = R.drawable.ic_jetpack_logo),
+            contentDescription = null,
+            modifier = logoModifier
+        )
+        Image(painter = painterResource(id = R.drawable.ic_connecting), contentDescription = null)
+        Image(
+            painter = painterResource(id = R.drawable.ic_woo_bubble),
+            contentDescription = null,
+            modifier = logoModifier
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.JetpackActivationSiteCredentialsViewState
 
@@ -49,6 +50,7 @@ fun JetpackActivationSiteCredentialsScreen(viewModel: JetpackActivationSiteCrede
             onUsernameChanged = viewModel::onUsernameChanged,
             onPasswordChanged = viewModel::onPasswordChanged,
             onContinueClick = viewModel::onContinueClick,
+            onResetPasswordClick = viewModel::onResetPasswordClick,
             onCloseClick = viewModel::onCloseClick
         )
     }
@@ -60,6 +62,7 @@ fun JetpackActivationSiteCredentialsScreen(
     onUsernameChanged: (String) -> Unit = {},
     onPasswordChanged: (String) -> Unit = {},
     onContinueClick: () -> Unit = {},
+    onResetPasswordClick: () -> Unit = {},
     onCloseClick: () -> Unit = {}
 ) {
     Column(
@@ -103,6 +106,9 @@ fun JetpackActivationSiteCredentialsScreen(
                     onDone = { onContinueClick() }
                 )
             )
+            WCTextButton(onClick = onResetPasswordClick) {
+                Text(text = stringResource(id = R.string.reset_your_password))
+            }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
             Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))) {
                 Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
@@ -67,85 +68,89 @@ fun JetpackActivationSiteCredentialsScreen(
     onResetPasswordClick: () -> Unit = {},
     onCloseClick: () -> Unit = {}
 ) {
-    Column(
-        modifier = Modifier
-            .background(MaterialTheme.colors.surface)
-            .fillMaxSize(),
-    ) {
-        Toolbar(onCloseClick = onCloseClick)
+    Scaffold(
+        topBar = { Toolbar(onCloseClick = onCloseClick) }
+    ) { paddingValues ->
         Column(
             modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(dimensionResource(id = R.dimen.major_100)),
+                .background(MaterialTheme.colors.surface)
+                .padding(paddingValues)
+                .fillMaxSize(),
         ) {
-            JetpackToWoo()
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-            Text(
-                text = annotatedStringRes(
-                    stringResId = if (viewState.isJetpackInstalled) {
-                        R.string.login_jetpack_connection_enter_site_credentials
-                    } else {
-                        R.string.login_jetpack_installation_enter_site_credentials
-                    },
-                    viewState.siteUrl
-                )
-            )
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-            WCOutlinedTextField(
-                value = viewState.username,
-                onValueChange = onUsernameChanged,
-                label = stringResource(id = R.string.username),
-                isError = viewState.errorMessage != null,
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
-            )
-            WCPasswordField(
-                value = viewState.password,
-                onValueChange = onPasswordChanged,
-                label = stringResource(id = R.string.password),
-                isError = viewState.errorMessage != null,
-                helperText = viewState.errorMessage?.let { stringResource(id = it) },
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(
-                    onDone = { onContinueClick() }
-                )
-            )
-            WCTextButton(onClick = onResetPasswordClick) {
-                Text(text = stringResource(id = R.string.reset_your_password))
-            }
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-            Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))) {
-                Icon(
-                    imageVector = Icons.Outlined.Info,
-                    contentDescription = null,
-                    tint = colorResource(id = R.color.color_on_surface_medium),
-                    modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40))
-                )
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(dimensionResource(id = R.dimen.major_100)),
+            ) {
+                JetpackToWoo()
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 Text(
-                    text = stringResource(id = R.string.login_jetpack_connection_approval_hint),
-                    style = MaterialTheme.typography.caption,
-                    color = colorResource(id = R.color.color_on_surface_medium)
+                    text = annotatedStringRes(
+                        stringResId = if (viewState.isJetpackInstalled) {
+                            R.string.login_jetpack_connection_enter_site_credentials
+                        } else {
+                            R.string.login_jetpack_installation_enter_site_credentials
+                        },
+                        viewState.siteUrl
+                    )
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                WCOutlinedTextField(
+                    value = viewState.username,
+                    onValueChange = onUsernameChanged,
+                    label = stringResource(id = R.string.username),
+                    isError = viewState.errorMessage != null,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+                )
+                WCPasswordField(
+                    value = viewState.password,
+                    onValueChange = onPasswordChanged,
+                    label = stringResource(id = R.string.password),
+                    isError = viewState.errorMessage != null,
+                    helperText = viewState.errorMessage?.let { stringResource(id = it) },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = { onContinueClick() }
+                    )
+                )
+                WCTextButton(onClick = onResetPasswordClick) {
+                    Text(text = stringResource(id = R.string.reset_your_password))
+                }
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))) {
+                    Icon(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = null,
+                        tint = colorResource(id = R.color.color_on_surface_medium),
+                        modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40))
+                    )
+                    Text(
+                        text = stringResource(id = R.string.login_jetpack_connection_approval_hint),
+                        style = MaterialTheme.typography.caption,
+                        color = colorResource(id = R.color.color_on_surface_medium)
+                    )
+                }
+            }
+
+            WCColoredButton(
+                onClick = onContinueClick,
+                enabled = viewState.isValid,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            ) {
+                Text(
+                    text = stringResource(
+                        id = if (viewState.isJetpackInstalled) R.string.login_jetpack_connect
+                        else R.string.login_jetpack_install
+                    )
                 )
             }
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
-
-        WCColoredButton(
-            onClick = onContinueClick,
-            enabled = viewState.isValid,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-        ) {
-            Text(
-                text = stringResource(
-                    id = if (viewState.isJetpackInstalled) R.string.login_jetpack_connect
-                    else R.string.login_jetpack_install
-                )
-            )
-        }
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
     }
 
     if (viewState.isLoading) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -76,6 +76,7 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
 
     fun onContinueClick() = launch {
         _viewState.update { it.copy(isLoading = true) }
+
         val state = _viewState.value
         wpApiSiteRepository.login(
             url = state.siteUrl,
@@ -91,9 +92,6 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
                 )
             },
             onFailure = { exception ->
-                _viewState.update { state ->
-                    state.copy(isLoading = false)
-                }
                 if (exception is OnChangedException && exception.error is AuthenticationError) {
                     val errorMessage = exception.error.toErrorMessage()
                     if (errorMessage == null) {
@@ -109,6 +107,8 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
                 }
             }
         )
+
+        _viewState.update { it.copy(isLoading = false) }
     }
 
     private fun AuthenticationError.toErrorMessage() = when (type) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.login.jetpack.sitecredentials
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class JetpackActivationSiteCredentialsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -69,6 +69,10 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
+    fun onResetPasswordClick() {
+        triggerEvent(ResetPassword(_viewState.value.siteUrl))
+    }
+
     fun onContinueClick() = launch {
         _viewState.update { it.copy(isLoading = true) }
         val state = _viewState.value
@@ -80,7 +84,7 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
             onSuccess = {
                 triggerEvent(
                     NavigateToJetpackActivationSteps(
-                        navArgs.siteUrl,
+                        state.siteUrl,
                         navArgs.isJetpackInstalled
                     )
                 )
@@ -137,4 +141,6 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         val siteUrl: String,
         val isJetpackInstalled: Boolean
     ) : MultiLiveEvent.Event()
+
+    data class ResetPassword(val siteUrl: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -23,7 +23,7 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
 
     private val _viewState = savedStateHandle.getStateFlow(
         viewModelScope, JetpackActivationSiteCredentialsViewState(
-            isJetpackInstalled = TODO(),
+            isJetpackInstalled = navArgs.isJetpackInstalled,
             siteUrl = navArgs.siteUrl
         )
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -65,7 +66,7 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
     }
 
     fun onCloseClick() {
-        TODO()
+        triggerEvent(Exit)
     }
 
     fun onContinueClick() = launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -40,7 +40,8 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
     private val navArgs: JetpackActivationSiteCredentialsFragmentArgs by savedStateHandle.navArgs()
 
     private val _viewState = savedStateHandle.getStateFlow(
-        viewModelScope, JetpackActivationSiteCredentialsViewState(
+        scope = viewModelScope,
+        initialValue = JetpackActivationSiteCredentialsViewState(
             isJetpackInstalled = navArgs.isJetpackInstalled,
             siteUrl = navArgs.siteUrl
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -1,13 +1,59 @@
 package com.woocommerce.android.ui.login.jetpack.sitecredentials
 
+import android.os.Parcelable
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.update
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
 class JetpackActivationSiteCredentialsViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val wpApiSiteRepository: WPApiSiteRepository
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: JetpackActivationSiteCredentialsFragmentArgs by savedStateHandle.navArgs()
 
+    private val _viewState = savedStateHandle.getStateFlow(
+        viewModelScope, JetpackActivationSiteCredentialsViewState(
+            isJetpackInstalled = TODO(),
+            siteUrl = navArgs.siteUrl
+        )
+    )
+    val viewState = _viewState.asLiveData()
+
+    fun onUsernameChanged(username: String) {
+        _viewState.update { it.copy(username = username) }
+    }
+
+    fun onPasswordChanged(password: String) {
+        _viewState.update { it.copy(password = password) }
+    }
+
+    fun onCloseClick() {
+        TODO()
+    }
+
+    fun onContinueClick() {
+        TODO()
+    }
+
+    @Parcelize
+    data class JetpackActivationSiteCredentialsViewState(
+        val isJetpackInstalled: Boolean,
+        val siteUrl: String,
+        val username: String = "",
+        val password: String = "",
+        @StringRes val errorMessage: Int? = null
+    ) : Parcelable {
+        @IgnoredOnParcel
+        val isValid = username.isNotBlank() && password.isNotBlank()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/WPApiSiteRepository.kt
@@ -1,0 +1,107 @@
+package com.woocommerce.android.ui.login.jetpack.sitecredentials
+
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.awaitAny
+import com.woocommerce.android.util.awaitEvent
+import com.woocommerce.android.util.dispatchAndAwait
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
+import org.wordpress.android.fluxc.store.AccountStore.OnDiscoveryResponse
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload
+import javax.inject.Inject
+
+class WPApiSiteRepository @Inject constructor(private val dispatcher: Dispatcher) {
+    /**
+     * Handles authentication to the given [url] using wp-admin credentials.
+     * After calling this, and if the authentication is successful, a [SiteModel] matching this site will be persisted
+     * in the DB.
+     *
+     * Note: this function uses XMLRPC behind the scenes
+     */
+    suspend fun login(url: String, username: String, password: String): Result<Unit> {
+        WooLog.d(WooLog.T.LOGIN, "Authenticating in to site $url using site credentials")
+
+        return discoverXMLRPCAddress(url)
+            .mapCatching { xmlrpcEndpoint ->
+                fetchXMLRPCSite(url, xmlrpcEndpoint, username, password).getOrThrow()
+            }
+    }
+
+    private suspend fun discoverXMLRPCAddress(siteUrl: String): Result<String> {
+        WooLog.d(WooLog.T.LOGIN, "Running discovery to fetch XMLRPC endpoint for site $siteUrl")
+
+        val action = AuthenticationActionBuilder.newDiscoverEndpointAction(siteUrl)
+        val event: OnDiscoveryResponse = dispatcher.dispatchAndAwait(action)
+
+        return if (event.isError) {
+            WooLog.w(WooLog.T.LOGIN, "XMLRPC Discovery failed, error: ${event.error}")
+            Result.failure(OnChangedException(event.error, event.error.name))
+        } else {
+            WooLog.d(
+                tag = WooLog.T.LOGIN,
+                message = "XMLRPC Discovery succeeded, xmrlpc endpoint: ${event.xmlRpcEndpoint}"
+            )
+            Result.success(event.xmlRpcEndpoint)
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private suspend fun fetchXMLRPCSite(
+        siteUrl: String,
+        xmlrpcEndpoint: String,
+        username: String,
+        password: String
+    ): Result<Unit> = coroutineScope {
+        val authenticationTask = async {
+            dispatcher.awaitEvent<OnAuthenticationChanged>().also { event ->
+                if (event.isError) {
+                    WooLog.w(
+                        tag = WooLog.T.LOGIN,
+                        message = "Authenticating to XMLRPC site $xmlrpcEndpoint failed, " +
+                            "error: ${event.error.message}"
+                    )
+                }
+            }
+        }
+        val siteTask = async {
+            val selfHostedPayload = RefreshSitesXMLRPCPayload(
+                username = username,
+                password = password,
+                url = xmlrpcEndpoint
+            )
+            dispatcher.dispatchAndAwait<RefreshSitesXMLRPCPayload, OnSiteChanged>(
+                action = SiteActionBuilder.newFetchSitesXmlRpcAction(
+                    selfHostedPayload
+                )
+            ).also { event ->
+                if (event.isError) {
+                    WooLog.w(
+                        tag = WooLog.T.LOGIN,
+                        message = "XMLRPC site $xmlrpcEndpoint fetch failed, error: ${event.error.message}"
+                    )
+                } else {
+                    WooLog.d(WooLog.T.LOGIN, "XMLRPC site $xmlrpcEndpoint fetch succeeded")
+                }
+            }
+        }
+
+        val tasks = listOf(authenticationTask, siteTask)
+
+        val event = tasks.awaitAny()
+
+        return@coroutineScope when {
+            event.isError -> Result.failure(OnChangedException(event.error))
+            else -> {
+                WooLog.d(WooLog.T.LOGIN, "XMLRPC site $siteUrl fetch succeeded")
+                Result.success(Unit)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartFragment.kt
@@ -8,10 +8,12 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.start.JetpackActivationStartViewModel.NavigateToHelpScreen
+import com.woocommerce.android.ui.login.jetpack.start.JetpackActivationStartViewModel.NavigateToSiteCredentialsScreen
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
@@ -43,10 +45,21 @@ class JetpackActivationStartFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is NavigateToSiteCredentialsScreen -> navigateToSiteCredentialsScreen(event)
                 NavigateToHelpScreen -> navigateToHelpScreen()
                 Exit -> findNavController().navigateUp()
             }
         }
+    }
+
+    private fun navigateToSiteCredentialsScreen(event: NavigateToSiteCredentialsScreen) {
+        findNavController().navigateSafely(
+            JetpackActivationStartFragmentDirections
+                .actionJetpackActivationStartFragmentToJetpackActivationSiteCredentialsFragment(
+                    siteUrl = event.siteUrl,
+                    isJetpackInstalled = event.isJetpackInstalled
+                )
+        )
     }
 
     private fun navigateToHelpScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartScreen.kt
@@ -44,6 +44,7 @@ fun JetpackActivationStartScreen(viewModel: JetpackActivationStartViewModel) {
     viewModel.viewState.observeAsState().value?.let {
         JetpackActivationStartScreen(
             it,
+            onContinueButtonClick = viewModel::onContinueButtonClick,
             onHelpButtonClick = viewModel::onHelpButtonClick,
             onBackButtonClick = viewModel::onBackButtonClick
         )
@@ -53,6 +54,7 @@ fun JetpackActivationStartScreen(viewModel: JetpackActivationStartViewModel) {
 @Composable
 fun JetpackActivationStartScreen(
     viewState: JetpackActivationState,
+    onContinueButtonClick: () -> Unit = {},
     onHelpButtonClick: () -> Unit = {},
     onBackButtonClick: () -> Unit = {}
 ) {
@@ -106,7 +108,7 @@ fun JetpackActivationStartScreen(
                 )
             }
             WCColoredButton(
-                onClick = { /*TODO*/ },
+                onClick = onContinueButtonClick,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartViewModel.kt
@@ -31,10 +31,23 @@ class JetpackActivationStartViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
+    fun onContinueButtonClick() {
+        triggerEvent(
+            NavigateToSiteCredentialsScreen(
+                siteUrl = navArgs.siteUrl,
+                isJetpackInstalled = navArgs.isJetpackInstalled
+            )
+        )
+    }
+
     data class JetpackActivationState(
         val url: String,
         val isJetpackInstalled: Boolean,
     )
 
     object NavigateToHelpScreen : MultiLiveEvent.Event()
+    data class NavigateToSiteCredentialsScreen(
+        val siteUrl: String,
+        val isJetpackInstalled: Boolean
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -25,5 +25,8 @@
         <argument
             android:name="siteUrl"
             app:argType="string" />
+        <argument
+            android:name="isJetpackInstalled"
+            app:argType="boolean" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -14,5 +14,16 @@
         <argument
             android:name="isJetpackInstalled"
             app:argType="boolean" />
+        <action
+            android:id="@+id/action_jetpackActivationStartFragment_to_jetpackActivationSiteCredentialsFragment"
+            app:destination="@id/jetpackActivationSiteCredentialsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/jetpackActivationSiteCredentialsFragment"
+        android:name="com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsFragment"
+        android:label="JetpackActivationSiteCredentialsFragment">
+        <argument
+            android:name="siteUrl"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -298,6 +298,7 @@
     <string name="login_jetpack_installation_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to install Jetpack.</string>
     <string name="login_jetpack_connection_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to connect Jetpack.</string>
     <string name="login_jetpack_connection_approval_hint">We will ask for your approval to complete the Jetpack connection.</string>
+    <string name="login_jetpack_site_credentials_screen_title">Log in to your store</string>
 
     <!--
         My Store View

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -295,6 +295,9 @@
     <string name="login_jetpack_connection_explanation">To use this app for&lt;br&gt;&lt;b&gt;%1$s&lt;/b&gt;&lt;br&gt;you\'ll need to connect your store to Jetpack.</string>
     <string name="login_jetpack_installation_credentials_hint">You\’ll need your store credentials to begin the installation.</string>
     <string name="login_jetpack_connect">Connect Jetpack</string>
+    <string name="login_jetpack_installation_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to install Jetpack.</string>
+    <string name="login_jetpack_connection_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to connect Jetpack.</string>
+    <string name="login_jetpack_connection_approval_hint">We will ask for your approval to complete the Jetpack connection.</string>
 
     <!--
         My Store View


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7796 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the site credentials step for the native Jetpack installation, the work is based on what we've added previously for the account mismatch (the PR #7471), I didn't try to make the code reusable, I just copied it, as we will be removing the feature from the account mismatch after the end of the experiment.

@JorgeMucientes I'm requesting your review alone, as you reviewed #7471, and this PR is basically a copy paste of those changes, thanks in advance 🙏.

### Testing instructions
1. Repeat steps of #7850, the click on the primary button
2. Confirm the UI is correct for both installation and connection flows.
3. Enter username/password and confirm they work as expected.
4. Try signing using  a wrong username/password.
5. Confirm an error message is shown.
6. Try using the correct username/password.
7. Confirm a Toast is shown with the text TODO.

### Images/gif
| Install | Connect |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1657201/202162443-78adb3cf-2b8c-48a3-b753-0a12e4847708.png) | ![image](https://user-images.githubusercontent.com/1657201/202162653-0168eb7f-1ffd-446b-bda5-26dbed807994.png) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
