### PR TITLE
[REST API] Feature Flag for testing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/LoginFragmentsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/LoginFragmentsModule.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.di
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailPasswordFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
+import com.woocommerce.android.ui.login.overrides.WooLoginUsernamePasswordFragment
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import dagger.hilt.InstallIn
@@ -19,4 +20,7 @@ abstract class LoginFragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooLoginEmailPasswordFragment(): WooLoginEmailPasswordFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooLoginUsernamePasswordFragment(): WooLoginUsernamePasswordFragment
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login
 
 import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.SITE_PICKER
 import com.woocommerce.android.util.dispatchAndAwait
@@ -8,12 +9,14 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import javax.inject.Inject
 
 class AccountRepository @Inject constructor(
     private val accountStore: AccountStore,
+    private val selectedSite: SelectedSite,
     private val dispatcher: Dispatcher
 ) {
     fun getUserAccount(): AccountModel? = accountStore.account.takeIf { it.userId != 0L }
@@ -27,19 +30,27 @@ class AccountRepository @Inject constructor(
         }
     }
 
-    fun isUserLoggedIn() = accountStore.hasAccessToken()
+    fun isUserLoggedIn(): Boolean {
+        return accountStore.hasAccessToken() ||
+            (selectedSite.exists() && selectedSite.get().origin != SiteModel.ORIGIN_WPCOM_REST)
+    }
 
     suspend fun logout(): Boolean {
-        val event: OnAccountChanged = dispatcher.dispatchAndAwait(AccountActionBuilder.newSignOutAction())
-        return if (event.isError) {
-            WooLog.e(
-                SITE_PICKER,
-                "Account error [type = ${event.causeOfChange}] : " +
-                    "${event.error.type} > ${event.error.message}"
-            )
-            false
+        return if (accountStore.hasAccessToken()) {
+            val event: OnAccountChanged = dispatcher.dispatchAndAwait(AccountActionBuilder.newSignOutAction())
+            if (event.isError) {
+                WooLog.e(
+                    SITE_PICKER,
+                    "Account error [type = ${event.causeOfChange}] : " +
+                        "${event.error.type} > ${event.error.message}"
+                )
+                false
+            } else {
+                dispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction())
+                true
+            }
         } else {
-            dispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction())
+            selectedSite.reset()
             true
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -50,6 +50,7 @@ class AccountRepository @Inject constructor(
                 true
             }
         } else {
+            // TODO send a request to delete the application password
             selectedSite.reset()
             true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -54,6 +54,7 @@ import com.woocommerce.android.ui.login.localnotifications.LoginNotificationSche
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailPasswordFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
+import com.woocommerce.android.ui.login.overrides.WooLoginUsernamePasswordFragment
 import com.woocommerce.android.ui.login.qrcode.QrCodeLoginListener
 import com.woocommerce.android.ui.login.qrcode.showCameraPermissionDeniedDialog
 import com.woocommerce.android.ui.login.signup.SignUpFragment
@@ -91,7 +92,6 @@ import org.wordpress.android.login.LoginListener
 import org.wordpress.android.login.LoginMagicLinkRequestFragment
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.login.LoginSiteAddressFragment
-import org.wordpress.android.login.LoginUsernamePasswordFragment
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
@@ -391,10 +391,10 @@ class LoginActivity :
     }
 
     private fun jumpToUsernamePassword(username: String?, password: String?) {
-        val loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
+        val loginUsernamePasswordFragment = WooLoginUsernamePasswordFragment.newInstance(
             "wordpress.com", "wordpress.com", username, password, true
         )
-        changeFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG)
+        changeFragment(loginUsernamePasswordFragment, true, WooLoginUsernamePasswordFragment.TAG)
     }
 
     private fun startLoginViaWPCom() {
@@ -595,10 +595,10 @@ class LoginActivity :
         // logs into the app.
         inputSiteAddress?.let { AppPrefs.setLoginSiteAddress(it) }
 
-        val loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
+        val loginUsernamePasswordFragment = WooLoginUsernamePasswordFragment.newInstance(
             inputSiteAddress, endpointAddress, null, null, false
         )
-        changeFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG)
+        changeFragment(loginUsernamePasswordFragment, true, WooLoginUsernamePasswordFragment.TAG)
     }
 
     override fun handleSslCertificateError(
@@ -829,10 +829,10 @@ class LoginActivity :
         inputUsername: String?,
         inputPassword: String?
     ) {
-        val loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
+        val loginUsernamePasswordFragment = WooLoginUsernamePasswordFragment.newInstance(
             siteAddress, endpointAddress, inputUsername, inputPassword, false
         )
-        changeFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG)
+        changeFragment(loginUsernamePasswordFragment, true, WooLoginUsernamePasswordFragment.TAG)
     }
 
     override fun startJetpackInstall(siteAddress: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginUsernamePasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginUsernamePasswordFragment.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.ui.login.overrides
+
+import android.os.Bundle
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.FeatureFlag
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.login.LoginUsernamePasswordFragment
+import org.wordpress.android.login.util.SiteUtils
+import javax.inject.Inject
+
+/**
+ * This class is a temporary implementation to be used during the development of the REST API project.
+ * The implementation will be updated according to product specs at the end of the project.
+ */
+class WooLoginUsernamePasswordFragment : LoginUsernamePasswordFragment() {
+    companion object {
+        private const val ARG_INPUT_SITE_ADDRESS = "ARG_INPUT_SITE_ADDRESS"
+        private const val ARG_ENDPOINT_ADDRESS = "ARG_ENDPOINT_ADDRESS"
+        private const val ARG_INPUT_USERNAME = "ARG_INPUT_USERNAME"
+        private const val ARG_INPUT_PASSWORD = "ARG_INPUT_PASSWORD"
+        private const val ARG_IS_WPCOM = "ARG_IS_WPCOM"
+        const val TAG = "login_username_password_fragment_tag"
+
+        fun newInstance(
+            inputSiteAddress: String?,
+            endpointAddress: String?,
+            inputUsername: String?,
+            inputPassword: String?,
+            isWpcom: Boolean
+        ): WooLoginUsernamePasswordFragment {
+            val fragment = WooLoginUsernamePasswordFragment()
+            val args = Bundle()
+            args.putString(ARG_INPUT_SITE_ADDRESS, inputSiteAddress)
+            args.putString(ARG_ENDPOINT_ADDRESS, endpointAddress)
+            args.putString(ARG_INPUT_USERNAME, inputUsername)
+            args.putString(ARG_INPUT_PASSWORD, inputPassword)
+            args.putBoolean(ARG_IS_WPCOM, isWpcom)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    @Inject
+    lateinit var selectedSite: SelectedSite
+
+    override fun onSiteChanged(event: OnSiteChanged) {
+        if (!event.isError && FeatureFlag.REST_API.isEnabled()) {
+            val siteAddress = requireArguments().getString(ARG_INPUT_SITE_ADDRESS)
+            val site = SiteUtils.getXMLRPCSiteByUrl(mSiteStore, siteAddress)!!
+            selectedSite.set(site)
+            mLoginListener.loggedInViaUsernamePassword(SiteUtils.getCurrentSiteIds(mSiteStore, false))
+        } else {
+            super.onSiteChanged(event)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.push.NotificationChannelType.NEW_ORDER
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SelectedSite.SelectedSiteChangedEvent
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.payments.cardreader.ClearCardReaderDataAction
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -26,7 +27,6 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
@@ -39,13 +39,13 @@ import javax.inject.Inject
 
 class MainPresenter @Inject constructor(
     private val dispatcher: Dispatcher,
-    private val accountStore: AccountStore,
     private val wooCommerceStore: WooCommerceStore,
     private val selectedSite: SelectedSite,
     private val productImageMap: ProductImageMap,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val wcOrderStore: WCOrderStore,
-    private val clearCardReaderDataAction: ClearCardReaderDataAction
+    private val clearCardReaderDataAction: ClearCardReaderDataAction,
+    private val accountRepository: AccountRepository
 ) : MainContract.Presenter {
     private var mainView: MainContract.View? = null
 
@@ -83,9 +83,7 @@ class MainPresenter @Inject constructor(
         ConnectionChangeReceiver.getEventBus().unregister(this)
     }
 
-    override fun userIsLoggedIn(): Boolean {
-        return accountStore.hasAccessToken()
-    }
+    override fun userIsLoggedIn(): Boolean = accountRepository.isUserLoggedIn()
 
     override fun storeMagicLinkToken(token: String) {
         isHandlingMagicLink = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,7 +14,8 @@ enum class FeatureFlag {
     UNIFIED_ORDER_EDITING,
     ORDER_CREATION_CUSTOMER_SEARCH,
     NATIVE_STORE_CREATION_FLOW,
-    STORE_PROFILER_FLOW;
+    STORE_PROFILER_FLOW,
+    REST_API;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -29,7 +30,8 @@ enum class FeatureFlag {
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            STORE_PROFILER_FLOW -> PackageUtils.isDebugBuild()
+            STORE_PROFILER_FLOW,
+            REST_API -> PackageUtils.isDebugBuild()
 
             NATIVE_STORE_CREATION_FLOW -> true
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8051
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds a new feature flag to allow testing the REST API support in the app, when enabled, then the user signs in using site credentials, the app will use the entered site directly without passing by the site picker.

### Testing instructions
1. Open the app, then sign out if you are already signed in.
2. Select "Enter site address" in the prologue.
3. Enter your site address (a self-hosted site, regardless of the status of Jetpack).
4. Select "Cotinue with store credentials"
5. Enter your site's credentials.
6. Confirm the app logs you in.
8. Open the Coupons (make sure it's enabled in the experimental features screen).
9. Confirm it works as expected.

### Images/gif
https://user-images.githubusercontent.com/1657201/208162487-e47a674a-7b40-49c2-915a-c03c01d9d863.mp4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
