### PR TITLE
Feature/7918 native store creation tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -140,8 +140,6 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_PICKER_JETPACK_TIMEOUT_CONTACT_SUPPORT_CLICKED(siteless = true),
     SITE_PICKER_CREATE_SITE_TAPPED(siteless = true),
     LOGIN_WOOCOMMERCE_SITE_CREATED(siteless = true),
-    SITE_CREATION_FAILED(siteless = true),
-    SITE_CREATION_DISMISSED(siteless = true),
 
     // -- Dashboard
     DASHBOARD_PULLED_TO_REFRESH,
@@ -727,5 +725,9 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     UNIVERSAL_LINK_FAILED,
 
     // Analytics Hub
-    ANALYTICS_HUB_WAITING_TIME_LOADED
+    ANALYTICS_HUB_WAITING_TIME_LOADED,
+
+    // Site creation native flow
+    SITE_CREATION_FAILED(siteless = true),
+    SITE_CREATION_DISMISSED(siteless = true),
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -731,4 +731,5 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_CREATION_FAILED(siteless = true),
     SITE_CREATION_DISMISSED(siteless = true),
     SITE_CREATION_SITE_PREVIEWED,
+    SITE_CREATION_STEP(siteless = true),
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -730,4 +730,5 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     // Site creation native flow
     SITE_CREATION_FAILED(siteless = true),
     SITE_CREATION_DISMISSED(siteless = true),
+    SITE_CREATION_SITE_PREVIEWED,
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -424,6 +424,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_PROLOGUE = "prologue"
         const val VALUE_LOGIN = "login"
         const val VALUE_OTHER = "other"
+        const val VALUE_WEB = "web"
+        const val VALUE_NATIVE = "native"
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -426,6 +426,12 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_OTHER = "other"
         const val VALUE_WEB = "web"
         const val VALUE_NATIVE = "native"
+        const val VALUE_STEP_STORE_NAME = "store_name"
+        const val VALUE_STEP_STORE_PROFILER = "store_profiler"
+        const val VALUE_STEP_DOMAIN_PICKER = "domain_picker"
+        const val VALUE_STEP_STORE_SUMMARY = "store_summary"
+        const val VALUE_STEP_PLAN_PURCHASE = "plan_purchase"
+        const val VALUE_STEP_STORE_CREATED = "store_created"
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerViewModel.LoadingState.Idle
 import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerViewModel.LoadingState.Loading
@@ -29,7 +32,8 @@ import javax.inject.Inject
 class DomainPickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     domainSuggestionsRepository: DomainSuggestionsRepository,
-    private val newStore: NewStore
+    private val newStore: NewStore,
+    val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val domainQuery = savedState.getStateFlow(this, newStore.store.value.name ?: "")
     private val loadingState = MutableStateFlow(Idle)
@@ -50,6 +54,12 @@ class DomainPickerViewModel @Inject constructor(
     }.asLiveData()
 
     init {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SITE_CREATION_STEP,
+            mapOf(
+                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_DOMAIN_PICKER
+            )
+        )
         viewModelScope.launch {
             domainQuery
                 .filter { it.isNotBlank() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.login.storecreation.installation.InstallationViewModel.ViewState.LoadingState
@@ -35,12 +34,6 @@ class InstallationViewModel @Inject constructor(
         launch {
             _viewState.update { SuccessState(url) }
         }
-        analyticsTrackerWrapper.track(
-            AnalyticsEvent.SITE_CREATION_STEP,
-            mapOf(
-                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_CREATED
-            )
-        )
     }
 
     fun onShowPreviewButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.login.storecreation.installation
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.login.storecreation.installation.InstallationViewModel.ViewState.LoadingState
 import com.woocommerce.android.ui.login.storecreation.installation.InstallationViewModel.ViewState.SuccessState
@@ -21,6 +23,7 @@ class InstallationViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent,
+    val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val _viewState = savedState.getStateFlow<ViewState>(this, LoadingState)
     val viewState = _viewState.asLiveData()
@@ -34,6 +37,7 @@ class InstallationViewModel @Inject constructor(
     }
 
     fun onShowPreviewButtonClicked() {
+        analyticsTrackerWrapper.track(AnalyticsEvent.SITE_CREATION_SITE_PREVIEWED)
         triggerEvent(OpenStore(url))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.login.storecreation.installation.InstallationViewModel.ViewState.LoadingState
@@ -34,6 +35,12 @@ class InstallationViewModel @Inject constructor(
         launch {
             _viewState.update { SuccessState(url) }
         }
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SITE_CREATION_STEP,
+            mapOf(
+                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_CREATED
+            )
+        )
     }
 
     fun onShowPreviewButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryScreen.kt
@@ -164,10 +164,12 @@ private fun StoreDataSummary(
                         )
                     }
                 }
