### PR TITLE
Fix event name for tracking the Jetpack installation variant

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -745,6 +745,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     PROLOGUE_EXPERIMENT,
     JETPACK_TIMEOUT_EXPERIMENT,
     SIMPLIFIED_LOGIN_EXPERIMENT,
+    JETPACK_INSTALLATION_EXPERIMENT,
 
     // Widgets
     WIDGET_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/JetpackInstallationExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/JetpackInstallationExperiment.kt
@@ -20,7 +20,7 @@ class JetpackInstallationExperiment @Inject constructor(
         // Track used variant
         val variant = getCurrentVariant()
         analyticsTrackerWrapper.track(
-            AnalyticsEvent.SIMPLIFIED_LOGIN_EXPERIMENT,
+            AnalyticsEvent.JETPACK_INSTALLATION_EXPERIMENT,
             mapOf(Pair(AnalyticsTracker.KEY_EXPERIMENT_VARIANT, variant.name))
         )
     }


### PR DESCRIPTION
### Description
When creating the A/B test experiment for the Jetpack installation, and when copying the implementation from the previous experiment, I missed the part about the Tracks event name to track the used variant 🤦.

This PR simply fixes that.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
