### PR TITLE
Merge release/11.7-rc-1 into trunk (take.2)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+11.8
+-----
+
+
 11.7
 -----
 - [*] Adds a feature of bulk updating products from the product's list. [https://github.com/woocommerce/woocommerce-android/pull/8020]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,9 +74,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "11.6"
+            versionName "11.7-rc-1"
         }
-        versionCode 367
+        versionCode 368
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,18 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_117"
+msgid ""
+"11.7:\n"
+"Exciting news! Now you can edit products in bulk. We also focused on polishing a few things with in person payments and order creation. Please check it out and share your feedback!\n"
+"\n"
+"Keep your feedback rolling in; it helps us figure out what to work on next.\n"
+msgstr ""
+
 msgctxt "release_note_116"
 msgid ""
 "11.6:\n"
 "This release includes a handful of minor improvements and bug fixes that our team found. Don't be fooled though – we're working on some exciting new features for you! Stay tuned!\n"
-msgstr ""
-
-msgctxt "release_note_115"
-msgid ""
-"11.5:\n"
-"Exciting news! It's possible to generate every variation combinations from your attributes. Please try it out and share your feedback!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,4 @@
-This release includes a handful of minor improvements and bug fixes that our team found. Don't be fooled though – we're working on some exciting new features for you! Stay tuned!
+- [*] Adds a feature of bulk updating products from the product's list. [https://github.com/woocommerce/woocommerce-android/pull/8020]
+- [*][Internal] Disconnect from a reader if a user clicks on "cancel" during connection flow [https://github.com/woocommerce/woocommerce-android/pull/7995]
+- [*] Fix for the create a new order button jerky animation [https://github.com/woocommerce/woocommerce-android/pull/7987]
+

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,4 +1,3 @@
-- [*] Adds a feature of bulk updating products from the product's list. [https://github.com/woocommerce/woocommerce-android/pull/8020]
-- [*][Internal] Disconnect from a reader if a user clicks on "cancel" during connection flow [https://github.com/woocommerce/woocommerce-android/pull/7995]
-- [*] Fix for the create a new order button jerky animation [https://github.com/woocommerce/woocommerce-android/pull/7987]
+Exciting news! Now you can edit products in bulk. We also focused on polishing a few things with in person payments and order creation. Please check it out and share your feedback!
 
+Keep your feedback rolling in; it helps us figure out what to work on next.

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -86,6 +86,10 @@
     <string name="product_attribute_error_renaming">Error while renaming your attribute</string>
     <string name="product_attributes_error_saving">Error while saving your attributes</string>
     <string name="product_attribute_remove">Remove this attribute?</string>
+    <string name="product_bulk_update_regular_price">Update regular price</string>
+    <string name="product_bulk_update_price_updated">Price updated!</string>
+    <string name="product_bulk_update_status">Update status</string>
+    <string name="product_bulk_update_status_updated">Status updated!</string>
     <string name="review_notifications">Reviews</string>
     <string name="more_menu">Menu</string>
     <string name="more_menu_button_woo_admin">WooCommerce Admin</string>
@@ -1597,6 +1601,9 @@
     <string name="grouped_product_empty">Add products to the group</string>
     <string name="product_selection_count">%d products selected</string>
     <string name="product_selection_count_single">%d product selected</string>
+    <string name="product_selection_menu_update_status">Update status</string>
+    <string name="product_selection_menu_update_price">Update price</string>
+    <string name="product_selection_menu_select_all">Select all</string>
     <string name="product_detail_save_as_draft">Save as draft</string>
     <string name="product_detail_linked_products">Linked products</string>
     <string name="upsells_label">Upsells</string>
@@ -2797,4 +2804,9 @@
     <string name="store_creation_store_name_title">What’s your store name?</string>
     <string name="store_creation_store_name_subtitle">Don’t worry you can always change it later. </string>
     <string name="store_creation_store_name_hint">Store name</string>
+
+    <string name="store_creation_store_categories_title">What’s your business about?</string>
+    <string name="store_creation_store_categories_subtitle">Choose a category that defines
+your business the best.</string>
+
 </resources>


### PR DESCRIPTION
[take.1](https://github.com/woocommerce/woocommerce-android/pull/8047) -> [close comment](https://github.com/woocommerce/woocommerce-android/pull/8047#issuecomment-1354989837)

-----

- [x] `release notes` related files updated. (022bbd385d4b7f99fee70274c5491362f6f201a9 + 0ecd6a343fc72f9c67641374c8fc12b3aa2216cc + ba435e8f2f6066c6b6b9c5e7d462e3ed6aa8acaa + 325f272f070e8cc01ba1f644f48a96993e9ab108)
- [x] `build.gradle` file on `WooCommerce` module updated  with version bump. (a2bcd892b4403f97a7e312ed52e95fa37d938703)
- [x] `new strings` frozen/copied into `fastlane/resources/values/strings.xml`. (0fc7c308711a753c06e1401331b9aac1681166b7)
- [x] WCAndroid Beta submitted to Google for review.

-----

### Merge Conflict(s)

`RELEASE-NOTES.txt`

```
11.8
<<<<<<< release/11.7
-----

=======
- [*] Add variations bottom sheet is fully visible right after showing up in the landscape mode [https://github.com/woocommerce/woocommerce-android/pull/8043]
>>>>>>> trunk

```

I chose `trunk`'s version to resolve this conflict.