### PR TITLE
Exclude variation duplicates from variation candidates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidates.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidates.kt
@@ -2,21 +2,23 @@ package com.woocommerce.android.ui.products.variations.domain
 
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductAttribute
-import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.model.VariantOption
 import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.ui.products.variations.VariationRepository
+import javax.inject.Inject
 
 typealias VariationCandidate = List<VariantOption>
 
-class GenerateVariationCandidates {
+class GenerateVariationCandidates @Inject constructor(
+    val variationRepository: VariationRepository
+) {
 
-    operator fun invoke(
-        product: Product,
-        existingVariations: List<ProductVariation>
-    ): List<VariationCandidate> {
+    operator fun invoke(product: Product,): List<VariationCandidate> {
         if (product.type != ProductType.VARIABLE.value) {
             return emptyList()
         }
+
+        val existingVariations = variationRepository.getProductVariationList(product.remoteId)
 
         val termAssignmentsGroupedByAttribute: List<List<VariantOption>> = product.attributes
             .filter(ProductAttribute::isVariation)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidates.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidates.kt
@@ -13,7 +13,7 @@ class GenerateVariationCandidates @Inject constructor(
     val variationRepository: VariationRepository
 ) {
 
-    operator fun invoke(product: Product,): List<VariationCandidate> {
+    operator fun invoke(product: Product): List<VariationCandidate> {
         if (product.type != ProductType.VARIABLE.value) {
             return emptyList()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7886 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new behaviour for `GenerateVariationCandidates` algorithm. Now, the algorithm won't propose a variation candidate same as one that 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Verify if added code and unit test makes sense :).


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
