### PR TITLE
Improve variations bulk update code scalability

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseFragment.kt
@@ -1,0 +1,115 @@
+package com.woocommerce.android.ui.products.variations
+
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import androidx.annotation.CallSuper
+import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
+import androidx.core.view.MenuProvider
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.widgets.CustomProgressDialog
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.ActivityUtils
+import javax.inject.Inject
+
+/**
+ * Base class for all variations bulk update fragments.
+ */
+@AndroidEntryPoint
+abstract class VariationsBulkUpdateBaseFragment(@LayoutRes layoutId: Int) : BaseFragment(layoutId) {
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
+
+    private var doneMenuItem: MenuItem? = null
+    private var progressDialog: CustomProgressDialog? = null
+
+    /**
+     * The view model for this fragment. A subclass of [VariationsBulkUpdateBaseViewModel].
+     */
+    abstract val viewModel: VariationsBulkUpdateBaseViewModel
+
+    @CallSuper
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupMenu()
+        observeEvents()
+    }
+
+    private fun setupMenu() {
+        requireActivity().addMenuProvider(
+            object : MenuProvider {
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.menu_variations_bulk_update, menu)
+                    doneMenuItem = menu.findItem(R.id.done)
+                }
+
+                override fun onMenuItemSelected(item: MenuItem): Boolean {
+                    return when (item.itemId) {
+                        R.id.done -> {
+                            viewModel.onDoneClicked()
+                            true
+                        }
+                        else -> false
+                    }
+                }
+            },
+            viewLifecycleOwner
+        )
+    }
+
+    private fun observeEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ShowSnackbar -> {
+                    ActivityUtils.hideKeyboard(requireActivity())
+                    uiMessageResolver.showSnack(event.message)
+                }
+                is MultiLiveEvent.Event.Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
+            }
+        }
+    }
+
+    /**
+     * Hides and shows progress dialog.
+     *
+     * @param visible true to show the dialog, false to hide it.
+     * @param title String resource id of the title to be shown in the dialog.
+     */
+    fun updateProgressbarDialogVisibility(visible: Boolean, @StringRes title: Int) {
+        if (visible) {
+            hideProgressDialog()
+            progressDialog = CustomProgressDialog.show(
+                getString(title),
+                getString(R.string.product_update_dialog_message)
+            ).also { it.show(parentFragmentManager, CustomProgressDialog.TAG) }
+            progressDialog?.isCancelable = false
+        } else {
+            hideProgressDialog()
+        }
+    }
+
+    private fun hideProgressDialog() {
+        progressDialog?.dismiss()
+        progressDialog = null
+    }
+
+    /**
+     * Enables and disables the "Done" menu item.
+     *
+     * @param enabled true to enable the menu item, false to disable it.
+     */
+    fun enableDoneButton(enabled: Boolean) {
+        doneMenuItem?.isEnabled = enabled
+    }
+
+    @CallSuper
+    override fun onPause() {
+        super.onPause()
+        hideProgressDialog()
+        ActivityUtils.hideKeyboard(requireActivity())
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseViewModel.kt
@@ -1,0 +1,80 @@
+package com.woocommerce.android.ui.products.variations
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.track
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Base class for the variations bulk update view models.
+ * This class handles the common logic for the variations bulk update feature:
+ * * managing progress dialog visibility,
+ * * sending analytics events
+ * * and showing snackbars.
+ *
+ * The subclasses are responsible for handling the specific logic for each bulk update type, required by the abstract
+ * methods of this class.
+ */
+abstract class VariationsBulkUpdateBaseViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val dispatchers: CoroutineDispatchers,
+) : ScopedViewModel(savedStateHandle) {
+
+    private val _isProgressDialogShown: MutableLiveData<Boolean> =
+        savedStateHandle.getLiveData("progress_dialog_visibility", false)
+
+    /**
+     * Provides a live data object that can be observed for changes to the progress dialog visibility.
+     */
+    val isProgressDialogShown: LiveData<Boolean> = _isProgressDialogShown
+
+    /**
+     * Called from the UI layer when the user clicks on the "Done" button.
+     */
+    fun onDoneClicked() {
+        _isProgressDialogShown.value = true
+
+        track(getDoneClickedAnalyticsEvent())
+
+        viewModelScope.launch {
+            val result = performBulkUpdate()
+
+            val snackText = if (result) {
+                getSnackbarSuccessMessageTextRes()
+            } else {
+                R.string.variations_bulk_update_error
+            }
+
+            withContext(dispatchers.main) {
+                _isProgressDialogShown.value = false
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(snackText))
+                if (result) triggerEvent(MultiLiveEvent.Event.Exit)
+            }
+        }
+    }
+
+    /**
+     * Provides the analytics event to be tracked when the user clicks on the "Done" button.
+     */
+    abstract fun getDoneClickedAnalyticsEvent(): AnalyticsEvent
+
+    /**
+     * Provides the text resource for the snackbar message to be shown when the bulk update is successful.
+     */
+    @StringRes
+    abstract fun getSnackbarSuccessMessageTextRes(): Int
+
+    /**
+     * Performs the bulk update of the variations.
+     */
+    abstract suspend fun performBulkUpdate(): Boolean
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
@@ -1,43 +1,26 @@
 package com.woocommerce.android.ui.products.variations
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentVariationsBulkUpdateInventoryBinding
 import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.products.variations.ValuesGroupType.Common
 import com.woocommerce.android.ui.products.variations.ValuesGroupType.Mixed
 import com.woocommerce.android.ui.products.variations.ValuesGroupType.None
 import com.woocommerce.android.util.StringUtils
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
-import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.ActivityUtils
-import org.wordpress.android.util.ActivityUtils.hideKeyboard
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class VariationsBulkUpdateInventoryFragment :
-    BaseFragment(R.layout.fragment_variations_bulk_update_inventory) {
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    VariationsBulkUpdateBaseFragment(R.layout.fragment_variations_bulk_update_inventory) {
 
-    private val viewModel: VariationsBulkUpdateInventoryViewModel by viewModels()
+    override val viewModel: VariationsBulkUpdateInventoryViewModel by viewModels()
 
     private var _binding: FragmentVariationsBulkUpdateInventoryBinding? = null
     private val binding get() = _binding!!
-
-    private var progressDialog: CustomProgressDialog? = null
-
-    private var doneMenuItem: MenuItem? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -51,47 +34,11 @@ class VariationsBulkUpdateInventoryFragment :
         }
 
         observeViewStateChanges()
-        observeEvents()
-        setupMenu()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-
-    private fun setupMenu() {
-        requireActivity().addMenuProvider(
-            object : MenuProvider {
-                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-                    menuInflater.inflate(R.menu.menu_variations_bulk_update, menu)
-                    doneMenuItem = menu.findItem(R.id.done)
-                }
-
-                override fun onMenuItemSelected(item: MenuItem): Boolean {
-                    return when (item.itemId) {
-                        R.id.done -> {
-                            viewModel.onDoneClicked()
-                            true
-                        }
-                        else -> false
-                    }
-                }
-            },
-            viewLifecycleOwner
-        )
-    }
-
-    private fun observeEvents() {
-        viewModel.event.observe(viewLifecycleOwner) { event ->
-            when (event) {
-                is ShowSnackbar -> {
-                    ActivityUtils.hideKeyboardForced(binding.stockQuantityEditText.editText)
-                    uiMessageResolver.showSnack(event.message)
-                }
-                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
-            }
-        }
     }
 
     private fun observeViewStateChanges() {
@@ -108,17 +55,13 @@ class VariationsBulkUpdateInventoryFragment :
                 updateCurrentStockQuantityLabel(new.stockQuantityGroupType, new)
             }
             new.isDoneEnabled.takeIfNotEqualTo(old?.isDoneEnabled) { isEnabled ->
-                doneMenuItem?.isEnabled = isEnabled
+                enableDoneButton(isEnabled)
             }
         }
         viewModel.isProgressDialogShown.observe(viewLifecycleOwner) { isVisible ->
-            updateProgressbarDialogVisibility(isVisible)
+            val title = R.string.variations_bulk_update_stock_quantity_dialog_title
+            updateProgressbarDialogVisibility(isVisible, title)
         }
