### PR TITLE
[Tooling] Report Firebase Test Failures as Buildkite Annotations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'nokogiri'
 
 ### Fastlane Plugins
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.1'
 #gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 #gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: '…'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (6.0.0)
+    fastlane-plugin-wpmreleasetoolkit (6.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)
@@ -124,7 +124,6 @@ GEM
       diffy (~> 3.3)
       git (~> 1.3)
       google-cloud-storage (~> 1.31)
-      jsonlint (~> 0.3)
       nokogiri (~> 1.11)
       octokit (~> 4.18)
       parallel (~> 1.14)
@@ -182,9 +181,6 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.6.1)
     json (2.6.2)
-    jsonlint (0.3.0)
-      oj (~> 3)
-      optimist (~> 3)
     jwt (2.5.0)
     memoist (0.16.2)
     mini_magick (4.11.0)
@@ -201,8 +197,6 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    oj (3.13.23)
-    optimist (3.0.1)
     options (2.3.2)
     optparse (0.1.1)
     os (1.1.4)
@@ -274,7 +268,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 6.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 6.1)
   nokogiri
   rmagick (~> 4.1)
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/performance/WooRequestFormatterTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/performance/WooRequestFormatterTest.kt
@@ -18,7 +18,7 @@ class WooRequestFormatterTest {
         )
 
         assertThat(result).isEqualTo(
-            "https://test.com/?path=/wc/v2/shipment-trackings/&_method=get&json=truezzz" // Forced test failure to test FTL failure reporting
+            "https://test.com/?path=/wc/v2/shipment-trackings/&_method=get&json=true"
         )
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/performance/WooRequestFormatterTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/performance/WooRequestFormatterTest.kt
@@ -18,7 +18,7 @@ class WooRequestFormatterTest {
         )
 
         assertThat(result).isEqualTo(
-            "https://test.com/?path=/wc/v2/shipment-trackings/&_method=get&json=true"
+            "https://test.com/?path=/wc/v2/shipment-trackings/&_method=get&json=truezzz" // Forced test failure to test FTL failure reporting
         )
     }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -741,7 +741,7 @@ platform :android do
       version: 30,
       test_apk_path: File.join(apk_dir, 'androidTest', 'vanilla', 'debug', 'WooCommerce-vanilla-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'vanilla', 'debug', 'WooCommerce-vanilla-debug.apk'),
-      test_targets: 'notPackage com.woocommerce.android.e2e.tests.screenshot',
+      test_targets: 'package com.woocommerce.android.performance', # 'notPackage com.woocommerce.android.e2e.tests.screenshot',
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests'),
       crash_on_test_failure: false
      )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -734,7 +734,7 @@ platform :android do
 
     apk_dir = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'build', 'outputs', 'apk')
 
-    android_firebase_test(
+    test_succeeded = android_firebase_test(
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
       model: 'Pixel2.arm',
@@ -742,8 +742,19 @@ platform :android do
       test_apk_path: File.join(apk_dir, 'androidTest', 'vanilla', 'debug', 'WooCommerce-vanilla-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'vanilla', 'debug', 'WooCommerce-vanilla-debug.apk'),
       test_targets: 'notPackage com.woocommerce.android.e2e.tests.screenshot',
-      results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
+      results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests'),
+      crash_on_test_failure: false
      )
+
+     annotation_ctx = 'firebase-test-woocommerce-vanilla-debug'
+     if test_succeeded
+      sh("buildkite-agent annotation remove --context '#{annotation_ctx}' || true") if is_ci?
+     else
+      details_url = lane_context[SharedValues::FIREBASE_TEST_MORE_DETAILS_URL]
+      message = "Firebase Tests failed. Failure details can be seen [here in Firebase Console](#{details_url})"
+      sh('buildkite-agent', 'annotate', message, '--style', 'error', '--context', annotation_ctx) if is_ci?
+      UI.test_failure!(message)
+    end
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -741,7 +741,7 @@ platform :android do
       version: 30,
       test_apk_path: File.join(apk_dir, 'androidTest', 'vanilla', 'debug', 'WooCommerce-vanilla-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'vanilla', 'debug', 'WooCommerce-vanilla-debug.apk'),
-      test_targets: 'package com.woocommerce.android.performance', # 'notPackage com.woocommerce.android.e2e.tests.screenshot',
+      test_targets: 'notPackage com.woocommerce.android.e2e.tests.screenshot',
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests'),
       crash_on_test_failure: false
      )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -744,12 +744,12 @@ platform :android do
       test_targets: 'notPackage com.woocommerce.android.e2e.tests.screenshot',
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests'),
       crash_on_test_failure: false
-     )
+    )
 
-     annotation_ctx = 'firebase-test-woocommerce-vanilla-debug'
-     if test_succeeded
+    annotation_ctx = 'firebase-test-woocommerce-vanilla-debug'
+    if test_succeeded
       sh("buildkite-agent annotation remove --context '#{annotation_ctx}' || true") if is_ci?
-     else
+    else
       details_url = lane_context[SharedValues::FIREBASE_TEST_MORE_DETAILS_URL]
       message = "Firebase Tests failed. Failure details can be seen [here in Firebase Console](#{details_url})"
       sh('buildkite-agent', 'annotate', message, '--style', 'error', '--context', annotation_ctx) if is_ci?


### PR DESCRIPTION
### What

This PR catches test failures happening when running Instrumented Tests in Firebase, and add a Buildkite annotation at the top of the failed build so it's way easier to jump to the details of the test failure on Firebase Console.

This is a reproduction of the similar changes that were done in https://github.com/wordpress-mobile/WordPress-Android/pull/17581

### How it looks

[This is how the annotation appears on Buildkite](https://buildkite.com/automattic/woocommerce-android/builds/8193) if an Instrumented Test failure occurs:

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/216089/205111947-8929410d-4083-472e-9511-508d6b72a4ce.png">

### To Test

Observe that the intentional failure that I've forced to happen in 2065505ea7d7677b37c0d8ff35d251210140de22 indeed [generated a Buildkite annotation](https://buildkite.com/automattic/woocommerce-android/builds/8193) (see screenshot above) — while a [successful Instrumented Tests run like the one at the HEAD of this branch](https://buildkite.com/automattic/woocommerce-android/builds/latest?branch=tooling/firebase-test-failure-annotation) doesn't.
