### PR TITLE
Fix: Navigation from `Products > Filter > Filter options` "Show products" button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -95,7 +95,7 @@ class ProductFilterOptionListFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ExitWithResult<*> -> {
-                    navigateBackWithResult(ProductListFragment.PRODUCT_FILTER_RESULT_KEY, event.data)
+                    navigateBackWithResult(ProductListFragment.PRODUCT_FILTER_RESULT_KEY, event.data, R.id.products)
                 }
                 else -> event.isHandled = false
             }


### PR DESCRIPTION
Fix for navigating from Products filter options "Show products" button

Clicking "Show products" on filters' subpages, eg. `Products > Filters > Category > Categories` page, will now redirect to the main products page.

Previously this button would just navigate back (pop fragments back stack) which was confusing and not expected.

Closes: https://github.com/woocommerce/woocommerce-android/issues/7710

### Testing instructions
1. Go to: Products
2. Click Filters and choose a filter. You'll be redirected to FilterOptions Fragment.
3. Click "Show Products" at the bottom and verify it redirects to the main Products page.

Try it out with various filters and navigation scenarios.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
