### PR TITLE
Selection with opacity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
@@ -38,7 +38,6 @@ class ProductItemView @JvmOverloads constructor(
     private val bullet = "\u2022"
     private val statusColor = ContextCompat.getColor(context, R.color.product_status_fg_other)
     private val statusPendingColor = ContextCompat.getColor(context, R.color.product_status_fg_pending)
-    private val selectedBackgroundColor = ContextCompat.getColor(context, R.color.color_primary)
     private val unSelectedBackgroundColor = ContextCompat.getColor(context, R.color.color_on_primary_high)
 
     fun bind(
@@ -108,11 +107,6 @@ class ProductItemView @JvmOverloads constructor(
     ) {
         val size: Int
         when {
-            isActivated -> {
-                size = imageSize / 2
-                binding.productImage.setImageResource(R.drawable.ic_menu_action_mode_check)
-                binding.productImageFrame.setBackgroundColor(selectedBackgroundColor)
-            }
             imageUrl.isNullOrEmpty() -> {
                 size = imageSize / 2
                 binding.productImageFrame.setBackgroundColor(unSelectedBackgroundColor)
@@ -128,7 +122,7 @@ class ProductItemView @JvmOverloads constructor(
                     .into(binding.productImage)
             }
         }
-
+        binding.productImageSelected.visibility = if(isActivated) View.VISIBLE else View.GONE
         binding.productImage.layoutParams.apply {
             height = size
             width = size

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
@@ -7,6 +7,8 @@ import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ProductItemViewBinding
 import com.woocommerce.android.di.GlideApp
@@ -35,10 +37,10 @@ class ProductItemView @JvmOverloads constructor(
     val binding = ProductItemViewBinding.inflate(LayoutInflater.from(context), this, true)
 
     private val imageSize = context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
+    private val imageCornerRadius = context.resources.getDimensionPixelSize(R.dimen.corner_radius_image)
     private val bullet = "\u2022"
     private val statusColor = ContextCompat.getColor(context, R.color.product_status_fg_other)
     private val statusPendingColor = ContextCompat.getColor(context, R.color.product_status_fg_pending)
-    private val unSelectedBackgroundColor = ContextCompat.getColor(context, R.color.color_on_primary_high)
 
     fun bind(
         product: Product,
@@ -109,15 +111,14 @@ class ProductItemView @JvmOverloads constructor(
         when {
             imageUrl.isNullOrEmpty() -> {
                 size = imageSize / 2
-                binding.productImageFrame.setBackgroundColor(unSelectedBackgroundColor)
                 binding.productImage.setImageResource(R.drawable.ic_product)
             }
             else -> {
                 size = imageSize
-                binding.productImageFrame.setBackgroundColor(unSelectedBackgroundColor)
                 val photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, imageSize, imageSize)
                 GlideApp.with(context)
                     .load(photonUrl)
+                    .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                     .placeholder(R.drawable.ic_product)
                     .into(binding.productImage)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
@@ -122,7 +122,7 @@ class ProductItemView @JvmOverloads constructor(
                     .into(binding.productImage)
             }
         }
-        binding.productImageSelected.visibility = if(isActivated) View.VISIBLE else View.GONE
+        binding.productImageSelected.visibility = if (isActivated) View.VISIBLE else View.GONE
         binding.productImage.layoutParams.apply {
             height = size
             width = size

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -53,7 +53,6 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowUpdateDialog
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
@@ -95,7 +94,6 @@ class ProductListFragment :
     private val skeletonView = SkeletonView()
 
     private var searchMenuItem: MenuItem? = null
-    private var multiSelectMenuItem: MenuItem? = null
     private var searchView: SearchView? = null
 
     private var trashProductUndoSnack: Snackbar? = null
@@ -198,7 +196,6 @@ class ProductListFragment :
         actionMode = null
         tracker = null
         searchMenuItem = null
-        multiSelectMenuItem = null
         binding.productsSearchTabView.hide()
         super.onDestroyView()
         _binding = null
@@ -245,9 +242,6 @@ class ProductListFragment :
         searchMenuItem = menu.findItem(R.id.menu_search)
         searchView = searchMenuItem?.actionView as SearchView?
         searchView?.queryHint = getString(R.string.product_search_hint)
-
-        multiSelectMenuItem = menu.findItem(R.id.menu_multiselect)
-        multiSelectMenuItem?.isVisible = FeatureFlag.PRODUCTS_BULK_EDITING.isEnabled() && !viewModel.isSearching()
     }
 
     override fun onPrepareMenu(menu: Menu) {
@@ -299,10 +293,6 @@ class ProductListFragment :
                 enableSearchListeners()
                 true
             }
-            R.id.menu_multiselect -> {
-                viewModel.onSelectProductsClicked()
-                true
-            }
             else -> false
         }
     }
@@ -336,7 +326,6 @@ class ProductListFragment :
         viewModel.onSearchOpened()
         onSearchViewActiveChanged(isActive = true)
         binding.productsSearchTabView.show(this)
-        multiSelectMenuItem?.isVisible = false
         return true
     }
 
@@ -345,7 +334,6 @@ class ProductListFragment :
         updateActivityTitle()
         onSearchViewActiveChanged(isActive = false)
         binding.productsSearchTabView.hide()
-        multiSelectMenuItem?.isVisible = FeatureFlag.PRODUCTS_BULK_EDITING.isEnabled()
         return true
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -53,6 +53,7 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowUpdateDialog
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
@@ -155,6 +156,7 @@ class ProductListFragment :
     }
 
     private fun addSelectionTracker() {
+        if (!FeatureFlag.PRODUCTS_BULK_EDITING.isEnabled()) return
         tracker = SelectionTracker.Builder(
             "productSelection", // a string to identity our selection in the context of this fragment
             binding.productsRecycler, // the RecyclerView where we will apply the tracker

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -398,12 +398,6 @@ class ProductListViewModel @Inject constructor(
         }
     }
 
-    fun onSelectProductsClicked() {
-        productList.value?.first()?.let { product ->
-            triggerEvent(SelectProducts(listOf(product.remoteId)))
-        }
-    }
-
     fun onSelectionChanged(count: Int) {
         when {
             count == 0 -> exitSelectionMode()

--- a/WooCommerce/src/main/res/drawable/picture_frame.xml
+++ b/WooCommerce/src/main/res/drawable/picture_frame.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <corners android:radius="2dp" />
+    <corners android:radius="@dimen/corner_radius_image" />
     <stroke
-        android:width="1dp"
+        android:width="@dimen/image_frame_stroke_width"
         android:color="@color/divider_color" />
 </shape>

--- a/WooCommerce/src/main/res/drawable/product_selected_overlay.xml
+++ b/WooCommerce/src/main/res/drawable/product_selected_overlay.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="@dimen/corner_radius_image" />
+            <solid android:color="@color/color_primary"/>
+        </shape>
+    </item>
+    <item android:drawable="@drawable/ic_menu_action_mode_check"
+        android:top="@dimen/minor_100"
+        android:left="@dimen/minor_100"
+        android:right="@dimen/minor_100"
+        android:bottom="@dimen/minor_100"/>
+</layer-list>
+

--- a/WooCommerce/src/main/res/layout/product_item_view.xml
+++ b/WooCommerce/src/main/res/layout/product_item_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/linearLayout"
@@ -13,34 +12,33 @@
         android:layout_height="@dimen/image_minor_100"
         android:layout_margin="@dimen/major_100"
         android:background="@drawable/picture_frame"
-        android:padding="1dp"
-        app:layout_constraintVertical_bias="0.50"
+        android:padding="@dimen/image_frame_stroke_width"
         app:layout_constraintBottom_toTopOf="@+id/divider"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.50">
 
         <ImageView
             android:id="@+id/productImage"
             android:layout_width="@dimen/image_minor_100"
             android:layout_height="@dimen/image_minor_100"
             android:layout_gravity="center"
-            android:background="@drawable/picture_corners"
             android:importantForAccessibility="no"
-            android:scaleType="centerCrop"
+            android:padding="@dimen/image_frame_stroke_width"
             tools:src="@drawable/ic_product" />
-
-        <ImageView
-            android:id="@+id/productImageSelected"
-            android:layout_width="@dimen/image_minor_100"
-            android:layout_height="@dimen/image_minor_100"
-            android:layout_gravity="center"
-            android:background="@color/color_primary"
-            android:importantForAccessibility="no"
-            android:scaleType="centerCrop"
-            android:padding="@dimen/minor_100"
-            android:alpha="@dimen/alpha_emphasis_high"
-            android:src="@drawable/ic_menu_action_mode_check" />
     </FrameLayout>
+
+    <ImageView
+        android:id="@+id/productImageSelected"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:alpha="@dimen/alpha_emphasis_high"
+        android:importantForAccessibility="no"
+        android:src="@drawable/product_selected_overlay"
+        app:layout_constraintTop_toTopOf="@+id/productImageFrame"
+        app:layout_constraintStart_toStartOf="@+id/productImageFrame"
+        app:layout_constraintEnd_toEndOf="@+id/productImageFrame"
+        app:layout_constraintBottom_toBottomOf="@+id/productImageFrame"/>
 
     <!--
         LinearLayout is necessary to ensure the contents will always center properly in the
@@ -91,14 +89,14 @@
     <ImageButton
         android:id="@+id/product_btnDelete"
         style="@style/Woo.ImageButton.Close"
+        android:layout_margin="@dimen/minor_100"
         android:contentDescription="@string/grouped_product_btn_delete"
         android:scaleType="centerInside"
-        android:layout_margin="@dimen/minor_100"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:visibility="gone"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <View
         android:id="@+id/divider"
@@ -108,6 +106,6 @@
         android:layout_marginBottom="@dimen/minor_00"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/productInfoContainer"/>
+        app:layout_constraintStart_toStartOf="@+id/productInfoContainer" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/product_item_view.xml
+++ b/WooCommerce/src/main/res/layout/product_item_view.xml
@@ -28,6 +28,18 @@
             android:importantForAccessibility="no"
             android:scaleType="centerCrop"
             tools:src="@drawable/ic_product" />
+
+        <ImageView
+            android:id="@+id/productImageSelected"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_gravity="center"
+            android:background="@color/color_primary"
+            android:importantForAccessibility="no"
+            android:scaleType="centerCrop"
+            android:padding="@dimen/minor_100"
+            android:alpha="@dimen/alpha_emphasis_high"
+            android:src="@drawable/ic_menu_action_mode_check" />
     </FrameLayout>
 
     <!--

--- a/WooCommerce/src/main/res/menu/menu_product_list_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_list_fragment.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <item
-        android:id="@+id/menu_multiselect"
-        android:icon="@drawable/ic_multiselect"
-        android:title="@string/product_list_multiselect"
-        android:visible="false"
-        app:showAsAction="always|collapseActionView" />
-
     <item
         android:id="@+id/menu_search"
         android:icon="@drawable/ic_search_24dp"

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -79,6 +79,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="image_major_120">128dp</dimen>
     <dimen name="image_major_150">156dp</dimen>
     <dimen name="image_major_200">200dp</dimen>
+    <dimen name="image_frame_stroke_width">1dp</dimen>
 
     <!-- Skeleton sizes -->
     <dimen name="skeleton_list_item_icon_100">@dimen/image_minor_50</dimen>
@@ -106,6 +107,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="corner_radius_medium">4dp</dimen>
     <dimen name="corner_radius_large">8dp</dimen>
     <dimen name="corner_radius_round_button">20dp</dimen>
+    <dimen name="corner_radius_image">4dp</dimen>
 
     <!-- Chart dimens -->
     <dimen name="chart_height">200dp</dimen>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8022

### Why
This PR contains the implementation of the design adjustments proposed after the design review pe5pgL-1us-p2

> I agree that we added some opacity to the purple area so we can still see the product like you have discussed. And we also want to apply border-radius to it to keep consistency.

> I’d vote to remove this icon, and I’d vote to do this in the first iteration

### Description
This PR adds transparency to the selection state of products, so the product's image is still visible when selected. It also adds a round corner radius to the product's images and removes the selection button from the Toolbar.

### Testing instructions

1. Open the product list screen.
2. Check that product's image corners are rounded.
3. Check that there is no selection checkbox button in the Toolbar.
4. Long press a product to enter selection mode.
5. Check that in selection mode, the product's image is still visible under the selection checkmark


### Images/gif


https://user-images.githubusercontent.com/18119390/207919883-826fc724-bdf6-47b2-afec-f98de03cb157.mp4



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->