### PR TITLE
Fix/list multi-select top fragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/MutableMultipleSelectionPredicate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/MutableMultipleSelectionPredicate.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.products
+
+import androidx.recyclerview.selection.SelectionTracker
+
+class MutableMultipleSelectionPredicate<K : Any> : SelectionTracker.SelectionPredicate<K>() {
+    var selectMultiple = true
+
+    override fun canSetStateForKey(key: K, nextState: Boolean): Boolean = true
+
+    override fun canSetStateAtPosition(position: Int, nextState: Boolean): Boolean = true
+
+    override fun canSelectMultiple(): Boolean = selectMultiple
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -18,7 +18,6 @@ import androidx.core.view.isVisible
 import androidx.core.view.iterator
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.selection.SelectionPredicates
 import androidx.recyclerview.selection.SelectionTracker
 import androidx.recyclerview.selection.StorageStrategy
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -82,6 +81,7 @@ class ProductListFragment :
 
     private var tracker: SelectionTracker<Long>? = null
     private var actionMode: ActionMode? = null
+    private val selectionPredicate = MutableMultipleSelectionPredicate<Long>()
 
     private val viewModel: ProductListViewModel by viewModels()
 
@@ -158,9 +158,8 @@ class ProductListFragment :
             ProductSelectionItemKeyProvider(binding.productsRecycler), // the source of selection keys
             DefaultProductListItemLookup(binding.productsRecycler), // the source of information about recycler items
             StorageStrategy.createLongStorage() // strategy for type-safe storage of the selection state
-        ).withSelectionPredicate(
-            SelectionPredicates.createSelectAnything() // allows multiple items to be selected without any restriction
-        ).build()
+        ).withSelectionPredicate(selectionPredicate)
+            .build() // allows multiple items to be selected without any restriction
 
         productAdapter.tracker = tracker
 
@@ -457,6 +456,7 @@ class ProductListFragment :
     private fun handleListState(productListState: ProductListViewModel.ProductListState) {
         when (productListState) {
             ProductListViewModel.ProductListState.Selecting -> {
+                delayMultiSelection()
                 onListSelectionActiveChanged(true)
                 enableProductsRefresh(false)
                 enableProductSortAndFiltersCard(false)
@@ -466,6 +466,13 @@ class ProductListFragment :
                 enableProductsRefresh(true)
                 enableProductSortAndFiltersCard(true)
             }
+        }
+    }
+
+    private fun delayMultiSelection() {
+        selectionPredicate.selectMultiple = false
+        binding.productsRecycler.post {
+            selectionPredicate.selectMultiple = true
         }
     }
 


### PR DESCRIPTION
### Why 
> The demo looks nice! I think we should address the issue with the size of the toolbar. When I was testing the feature multiple times, I selected 2 items instead of one because the toolbar in selection mode is shorter

When entering selection mode, sometimes two items will appear selected. The reason is because of the different sizes we have on the Toolbar while it is expanded/collapsed.

When we enter the selection mode by long pressing an item having the Toolbar expanded, the selection mode will collapse the Toolbar, causing the element we were pressing to change its position. This could be interpreted as a dragging gesture sometimes, selecting the item below the one we were pressing.

pe5pgL-1us-p2#comment-1387

### Description
This PR tries to solve the two items selected issue by disabling multi-selection when entering selection mode. It does that by using MutableMultipleSelectionPredicate, a class where we can change the `selectMultiple` property and delaying the tracker multi-selection.

### Testing instructions
TC1
1. Open the products screen
2. Enter selection mode by long a product
3. Check that only one product is selected after entering selection mode.
4. Exit selection mode by tapping <- (Back)
5. Repeat steps 2-4 with different products

TC2
1. Open the products screen
2. Enter selection mode by long a product
3. Check that only one product is selected after entering selection mode.
4. Long press another product and drag your finger up or down.
5. Check adjacent products are selected 
### Images/gif

https://user-images.githubusercontent.com/18119390/205773545-c9e506a4-3d70-44f4-a7ff-ef6965fe31ff.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->