-                Text(
-                    text = myStoreSummaryState.country,
-                    style = MaterialTheme.typography.subtitle1,
-                )
+                if (!myStoreSummaryState.country.isNullOrEmpty()) {
+                    Text(
+                        text = myStoreSummaryState.country,
+                        style = MaterialTheme.typography.subtitle1,
+                    )
+                }
                 if (!myStoreSummaryState.category.isNullOrEmpty()) {
                     Text(
                         text = myStoreSummaryState.category,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryViewModel.kt
@@ -25,7 +25,7 @@ class MyStoreSummaryViewModel @Inject constructor(
                 name = it.name,
                 domain = it.domain ?: "",
                 category = it.category,
-                country = it.country ?: "TODO default value locale?"
+                country = it.country
             )
         }
         .asLiveData()
@@ -51,7 +51,7 @@ class MyStoreSummaryViewModel @Inject constructor(
         val name: String? = null,
         val domain: String,
         val category: String? = null,
-        val country: String,
+        val country: String? = null,
     )
 
     object NavigateToNextStep : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryViewModel.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.login.storecreation.mystoresummary
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -12,7 +15,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MyStoreSummaryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    newStore: NewStore
+    newStore: NewStore,
+    val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
 
     val viewState = newStore.store
@@ -25,6 +29,15 @@ class MyStoreSummaryViewModel @Inject constructor(
             )
         }
         .asLiveData()
+
+    init {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SITE_CREATION_STEP,
+            mapOf(
+                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_SUMMARY
+            )
+        )
+    }
 
     fun onBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -3,9 +3,9 @@ package com.woocommerce.android.ui.login.storecreation.name
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STEP
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STEP_STORE_NAME
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -19,7 +19,8 @@ import javax.inject.Inject
 class StoreNamePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val newStore: NewStore,
-    val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val _storeName = savedState.getStateFlow(scope = this, initialValue = "")
     val storeName: LiveData<String> = _storeName.asLiveData()
