### PR TITLE
[Application Passwords] Specify the correct device name when creating application passwords

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ApplicationPasswordsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ApplicationPasswordsModule.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.di
 
-import android.os.Build
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
+import com.woocommerce.android.util.DeviceInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -22,6 +22,7 @@ interface ApplicationPasswordsModule {
     companion object {
         @Provides
         @ApplicationPasswordClientId
-        fun providesApplicationPasswordClientId() = "${BuildConfig.APPLICATION_ID}.app-client.${Build.DEVICE}"
+        fun providesApplicationPasswordClientId() =
+            "${BuildConfig.APPLICATION_ID}.app-client.${DeviceInfo.name.replace(' ', '-')}"
     }
 }


### PR DESCRIPTION
### Description
As discussed internally p1670234854678149/1669995814.818729-slack-C046HDZL87J, we want to add the device model as a suffix to the created application passwords. In the PR #7989, I used the constant `Build.DEVICE` in the created application passwords, while this works, the name references the industrial name of the device, and not the commercial name, and with this, we'll lose the advantage of allowing the users to identify the origin of the application passwords in wp-admin.

Thir PR updates this to use the value from our own class `DeviceInfo`, with this, the suffix will be `Manufacturer-Model`, so for example for a Pixel 3a:

| Before | After |
| --- | --- |
| com.woocommerce.android.app-client.sargo | com.woocommerce.android.app-client.Google-Pixel-3a |

I'm targeting the release branch to avoid having duplicate passwords created for our users because of this (the beta users would still be impacted, but it should still be limited).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->