### PR TITLE
[Simplified Login] Various native jetpack install UI updates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -303,9 +303,7 @@ private fun JetpackActivationStep(
 
             if (step.state is JetpackActivationMainViewModel.StepState.Error) {
                 Text(
-                    text = step.state.code?.let {
-                        stringResource(id = R.string.login_jetpack_installation_error)
-                    } ?: stringResource(id = R.string.error_generic),
+                    text = stringResource(id = R.string.login_jetpack_installation_error),
                     color = colorResource(id = R.color.color_error),
                     style = MaterialTheme.typography.caption,
                     fontWeight = FontWeight.SemiBold

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -27,10 +27,8 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -321,29 +319,15 @@ private fun JetpackActivationStep(
 
 @Composable
 private fun ConnectionStepHint(connectionStep: JetpackActivationMainViewModel.ConnectionStep) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_50)),
-    ) {
-        if (connectionStep == JetpackActivationMainViewModel.ConnectionStep.PreConnection) {
-            Icon(
-                imageVector = Icons.Default.Info,
-                contentDescription = null,
-                tint = colorResource(id = R.color.woo_orange_50),
-                modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40))
-            )
-        }
+    // Show no hint for PreConnection step
+    if (connectionStep != JetpackActivationMainViewModel.ConnectionStep.PreConnection) {
         val (text, color) = when (connectionStep) {
-            JetpackActivationMainViewModel.ConnectionStep.PreConnection ->
-                Pair(
-                    R.string.login_jetpack_steps_authorizing_hint,
-                    R.color.woo_orange_50
-                )
             JetpackActivationMainViewModel.ConnectionStep.Validation ->
                 Pair(
                     R.string.login_jetpack_steps_authorizing_validation,
                     R.color.color_on_surface_medium
                 )
-            JetpackActivationMainViewModel.ConnectionStep.Approved ->
+            else ->
                 Pair(
                     R.string.login_jetpack_steps_authorizing_done,
                     R.color.woo_green_50

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -306,7 +306,7 @@ private fun JetpackActivationStep(
             if (step.state is JetpackActivationMainViewModel.StepState.Error) {
                 Text(
                     text = step.state.code?.let {
-                        stringResource(id = R.string.login_jetpack_installation_error_code_template, it)
+                        stringResource(id = R.string.login_jetpack_installation_error)
                     } ?: stringResource(id = R.string.error_generic),
                     color = colorResource(id = R.color.color_error),
                     style = MaterialTheme.typography.caption,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -1,15 +1,12 @@
 package com.woocommerce.android.ui.login.jetpack.sitecredentials
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -22,11 +19,9 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -117,20 +117,6 @@ fun JetpackActivationSiteCredentialsScreen(
                 WCTextButton(onClick = onResetPasswordClick) {
                     Text(text = stringResource(id = R.string.reset_your_password))
                 }
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-                Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))) {
-                    Icon(
-                        imageVector = Icons.Outlined.Info,
-                        contentDescription = null,
-                        tint = colorResource(id = R.color.color_on_surface_medium),
-                        modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40))
-                    )
-                    Text(
-                        text = stringResource(id = R.string.login_jetpack_connection_approval_hint),
-                        style = MaterialTheme.typography.caption,
-                        color = colorResource(id = R.color.color_on_surface_medium)
-                    )
-                }
             }
 
             WCColoredButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -83,7 +84,18 @@ fun JetpackActivationSiteCredentialsScreen(
                     .padding(dimensionResource(id = R.dimen.major_100)),
             ) {
                 JetpackToWooHeader()
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+                val title = if (viewState.isJetpackInstalled) {
+                    R.string.login_jetpack_connect
+                } else {
+                    R.string.login_jetpack_install
+                }
+                Text(
+                    text = stringResource(id = title),
+                    style = MaterialTheme.typography.h4,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                 Text(
                     text = annotatedStringRes(
                         stringResId = if (viewState.isJetpackInstalled) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -149,7 +149,7 @@ private fun Toolbar(
 ) {
     TopAppBar(
         backgroundColor = MaterialTheme.colors.surface,
-        title = { Text(stringResource(id = R.string.login_jetpack_site_credentials_screen_title)) },
+        title = { /* Intentionally empty */ },
         navigationIcon = {
             IconButton(onClick = onCloseClick) {
                 Icon(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -301,7 +301,7 @@
     <string name="login_jetpack_site_credentials_screen_title">Log in to your store</string>
     <string name="login_jetpack_steps_installing">Installing Jetpack</string>
     <string name="login_jetpack_steps_activating">Activating</string>
-    <string name="login_jetpack_steps_authorizing">Authorising connection</string>
+    <string name="login_jetpack_steps_authorizing">Connect store to Jetpack</string>
     <string name="login_jetpack_steps_authorizing_hint">Approval required</string>
     <string name="login_jetpack_steps_authorizing_validation">Validating</string>
     <string name="login_jetpack_steps_authorizing_done">Connected</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -298,7 +298,6 @@
     <string name="login_jetpack_connect">Connect Jetpack</string>
     <string name="login_jetpack_installation_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to install Jetpack.</string>
     <string name="login_jetpack_connection_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to connect Jetpack.</string>
-    <string name="login_jetpack_site_credentials_screen_title">Log in to your store</string>
     <string name="login_jetpack_steps_installing">Installing Jetpack</string>
     <string name="login_jetpack_steps_activating">Activating</string>
     <string name="login_jetpack_steps_authorizing">Connect store to Jetpack</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -304,7 +304,7 @@
     <string name="login_jetpack_steps_authorizing">Authorising connection</string>
     <string name="login_jetpack_steps_authorizing_hint">Approval required</string>
     <string name="login_jetpack_steps_authorizing_validation">Validating</string>
-    <string name="login_jetpack_steps_authorizing_done">Connection approved</string>
+    <string name="login_jetpack_steps_authorizing_done">Connected</string>
     <string name="login_jetpack_steps_done">All done</string>
     <string name="login_jetpack_installation_steps_screen_title">Installing Jetpack</string>
     <string name="login_jetpack_connection_steps_screen_title">Connecting Jetpack</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -301,7 +301,6 @@
     <string name="login_jetpack_steps_installing">Installing Jetpack</string>
     <string name="login_jetpack_steps_activating">Activating</string>
     <string name="login_jetpack_steps_authorizing">Connect store to Jetpack</string>
-    <string name="login_jetpack_steps_authorizing_hint">Approval required</string>
     <string name="login_jetpack_steps_authorizing_validation">Validating</string>
     <string name="login_jetpack_steps_authorizing_done">Connected</string>
     <string name="login_jetpack_steps_done">All done</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -313,6 +313,7 @@
     <string name="login_jetpack_steps_screen_subtitle">Please wait while we connect your store &lt;b&gt;%1$s&lt;/b&gt; with Jetpack.</string>
     <string name="login_jetpack_steps_screen_subtitle_done">Your store &lt;b&gt;%1$s&lt;/b&gt; is now connected to Jetpack.</string>
     <string name="login_jetpack_installation_error_code_template">Error code %1$s</string>
+    <string name="login_jetpack_installation_error">Error</string>
     <string name="login_jetpack_installation_go_to_store_button">Go to store</string>
     <string name="login_jetpack_installation_approve_connection">Approve connection</string>
     <string name="login_jetpack_installation_error_installing">Error installing Jetpack</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -315,7 +315,7 @@
     <string name="login_jetpack_installation_error_code_template">Error code %1$s</string>
     <string name="login_jetpack_installation_error">Error</string>
     <string name="login_jetpack_installation_go_to_store_button">Go to store</string>
-    <string name="login_jetpack_installation_approve_connection">Approve connection</string>
+    <string name="login_jetpack_installation_approve_connection">Connect Jetpack</string>
     <string name="login_jetpack_installation_error_installing">Error installing Jetpack</string>
     <string name="login_jetpack_installation_error_activating">Error activating Jetpack</string>
     <string name="login_jetpack_installation_error_authorizing">Error authorising connection to Jetpack</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -298,7 +298,6 @@
     <string name="login_jetpack_connect">Connect Jetpack</string>
     <string name="login_jetpack_installation_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to install Jetpack.</string>
     <string name="login_jetpack_connection_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to connect Jetpack.</string>
-    <string name="login_jetpack_connection_approval_hint">We will ask for your approval to complete the Jetpack connection.</string>
     <string name="login_jetpack_site_credentials_screen_title">Log in to your store</string>
     <string name="login_jetpack_steps_installing">Installing Jetpack</string>
     <string name="login_jetpack_steps_activating">Activating</string>


### PR DESCRIPTION
# List of changes:

## Jetpack site credentials screen
1. Remove approval disclaimer at the bottom
2. Display title under the icon instead of in the top app bar

| &nbsp; | &nbsp; |
|-|-|
|![image (1)](https://user-images.githubusercontent.com/266376/203947917-73b59a1b-3c54-40d1-902b-8ec4ea871b5c.png)|![image](https://user-images.githubusercontent.com/266376/203947959-fd4e75a9-b70c-4341-b43e-c34357d949fb.png) |

## Jetpack installation steps screen
1. Remove the error code from the install steps (instead just say "Error"). Keep displaying the error code in the full error screen.
2. Remove "Approval required" warning from Authorising step.
3. Reword "Authorising" step to "Connect store to Jetpack" in the steps list
4. In the webview for authorizing, reword title to "Connect Jetpack"
5. Reword "Connection approved" status to just "Connected"

| &nbsp; | &nbsp; |
|-|-|
| ![image (2)](https://user-images.githubusercontent.com/266376/203949235-443b0251-c118-4133-bc10-9396093e2144.png) | ![image (3)](https://user-images.githubusercontent.com/266376/203949230-b9f43718-5737-44a6-a991-961adb4ca2b0.png) |
| ![image (4)](https://user-images.githubusercontent.com/266376/203949228-3079cb2b-b39d-4931-b4e6-13a311ad8cbf.png) | ![image (5)](https://user-images.githubusercontent.com/266376/203949227-3d25dde3-42a0-40ab-8fb3-c389a065017a.png) |
| ![image (6)](https://user-images.githubusercontent.com/266376/203949223-d227ce67-cd54-413b-aaaf-aed1c463ef1d.png) | ![image (7)](https://user-images.githubusercontent.com/266376/203949214-be0191c3-eecc-49e8-983d-7987c7af40a6.png) |

