### PR TITLE
Feature/per app language preferences

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -99,7 +99,9 @@ android {
             pickFirst 'META-INF/LGPL2.1'
         }
 
-        resConfigs("en", "ar", "de", "es", "fr", "he", "id", "in", "it", "iw", "ja", "ko")
+        resConfigs(
+                "en", "ar", "de", "es", "fr", "he", "id", "in", "it", "iw", "ja", "ko", "nl", "pt-rBR", "ru", "sv", "tr", "zh-rCN", "zh-rTW"
+        )
     }
 
     buildFeatures {

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -98,6 +98,8 @@ android {
             pickFirst 'META-INF/AL2.0'
             pickFirst 'META-INF/LGPL2.1'
         }
+
+        resConfigs("en", "ar", "de", "es", "fr", "he", "id", "in", "it", "iw", "ja", "ko")
     }
 
     buildFeatures {

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Woo.DayNight"
+        android:localeConfig="@xml/locales_config"
         tools:ignore="UnusedAttribute">
 
         <!-- TODO: we eventually want to drop support for Apache, but for now it's used by FluxC -->

--- a/WooCommerce/src/main/res/xml/locales_config.xml
+++ b/WooCommerce/src/main/res/xml/locales_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="ar"/>
+    <locale android:name="de"/>
+    <locale android:name="es"/>
+    <locale android:name="fr"/>
+    <locale android:name="he"/>
+    <locale android:name="id"/>
+    <locale android:name="in"/>
+    <locale android:name="it"/>
+    <locale android:name="iw"/>
+    <locale android:name="ja"/>
+    <locale android:name="ko"/>
+</locale-config>

--- a/WooCommerce/src/main/res/xml/locales_config.xml
+++ b/WooCommerce/src/main/res/xml/locales_config.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
-    <locale android:name="en"/>
-    <locale android:name="ar"/>
-    <locale android:name="de"/>
-    <locale android:name="es"/>
-    <locale android:name="fr"/>
-    <locale android:name="he"/>
-    <locale android:name="id"/>
-    <locale android:name="in"/>
-    <locale android:name="it"/>
-    <locale android:name="iw"/>
-    <locale android:name="ja"/>
-    <locale android:name="ko"/>
+    <locale android:name="en"/> <!-- English -->
+    <locale android:name="ar"/> <!-- Arabic -->
+    <locale android:name="de"/> <!-- German -->
+    <locale android:name="es"/> <!-- Spanish (Spain) -->
+    <locale android:name="fr"/> <!-- French (France) -->
+    <locale android:name="he"/> <!-- Hebrew -->
+    <locale android:name="id"/> <!-- Indonesian -->
+    <locale android:name="in"/> <!-- Indonesian -->
+    <locale android:name="it"/> <!-- Italian -->
+    <locale android:name="iw"/> <!-- Hebrew -->
+    <locale android:name="ja"/> <!-- Japanese -->
+    <locale android:name="ko"/> <!-- Korean -->
+    <locale android:name="nl"/> <!-- Dutch -->
+    <locale android:name="pt-BR"/> <!-- Portuguese (Brazil) -->
+    <locale android:name="ru"/> <!-- Russian -->
+    <locale android:name="sv"/> <!-- Swedish -->
+    <locale android:name="tr"/> <!-- Turkish -->
+    <locale android:name="zh-CN"/> <!-- Chinese (Simplified) -->
+    <locale android:name="zh-TW"/> <!-- Chinese (Traditional) -->
 </locale-config>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8032 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Android 13 and above support [per-app language preferences](https://developer.android.com/guide/topics/resources/app-languages)

In many cases, multilingual users set their system language to one language—such as English—but they want to select other languages for specific apps, such as Dutch, Chinese, or Hindi. To help apps provide a better experience for these users, Android 13 introduces the per-app language preferences for apps that support multiple languages.

This PR makes the WooCommerce android app support per-app language preference.

Users can select their preferred language for each app through the system settings. They can access these settings in two different ways:

1. Access through the System settings

Settings > System > Languages & Input > App Languages > (select an app)

2. Access through Apps settings

Settings > Apps > (select an app) > Language

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**NOTE:** Works only on Android 13 and above. 

### Access through Apps settings


1. Navigate to Settings > Apps > (select WooCommerce app) OR Long press the app icon and select `info` option
2. Ensure you see the `Language` option there.
3. Select any of the available languages
4. Open the WooCommerce app and ensure the app is displayed in the selected language.

### Access through the System settings
1. Navigate to Settings > System > Languages & Input > App Languages
2. Ensure you see the WooCommerce app listed.
3. Select the WooCommerce app
4. Select any of the available languages
5. Open the WooCommerce app and ensure the app is displayed in the selected language.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/1331230/207853910-aaab8a4d-61af-456b-bbb4-210b981096cc.mov


https://user-images.githubusercontent.com/1331230/207854601-524a6fd1-ccfb-4de1-aa6d-72ee6ccaa43e.mov



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
