### PR TITLE
[Simplified login] UI for Jetpack Activation steps

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/UiStringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/UiStringExt.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.woocommerce.android.model.UiString
+import com.woocommerce.android.util.UiHelpers
+
+@Composable
+fun UiString.getText(): String {
+    return UiHelpers.getTextOfUiString(LocalContext.current, this)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/components/JetpackToWoo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/components/JetpackToWoo.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.ui.login.jetpack.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import com.woocommerce.android.R
+
+@Composable
+fun JetpackToWooHeader(modifier: Modifier = Modifier) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+    ) {
+        val logoModifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_100))
+        Image(
+            painter = painterResource(id = R.drawable.ic_jetpack_logo),
+            contentDescription = null,
+            modifier = logoModifier
+        )
+        Image(painter = painterResource(id = R.drawable.ic_connecting), contentDescription = null)
+        Image(
+            painter = painterResource(id = R.drawable.ic_woo_bubble),
+            contentDescription = null,
+            modifier = logoModifier
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.login.jetpack.main
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class JetpackActivationMainFragment : BaseFragment() {
+    private val viewModel: JetpackActivationMainViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireActivity()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    JetpackActivationMainScreen(viewModel)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
@@ -7,9 +7,11 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -27,6 +29,14 @@ class JetpackActivationMainFragment : BaseFragment() {
                 WooThemeWithBackground {
                     JetpackActivationMainScreen(viewModel)
                 }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.login.jetpack.main
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun JetpackActivationMainScreen(viewModel: JetpackActivationMainViewModel) {
+    TODO("Not yet implemented")
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -50,7 +50,10 @@ import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 @Composable
 fun JetpackActivationMainScreen(viewModel: JetpackActivationMainViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        JetpackActivationMainScreen(it)
+        JetpackActivationMainScreen(
+            viewState = it,
+            onCloseClick = viewModel::onCloseClick
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -1,8 +1,137 @@
 package com.woocommerce.android.ui.login.jetpack.main
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons.Filled
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
 fun JetpackActivationMainScreen(viewModel: JetpackActivationMainViewModel) {
-    TODO("Not yet implemented")
+    viewModel.viewState.observeAsState().value?.let {
+        JetpackActivationMainScreen(it)
+    }
+}
+
+@Composable
+fun JetpackActivationMainScreen(
+    viewState: JetpackActivationMainViewModel.ViewState,
+    onCloseClick: () -> Unit = {}
+) {
+    Scaffold(
+        topBar = { Toolbar(onCloseClick) }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(dimensionResource(id = R.dimen.major_100))
+                .verticalScroll(rememberScrollState())
+        ) {
+            JetpackToWooHeader()
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+            Text(
+                text = stringResource(
+                    id = if (viewState.isJetpackInstalled) R.string.login_jetpack_connection_steps_screen_title
+                    else R.string.login_jetpack_installation_steps_screen_title
+                ),
+                style = MaterialTheme.typography.h4,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+            Text(
+                text = annotatedStringRes(
+                    stringResId = R.string.login_jetpack_steps_screen_subtitle,
+                    viewState.siteUrl
+                ),
+                style = MaterialTheme.typography.body1
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            viewState.steps.forEach {
+                JetpackActivationStep(it)
+            }
+        }
+    }
+}
+
+@Composable
+fun JetpackActivationStep(step: JetpackActivationMainViewModel.Step, modifier: Modifier = Modifier) {
+    /*TODO*/
+}
+
+@Composable
+private fun Toolbar(
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TopAppBar(
+        backgroundColor = MaterialTheme.colors.surface,
+        title = {},
+        navigationIcon = {
+            IconButton(onClick = onCloseClick) {
+                Icon(
+                    Filled.Clear,
+                    contentDescription = stringResource(id = R.string.back)
+                )
+            }
+        },
+        elevation = 0.dp,
+        modifier = modifier
+    )
+}
+
+@Composable
+@Preview
+private fun JetpackActivationMainScreenPreview() {
+    WooThemeWithBackground {
+        JetpackActivationMainScreen(
+            viewState = JetpackActivationMainViewModel.ViewState(
+                siteUrl = "reallyniceshirts.com",
+                isJetpackInstalled = false,
+                steps = listOf(
+                    JetpackActivationMainViewModel.Step(
+                        title = R.string.login_jetpack_steps_installing,
+                        state = JetpackActivationMainViewModel.StepState.Success
+                    ),
+                    JetpackActivationMainViewModel.Step(
+                        title = R.string.login_jetpack_steps_activating,
+                        state = JetpackActivationMainViewModel.StepState.Ongoing
+                    ),
+                    JetpackActivationMainViewModel.Step(
+                        title = R.string.login_jetpack_steps_authorizing,
+                        state = JetpackActivationMainViewModel.StepState.Idle,
+                        additionalInfo = R.string.login_jetpack_steps_authorizing_hint
+                    ),
+                    JetpackActivationMainViewModel.Step(
+                        title = R.string.login_jetpack_steps_done,
+                        state = JetpackActivationMainViewModel.StepState.Idle
+                    )
+                )
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -1,31 +1,49 @@
 package com.woocommerce.android.ui.login.jetpack.main
 
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
@@ -71,16 +89,102 @@ fun JetpackActivationMainScreen(
                 style = MaterialTheme.typography.body1
             )
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-            viewState.steps.forEach {
-                JetpackActivationStep(it)
+            viewState.steps.forEach { step ->
+                JetpackActivationStep(
+                    step,
+                    modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_100))
+                )
             }
         }
     }
 }
 
 @Composable
-fun JetpackActivationStep(step: JetpackActivationMainViewModel.Step, modifier: Modifier = Modifier) {
-    /*TODO*/
+private fun JetpackActivationStep(step: JetpackActivationMainViewModel.Step, modifier: Modifier = Modifier) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.defaultMinSize(minHeight = dimensionResource(id = R.dimen.major_300))
+    ) {
+        val indicatorModifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_60))
+        when (step.state) {
+            JetpackActivationMainViewModel.StepState.Idle -> {
+                IdleCircle(indicatorModifier)
+            }
+            JetpackActivationMainViewModel.StepState.Ongoing -> {
+                CircularProgressIndicator(indicatorModifier)
+            }
+            JetpackActivationMainViewModel.StepState.Success -> {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_progress_circle_complete),
+                    contentDescription = null,
+                    modifier = indicatorModifier
+                )
+            }
+            JetpackActivationMainViewModel.StepState.Error -> {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_gridicons_notice),
+                    contentDescription = null,
+                    tint = colorResource(id = R.color.color_error),
+                    modifier = indicatorModifier
+                )
+            }
+        }
+
+        Column {
+            val isIdle = step.state == JetpackActivationMainViewModel.StepState.Idle
+            Text(
+                text = stringResource(id = step.title),
+                style = MaterialTheme.typography.subtitle1,
+                fontWeight = if (isIdle) FontWeight.Normal
+                else FontWeight.Bold,
+                color = colorResource(
+                    id = if (isIdle) R.color.color_on_surface_medium
+                    else R.color.color_on_surface
+                )
+            )
+            step.additionalInfo?.let { infoText ->
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_50)))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_50)),
+                ) {
+                    val isError = step.state == JetpackActivationMainViewModel.StepState.Error
+                    if (!isError) {
+                        Icon(
+                            imageVector = Icons.Default.Info,
+                            contentDescription = null,
+                            tint = colorResource(id = R.color.woo_orange_50),
+                            modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40))
+                        )
+                    }
+                    Text(
+                        text = infoText.getText(),
+                        color = colorResource(
+                            id = if (isError) R.color.color_error
+                            else R.color.woo_orange_50
+                        ),
+                        style = MaterialTheme.typography.caption,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IdleCircle(modifier: Modifier = Modifier) {
+    val color = colorResource(id = R.color.color_on_surface_medium)
+    val stroke = with(LocalDensity.current) {
+        Stroke(width = dimensionResource(id = R.dimen.minor_25).toPx(), cap = StrokeCap.Round)
+    }
+    Canvas(modifier = modifier) {
+        drawCircle(
+            color = color,
+            radius = (size.minDimension - stroke.width) / 2,
+            style = stroke
+        )
+    }
 }
 
 @Composable
@@ -122,9 +226,17 @@ private fun JetpackActivationMainScreenPreview() {
                         state = JetpackActivationMainViewModel.StepState.Ongoing
                     ),
                     JetpackActivationMainViewModel.Step(
+                        title = R.string.login_jetpack_steps_activating,
+                        state = JetpackActivationMainViewModel.StepState.Error,
+                        additionalInfo = UiStringRes(
+                            R.string.login_jetpack_installation_error_code_template,
+                            listOf(UiStringText("403"))
+                        )
+                    ),
+                    JetpackActivationMainViewModel.Step(
                         title = R.string.login_jetpack_steps_authorizing,
                         state = JetpackActivationMainViewModel.StepState.Idle,
-                        additionalInfo = R.string.login_jetpack_steps_authorizing_hint
+                        additionalInfo = UiStringRes(R.string.login_jetpack_steps_authorizing_hint)
                     ),
                     JetpackActivationMainViewModel.Step(
                         title = R.string.login_jetpack_steps_done,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -1,8 +1,11 @@
 package com.woocommerce.android.ui.login.jetpack.main
 
+import android.os.Parcelable
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -10,4 +13,29 @@ class JetpackActivationMainViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
 
+    @Parcelize
+    data class ViewState(
+        val steps: List<Step>
+    ) : Parcelable
+
+    @Parcelize
+    data class Step(
+        @StringRes val title: Int,
+        val state: StepState,
+        @StringRes val additionalInfo: Int? = null
+    ) : Parcelable
+
+    sealed interface StepState : Parcelable {
+        @Parcelize
+        object Idle : StepState
+
+        @Parcelize
+        object Ongoing : StepState
+
+        @Parcelize
+        object Success : StepState
+
+        @Parcelize
+        data class Error(val code: Int) : StepState
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
@@ -28,6 +29,10 @@ class JetpackActivationMainViewModel @Inject constructor(
         )
     )
     val viewState = _viewState.asLiveData()
+
+    fun onCloseClick() {
+        triggerEvent(Exit)
+    }
 
     @Parcelize
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.map
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
@@ -20,26 +21,27 @@ class JetpackActivationMainViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: JetpackActivationMainFragmentArgs by savedStateHandle.navArgs()
 
-    private val _viewState = savedStateHandle.getStateFlow(
+    private val steps = savedStateHandle.getStateFlow(
         scope = viewModelScope,
-        initialValue = ViewState(
+        initialValue = emptyList<Step>()
+    )
+    val viewState = steps.map {
+        ViewState(
             siteUrl = navArgs.siteUrl,
             isJetpackInstalled = navArgs.isJetpackInstalled,
-            steps = emptyList()
+            steps = it
         )
-    )
-    val viewState = _viewState.asLiveData()
+    }.asLiveData()
 
     fun onCloseClick() {
         triggerEvent(Exit)
     }
 
-    @Parcelize
     data class ViewState(
         val siteUrl: String,
         val isJetpackInstalled: Boolean,
         val steps: List<Step>
-    ) : Parcelable
+    )
 
     @Parcelize
     data class Step(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -5,7 +5,10 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -15,6 +18,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
+private const val STEPS_SAVED_STATE_KEY = "steps"
+
 @HiltViewModel
 class JetpackActivationMainViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
@@ -23,7 +28,35 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     private val steps = savedStateHandle.getStateFlow(
         scope = viewModelScope,
-        initialValue = emptyList<Step>()
+        // Just for demo
+        initialValue = listOf(
+            Step(
+                title = R.string.login_jetpack_steps_installing,
+                state = StepState.Success
+            ),
+            Step(
+                title = R.string.login_jetpack_steps_activating,
+                state = StepState.Ongoing
+            ),
+            Step(
+                title = R.string.login_jetpack_steps_activating,
+                state = StepState.Error,
+                additionalInfo = UiStringRes(
+                    R.string.login_jetpack_installation_error_code_template,
+                    listOf(UiStringText("403"))
+                )
+            ),
+            Step(
+                title = R.string.login_jetpack_steps_authorizing,
+                state = StepState.Idle,
+                additionalInfo = UiStringRes(R.string.login_jetpack_steps_authorizing_hint)
+            ),
+            Step(
+                title = R.string.login_jetpack_steps_done,
+                state = StepState.Idle
+            )
+        ),
+        key = STEPS_SAVED_STATE_KEY
     )
     val viewState = steps.map {
         ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -1,14 +1,9 @@
 package com.woocommerce.android.ui.login.jetpack.main
 
 import android.os.Parcelable
-import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.R
-import com.woocommerce.android.model.UiString
-import com.woocommerce.android.model.UiString.UiStringRes
-import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -31,28 +26,24 @@ class JetpackActivationMainViewModel @Inject constructor(
         // Just for demo
         initialValue = listOf(
             Step(
-                title = R.string.login_jetpack_steps_installing,
+                type = StepType.Installation,
                 state = StepState.Success
             ),
             Step(
-                title = R.string.login_jetpack_steps_activating,
+                type = StepType.Activation,
                 state = StepState.Ongoing
             ),
+            @Suppress("MagicNumber")
             Step(
-                title = R.string.login_jetpack_steps_activating,
-                state = StepState.Error,
-                additionalInfo = UiStringRes(
-                    R.string.login_jetpack_installation_error_code_template,
-                    listOf(UiStringText("403"))
-                )
+                type = StepType.Activation,
+                state = StepState.Error(403)
             ),
             Step(
-                title = R.string.login_jetpack_steps_authorizing,
-                state = StepState.Idle,
-                additionalInfo = UiStringRes(R.string.login_jetpack_steps_authorizing_hint)
+                type = StepType.Connection,
+                state = StepState.Idle
             ),
             Step(
-                title = R.string.login_jetpack_steps_done,
+                type = StepType.Done,
                 state = StepState.Idle
             )
         ),
@@ -78,12 +69,25 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     @Parcelize
     data class Step(
-        @StringRes val title: Int,
-        val state: StepState,
-        val additionalInfo: UiString? = null
+        val type: StepType,
+        val state: StepState
     ) : Parcelable
 
-    enum class StepState {
-        Idle, Ongoing, Success, Error
+    enum class StepType {
+        Installation, Activation, Connection, Done
+    }
+
+    sealed interface StepState : Parcelable {
+        @Parcelize
+        object Idle : StepState
+
+        @Parcelize
+        object Ongoing : StepState
+
+        @Parcelize
+        object Success : StepState
+
+        @Parcelize
+        data class Error(val code: Int) : StepState
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.login.jetpack.main
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class JetpackActivationMainViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -3,7 +3,11 @@ package com.woocommerce.android.ui.login.jetpack.main
 import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -12,9 +16,22 @@ import javax.inject.Inject
 class JetpackActivationMainViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: JetpackActivationMainFragmentArgs by savedStateHandle.navArgs()
+
+    private val _viewState = savedStateHandle.getStateFlow(
+        scope = viewModelScope,
+        initialValue = ViewState(
+            siteUrl = navArgs.siteUrl,
+            isJetpackInstalled = navArgs.isJetpackInstalled,
+            steps = emptyList()
+        )
+    )
+    val viewState = _viewState.asLiveData()
 
     @Parcelize
     data class ViewState(
+        val siteUrl: String,
+        val isJetpackInstalled: Boolean,
         val steps: List<Step>
     ) : Parcelable
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
@@ -39,20 +40,10 @@ class JetpackActivationMainViewModel @Inject constructor(
     data class Step(
         @StringRes val title: Int,
         val state: StepState,
-        @StringRes val additionalInfo: Int? = null
+        val additionalInfo: UiString? = null
     ) : Parcelable
 
-    sealed interface StepState : Parcelable {
-        @Parcelize
-        object Idle : StepState
-
-        @Parcelize
-        object Ongoing : StepState
-
-        @Parcelize
-        object Success : StepState
-
-        @Parcelize
-        data class Error(val code: Int) : StepState
+    enum class StepState {
+        Idle, Ongoing, Success, Error
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
@@ -4,11 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -62,7 +62,13 @@ class JetpackActivationSiteCredentialsFragment : BaseFragment() {
 
     @Suppress("UNUSED_PARAMETER")
     private fun navigateToJetpackActivationSteps(event: NavigateToJetpackActivationSteps) {
-        Toast.makeText(requireContext(), "TODO", Toast.LENGTH_LONG).show()
+        findNavController().navigateSafely(
+            JetpackActivationSiteCredentialsFragmentDirections
+                .actionJetpackActivationSiteCredentialsFragmentToJetpackActivationMainFragment(
+                    siteUrl = event.siteUrl,
+                    isJetpackInstalled = event.isJetpackInstalled
+                )
+        )
     }
 
     private fun showResetPasswordWebPage(siteUrl: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.login.jetpack.sitecredentials
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -26,11 +25,9 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
@@ -43,6 +40,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.JetpackActivationSiteCredentialsViewState
 
 @Composable
@@ -84,7 +82,7 @@ fun JetpackActivationSiteCredentialsScreen(
                     .verticalScroll(rememberScrollState())
                     .padding(dimensionResource(id = R.dimen.major_100)),
             ) {
-                JetpackToWoo()
+                JetpackToWooHeader()
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 Text(
                     text = annotatedStringRes(
@@ -155,28 +153,6 @@ fun JetpackActivationSiteCredentialsScreen(
 
     if (viewState.isLoading) {
         ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
-    }
-}
-
-@Composable
-private fun JetpackToWoo(modifier: Modifier = Modifier) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-    ) {
-        val logoModifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_100))
-        Image(
-            painter = painterResource(id = R.drawable.ic_jetpack_logo),
-            contentDescription = null,
-            modifier = logoModifier
-        )
-        Image(painter = painterResource(id = R.drawable.ic_connecting), contentDescription = null)
-        Image(
-            painter = painterResource(id = R.drawable.ic_woo_bubble),
-            contentDescription = null,
-            modifier = logoModifier
-        )
     }
 }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -28,5 +28,19 @@
         <argument
             android:name="isJetpackInstalled"
             app:argType="boolean" />
+        <action
+            android:id="@+id/action_jetpackActivationSiteCredentialsFragment_to_jetpackActivationMainFragment"
+            app:destination="@id/jetpackActivationMainFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/jetpackActivationMainFragment"
+        android:name="com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainFragment"
+        android:label="JetpackActivationMainFragment" >
+        <argument
+            android:name="siteUrl"
+            app:argType="string" />
+        <argument
+            android:name="isJetpackInstalled"
+            app:argType="boolean" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -30,12 +30,14 @@
             app:argType="boolean" />
         <action
             android:id="@+id/action_jetpackActivationSiteCredentialsFragment_to_jetpackActivationMainFragment"
-            app:destination="@id/jetpackActivationMainFragment" />
+            app:destination="@id/jetpackActivationMainFragment"
+            app:popUpTo="@id/jetpackActivationStartFragment"
+            app:popUpToInclusive="false" />
     </fragment>
     <fragment
         android:id="@+id/jetpackActivationMainFragment"
         android:name="com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainFragment"
-        android:label="JetpackActivationMainFragment" >
+        android:label="JetpackActivationMainFragment">
         <argument
             android:name="siteUrl"
             app:argType="string" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -307,6 +307,7 @@
     <string name="login_jetpack_installation_steps_screen_title">Installing Jetpack</string>
     <string name="login_jetpack_connection_steps_screen_title">Connecting Jetpack</string>
     <string name="login_jetpack_steps_screen_subtitle">Please wait while we connect your store &lt;b&gt;%1$s&lt;/b&gt; with Jetpack.</string>
+    <string name="login_jetpack_installation_error_code_template">Error code %1$s</string>
 
     <!--
         My Store View

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -299,6 +299,14 @@
     <string name="login_jetpack_connection_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to connect Jetpack.</string>
     <string name="login_jetpack_connection_approval_hint">We will ask for your approval to complete the Jetpack connection.</string>
     <string name="login_jetpack_site_credentials_screen_title">Log in to your store</string>
+    <string name="login_jetpack_steps_installing">Installing Jetpack</string>
+    <string name="login_jetpack_steps_activating">Activating</string>
+    <string name="login_jetpack_steps_authorizing">Authorising connection</string>
+    <string name="login_jetpack_steps_authorizing_hint">Approval required</string>
+    <string name="login_jetpack_steps_done">All done</string>
+    <string name="login_jetpack_installation_steps_screen_title">Installing Jetpack</string>
+    <string name="login_jetpack_connection_steps_screen_title">Connecting Jetpack</string>
+    <string name="login_jetpack_steps_screen_subtitle">Please wait while we connect your store &lt;b&gt;%1$s&lt;/b&gt; with Jetpack.</string>
 
     <!--
         My Store View


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7848 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Please don't merge before #7872 

### Description
This PR adds the UI part for the installation steps.

### Testing instructions
Either launch the preview `JetpackActivationMainScreenPreview` or follow the below steps
1. Open the site picker (from login or settings)
2. Click on "Add a store"
3. Click on "Connect an existing store"
4. Enter the address of a non-jetpack store.
5. Click on "Install Jetpack".
6. Enter site credentials and click on "Install Jetpack"
7. Confirm the installation steps are shown like the below screenshots.
8. Click on the Close button.
9. Confirm you are navigated to the initial screen.

### Images/gif
| Light | Dark |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1657201/202426585-1bee5a54-8d86-460f-b95f-ee8c1fca9e0e.png) | ![image](https://user-images.githubusercontent.com/1657201/202426697-7a878b77-9b20-4d4b-a82d-bdf3ed6793f0.png) |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
