### PR TITLE
[Simplified login] Improve animation to error state during Jetpack Installation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/components/JetpackToWoo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/components/JetpackToWoo.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.login.jetpack.components
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/components/JetpackToWoo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/components/JetpackToWoo.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.login.jetpack.components
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -31,19 +33,21 @@ fun JetpackToWooHeader(
             modifier = logoModifier.padding(dimensionResource(id = R.dimen.minor_50))
         )
         Image(painter = painterResource(id = R.drawable.ic_connecting), contentDescription = null)
-        if (!isError) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_woo_bubble),
-                contentDescription = null,
-                modifier = logoModifier.padding(dimensionResource(id = R.dimen.minor_50))
-            )
-        } else {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_gridicons_notice),
-                contentDescription = null,
-                tint = colorResource(id = R.color.color_error),
-                modifier = logoModifier
-            )
+        Crossfade(targetState = isError) { isError ->
+            if (!isError) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_woo_bubble),
+                    contentDescription = null,
+                    modifier = logoModifier.padding(dimensionResource(id = R.dimen.minor_50))
+                )
+            } else {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_gridicons_notice),
+                    contentDescription = null,
+                    tint = colorResource(id = R.color.color_error),
+                    modifier = logoModifier
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -57,6 +57,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.annotatedStringRes
@@ -420,12 +422,11 @@ private fun Toolbar(
     )
 }
 