-    }
-
-    private fun hideProgressDialog() {
-        progressDialog?.dismiss()
-        progressDialog = null
     }
 
     private fun updateCurrentStockQuantityLabel(
@@ -130,25 +73,6 @@ class VariationsBulkUpdateInventoryFragment :
             None -> ""
             is Common -> getString(R.string.variations_bulk_update_current_stock_quantity, viewState.stockQuantity)
         }
-    }
-
-    private fun updateProgressbarDialogVisibility(visible: Boolean) {
-        if (visible) {
-            hideProgressDialog()
-            progressDialog = CustomProgressDialog.show(
-                getString(R.string.variations_bulk_update_stock_quantity_dialog_title),
-                getString(R.string.product_update_dialog_message)
-            ).also { it.show(parentFragmentManager, CustomProgressDialog.TAG) }
-            progressDialog?.isCancelable = false
-        } else {
-            hideProgressDialog()
-        }
-    }
-
-    override fun onPause() {
-        super.onPause()
-        hideProgressDialog()
-        hideKeyboard(requireActivity())
     }
 
     override fun getFragmentTitle() = getString(R.string.product_stock_quantity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryFragment.kt
@@ -107,12 +107,12 @@ class VariationsBulkUpdateInventoryFragment :
             new.stockQuantityGroupType?.takeIfNotEqualTo(old?.stockQuantityGroupType) {
                 updateCurrentStockQuantityLabel(new.stockQuantityGroupType, new)
             }
-            new.isProgressDialogShown.takeIfNotEqualTo(old?.isProgressDialogShown) { isVisible ->
-                updateProgressbarDialogVisibility(isVisible)
-            }
             new.isDoneEnabled.takeIfNotEqualTo(old?.isDoneEnabled) { isEnabled ->
                 doneMenuItem?.isEnabled = isEnabled
             }
+        }
+        viewModel.isProgressDialogShown.observe(viewLifecycleOwner) { isVisible ->
+            updateProgressbarDialogVisibility(isVisible)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
@@ -2,19 +2,13 @@ package com.woocommerce.android.ui.products.variations
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.track
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
-import com.woocommerce.android.viewmodel.MultiLiveEvent
-import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
@@ -22,8 +16,8 @@ import javax.inject.Inject
 class VariationsBulkUpdateInventoryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val variationRepository: VariationRepository,
-    private val dispatchers: CoroutineDispatchers,
-) : ScopedViewModel(savedStateHandle) {
+    dispatchers: CoroutineDispatchers,
+) : VariationsBulkUpdateBaseViewModel(savedStateHandle, dispatchers) {
     private val args: VariationsBulkUpdateInventoryFragmentArgs by savedStateHandle.navArgs()
     private val data: InventoryUpdateData = args.inventoryUpdateData
     private val variationsToUpdate: List<ProductVariation> = args.inventoryUpdateData.variationsToUpdate
@@ -38,30 +32,19 @@ class VariationsBulkUpdateInventoryViewModel @Inject constructor(
         )
     }
 
