### PR TITLE
feat: fetch all variations before generating candidates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/GenerateVariationPickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/GenerateVariationPickerDialog.kt
@@ -2,11 +2,8 @@ package com.woocommerce.android.ui.products.variations
 
 import android.content.Context
 import android.view.LayoutInflater
-import android.view.View
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogGenerateVariationsBinding
-import com.woocommerce.android.ui.products.variations.domain.VariationCandidate
 
 class GenerateVariationPickerDialog(context: Context) : BottomSheetDialog(context) {
     private var binding: DialogGenerateVariationsBinding =
@@ -15,7 +12,7 @@ class GenerateVariationPickerDialog(context: Context) : BottomSheetDialog(contex
     init {
         setContentView(binding.root)
         binding.allVariation.setOnClickListener {
-            listener?.onGenerateAllVariations(variationCandidates)
+            listener?.onGenerateAllVariations()
             dismiss()
         }
         binding.newVariation.setOnClickListener {
@@ -24,19 +21,10 @@ class GenerateVariationPickerDialog(context: Context) : BottomSheetDialog(contex
         }
     }
 
-    var variationCandidates: List<VariationCandidate> = emptyList()
-        set(value) {
-            field = value
-            binding.allVariation.visibility = if (variationCandidates.isNotEmpty()) View.VISIBLE else View.GONE
-            if (variationCandidates.isNotEmpty()) {
-                binding.allVariationTitle.text = context.getString(R.string.variation_add_all, variationCandidates.size)
-            }
-        }
-
     var listener: GenerateVariationPickerDialogListener? = null
 
     interface GenerateVariationPickerDialogListener {
-        fun onGenerateAllVariations(variationCandidates: List<VariationCandidate>)
+        fun onGenerateAllVariations()
         fun onGenerateNewVariation()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -48,6 +48,7 @@ import com.woocommerce.android.ui.products.variations.VariationListViewModel.Sho
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowGenerateVariationsError
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowGenerateVariationsError.LimitExceeded
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowGenerateVariationsError.NetworkError
+import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowGenerateVariationsError.NoCandidates
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowVariationDetail
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowVariationDialog
 import com.woocommerce.android.ui.products.variations.domain.GenerateVariationCandidates
@@ -215,9 +216,9 @@ class VariationListFragment :
                 is ShowBulkUpdateLimitExceededWarning -> showBulkUpdateLimitExceededWarning()
                 is ShowGenerateVariationConfirmation -> showGenerateVariationConfirmation(event.variationCandidates)
                 is ShowGenerateVariationsError -> handleGenerateVariationError(event)
+                is ShowVariationDialog -> showAddVariationSelectDialog()
                 is ExitWithResult<*> -> navigateBackWithResult(KEY_VARIATION_LIST_RESULT, event.data)
                 is Exit -> activity?.onBackPressedDispatcher?.onBackPressed()
-                is ShowVariationDialog -> showAddVariationSelectDialog(event.variationCandidates)
             }
         }
     }
@@ -241,6 +242,7 @@ class VariationListFragment :
         when (event) {
             is LimitExceeded -> showGenerateVariationsLimitExceeded(event.variationCandidatesSize)
             NetworkError -> showGenerateVariationsNetworkError()
+            NoCandidates -> showNoVariationCandidatesError()
         }
     }
 
@@ -253,6 +255,16 @@ class VariationListFragment :
                 dialogInterface.dismiss()
             }
             .setNegativeButton(android.R.string.cancel) { dialogInterface, _ ->
+                dialogInterface.dismiss()
+            }
+            .show()
+    }
+
+    private fun showNoVariationCandidatesError() {
+        MaterialAlertDialogBuilder(requireActivity())
+            .setTitle(R.string.variations_bulk_creation_no_candidates_title)
+            .setMessage(R.string.variations_bulk_creation_no_candidates_message)
+            .setPositiveButton(android.R.string.ok) { dialogInterface, _ ->
                 dialogInterface.dismiss()
             }
             .show()
@@ -282,12 +294,11 @@ class VariationListFragment :
             .show()
     }
 
