### PR TITLE
Track and update unfulfilled orders count only when it's changed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SelectedSite.SelectedSiteChangedEvent
 import com.woocommerce.android.ui.payments.cardreader.ClearCardReaderDataAction
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -60,7 +61,7 @@ class MainPresenter @Inject constructor(
             selectedSite.getIfExists()?.let { siteModel ->
                 wcOrderStore.observeOrderCountForSite(
                     siteModel, listOf(PROCESSING.value)
-                ).collect { count ->
+                ).distinctUntilChanged().collect { count ->
                     AnalyticsTracker.track(
                         AnalyticsEvent.UNFULFILLED_ORDERS_LOADED,
                         mapOf(AnalyticsTracker.KEY_HAS_UNFULFILLED_ORDERS to count)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7993
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For some reason, `observeOrderCountForSite` bring updates many many times. As a result, we track `UNFULFILLED_ORDERS_LOADED` countless times as well. The PR adds `distinctUntilChanged` so it will be tracked only when it actually changed 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Change a status of any order from or to "Processing"
* Notice that `UNFULFILLED_ORDERS_LOADED` tracked only once 

also

* Create an order
* Notice that `UNFULFILLED_ORDERS_LOADED` is not tracked