### PR TITLE
Reinitialize simulated reader upon update frequency change

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
@@ -63,6 +63,7 @@ class MockCardReaderManagerModule {
             get() = emptyFlow()
 
         override fun initialize(updateFrequency: CardReaderManager.SimulatorUpdateFrequency) {}
+        override fun initializeOnUpdateFrequencyChange(updateFrequency: CardReaderManager.SimulatorUpdateFrequency) {}
 
         override fun discoverReaders(
             isSimulated: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -99,7 +99,7 @@ class DeveloperOptionsViewModel @Inject constructor(
     private fun onUpdateSimulatedReaderClicked() {
         triggerEvent(
             DeveloperOptionsEvents.ShowUpdateOptionsDialog(
-                DeveloperOptionsViewState.UpdateOptions.values().toList(),
+                UpdateOptions.values().toList(),
                 developerOptionsRepository.getUpdateSimulatedReaderOption()
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -112,7 +112,7 @@ class DeveloperOptionsViewModel @Inject constructor(
         cardReaderManager.initializeOnUpdateFrequencyChange(mapUpdateOptions(selectedOption))
     }
 
-    private fun mapUpdateOptions(updateFrequency: UpdateOptions): CardReaderManager.SimulatorUpdateFrequency  {
+    private fun mapUpdateOptions(updateFrequency: UpdateOptions): CardReaderManager.SimulatorUpdateFrequency {
         return when (updateFrequency) {
             UpdateOptions.ALWAYS -> CardReaderManager.SimulatorUpdateFrequency.ALWAYS
             UpdateOptions.NEVER -> CardReaderManager.SimulatorUpdateFrequency.NEVER

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 class DeveloperOptionsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val developerOptionsRepository: DeveloperOptionsRepository,
-    private val cardReaderManager: CardReaderManager
+    private val cardReaderManager: CardReaderManager,
 ) : ScopedViewModel(savedState) {
 
     private val _viewState = MutableLiveData(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -109,6 +109,9 @@ class DeveloperOptionsViewModel @Inject constructor(
 
     fun onUpdateReaderOptionChanged(selectedOption: UpdateOptions) {
         developerOptionsRepository.updateSimulatedReaderOption(selectedOption)
+        if (!cardReaderManager.initialized) {
+            cardReaderManager.initialize(mapUpdateOptions(selectedOption))
+        }
         cardReaderManager.initializeOnUpdateFrequencyChange(mapUpdateOptions(selectedOption))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 class DeveloperOptionsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val developerOptionsRepository: DeveloperOptionsRepository,
-    private val cardReaderManager: CardReaderManager,
+    private val cardReaderManager: CardReaderManager
 ) : ScopedViewModel(savedState) {
 
     private val _viewState = MutableLiveData(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -108,11 +108,10 @@ class DeveloperOptionsViewModel @Inject constructor(
     }
 
     fun onUpdateReaderOptionChanged(selectedOption: UpdateOptions) {
-        developerOptionsRepository.updateSimulatedReaderOption(selectedOption)
-        if (!cardReaderManager.initialized) {
-            cardReaderManager.initialize(mapUpdateOptions(selectedOption))
+        if (cardReaderManager.initialized) {
+            cardReaderManager.initializeOnUpdateFrequencyChange(mapUpdateOptions(selectedOption))
         }
-        cardReaderManager.initializeOnUpdateFrequencyChange(mapUpdateOptions(selectedOption))
+        developerOptionsRepository.updateSimulatedReaderOption(selectedOption)
     }
 
     private fun mapUpdateOptions(updateFrequency: UpdateOptions): CardReaderManager.SimulatorUpdateFrequency {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
+import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.ui.prefs.DeveloperOptionsViewModel.DeveloperOptionsViewState.ListItem
@@ -23,6 +24,7 @@ import javax.inject.Inject
 class DeveloperOptionsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val developerOptionsRepository: DeveloperOptionsRepository,
+    private val cardReaderManager: CardReaderManager,
 ) : ScopedViewModel(savedState) {
 
     private val _viewState = MutableLiveData(
@@ -107,6 +109,15 @@ class DeveloperOptionsViewModel @Inject constructor(
 
     fun onUpdateReaderOptionChanged(selectedOption: UpdateOptions) {
         developerOptionsRepository.updateSimulatedReaderOption(selectedOption)
+        cardReaderManager.initializeOnUpdateFrequencyChange(mapUpdateOptions(selectedOption))
+    }
+
+    private fun mapUpdateOptions(updateFrequency: UpdateOptions): CardReaderManager.SimulatorUpdateFrequency  {
+        return when (updateFrequency) {
+            UpdateOptions.ALWAYS -> CardReaderManager.SimulatorUpdateFrequency.ALWAYS
+            UpdateOptions.NEVER -> CardReaderManager.SimulatorUpdateFrequency.NEVER
+            UpdateOptions.RANDOM -> CardReaderManager.SimulatorUpdateFrequency.RANDOM
+        }
     }
 
     sealed class DeveloperOptionsEvents : MultiLiveEvent.Event() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.prefs
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,6 +18,7 @@ class DeveloperOptionsTest : BaseUnitTest() {
 
     private val savedStateHandle: SavedStateHandle = SavedStateHandle()
     private val developerOptionsRepository: DeveloperOptionsRepository = mock()
+    private val cardReaderManager: CardReaderManager = mock()
 
     @Before
     fun setup() {
@@ -105,7 +107,8 @@ class DeveloperOptionsTest : BaseUnitTest() {
     private fun initViewModel() {
         viewModel = DeveloperOptionsViewModel(
             savedStateHandle,
-            developerOptionsRepository
+            developerOptionsRepository,
+            cardReaderManager,
         )
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -29,6 +29,8 @@ interface CardReaderManager {
     val displayBluetoothCardReaderMessages: Flow<BluetoothCardReaderMessages>
 
     fun initialize(updateFrequency: SimulatorUpdateFrequency)
+    // reinitialize the simulated reader when the user changes the update frequency option
+    fun initializeOnUpdateFrequencyChange(updateFrequency: SimulatorUpdateFrequency)
     fun discoverReaders(
         isSimulated: Boolean,
         cardReaderTypesToDiscover: CardReaderTypesToDiscover,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -81,6 +81,10 @@ internal class CardReaderManagerImpl(
         }
     }
 
+    override fun initializeOnUpdateFrequencyChange(updateFrequency: CardReaderManager.SimulatorUpdateFrequency) {
+        terminal.setupSimulator(updateFrequency)
+    }
+
     override fun discoverReaders(
         isSimulated: Boolean,
         cardReaderTypesToDiscover: CardReaderTypesToDiscover,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7973 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Context [here](https://github.com/woocommerce/woocommerce-android/pull/7948#discussion_r1036974002)

As pointed, the code to change the update frequency on the simulated reader did not cover for one scenario which is when you connect the reader via Card Reader Manager. 

This PR adds the logic to change this behaviour and reinitializes the reader when connected via Manage Card Reader.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Menu - Settings - Developer Options
2. Make sure the Simulated reader is enabled
3. Click on Update Simulated Row
4. Set frequency to "Always"
5. Go to Payments -> Manage card reader.
6. Start connecting to the reader.
7. Notice an update of the software starts.
8. Cancel it or wait until it completes and **disconnect from the reader**.
9. Go back to the Developer options screen and set frequency to "Never"
10. Go to Payments -> Manage card reader.
11. Start connecting to the reader.
12. Make sure the reader gets connected without an update

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

Before:

https://user-images.githubusercontent.com/30724184/205294987-192cf122-1bf8-41fa-8f23-84f16cd000de.mp4



After: 

https://user-images.githubusercontent.com/30724184/205295013-362b9678-d039-45a9-a61c-622ec8cd51eb.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->