### PR TITLE
Fixed newly added kotlin warnings

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseActivity.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseActivity.kt
@@ -21,6 +21,7 @@ private const val REMOTE_SITE_ID = 1L
 class IAPShowcaseActivity : AppCompatActivity() {
     private val viewModel: IAPShowcaseViewModel by viewModels(null) {
         object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>) =
                 IAPShowcaseViewModel(
                     IAPSitePurchasePlanFactory.createIAPSitePurchasePlan(

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseViewModel.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/IAPShowcaseViewModel.kt
@@ -70,7 +70,7 @@ class IAPShowcaseViewModel(private val iapManager: PurchaseWPComPlanActions) : V
             _iapLoading.value = true
             val response = iapManager.fetchWPComPlanProduct()
             _iapLoading.value = false
-            when (val response = response) {
+            when (response) {
                 is WPComProductResult.Success -> _productInfo.value = response.productInfo
                 is WPComProductResult.Error -> handleError(response.errorType)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsFragment.kt
@@ -71,7 +71,7 @@ class DeveloperOptionsFragment : BaseFragment(R.layout.fragment_developer_option
             .setOnDismissListener {
                 viewModel.onUpdateReaderOptionChanged(currentlySelectedValue)
             }
-            .setSingleChoiceItems(textValues, selectedValue.ordinal) { dialog, which ->
+            .setSingleChoiceItems(textValues, selectedValue.ordinal) { _, which ->
                 currentlySelectedValue = values[which]
             }.show()
     }

--- a/libs/iap/src/test/kotlin/com/woocommerce/android/iap/pub/IAPPurchaseWPComPlanActionsTest.kt
+++ b/libs/iap/src/test/kotlin/com/woocommerce/android/iap/pub/IAPPurchaseWPComPlanActionsTest.kt
@@ -879,6 +879,7 @@ class IAPPurchaseWPComPlanActionsTest {
     private fun setupPeriodicJob(purchasesResult: PurchasesResult) {
         whenever(periodicPurchaseStatusCheckerMock.startPeriodicPurchasesCheckJob(any(), any(), any()))
             .thenAnswer {
+                @Suppress("UNCHECKED_CAST")
                 (it.arguments[2] as (PurchasesResult) -> Unit).invoke(purchasesResult)
                 mock<Job>()
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Some warnings we added after we set kotlin compiler warnings as error

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
