### PR TITLE
Fix event name for Jetpack URL connection failure

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -307,7 +307,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             onFailure = {
                 val error = (it as? OnChangedException)?.error as? JetpackConnectionUrlError
                 analyticsTrackerWrapper.track(
-                    stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_ACTIVATION_FAILED,
+                    stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_FETCH_JETPACK_CONNECTION_URL_FAILED,
                     properties = mapOf(AnalyticsTracker.KEY_ERROR_CODE to error?.errorCode.toString()),
                     errorContext = this@JetpackActivationMainViewModel::class.simpleName,
                     errorType = it::class.simpleName,


### PR DESCRIPTION
### Description
While trying to check some early metrics about the Jetpack installation failures, I noticed that I used one wrong event 🤦, it's not for the happy path itself, so it won't impact the success metrics we care more about, and that's why I'm targeting for the 11.5 release instead of having to release a hotfix for 11.4. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
