### PR TITLE
Fix a crashed caused by lambdas

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationScreen.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.AlertDialog
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCWebView
-import com.woocommerce.android.ui.login.storecreation.webview.WebViewStoreCreationViewModel.DialogState
 import com.woocommerce.android.ui.login.storecreation.webview.WebViewStoreCreationViewModel.ViewState.ErrorState
 import com.woocommerce.android.ui.login.storecreation.webview.WebViewStoreCreationViewModel.ViewState.StoreCreationState
 import com.woocommerce.android.ui.login.storecreation.webview.WebViewStoreCreationViewModel.ViewState.StoreLoadingState
@@ -77,7 +76,7 @@ fun WebViewStoreCreationScreen(viewModel: WebViewStoreCreationViewModel) {
 
     viewModel.dialogViewState.observeAsState().value?.let {
         if (it.isDialogVisible) {
-            ConfirmExitDialog(it)
+            ConfirmExitDialog(viewModel)
         }
     }
 }
@@ -162,9 +161,9 @@ private fun StoreCreationInProgress() {
 }
 
 @Composable
-private fun ConfirmExitDialog(viewState: DialogState) {
+private fun ConfirmExitDialog(viewModel: WebViewStoreCreationViewModel) {
     AlertDialog(
-        onDismissRequest = { viewState.onDialogDismissed() },
+        onDismissRequest = { viewModel.onDialogDismissed() },
         title = {
             Text(text = stringResource(id = string.store_creation_exit_dialog_title))
         },
@@ -172,12 +171,12 @@ private fun ConfirmExitDialog(viewState: DialogState) {
             Text(text = stringResource(id = string.store_creation_exit_dialog_message))
         },
         confirmButton = {
-            TextButton(onClick = { viewState.onExitConfirmed() }) {
+            TextButton(onClick = { viewModel.onExitTriggered() }) {
                 Text(stringResource(id = string.store_creation_confirm_and_leave))
             }
         },
         dismissButton = {
-            TextButton(onClick = { viewState.onDialogDismissed() }) {
+            TextButton(onClick = { viewModel.onDialogDismissed() }) {
                 Text(stringResource(id = string.cancel))
             }
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
@@ -72,7 +72,7 @@ class WebViewStoreCreationViewModel @Inject constructor(
         exitTriggerKeyword = WEBVIEW_EXIT_TRIGGER_KEYWORD,
         onStoreCreated = ::onStoreCreated,
         onSiteAddressFound = ::onSiteAddressFound,
-        onExitTriggered = ::exitStoreCreation
+        onExitTriggered = ::onExitTriggered
     )
 
     private fun prepareErrorState() = ErrorState(
@@ -80,14 +80,8 @@ class WebViewStoreCreationViewModel @Inject constructor(
     )
 
     private fun setDialogState(isVisible: Boolean) = DialogState(
-        isDialogVisible = isVisible,
-        onExitConfirmed = ::exitStoreCreation,
-        onDialogDismissed = ::onDialogDismissed
+        isDialogVisible = isVisible
     )
-
-    private fun onDialogDismissed() {
-        _dialogViewState.value = setDialogState(isVisible = false)
-    }
 
     private suspend fun getOrFetchNewSite(): StoreLoadResult {
         val newSite = possibleStoreUrls.firstNotNullOfOrNull { url -> repository.getSiteBySiteUrl(url) }
@@ -142,7 +136,11 @@ class WebViewStoreCreationViewModel @Inject constructor(
         possibleStoreUrls.add(url)
     }
 
-    private fun exitStoreCreation() {
+    fun onDialogDismissed() {
+        _dialogViewState.value = setDialogState(isVisible = false)
+    }
+
+    fun onExitTriggered() {
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SITE_CREATION_DISMISSED,
             mapOf(
@@ -178,9 +176,7 @@ class WebViewStoreCreationViewModel @Inject constructor(
 
     @Parcelize
     data class DialogState(
-        val isDialogVisible: Boolean,
-        val onExitConfirmed: () -> Unit,
-        val onDialogDismissed: () -> Unit
+        val isDialogVisible: Boolean
     ) : Parcelable
 
     object NavigateToNewStore : MultiLiveEvent.Event()


### PR DESCRIPTION
Fixes: #7873

This PR fixes a crash that were caused by the lambdas in a `Parcelized` class.

**To Test:**
1. Disable the `NATIVE_STORE_CREATION_FLOW` feature flag
2. Go to the Site picker and start the store creation flow
3. Tap on the back button
4. Confirm the dialog buttons function as expected
5. Enable `Don't keep activities` in Developer options
6. With the dialog showing, rotate the device
7. Verify the dialog is preserved and the app doesn't crash