-    fun onDoneClicked() {
-        track(AnalyticsEvent.PRODUCT_VARIANTS_BULK_UPDATE_STOCK_QUANTITY_DONE_TAPPED)
-        viewState = viewState.copy(isProgressDialogShown = true)
+    override fun getDoneClickedAnalyticsEvent(): AnalyticsEvent =
+        AnalyticsEvent.PRODUCT_VARIANTS_BULK_UPDATE_STOCK_QUANTITY_DONE_TAPPED
 
-        viewModelScope.launch(dispatchers.io) {
-            val productId = variationsToUpdate.first().remoteProductId
-            val variationsIds = variationsToUpdate.map { it.remoteVariationId }
-            val result = variationRepository.bulkUpdateVariations(
-                productId,
-                variationsIds,
-                stockQuantity = viewState.stockQuantity ?: 0.0
-            )
-            val snackText = if (result) {
-                R.string.variations_bulk_update_stock_quantity_success
-            } else {
-                R.string.variations_bulk_update_error
-            }
+    override fun getSnackbarSuccessMessageTextRes(): Int = R.string.variations_bulk_update_stock_quantity_success
 
-            withContext(dispatchers.main) {
-                viewState = viewState.copy(isProgressDialogShown = false)
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(snackText))
-                if (result) triggerEvent(MultiLiveEvent.Event.Exit)
-            }
-        }
+    override suspend fun performBulkUpdate(): Boolean {
+        val productId = variationsToUpdate.first().remoteProductId
+        val variationsIds = variationsToUpdate.map { it.remoteVariationId }
+        return variationRepository.bulkUpdateVariations(
+            productId,
+            variationsIds,
+            stockQuantity = viewState.stockQuantity ?: 0.0
+        )
     }
 
     fun onStockQuantityChanged(rawQuantity: String) {
@@ -75,7 +58,6 @@ class VariationsBulkUpdateInventoryViewModel @Inject constructor(
         val variationsToUpdateCount: Int? = null,
         val stockQuantity: Double? = null,
         val stockQuantityGroupType: ValuesGroupType? = null,
-        val isProgressDialogShown: Boolean = false,
         val isDoneEnabled: Boolean = true
     ) : Parcelable
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceFragment.kt
@@ -87,13 +87,14 @@ class VariationsBulkUpdatePriceFragment :
             new.pricesGroupType?.takeIfNotEqualTo(old?.pricesGroupType) {
                 updateCurrentPricesLabel(new.pricesGroupType, new)
             }
-            new.isProgressDialogShown.takeIfNotEqualTo(old?.isProgressDialogShown) { isVisible ->
-                val title = when (new.priceType) {
-                    Sale -> R.string.variations_bulk_update_sale_prices_dialog_title
-                    Regular -> R.string.variations_bulk_update_regular_prices_dialog_title
-                }
-                updateProgressbarDialogVisibility(isVisible, title)
+        }
+        viewModel.isProgressDialogShown.observe(viewLifecycleOwner) { isShown ->
+            val priceType = viewModel.viewStateData.liveData.value?.priceType ?: return@observe
+            val title = when (priceType) {
+                Sale -> R.string.variations_bulk_update_sale_prices_dialog_title
+                Regular -> R.string.variations_bulk_update_regular_prices_dialog_title
             }
+            updateProgressbarDialogVisibility(isShown, title)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceViewModel.kt
@@ -2,22 +2,16 @@ package com.woocommerce.android.ui.products.variations
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_VARIANTS_BULK_UPDATE_REGULAR_PRICE_DONE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_VARIANTS_BULK_UPDATE_SALE_PRICE_DONE_TAPPED
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.track
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
-import com.woocommerce.android.viewmodel.MultiLiveEvent
-import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -27,8 +21,9 @@ class VariationsBulkUpdatePriceViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     parameterRepository: ParameterRepository,
     private val variationRepository: VariationRepository,
-    private val dispatchers: CoroutineDispatchers,
-) : ScopedViewModel(savedStateHandle) {
+    dispatchers: CoroutineDispatchers,
+) : VariationsBulkUpdateBaseViewModel(savedStateHandle, dispatchers) {
+
     private val args: VariationsBulkUpdatePriceFragmentArgs by savedStateHandle.navArgs()
     private val data: PriceUpdateData = args.priceUpdateData
     private val variationsToUpdate: List<ProductVariation> = args.priceUpdateData.variationsToUpdate
@@ -38,7 +33,7 @@ class VariationsBulkUpdatePriceViewModel @Inject constructor(
     }
 
     val viewStateData = LiveDataDelegate(savedState, ViewState(priceType = data.priceType))
-    private var viewState by viewStateData
+    private var viewState: ViewState by viewStateData
 
     init {
         viewState = viewState.copy(
@@ -49,49 +44,36 @@ class VariationsBulkUpdatePriceViewModel @Inject constructor(
         )
     }
 
-    fun onDoneClicked() {
-        track(getDoneClickedAnalyticsEvent())
-
-        viewState = viewState.copy(isProgressDialogShown = true)
-        viewModelScope.launch(dispatchers.io) {
-            val productId = variationsToUpdate.first().remoteProductId
-            val variationsIds = variationsToUpdate.map { it.remoteVariationId }
-            val result = when (viewState.priceType) {
-                PriceType.Regular -> variationRepository.bulkUpdateVariations(
-                    productId,
-                    variationsIds,
-                    newRegularPrice = viewState.price ?: ""
-                )
-                PriceType.Sale -> variationRepository.bulkUpdateVariations(
-                    productId,
-                    variationsIds,
-                    newSalePrice = viewState.price ?: ""
-                )
-            }
-            val snackText = if (result) {
-                when (viewState.priceType) {
-                    PriceType.Regular -> R.string.variations_bulk_update_regular_prices_success
-                    PriceType.Sale -> R.string.variations_bulk_update_sale_prices_success
-                }
-            } else {
-                R.string.variations_bulk_update_error
-            }
-
-            withContext(dispatchers.main) {
-                viewState = viewState.copy(isProgressDialogShown = false)
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(snackText))
-                if (result) triggerEvent(MultiLiveEvent.Event.Exit)
-            }
-        }
-    }
-
     fun onPriceEntered(price: String) {
         viewState = viewState.copy(price = price)
     }
 
-    private fun getDoneClickedAnalyticsEvent() = when (data.priceType) {
+    override fun getDoneClickedAnalyticsEvent() = when (data.priceType) {
         PriceType.Regular -> PRODUCT_VARIANTS_BULK_UPDATE_REGULAR_PRICE_DONE_TAPPED
         PriceType.Sale -> PRODUCT_VARIANTS_BULK_UPDATE_SALE_PRICE_DONE_TAPPED
+    }
+
+    override fun getSnackbarSuccessMessageTextRes(): Int = when (viewState.priceType) {
+        PriceType.Regular -> R.string.variations_bulk_update_regular_prices_success
+        PriceType.Sale -> R.string.variations_bulk_update_sale_prices_success
+    }
+
+    override suspend fun performBulkUpdate(): Boolean {
+        val productId = variationsToUpdate.first().remoteProductId
+        val variationsIds = variationsToUpdate.map { it.remoteVariationId }
+        val result = when (viewState.priceType) {
+            PriceType.Regular -> variationRepository.bulkUpdateVariations(
+                productId,
+                variationsIds,
+                newRegularPrice = viewState.price ?: ""
+            )
+            PriceType.Sale -> variationRepository.bulkUpdateVariations(
+                productId,
+                variationsIds,
+                newSalePrice = viewState.price ?: ""
+            )
+        }
+        return result
     }
 
     @Parcelize
@@ -101,7 +83,6 @@ class VariationsBulkUpdatePriceViewModel @Inject constructor(
         val priceType: PriceType,
         val pricesGroupType: ValuesGroupType? = null,
         val variationsToUpdateCount: Int? = null,
-        val isProgressDialogShown: Boolean = false,
     ) : Parcelable
 
     @Parcelize


### PR DESCRIPTION
HACK week: Product variations bulk update refactor, aiming to improve codebase scalability.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The goal of this PR is to extract common code to base classes and remove code duplicates. In the future, this is supposed to allow faster implementation of bulk update for other (currently missing) product variation attributes by reducing the need to introduce duplicate and boilerplate code. The scope and approach of this PR was discussed here: https://github.com/woocommerce/woocommerce-android/pull/7736, and p1667399352822669-slack-CGPNUU63E.

##### Details:
1. Introduced `VariationsBulkUpdateBaseViewModel` - a base class for view models related to variations bulk update attributes. It handles common logic like "Done" button clicks, managing progress bar visibility, showing confirmation snackbar, and tracking analytics event.
2. Introduced `VariationsBulkUpdateBaseFragment` - a base class for fragments related to variations bulk update attributes. It implements common UI parts like "Done" button menu item, progress dialog showing, confirmation snackbar, and navigation events handling.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Product variations bulk update should work without any change.

To test variations bulk update:
1. Create and open a product that has variations defined
2. Click "variations" on the product details page
3. Click 3-dots menu and choose "bulk update" item
4. Choose the variation attribute that you want to bulk-update and follow the flow

Note: In order to access the "stock quantity" bulk update option the product needs to be set as stock-managed. 

Sorry for a bit lengthy PR, it was hard to split it into smaller chunks. There's however no new business logic added - only extracting the duplicate code into base classes and deleting it from leaf classes.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->