### PR TITLE
Read `version` for `update_appstore_strings` from codebase

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -143,18 +143,10 @@ platform :android do
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
-  #####################################################################################
-  # update_appstore_strings
-  # -----------------------------------------------------------------------------------
-  # This lane gets the data from the txt files in the WooCommerce/metadata/ folder
-  # and updates the .pot file that is then picked by GlotPress for translations.
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # fastlane update_appstore_strings version:<version>
+  # Updates the `PlayStoreStrings.pot` file with the latest content from the `release_notes.txt` files and the other text sources.
   #
-  # Example:
-  # fastlane update_appstore_strings version:1.1
-  #####################################################################################
+  # @option [String] version The current `x.y` version of the app. Optional. Used to derive the `release_notes_xy` key to use in the `.pot` file.
+  #
   desc "Updates the PlayStoreStrings.pot file"
   lane :update_appstore_strings do |options|
     ensure_git_status_clean

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -159,6 +159,8 @@ platform :android do
   lane :update_appstore_strings do |options|
     ensure_git_status_clean
 
+    version = options.fetch(:version, android_get_app_version)
+
     files = {
       release_note: RELEASE_NOTES_PATH,
       play_store_promo: File.join(ORIGINALS_METADATA_DIR_PATH, 'short_description.txt'),
@@ -176,13 +178,13 @@ platform :android do
     an_update_metadata_source(
       po_file_path: po_path,
       source_files: files,
-      release_version: options[:version]
+      release_version: version
     )
 
     git_add(path: po_path)
     git_commit(
       path: po_path,
-      message: "Update `PlayStoreStrings.po` for #{options[:version]}",
+      message: "Update `PlayStoreStrings.po` for #{version}",
       allow_nothing_to_commit: true
     )
   end


### PR DESCRIPTION
### Description
The `update_appstore_strings` required a `version` parameter at call site, but the information we passed to it – the current app version – could be read from the codebase itself. See also https://github.com/woocommerce/woocommerce-ios/pull/8160

Not having to pass the parameter makes the process simpler, _and more shell history friendly_.

### Testing instructions

Here's a screenshot of the lane running with no parameter and correctly picking up [11.3](https://github.com/woocommerce/woocommerce-android/blob/6a381580e160b25cc5dc9e7b09ca69b75eb8d740/WooCommerce/build.gradle#L77) as the version

![image](https://user-images.githubusercontent.com/1218433/203028093-45a30fa7-180d-4ca6-af0e-b13519e91ad8.png)

Here's a screenshot of the lane running with `version: 1.2.3` to override the one in the code. You can see the lane uses it and updates the `.pot` file.

![image](https://user-images.githubusercontent.com/1218433/203028129-0ae82f8c-1681-404a-9a46-c5f28ef03ec4.png)



---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