@@ -28,12 +29,20 @@ class StoreNamePickerViewModel @Inject constructor(
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SITE_CREATION_STEP,
             mapOf(
-                KEY_STEP to VALUE_STEP_STORE_NAME
+                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_NAME
             )
         )
     }
 
     fun onCancelPressed() {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SITE_CREATION_DISMISSED,
+            mapOf(
+                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_CREATED,
+                AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_NATIVE,
+                AnalyticsTracker.KEY_SOURCE to prefsWrapper.getStoreCreationSource()
+            )
+        )
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -38,7 +38,7 @@ class StoreNamePickerViewModel @Inject constructor(
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SITE_CREATION_DISMISSED,
             mapOf(
-                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_CREATED,
+                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_NAME,
                 AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_NATIVE,
                 AnalyticsTracker.KEY_SOURCE to prefsWrapper.getStoreCreationSource()
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -3,6 +3,10 @@ package com.woocommerce.android.ui.login.storecreation.name
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STEP
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STEP_STORE_NAME
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -14,10 +18,20 @@ import javax.inject.Inject
 @HiltViewModel
 class StoreNamePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val newStore: NewStore
+    private val newStore: NewStore,
+    val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val _storeName = savedState.getStateFlow(scope = this, initialValue = "")
     val storeName: LiveData<String> = _storeName.asLiveData()
+
+    init {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SITE_CREATION_STEP,
+            mapOf(
+                KEY_STEP to VALUE_STEP_STORE_NAME
+            )
+        )
+    }
 
     fun onCancelPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
@@ -98,6 +98,7 @@ class PlansViewModel @Inject constructor(
     fun onConfirmClicked() {
         triggerEvent(NavigateToNextStep)
         // TODO add tracking for login_woocommerce_site_created and site_creation_failed once we have the result
+        // TODO wipe out data from "NewStore" singlenton once store is created successfully
     }
 
     fun onRetryClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
@@ -7,6 +7,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Plan.BillingPeriod.MONTHLY
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Plan.Feature
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.ViewState.LoadingState
@@ -23,7 +26,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PlansViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val ECOMMERCE_PLAN_NAME = "eCommerce"
@@ -35,6 +39,12 @@ class PlansViewModel @Inject constructor(
 
     init {
         loadPlan()
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SITE_CREATION_STEP,
+            mapOf(
+                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_PLAN_PURCHASE
+            )
+        )
     }
 
     private fun loadPlan() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
@@ -97,6 +97,7 @@ class PlansViewModel @Inject constructor(
 
     fun onConfirmClicked() {
         triggerEvent(NavigateToNextStep)
+        // TODO add tracking for login_woocommerce_site_created and site_creation_failed once we have the result
     }
 
     fun onRetryClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
@@ -92,7 +92,8 @@ class WebViewStoreCreationViewModel @Inject constructor(
 
             val args = mapOf<String, String>(
                 AnalyticsTracker.KEY_SOURCE to navigationSource,
-                AnalyticsTracker.KEY_URL to newSite.url
+                AnalyticsTracker.KEY_URL to newSite.url,
+                AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_WEB
             )
             analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_WOOCOMMERCE_SITE_CREATED, args)
             STORE_FOUND
@@ -105,7 +106,8 @@ class WebViewStoreCreationViewModel @Inject constructor(
                 analyticsTrackerWrapper.track(
                     AnalyticsEvent.SITE_CREATION_FAILED,
                     mapOf(
-                        AnalyticsTracker.KEY_SOURCE to navigationSource
+                        AnalyticsTracker.KEY_SOURCE to navigationSource,
+                        AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_WEB
                     )
                 )
                 ERROR
@@ -144,7 +146,8 @@ class WebViewStoreCreationViewModel @Inject constructor(
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SITE_CREATION_DISMISSED,
             mapOf(
-                AnalyticsTracker.KEY_SOURCE to navigationSource
+                AnalyticsTracker.KEY_SOURCE to navigationSource,
+                AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_WEB
             )
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationViewModel.kt
@@ -90,12 +90,12 @@ class WebViewStoreCreationViewModel @Inject constructor(
             repository.selectSite(newSite)
             triggerEvent(NavigateToNewStore)
 
-            val args = mapOf<String, String>(
+            val properties = mapOf<String, String>(
                 AnalyticsTracker.KEY_SOURCE to navigationSource,
                 AnalyticsTracker.KEY_URL to newSite.url,
                 AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_WEB
             )
-            analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_WOOCOMMERCE_SITE_CREATED, args)
+            analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_WOOCOMMERCE_SITE_CREATED, properties)
             STORE_FOUND
         } else {
             WooLog.d(T.LOGIN, "New site not found, retrying...")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7918 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds tracking for store creation M2 native flow. Tracking plan defined here: pe5sF9-I3-p2#comment-1291

### Testing instructions
Log into the app and kick off store creation flow
- [x] Check `site_creation_step, Properties: {"step":"store_name"` is tracked when first step store name is loaded
- [x] Check `site_creation_dismissed, Properties: {"step":"store_created","flow":"native","source":"login",` is tracked when dismissing flow from store name step
- [x] Proceed with store creation flow and check `site_creation_step, Properties: {"step":"domain_picker"` is tracked for domain step
- [x] Check `site_creation_step, Properties: {"step":"store_summary"` is tracked for store summary step
- [x] Check `Tracked: site_creation_step, Properties: {"step":"plan_purchase",` for plans screen
- [ ] Check `Tracked: site_creation_step, Properties: {"step":"store_created"` is tracked for final step where store is created

Disable native store creation flow. Use flag `NATIVE_STORE_CREATION_FLOW` for this and check the following on store creation flow web: 

- [x] Dismiss the store creation web flow and check new flow property is tracked on the event `Tracked: site_creation_dismissed, Properties: {"source":"login","flow":"web",`
- [x] Create a site and check `Tracked: login_woocommerce_site_created, Properties: {"source":"login","flow":"web",`


