### PR TITLE
Remove glance animation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -334,9 +334,6 @@ class OrderListFragment :
                     }
                     binding.orderRefreshLayout.isRefreshing = false
                 }
-                is OrderListViewModel.OrderListEvent.GlanceFirstSwipeAbleItem -> {
-                    glanceFirstSwipeAbleListItem()
-                }
                 else -> event.isHandled = false
             }
         }
@@ -605,25 +602,5 @@ class OrderListFragment :
 
     override fun onSwiped(gestureSource: OrderStatusUpdateSource.SwipeToCompleteGesture) {
         viewModel.onSwipeStatusUpdate(gestureSource)
-    }
-
-    private fun glanceFirstSwipeAbleListItem() {
-        val recyclerView = binding.orderListView.ordersList
-        val distance = resources.getDimensionPixelSize(R.dimen.swipeable_glance_distance)
-        // Iterate only on visible swipeable orders
-        for (i in 0 until recyclerView.childCount) {
-            val childView = recyclerView.getChildAt(i)
-            val viewHolder =
-                (recyclerView.getChildViewHolder(childView) as? SwipeToComplete.SwipeAbleViewHolder) ?: continue
-            if (viewHolder.isSwipeAble()) {
-                recyclerView.glanceSwipeAbleItem(
-                    index = i,
-                    direction = ItemTouchHelper.START,
-                    time = SWIPE_GLANCE_ANIMATION_DURATION_MILLIS,
-                    distance = distance
-                )
-                return
-            }
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -43,7 +43,6 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -65,8 +64,6 @@ import javax.inject.Inject
 
 private const val EMPTY_VIEW_THROTTLE = 250L
 
-// Small delay before triggering the glance animation event
-private const val DELAY_GLANCE_DURATION = 500L
 typealias PagedOrdersList = PagedList<OrderListItemUIType>
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -162,21 +159,6 @@ class OrderListViewModel @Inject constructor(
                     "Order list can't fetch site plugins, no selected site " +
                         "- siteId ${selectedSite.getSelectedSiteId()}$"
                 )
-            }
-        }
-
-        shouldGlanceFirstSwipeAbleItem()
-    }
-
-    private fun shouldGlanceFirstSwipeAbleItem() {
-        isFetchingFirstPage.observe(this) { isFetching ->
-            if (!isFetching && InAppLifecycleMemory.shouldGlanceFirstSwipeAbleItem) {
-                launch {
-                    // Wait for the list to be draw
-                    delay(DELAY_GLANCE_DURATION)
-                    InAppLifecycleMemory.shouldGlanceFirstSwipeAbleItem = false
-                    triggerEvent(OrderListEvent.GlanceFirstSwipeAbleItem)
-                }
             }
         }
     }
@@ -596,7 +578,6 @@ class OrderListViewModel @Inject constructor(
         ) : OrderListEvent()
 
         data class NotifyOrderChanged(val position: Int) : OrderListEvent()
-        object GlanceFirstSwipeAbleItem : OrderListEvent()
     }
 
     @Parcelize
@@ -614,8 +595,4 @@ class OrderListViewModel @Inject constructor(
         const val UTM_SOURCE = "orders_list"
         const val UTM_CONTENT = "upsell_card_readers"
     }
-}
-
-object InAppLifecycleMemory {
-    var shouldGlanceFirstSwipeAbleItem = true
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
@@ -1,18 +1,14 @@
 package com.woocommerce.android.ui.orders.list
 
-import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Rect
-import android.os.SystemClock
 import android.text.Layout
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.util.TypedValue
-import android.view.MotionEvent
-import androidx.core.animation.doOnEnd
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
@@ -216,73 +212,4 @@ class SwipeToComplete(
             toFloat(),
             context.resources.displayMetrics
         ).roundToInt()
-}
-
-/**
- *  Glance animation built using three main MotionEvent.
- *  MotionEvent.ACTION_DOWN -> to simulate the list item is pressed
- *  MotionEvent. ACTION_MOVE -> to simulate the list item is been dragging (ACTION_DOWN + ACTION_MOVE)
- *  MotionEvent.ACTION_UP -> to simulate the list item is released, so it can return to its start position
- */
-fun RecyclerView.glanceSwipeAbleItem(
-    index: Int,
-    direction: Int,
-    time: Long,
-    distance: Int
-) {
-    val childView = this.getChildAt(index) ?: return
-
-    val x = childView.width / 2F
-    val listCoordinates = IntArray(2)
-    val viewCoordinates = IntArray(2)
-
-    childView.getLocationInWindow(viewCoordinates)
-    this.getLocationInWindow(listCoordinates)
-    // Position the y coordinate relative to the list position (viewCoordinates[1] - listCoordinates[1])
-    // and then in the middle of the list item by dividing the list item height by 2 (childView.height / 2F)
-    val y = (viewCoordinates[1] - listCoordinates[1]) + (childView.height / 2F)
-    val downTime = SystemClock.uptimeMillis()
-    this.dispatchTouchEvent(
-        MotionEvent.obtain(
-            downTime,
-            downTime,
-            MotionEvent.ACTION_DOWN,
-            x,
-            y,
-            0
-        )
-    )
-    ValueAnimator.ofInt(0, distance).apply {
-        doOnEnd {
-            this@glanceSwipeAbleItem.dispatchTouchEvent(
-                MotionEvent.obtain(
-                    downTime,
-                    downTime,
-                    MotionEvent.ACTION_UP,
-                    x,
-                    y,
-                    0
-                )
-            )
-        }
-        duration = time
-        addUpdateListener {
-            val dX = it.animatedValue as Int
-            val mX = when (direction) {
-                ItemTouchHelper.END -> x + dX
-                ItemTouchHelper.START -> x - dX
-                else -> 0F
-            }
-            this@glanceSwipeAbleItem.dispatchTouchEvent(
-                MotionEvent.obtain(
-                    downTime,
-                    SystemClock.uptimeMillis(),
-                    MotionEvent.ACTION_MOVE,
-                    mX,
-                    y,
-                    0
-                )
-            )
-        }
-    }.start()
 }


### PR DESCRIPTION
Closes: #8025

### Why
We found merchant's assuming that the animation was a bug p1668314863698739-slack-C013AAPA4G0. So we decided to remove the glance animation p1668462672151549-slack-C02KUCFCSFP

### Description
This PR removes the glance animation shown when the orders list screen is opened for the first time.

### Testing instructions
1. Open the App
2. Tap on Orders
3. Check that the glance animation is not shown

### Images/gif

https://user-images.githubusercontent.com/18119390/207459096-d8012ff9-1f99-4fa3-a412-96294865dd4b.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->