### PR TITLE
Expand GenerateVariationPickerDialog everytime

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+11.8
+- [*] Add variations bottom sheet is fully visible right after showing up in the landscape mode [https://github.com/woocommerce/woocommerce-android/pull/8043]
+
 11.7
 -----
 - [*] Adds a feature of bulk updating products from the product's list. [https://github.com/woocommerce/woocommerce-android/pull/8020]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/GenerateVariationPickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/GenerateVariationPickerDialog.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.products.variations
 
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.woocommerce.android.databinding.DialogGenerateVariationsBinding
 
@@ -22,6 +24,12 @@ class GenerateVariationPickerDialog(context: Context) : BottomSheetDialog(contex
     }
 
     var listener: GenerateVariationPickerDialogListener? = null
+
+    override fun onStart() {
+        super.onStart()
+        val behavior = BottomSheetBehavior.from(binding.root.parent as View)
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+    }
 
     interface GenerateVariationPickerDialogListener {
         fun onGenerateAllVariations()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -285,9 +285,7 @@ class VariationListFragment :
         val dialog = generateVariationPickerDialog ?: GenerateVariationPickerDialog(requireContext()).apply {
             listener = this@VariationListFragment
         }
-        dialog.run {
-            show()
-        }
+        dialog.show()
     }
 
     private fun showBulkUpdateLimitExceededWarning() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7974 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
While looks like that it is [expected](https://issuetracker.google.com/issues/37132390) behavior by google, I agree that in our case it's kind of unusable

The PR expands this bottom sheet all the time

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open product with variations
* Open variations
* Click on "Add variation" in both landscape and portrait mode
* Notice that all options a visible right away

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/208085632-c2924fe3-6e9e-4212-8642-6a1c954f63cf.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
