### PR TITLE
Suppress missing class lint error

### DIFF
--- a/WooCommerce/src/release/AndroidManifest.xml
+++ b/WooCommerce/src/release/AndroidManifest.xml
@@ -13,6 +13,7 @@
 
         <activity
             android:name="com.android.billingclient.api.ProxyBillingActivity"
+            tools:ignore="MissingClass"
             tools:node="remove" />
 
     </application>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Suppresses probably false positive lint error 

```
Error: Class referenced in the manifest, com.android.billingclient.api.ProxyBillingActivity, was not found in the project or the libraries [MissingClass]
[2022-11-19T06:29:04Z]             android:name="com.android.billingclient.api.ProxyBillingActivity"
```