### PR TITLE
[UI Tests] Fix cancelling of failing UI tests

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/InitializationRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/InitializationRule.kt
@@ -25,7 +25,7 @@ class InitializationRule : TestRule {
     private val instrumentation
         get() = InstrumentationRegistry.getInstrumentation()
 
-    override fun apply(base: Statement?, description: Description?): Statement {
+    override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
                 val application = instrumentation.targetContext.applicationContext as Application
@@ -37,7 +37,7 @@ class InitializationRule : TestRule {
                     instrumentation.runOnMainSync {
                         entryPoint.initializer().init(application)
                     }
-                    base?.evaluate()
+                    base.evaluate()
                 } finally {
                     entryPoint.appCoroutineScope().cancel()
                 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/InitializationRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/InitializationRule.kt
@@ -33,11 +33,14 @@ class InitializationRule : TestRule {
                     application,
                     AppEntryPoint::class.java
                 )
-                instrumentation.runOnMainSync {
-                    entryPoint.initializer().init(application)
+                try {
+                    instrumentation.runOnMainSync {
+                        entryPoint.initializer().init(application)
+                    }
+                    base?.evaluate()
+                } finally {
+                    entryPoint.appCoroutineScope().cancel()
                 }
-                base?.evaluate()
-                entryPoint.appCoroutineScope().cancel()
             }
         }
     }


### PR DESCRIPTION
### Description
Before this change, when a UI test fail, we don't correctly cancel the `appCoroutineScope`, because a failure would result in throwing an `Error` (an `AssertionError` or an `Exception`), and leaving the coroutine scope non cancelled causes the `DataStore` to stay open, which causes the exception: `java.lang.IllegalStateException: There are multiple DataStores active for the same file` when running next tests.

This PR moves the canceling logic to a `finally` block, this way it will be executed for all cases.

This PR replaces https://github.com/woocommerce/woocommerce-android/pull/7805, cc @jostnes @pachlava 

### Testing instructions
1. Force the `OrdersUITest` to fail (a wrong assertion for example).
2. Execute the UI tests of the package `com.woocommerce.android.e2e.tests.ui` (either using Android Studio directly or Gradle)
3. Confirm the test suites `ProductsUITest` and `ReviewsUITest` finish successfully.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
