### PR TITLE
IAP: Removes check on isPurchaseInProgress

### DIFF
--- a/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
+++ b/libs/iap/src/main/java/com/woocommerce/android/iap/internal/planpurchase/IAPPurchaseWPComPlanActionsImpl.kt
@@ -26,9 +26,6 @@ internal class IAPPurchaseWPComPlanActionsImpl(
     private val remoteSiteId: Long,
     private val iapProduct: IAPProduct = IAPProduct.WPPremiumPlanTesting
 ) : PurchaseWPComPlanActions {
-    @Volatile
-    private var isPurchaseInProgress = false
-
     init {
         iapManager.connect()
     }
@@ -49,11 +46,7 @@ internal class IAPPurchaseWPComPlanActionsImpl(
     }
 
     override suspend fun purchaseWPComPlan(activityWrapper: IAPActivityWrapper) {
-        if (isPurchaseInProgress) return
-
-        isPurchaseInProgress = true
         purchaseWpComPlanHandler.purchaseWPComPlan(activityWrapper, iapProduct, remoteSiteId)
-        isPurchaseInProgress = false
     }
 
     override suspend fun fetchWPComPlanProduct(): WPComProductResult {

--- a/libs/iap/src/test/kotlin/com/woocommerce/android/iap/pub/IAPPurchaseWPComPlanActionsTest.kt
+++ b/libs/iap/src/test/kotlin/com/woocommerce/android/iap/pub/IAPPurchaseWPComPlanActionsTest.kt
@@ -24,8 +24,6 @@ import com.woocommerce.android.iap.pub.model.WPComProductResult
 import com.woocommerce.android.iap.pub.model.WPComPurchaseResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -33,8 +31,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
@@ -407,26 +403,6 @@ class IAPPurchaseWPComPlanActionsTest {
             IAPError.Billing.ServiceDisconnected::class.java
         )
         assertThat((result.errorType as IAPError.Billing).debugMessage).isEqualTo(debugMessage)
-    }
-
-    @Test
-    fun `given double invocation, when purchasing plan, then only one proceeds`() = runTest {
-        // GIVEN
-        setupPurchaseQuery(
-            responseCode = BillingClient.BillingResponseCode.OK,
-            listOf()
-        )
-
-        testPreparationHelper.setupQueryProductDetails(responseCode = BillingClient.BillingResponseCode.OK)
-
-        // WHEN
-        awaitAll(
-            async { sut.purchaseWPComPlan(activityWrapperMock) },
-            async { sut.purchaseWPComPlan(activityWrapperMock) }
-        )
-
-        // THEN
-        verify(billingClientMock, times(1)).queryPurchasesAsync(any())
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7953
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removed check on double invocation of the purchase flow. It doesn't handle much because the time of starting the IAP activity is long and double invocation is still possible, while this check brings complexity. This should be handled on the client side by locking the button while purchasing in progress

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Probably nothing to test here
