### PR TITLE
Draw only over the swiped list item background

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SwipeToComplete.kt
@@ -49,6 +49,9 @@ class SwipeToComplete(
         color = Color.WHITE
         textSize = messageSize
     }
+    private val nonSwipeAbleBackgroundPaint = Paint().apply { color = noSwipeAbleColor }
+    private val swipeAbleBackgroundPaint = Paint().apply { color = swipeAbleColor }
+
     private val margin = context.resources.getDimension(R.dimen.major_100).toInt()
 
     override fun onMove(
@@ -121,7 +124,13 @@ class SwipeToComplete(
     ) {
         val maxDX = (width * NO_SWIPE_ABLE_SCREEN_PERCENT).toFloat()
         val shrinkDX = if (dX > 0) dX.coerceAtMost(maxDX) else dX.coerceAtLeast(-maxDX)
-        canvas.drawColor(noSwipeAbleColor)
+        val background = Rect(
+            viewHolder.itemView.left,
+            viewHolder.itemView.top,
+            viewHolder.itemView.right,
+            viewHolder.itemView.bottom
+        )
+        canvas.drawRect(background, nonSwipeAbleBackgroundPaint)
         super.onChildDraw(canvas, recyclerView, viewHolder, shrinkDX, dY, actionState, isCurrentlyActive)
     }
 
@@ -136,7 +145,13 @@ class SwipeToComplete(
         isCurrentlyActive: Boolean
     ) {
         // Draw background
-        canvas.drawColor(swipeAbleColor)
+        val background = Rect(
+            viewHolder.itemView.left,
+            viewHolder.itemView.top,
+            viewHolder.itemView.right,
+            viewHolder.itemView.bottom
+        )
+        canvas.drawRect(background, swipeAbleBackgroundPaint)
         val isSwipingRight = dX > 0
 
         // Select the longest line to measure the text width


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8027

### Why
When there is only 1 order in the orders list, swiping to complete the order causes the swipe-to-complete background to extend to the whole orders list.

### Description
This PR fixes the weird behavior of the whole list changing its background when an item is swiped by limiting the drawing area to the list item size.

### Testing instructions

1. Go to the orders screen
2. Filter orders to have only 1 order not completed
3. Swipe to complete the order
4. Check that the purple background covers only the order swiped.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/207466281-611e44d9-cabd-4237-a0d1-1c2e9720e995.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
