### PR TITLE
Track card reader battery property card reader events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTracker.kt
@@ -93,9 +93,8 @@ class CardReaderTracker @Inject constructor(
     }
 
     private fun addCardReaderBatteryLevelProperty(properties: MutableMap<String, Any>) {
-        val cardReaderBatteryStatus = cardReaderTrackingInfoProvider.trackingInfo.cardReaderBatteryLevel
-        if (cardReaderBatteryStatus != null) {
-            properties["card_reader_battery_level"] = cardReaderBatteryStatus
+        cardReaderTrackingInfoProvider.trackingInfo.cardReaderBatteryLevelPercent?.let { batteryLevelPercent ->
+            properties["card_reader_battery_level"] = "$batteryLevelPercent %"
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTracker.kt
@@ -76,6 +76,7 @@ class CardReaderTracker @Inject constructor(
         addCurrencyProperty(properties)
         addPaymentMethodTypeProperty(properties)
         addCardReaderModelProperty(properties)
+        addCardReaderBatteryLevelProperty(properties)
 
         val isError = !errorType.isNullOrBlank() || !errorDescription.isNullOrEmpty()
         if (isError) {
@@ -88,6 +89,13 @@ class CardReaderTracker @Inject constructor(
             )
         } else {
             trackerWrapper.track(stat, properties)
+        }
+    }
+
+    private fun addCardReaderBatteryLevelProperty(properties: MutableMap<String, Any>) {
+        val cardReaderBatteryStatus = cardReaderTrackingInfoProvider.trackingInfo.cardReaderBatteryLevel
+        if (cardReaderBatteryStatus != null) {
+            properties["card_reader_battery_level"] = cardReaderBatteryStatus
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTrackingInfoProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTrackingInfoProvider.kt
@@ -16,6 +16,7 @@ interface CardReaderTrackingInfoKeeper {
     fun setCurrency(currency: String)
     fun setPaymentMethodType(paymentMethodType: String?)
     fun setCardReaderModel(cardReaderModel: String?)
+    fun setCardReaderBatteryLevel(batteryLevel: Float?)
 }
 
 @Singleton
@@ -41,6 +42,10 @@ class CardReaderTrackingInfoImpl @Inject constructor() : CardReaderTrackingInfoP
     override fun setCardReaderModel(cardReaderModel: String?) {
         trackingInfoInternal = trackingInfoInternal.copy(cardReaderModel = cardReaderModel)
     }
+
+    override fun setCardReaderBatteryLevel(batteryLevel: Float?) {
+        trackingInfoInternal = trackingInfoInternal.copy(cardReaderBatteryLevel = batteryLevel)
+    }
 }
 
 data class TrackingInfo(
@@ -48,6 +53,7 @@ data class TrackingInfo(
     val currency: String? = null,
     val paymentMethodType: String? = null,
     val cardReaderModel: String? = null,
+    val cardReaderBatteryLevel: Float? = null,
 )
 
 @InstallIn(SingletonComponent::class)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderUtils.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.payments.cardreader
+
+import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.connection.CardReader
+import com.woocommerce.android.model.UiString
+import kotlin.math.roundToInt
+
+private const val PERCENT_100 = 100
+private fun Float.toPercent(): Int = (this * PERCENT_100).roundToInt()
+
+internal fun CardReader.getReadersBatteryLevel(): UiString? =
+    getReadersBatteryLevelPercent()?.let { buildBatteryLevelUiString(it) }
+
+internal fun buildBatteryLevelUiString(batteryLevelPercent: Int) = UiString.UiStringRes(
+    R.string.card_reader_detail_connected_battery_percentage,
+    listOf(UiString.UiStringText(batteryLevelPercent.toString()))
+)
+
+internal fun buildBatteryLevelUiString(batteryLevel: Float) = UiString.UiStringRes(
+    R.string.card_reader_detail_connected_battery_percentage,
+    listOf(UiString.UiStringText(batteryLevel.toPercent().toString()))
+)
+
+internal fun CardReader.getReadersBatteryLevelPercent(): Int? = currentBatteryLevel?.toPercent()
+
+internal val TrackingInfo.cardReaderBatteryLevelPercent: Int?
+    get() = cardReaderBatteryLevel?.toPercent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -455,6 +455,7 @@ class CardReaderConnectViewModel @Inject constructor(
     }
 
     private fun onReaderConnected(cardReader: CardReader) {
+        cardReaderTrackingInfoKeeper.setCardReaderBatteryLevel(cardReader.currentBatteryLevel)
         tracker.trackConnectionSucceeded()
         WooLog.e(WooLog.T.CARD_READER, "Connecting to reader succeeded.")
         storeConnectedReader(cardReader)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -22,12 +22,14 @@ import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.CardReaderTracker
+import com.woocommerce.android.ui.payments.cardreader.buildBatteryLevelUiString
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.CardReaderDetailEvent.NavigateToUrlInGenericWebView
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.NavigationTarget.CardReaderConnectScreen
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.ConnectedState
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.ConnectedState.ButtonState
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.Loading
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.NotConnectedState
+import com.woocommerce.android.ui.payments.cardreader.getReadersBatteryLevel
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
@@ -42,9 +44,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.math.roundToInt
-
-private const val PERCENT_100 = 100
 
 @HiltViewModel
 class CardReaderDetailViewModel @Inject constructor(
@@ -297,16 +296,9 @@ private fun CardReader.getReadersName(): UiString {
     }
 }
 
-private fun CardReader.getReadersBatteryLevel(): UiString? = currentBatteryLevel?.let { buildBatteryLevelUiString(it) }
-
 private fun CardReader.getReaderFirmwareVersion(): UiString {
     return UiStringRes(
         R.string.card_reader_detail_connected_firmware_version,
         listOf(UiStringText(firmwareVersion))
     )
 }
-
-private fun buildBatteryLevelUiString(batteryLevel: Float) = UiStringRes(
-    R.string.card_reader_detail_connected_battery_percentage,
-    listOf(UiStringText((batteryLevel * PERCENT_100).roundToInt().toString()))
-)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -5,11 +5,13 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus.CollectingInteracRefund
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus.InitializingInteracRefund
@@ -146,6 +148,18 @@ class CardReaderPaymentViewModel
             }
         } else {
             exitWithSnackbar(R.string.card_reader_payment_reader_not_connected)
+        }
+
+        viewModelScope.launch {
+            listenToCardReaderBatteryChanges()
+        }
+    }
+
+    private suspend fun listenToCardReaderBatteryChanges() {
+        cardReaderManager.batteryStatus.collect { batteryStatus ->
+            if (batteryStatus is CardReaderBatteryStatus.StatusChanged) {
+                cardReaderTrackingInfoKeeper.setCardReaderBatteryLevel(batteryStatus.batteryLevel)
+            }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -87,6 +87,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyFloat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
@@ -2963,6 +2964,21 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             val inOrder = inOrder(cardReaderTrackingInfoKeeper)
             inOrder.verify(cardReaderTrackingInfoKeeper).setCardReaderBatteryLevel(batteryLevel1)
             inOrder.verify(cardReaderTrackingInfoKeeper).setCardReaderBatteryLevel(batteryLevel2)
+        }
+
+    @Test
+    fun `when new battery status event is received, then tracking is not updated if the battery level didn't change`() =
+        testBlocking {
+            whenever(cardReaderManager.batteryStatus).thenAnswer {
+                flow {
+                    emit(CardReaderBatteryStatus.Unknown)
+                    emit(CardReaderBatteryStatus.Warning)
+                }
+            }
+
+            viewModel.start()
+
+            verify(cardReaderTrackingInfoKeeper, never()).setCardReaderBatteryLevel(anyFloat())
         }
 
     private suspend fun simulateFetchOrderJobState(inProgress: Boolean) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -5,7 +5,9 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.event.BatteryStatus
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus.RefundStatusErrorType.DeclinedByBackendError.CardDeclined
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus
@@ -92,6 +94,7 @@ import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -2942,6 +2945,25 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     //endregion - Interac Refund tests
+
+    @Test
+    fun `when new battery status event is received, then tracking is updated with new battery level`() =
+        testBlocking {
+            val batteryLevel1 = .5F
+            val batteryLevel2 = .45F
+            whenever(cardReaderManager.batteryStatus).thenAnswer {
+                flow {
+                    emit(CardReaderBatteryStatus.StatusChanged(batteryLevel1, BatteryStatus.NOMINAL, false))
+                    emit(CardReaderBatteryStatus.StatusChanged(batteryLevel2, BatteryStatus.NOMINAL, false))
+                }
+            }
+
+            viewModel.start()
+
+            val inOrder = inOrder(cardReaderTrackingInfoKeeper)
+            inOrder.verify(cardReaderTrackingInfoKeeper).setCardReaderBatteryLevel(batteryLevel1)
+            inOrder.verify(cardReaderTrackingInfoKeeper).setCardReaderBatteryLevel(batteryLevel2)
+        }
 
     private suspend fun simulateFetchOrderJobState(inProgress: Boolean) {
         if (inProgress) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTrackerTest.kt
@@ -46,14 +46,17 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.check
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class CardReaderTrackerTest : BaseUnitTest() {
@@ -112,6 +115,22 @@ class CardReaderTrackerTest : BaseUnitTest() {
             cardReaderTracker.track(CARD_PRESENT_COLLECT_PAYMENT_SUCCESS, props)
 
             assertFalse(props.containsKey("card_reader_battery_level"))
+        }
+
+    @Test
+    fun `given battery level is not null, when event is tracked, then it should contain battery level property`() =
+        testBlocking {
+            val cardReaderTrackingInfo: TrackingInfo = mock {
+                on { cardReaderBatteryLevel } doReturn 0.5F // 50 %
+            }
+            whenever(cardReaderTrackingInfoProvider.trackingInfo).thenReturn(cardReaderTrackingInfo)
+            val props = mutableMapOf<String, Any>()
+
+            cardReaderTracker.track(CARD_PRESENT_COLLECT_PAYMENT_SUCCESS, props)
+
+            assertTrue(props.containsKey("card_reader_battery_level"))
+            val batteryLevelProperty = props["card_reader_battery_level"]
+            assertEquals("50 %", batteryLevelProperty)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTrackerTest.kt
@@ -52,6 +52,8 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 @ExperimentalCoroutinesApi
 class CardReaderTrackerTest : BaseUnitTest() {
@@ -99,6 +101,17 @@ class CardReaderTrackerTest : BaseUnitTest() {
                 eq(CARD_PRESENT_ONBOARDING_LEARN_MORE_TAPPED),
                 any()
             )
+        }
+
+    @Test
+    fun `given battery level is null, when event is tracked, then it shouldn't contain battery level property`() =
+        testBlocking {
+            assertNull(cardReaderTrackingInfoProvider.trackingInfo.cardReaderBatteryLevel)
+
+            val props = mutableMapOf<String, Any>()
+            cardReaderTracker.track(CARD_PRESENT_COLLECT_PAYMENT_SUCCESS, props)
+
+            assertFalse(props.containsKey("card_reader_battery_level"))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -9,8 +9,6 @@ import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.R
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.SpecificReader
-import com.woocommerce.android.cardreader.connection.event.BatteryStatus
-import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString.UiStringRes
@@ -68,7 +66,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyBoolean
-import org.mockito.ArgumentMatchers.anyFloat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor


### PR DESCRIPTION
Logging card reader's battery level tracking card reader events.

Closes: #7651

### Description
1. This PR adds the `CardReaderTrackingInfoKeeper::setCardReaderBatteryLevel` method for storing battery-level data in memory. 
2. Battery level is added as a property to events related to the card reader (tracked using `CardReaderTracker::track` method). The name of the event's property: `card_reader_battery_level`.
3. The battery level gets updated immediately after the reader is connected and then during the payment flow we subscribe to battery level changes and update it continuously using `CardReaderTrackingInfoKeeper`.

### Testing instructions
**1. Observe that events related to the card reader include the `card_reader_battery_level`.** 
Note: it won't be included if there are no battery-level data available. Usually, this shouldn't happen.
**2. Observe that the battery level is updated.** 
Eg. This can happen during long-running card payment flow if the reader is not connected to the cable. In that case, the battery level tracked with `*_card_reader_connection_success` event would differ from `*_card_present_collect_payment_success`. Note: the time from connecting to a reader to tapping a card must be long enough to observe battery level change.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