-    private fun showAddVariationSelectDialog(variationCandidates: List<VariationCandidate>) {
+    private fun showAddVariationSelectDialog() {
         val dialog = generateVariationPickerDialog ?: GenerateVariationPickerDialog(requireContext()).apply {
             listener = this@VariationListFragment
         }
         dialog.run {
-            this.variationCandidates = variationCandidates
             show()
         }
     }
@@ -405,8 +416,8 @@ class VariationListFragment :
         }
     }
 
-    override fun onGenerateAllVariations(variationCandidates: List<VariationCandidate>) {
-        viewModel.onAddAllVariationsClicked(variationCandidates)
+    override fun onGenerateAllVariations() {
+        viewModel.onAddAllVariationsClicked()
     }
 
     override fun onGenerateNewVariation() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -120,8 +120,8 @@ class VariationListViewModel @Inject constructor(
             triggerEvent(ShowBulkUpdateLimitExceededWarning)
         } else {
             viewState = viewState.copy(isBulkUpdateProgressDialogShown = true)
-            viewModelScope.launch(dispatchers.io) {
-                val variations = getAllVariations(remoteProductId)
+            viewModelScope.launch {
+                val variations = variationRepository.getAllVariations(remoteProductId)
                 withContext(dispatchers.main) {
                     triggerEvent(ShowBulkUpdateAttrPicker(variations))
                     viewState = viewState.copy(isBulkUpdateProgressDialogShown = false)
@@ -262,14 +262,6 @@ class VariationListViewModel @Inject constructor(
             isLoadingMore = false
         )
     }
-
-    private suspend fun getAllVariations(remoteProductId: Long): Collection<ProductVariation> {
-        while (variationRepository.canLoadMoreProductVariations) {
-            variationRepository.fetchProductVariations(remoteProductId, true)
-        }
-        return variationRepository.getProductVariationList(remoteProductId)
-    }
-
     private fun combineData(variations: List<ProductVariation>): List<ProductVariation> {
         val currencyCode = variationRepository.getCurrencyCode()
         variations.map { variation ->
@@ -291,20 +283,36 @@ class VariationListViewModel @Inject constructor(
     }
 
     fun onAddVariationsClicked() {
-        val product = viewState.parentProduct ?: return
-        triggerEvent(ShowVariationDialog(generateVariationCandidates.invoke(product)))
+        triggerEvent(ShowVariationDialog)
     }
 
-    fun onAddAllVariationsClicked(variationCandidates: List<VariationCandidate>) {
+    fun onAddAllVariationsClicked() {
         tracker.track(AnalyticsEvent.PRODUCT_VARIATION_GENERATION_REQUESTED)
-        if (variationCandidates.size <= GenerateVariationCandidates.VARIATION_CREATION_LIMIT) {
-            triggerEvent(ShowGenerateVariationConfirmation(variationCandidates))
-        } else {
-            tracker.track(
-                stat = AnalyticsEvent.PRODUCT_VARIATION_GENERATION_LIMIT_REACHED,
-                properties = mapOf(AnalyticsTracker.KEY_VARIATIONS_COUNT to variationCandidates.size)
-            )
-            triggerEvent(ShowGenerateVariationsError.LimitExceeded(variationCandidates.size))
+
+        launch {
+            viewState = viewState.copy(isBulkUpdateProgressDialogShown = true)
+            variationRepository.getAllVariations(remoteProductId)
+            viewState = viewState.copy(isBulkUpdateProgressDialogShown = false)
+
+            val variationCandidates = viewState.parentProduct?.let {
+                generateVariationCandidates.invoke(it)
+            }.orEmpty()
+
+            when {
+                variationCandidates.isEmpty() -> {
+                    triggerEvent(ShowGenerateVariationsError.NoCandidates)
+                }
+                variationCandidates.size <= GenerateVariationCandidates.VARIATION_CREATION_LIMIT -> {
+                    triggerEvent(ShowGenerateVariationConfirmation(variationCandidates))
+                }
+                else -> {
+                    tracker.track(
+                        stat = AnalyticsEvent.PRODUCT_VARIATION_GENERATION_LIMIT_REACHED,
+                        properties = mapOf(AnalyticsTracker.KEY_VARIATIONS_COUNT to variationCandidates.size)
+                    )
+                    triggerEvent(ShowGenerateVariationsError.LimitExceeded(variationCandidates.size))
+                }
+            }
         }
     }
 
@@ -375,12 +383,13 @@ class VariationListViewModel @Inject constructor(
      */
     object ShowBulkUpdateLimitExceededWarning : Event()
 
-    data class ShowVariationDialog(val variationCandidates: List<VariationCandidate>) : Event()
+    object ShowVariationDialog : Event()
 
     data class ShowGenerateVariationConfirmation(val variationCandidates: List<VariationCandidate>) : Event()
 
     sealed class ShowGenerateVariationsError : Event() {
         data class LimitExceeded(val variationCandidatesSize: Int) : ShowGenerateVariationsError()
         object NetworkError : ShowGenerateVariationsError()
+        object NoCandidates : ShowGenerateVariationsError()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationRepository.kt
@@ -132,6 +132,13 @@ class VariationRepository @Inject constructor(
         }
     }
 
+    suspend fun getAllVariations(remoteProductId: Long): Collection<ProductVariation> = withContext(dispatchers.io) {
+        while (canLoadMoreProductVariations) {
+            fetchProductVariations(remoteProductId, true)
+        }
+        getProductVariationList(remoteProductId)
+    }
+
     private fun WooResult<WCProductVariationModel>.handleVariationCreateResult(
         product: Product
     ) = if (isError) {

--- a/WooCommerce/src/main/res/layout/dialog_generate_variations.xml
+++ b/WooCommerce/src/main/res/layout/dialog_generate_variations.xml
@@ -8,15 +8,15 @@
         style="@style/Woo.Card.Header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColor="@color/color_on_surface_medium"
-        android:text="@string/product_detail_add_variations"/>
+        android:text="@string/product_detail_add_variations"
+        android:textColor="@color/color_on_surface_medium" />
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/new_variation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:background="?selectableItemBackground"
+        android:orientation="vertical"
         android:paddingBottom="@dimen/major_100">
 
         <com.google.android.material.textview.MaterialTextView
@@ -25,8 +25,8 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_100"
-            android:textColor="@color/color_on_surface_high_selector"
-            android:text="@string/variation_add_new" />
+            android:text="@string/variation_add_new"
+            android:textColor="@color/color_on_surface_high_selector" />
 
         <com.google.android.material.textview.MaterialTextView
             style="@style/Woo.Card.Body"
@@ -36,8 +36,8 @@
             android:ellipsize="end"
             android:lineSpacingExtra="@dimen/minor_25"
             android:paddingTop="@dimen/minor_50"
-            android:textColor="@color/color_on_surface_medium_selector"
-            android:text="@string/variation_add_new_description" />
+            android:text="@string/variation_add_new_description"
+            android:textColor="@color/color_on_surface_medium_selector" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 
     <View
@@ -49,8 +49,8 @@
         android:id="@+id/all_variation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:background="?selectableItemBackground"
+        android:orientation="vertical"
         android:paddingBottom="@dimen/major_100">
 
         <com.google.android.material.textview.MaterialTextView
@@ -60,7 +60,8 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_100"
-            android:textColor="@color/color_on_surface_high_selector"/>
+            android:text="@string/variation_add_all"
+            android:textColor="@color/color_on_surface_high_selector" />
 
         <com.google.android.material.textview.MaterialTextView
             style="@style/Woo.Card.Body"
@@ -70,7 +71,7 @@
             android:ellipsize="end"
             android:lineSpacingExtra="@dimen/minor_25"
             android:paddingTop="@dimen/minor_50"
-            android:textColor="@color/color_on_surface_medium_selector"
-            android:text="@string/variation_add_all_description" />
+            android:text="@string/variation_add_all_description"
+            android:textColor="@color/color_on_surface_medium_selector" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1659,7 +1659,7 @@
     <string name="variations_bulk_limit_exceeded_button_ok">OK</string>
     <string name="variation_add_new">Add new variation</string>
     <string name="variation_add_new_description">Create one new variation. Manually set which attributes belong to the variable product.</string>
-    <string name="variation_add_all">Generate all %1$d variations</string>
+    <string name="variation_add_all">Generate all variations</string>
     <string name="variation_add_all_description">Creates variations for all combinations of your attributes.</string>
 
     <!--
@@ -1694,6 +1694,8 @@
     <string name="variations_bulk_creation_confirmation_title">Generate all variations?</string>
     <string name="variations_bulk_creation_confirmation_message">This will create a new variation for each and every possible combination of variation attributes (%1$d variations).</string>
     <string name="variations_bulk_creation_progress_title">Generating variations</string>
+    <string name="variations_bulk_creation_no_candidates_title">No variations to generate</string>
+    <string name="variations_bulk_creation_no_candidates_message">All variations are already generated.</string>
 
     <!--
         Product images

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
@@ -162,10 +162,11 @@ class VariationListViewModelTest : BaseUnitTest() {
         createViewModel()
         val events = mutableListOf<MultiLiveEvent.Event>()
         viewModel.event.observeForever { event -> events.add(event) }
+        whenever(generateVariationCandidates(product)).thenReturn(variationCandidates)
 
         // when
         viewModel.start()
-        viewModel.onAddAllVariationsClicked(variationCandidates)
+        viewModel.onAddAllVariationsClicked()
 
         // then
         events
@@ -191,10 +192,11 @@ class VariationListViewModelTest : BaseUnitTest() {
         createViewModel()
         val events = mutableListOf<MultiLiveEvent.Event>()
         viewModel.event.observeForever { event -> events.add(event) }
+        whenever(generateVariationCandidates(product)).thenReturn(variationCandidatesAboveLimit)
 
         // when
         viewModel.start()
-        viewModel.onAddAllVariationsClicked(variationCandidatesAboveLimit)
+        viewModel.onAddAllVariationsClicked()
 
         // then
         events
@@ -292,10 +294,11 @@ class VariationListViewModelTest : BaseUnitTest() {
             }
         doReturn(variations).whenever(variationRepository).getProductVariationList(productRemoteId)
         createViewModel()
-        viewModel.start()
+        whenever(generateVariationCandidates(product)).thenReturn(exceedVariationsLimit)
 
         // When AddAllVariations is Clicked
-        viewModel.onAddAllVariationsClicked(exceedVariationsLimit)
+        viewModel.start()
+        viewModel.onAddAllVariationsClicked()
 
         // Then variation request is tracked
         verify(tracker).track(AnalyticsEvent.PRODUCT_VARIATION_GENERATION_REQUESTED)
@@ -315,10 +318,11 @@ class VariationListViewModelTest : BaseUnitTest() {
             }
         doReturn(variations).whenever(variationRepository).getProductVariationList(productRemoteId)
         createViewModel()
-        viewModel.start()
+        whenever(generateVariationCandidates(product)).thenReturn(reachVariationsLimit)
 
         // When AddAllVariations is Clicked
-        viewModel.onAddAllVariationsClicked(reachVariationsLimit)
+        viewModel.start()
+        viewModel.onAddAllVariationsClicked()
 
         // Then variation request is tracked
         verify(tracker).track(AnalyticsEvent.PRODUCT_VARIATION_GENERATION_REQUESTED)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7957 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new behaviour for "Generate all combinations of variations". Just before generating variation candidates, the app now will fetch all variations from the core. This asserts that we'll be preparing variation candidates based on the correct, remote state and not based on the local cache state.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open a product that can have more than 25 variations. It can already have some variations but doesn't have to.
2. Tap on "Add variation."
3. Tap on "Generate all variations."
4. Wait until all variations are generated
5. Repeat steps 2 and 3
6. **Assert there's "No variations to generate" message"**

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5845095/204314917-ebeb8eca-0539-417e-b7cf-24427f6feddb.mov


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
