### PR TITLE
Store switching improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerAdapter.kt
@@ -143,6 +143,14 @@ class SitePickerAdapter(
         override fun areContentsTheSame(
             oldItem: SitesListItem,
             newItem: SitesListItem
-        ): Boolean = oldItem == newItem
+        ): Boolean = when {
+            oldItem is WooSiteUiModel && newItem is WooSiteUiModel -> {
+                oldItem.site.getSiteName() == newItem.site.getSiteName()
+            }
+            oldItem is NonWooSiteUiModel && newItem is NonWooSiteUiModel -> {
+                oldItem.site.getSiteName() == newItem.site.getSiteName()
+            }
+            else -> oldItem == newItem
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerAdapter.kt
@@ -143,14 +143,6 @@ class SitePickerAdapter(
         override fun areContentsTheSame(
             oldItem: SitesListItem,
             newItem: SitesListItem
-        ): Boolean = when {
-            oldItem is WooSiteUiModel && newItem is WooSiteUiModel -> {
-                oldItem.site.getSiteName() == newItem.site.getSiteName()
-            }
-            oldItem is NonWooSiteUiModel && newItem is NonWooSiteUiModel -> {
-                oldItem.site.getSiteName() == newItem.site.getSiteName()
-            }
-            else -> oldItem == newItem
-        }
+        ): Boolean = oldItem == newItem
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -79,7 +79,7 @@ class SitePickerViewModel @Inject constructor(
     private val _sites = MutableLiveData<List<SitesListItem>>()
     val sites: LiveData<List<SitesListItem>> = _sites
 
-    private val selectedSiteId: MutableLiveData<Int> = MutableLiveData()
+    private val selectedSiteId: MutableLiveData<Int> = savedState.getLiveData("selected-site-id")
 
     private var loginSiteAddress: String?
         get() = savedState["key"] ?: appPrefsWrapper.getLoginSiteAddress()
@@ -97,8 +97,9 @@ class SitePickerViewModel @Inject constructor(
         loadAndDisplayUserInfo()
         loadAndDisplaySites()
         if (appPrefsWrapper.getIsNewSignUp()) startStoreCreationWebFlow()
-        val selectedSiteId = selectedSite.getSelectedSiteId()
-        if (selectedSiteId != -1) this.selectedSiteId.value = selectedSiteId
+        if (selectedSiteId.value == null && selectedSite.exists()) {
+            selectedSiteId.value = selectedSite.getSelectedSiteId()
+        }
     }
 
     private fun loadAndDisplayUserInfo() = launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -48,6 +48,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WCApiVersionResponse
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.UrlUtils
+import java.util.Objects
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
@@ -667,12 +668,25 @@ class SitePickerViewModel @Inject constructor(
         data class WooSiteUiModel(
             val site: SiteModel,
             val isSelected: Boolean
-        ) : SitesListItem
+        ) : SitesListItem {
+            override fun equals(other: Any?): Boolean = other is WooSiteUiModel &&
+                other.site.name == site.name &&
+                other.isSelected == isSelected &&
+                other.site.url == site.url
+
+            override fun hashCode(): Int = Objects.hash(site.siteId, site.selfHostedSiteId, site.url, isSelected)
+        }
 
         @Parcelize
         data class NonWooSiteUiModel(
             val site: SiteModel
-        ) : SitesListItem
+        ) : SitesListItem {
+            override fun equals(other: Any?): Boolean = other is NonWooSiteUiModel &&
+                other.site.name == site.name &&
+                other.site.url == site.url
+
+            override fun hashCode(): Int = Objects.hash(site.siteId, site.selfHostedSiteId, site.url)
+        }
     }
 
     sealed class SitePickerEvent : MultiLiveEvent.Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -673,11 +673,12 @@ class SitePickerViewModel @Inject constructor(
             val isSelected: Boolean
         ) : SitesListItem {
             override fun equals(other: Any?): Boolean = other is WooSiteUiModel &&
+                other.site.siteId == site.siteId &&
                 other.site.name == site.name &&
                 other.isSelected == isSelected &&
                 other.site.url == site.url
 
-            override fun hashCode(): Int = Objects.hash(site.siteId, site.selfHostedSiteId, site.url, isSelected)
+            override fun hashCode(): Int = Objects.hash(site.siteId, site.name, isSelected, site.url)
         }
 
         @Parcelize
@@ -685,10 +686,11 @@ class SitePickerViewModel @Inject constructor(
             val site: SiteModel
         ) : SitesListItem {
             override fun equals(other: Any?): Boolean = other is NonWooSiteUiModel &&
+                other.site.siteId == site.siteId &&
                 other.site.name == site.name &&
                 other.site.url == site.url
 
-            override fun hashCode(): Int = Objects.hash(site.siteId, site.selfHostedSiteId, site.url)
+            override fun hashCode(): Int = Objects.hash(site.siteId, site.name, site.url)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -364,6 +364,7 @@ class SitePickerViewModel @Inject constructor(
     }
 
     fun onSiteSelected(siteModel: SiteModel) {
+        selectedSite.set(siteModel)
         val updatedSites = _sites.value?.map {
             when (it) {
                 is WooSiteUiModel -> it.copy(isSelected = it.site.id == siteModel.id)


### PR DESCRIPTION
Store switching improvements.

Closes: #7979
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Problem:
1. The list of stores (websites) was populated initially from the DB and then fetched from API and re-rendered. During the re-render, a blink effect was visible even if the list remained the same.

2. If the user selected a new store before the list was refreshed (before the above re-render blink) their choice was reset after the refresh.

### Testing instructions
Run the `trunk` build and navigate to `Menu` > `Switch store`:
1.  Verify there is a blink visible on the list
2. Verify that the store choice is being reset if it's made before the blink

Then verify that the above issues are solved with this PR.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
