### PR TITLE
REST API: Integrate latest FluxC changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ApplicationPasswordsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ApplicationPasswordsModule.kt
@@ -8,7 +8,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import org.wordpress.android.fluxc.module.ApplicationPasswordClientId
+import org.wordpress.android.fluxc.module.ApplicationPasswordsClientId
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsListener
 
 @Module
@@ -21,7 +21,7 @@ interface ApplicationPasswordsModule {
 
     companion object {
         @Provides
-        @ApplicationPasswordClientId
+        @ApplicationPasswordsClientId
         fun providesApplicationPasswordClientId() =
             "${BuildConfig.APPLICATION_ID}.app-client.${DeviceInfo.name.replace(' ', '-')}"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationPasswordsTester.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationPasswordsTester.kt
@@ -7,7 +7,7 @@ import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
-import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordNetwork
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,7 +18,7 @@ import javax.inject.Singleton
 @Singleton
 class ApplicationPasswordsTester @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
-    private val network: ApplicationPasswordNetwork,
+    private val network: ApplicationPasswordsNetwork,
     private val selectedSite: SelectedSite,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2598-0a7b6c00fa1c7f195b0d8f0a159ce32556cd72f5'
+    fluxCVersion = 'trunk-94601a5d4c1c98068adde0352ecc25e6d0046f35'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.8.0'
+    fluxCVersion = '2598-0a7b6c00fa1c7f195b0d8f0a159ce32556cd72f5'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8011 Closes: #8016 

⚠️ Please don't merge until https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2598 is merged and the fluxc commit is updated.

### Description
This PR brings the latest changes regarding Application Passwords:
1. Update the usage in the app to align with the naming updates.
2. Migrates the Coupons endpoint following the two networking layers approach.

### Testing instructions
Confirm coupons feature works as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
