### PR TITLE
[Analytics Hub] Improve percentage rounding rule

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -38,6 +38,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.util.Date
 import javax.inject.Inject
+import kotlin.math.round
 
 @Suppress("TooManyFunctions")
 class AnalyticsRepository @Inject constructor(
@@ -363,7 +364,10 @@ class AnalyticsRepository @Inject constructor(
     private fun calculateDeltaPercentage(previousVal: Double, currentVal: Double): DeltaPercentage = when {
         previousVal <= ZERO_VALUE -> DeltaPercentage.NotExist
         currentVal <= ZERO_VALUE -> DeltaPercentage.Value((MINUS_ONE * ONE_H_PERCENT))
-        else -> DeltaPercentage.Value(((currentVal - previousVal) / previousVal * ONE_H_PERCENT).toInt())
+        else -> {
+            val rounded = round((currentVal - previousVal) / previousVal * ONE_H_PERCENT)
+            DeltaPercentage.Value(rounded.toInt())
+        }
     }
 
     private fun shouldUpdatePreviousStats(startDate: String, endDate: String, forceUpdate: Boolean) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepository.kt
@@ -364,10 +364,8 @@ class AnalyticsRepository @Inject constructor(
     private fun calculateDeltaPercentage(previousVal: Double, currentVal: Double): DeltaPercentage = when {
         previousVal <= ZERO_VALUE -> DeltaPercentage.NotExist
         currentVal <= ZERO_VALUE -> DeltaPercentage.Value((MINUS_ONE * ONE_H_PERCENT))
-        else -> {
-            val rounded = round((currentVal - previousVal) / previousVal * ONE_H_PERCENT)
-            DeltaPercentage.Value(rounded.toInt())
-        }
+        else -> round((currentVal - previousVal) / previousVal * ONE_H_PERCENT)
+            .let { DeltaPercentage.Value(it.toInt()) }
     }
 
     private fun shouldUpdatePreviousStats(startDate: String, endDate: String, forceUpdate: Boolean) =


### PR DESCRIPTION
Summary
==========
During the WCiOS Analytics Hub development, I noticed that the percentage badges between the iOS and Android sometimes differed in a way that suggested a rounding rule difference. 

At first, I decided to tweak the iOS rounding strategy. Still, after looking at the Android percentage calculation, I noticed we weren't rounding the number but truncating it through the `toInt()` call. 

With that said, this PR modifies the percentage calculation to round the value before casting it to `int`, rounding the percentage precision and matching the iOS behavior.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20221214_194718](https://user-images.githubusercontent.com/5920403/207733143-5ccf892b-cf75-46ec-a305-bbd0cd5cfbe1.png) | ![Screenshot_20221214_194349](https://user-images.githubusercontent.com/5920403/207733133-250d20ec-c18b-4c38-899a-d99f37c7d985.png) |

### iOS Hub for the same stats
<img src="https://user-images.githubusercontent.com/5920403/207733286-4be182f1-c7ec-45ce-a799-c022f6787d74.png" width="540" height="1140" />

How to Test
==========
1. I would recommend testing these changes by comparing the percentage badges from this PR with the iOS Analytics Hub. In case that's not possible, it would be necessary to verify that the badge numbers make sense from what's expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.