-@Composable
-@Preview
-private fun JetpackActivationMainScreenPreview() {
-    WooThemeWithBackground {
-        JetpackActivationMainScreen(
-            viewState = JetpackActivationMainViewModel.ViewState.ProgressViewState(
+@Suppress("MagicNumber")
+private class ViewStatePreviewProvider : PreviewParameterProvider<JetpackActivationMainViewModel.ViewState> {
+    override val values: Sequence<JetpackActivationMainViewModel.ViewState>
+        get() = sequenceOf(
+            JetpackActivationMainViewModel.ViewState.ProgressViewState(
                 siteUrl = "reallyniceshirts.com",
                 isJetpackInstalled = false,
                 steps = listOf(
@@ -451,20 +452,22 @@ private fun JetpackActivationMainScreenPreview() {
                     )
                 ),
                 connectionStep = JetpackActivationMainViewModel.ConnectionStep.PreConnection
+            ),
+            JetpackActivationMainViewModel.ViewState.ErrorViewState(
+                stepType = JetpackActivationMainViewModel.StepType.Installation,
+                errorCode = 503
             )
         )
-    }
 }
 
 @Composable
 @Preview
-private fun JetpackActivationErrorStatePreview() {
+private fun JetpackActivationPreview(
+    @PreviewParameter(provider = ViewStatePreviewProvider::class) state: JetpackActivationMainViewModel.ViewState
+) {
     WooThemeWithBackground {
         JetpackActivationMainScreen(
-            viewState = JetpackActivationMainViewModel.ViewState.ErrorViewState(
-                stepType = JetpackActivationMainViewModel.StepType.Installation,
-                errorCode = 503
-            )
+            viewState = state
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
+import kotlinx.coroutines.delay
 
 private const val FORBIDDEN_ERROR_CODE = 403
 
@@ -67,6 +68,7 @@ fun JetpackActivationMainScreen(viewModel: JetpackActivationMainViewModel) {
     }
 }
 
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun JetpackActivationMainScreen(
     viewState: JetpackActivationMainViewModel.ViewState,
@@ -78,26 +80,32 @@ fun JetpackActivationMainScreen(
     Scaffold(
         topBar = { Toolbar(onCloseClick) }
     ) { paddingValues ->
-        val modifier = Modifier
-            .background(MaterialTheme.colors.surface)
-            .fillMaxSize()
-            .padding(paddingValues)
-            .padding(dimensionResource(id = R.dimen.major_100))
-            .verticalScroll(rememberScrollState())
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(dimensionResource(id = R.dimen.major_100))
+                .verticalScroll(rememberScrollState())
+        ) {
+            JetpackToWooHeader(isError = viewState is JetpackActivationMainViewModel.ViewState.ErrorViewState)
 
-        when (viewState) {
-            is JetpackActivationMainViewModel.ViewState.ProgressViewState -> ProgressState(
-                viewState = viewState,
-                onContinueClick = onContinueClick,
-                modifier = modifier
-            )
-            is JetpackActivationMainViewModel.ViewState.ErrorViewState -> ErrorState(
-                viewState = viewState,
-                onGetHelpClick = onGetHelpClick,
-                onRetryClick = onRetryClick,
-                onCancelClick = onCloseClick,
-                modifier = modifier
-            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+
+            when (viewState) {
+                is JetpackActivationMainViewModel.ViewState.ProgressViewState -> ProgressState(
+                    viewState = viewState,
+                    onContinueClick = onContinueClick,
+                    modifier = Modifier.weight(1f)
+                )
+                is JetpackActivationMainViewModel.ViewState.ErrorViewState -> ErrorState(
+                    viewState = viewState,
+                    onGetHelpClick = onGetHelpClick,
+                    onRetryClick = onRetryClick,
+                    onCancelClick = onCloseClick,
+                    modifier = Modifier.weight(1f)
+                )
+            }
         }
     }
 }
@@ -106,13 +114,11 @@ fun JetpackActivationMainScreen(
 private fun ProgressState(
     viewState: JetpackActivationMainViewModel.ViewState.ProgressViewState,
     onContinueClick: () -> Unit,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
     ) {
-        JetpackToWooHeader()
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
         val title = if (viewState.isDone) {
             if (viewState.isJetpackInstalled) R.string.login_jetpack_connection_steps_screen_title_done
             else R.string.login_jetpack_installation_steps_screen_title_done
@@ -163,13 +169,11 @@ private fun ErrorState(
     onGetHelpClick: () -> Unit,
     onRetryClick: () -> Unit,
     onCancelClick: () -> Unit,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
     ) {
-        JetpackToWooHeader(isError = true)
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
         val title = when (viewState.stepType) {
             JetpackActivationMainViewModel.StepType.Installation -> R.string.login_jetpack_installation_error_installing
             JetpackActivationMainViewModel.StepType.Activation -> R.string.login_jetpack_installation_error_activating

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -57,8 +57,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.annotatedStringRes
@@ -467,6 +465,56 @@ private fun JetpackActivationErrorStatePreview() {
                 stepType = JetpackActivationMainViewModel.StepType.Installation,
                 errorCode = 503
             )
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun JetpackActivationProgressToErrorPreview() {
+    val defaultState = JetpackActivationMainViewModel.ViewState.ProgressViewState(
+        siteUrl = "reallyniceshirts.com",
+        isJetpackInstalled = false,
+        steps = listOf(
+            JetpackActivationMainViewModel.Step(
+                type = JetpackActivationMainViewModel.StepType.Installation,
+                state = JetpackActivationMainViewModel.StepState.Success
+            ),
+            JetpackActivationMainViewModel.Step(
+                type = JetpackActivationMainViewModel.StepType.Activation,
+                state = JetpackActivationMainViewModel.StepState.Error(503)
+            ),
+            JetpackActivationMainViewModel.Step(
+                type = JetpackActivationMainViewModel.StepType.Connection,
+                state = JetpackActivationMainViewModel.StepState.Idle
+            ),
+            JetpackActivationMainViewModel.Step(
+                type = JetpackActivationMainViewModel.StepType.Done,
+                state = JetpackActivationMainViewModel.StepState.Idle
+            )
+        ),
+        connectionStep = JetpackActivationMainViewModel.ConnectionStep.PreConnection
+    )
+    val errorState = JetpackActivationMainViewModel.ViewState.ErrorViewState(
+        stepType = JetpackActivationMainViewModel.StepType.Activation,
+        errorCode = 503
+    )
+
+    var state: JetpackActivationMainViewModel.ViewState by remember { mutableStateOf(defaultState) }
+    var retryTrigger by remember { mutableStateOf(false) }
+
+    LaunchedEffect(retryTrigger) {
+        delay(1000)
+        state = errorState
+    }
+
+    WooThemeWithBackground {
+        JetpackActivationMainScreen(
+            viewState = state,
+            onRetryClick = {
+                state = defaultState
+                retryTrigger = !retryTrigger
+            }
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7952 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR simply improves the transition to the error state in the Jetpack installation flow.

### Testing instructions
You can either simulate an error (Airplane mode or using Charles Proxy), or you can simply launch the preview `JetpackActivationProgressToErrorPreview` on your device, it allows switching between the normal and error states.

### Images/gif
| Before | After |
| --- | --- |
|  <video src=https://user-images.githubusercontent.com/1657201/204022005-c3539f5a-4d9c-450a-ac90-cbd74a06ead2.mp4 /> | <video src="https://user-images.githubusercontent.com/1657201/204020170-4ddbddff-0d65-4dd4-bc7f-0343efaac722.mp4" /> |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
