### PR TITLE
Extract JITM query params encoder logic into a reusable class

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/QueryParamsEncoder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/QueryParamsEncoder.kt
@@ -1,6 +1,7 @@
-package com.woocommerce.android.util
+package com.woocommerce.android.ui.jitm
 
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.util.BuildConfigWrapper
 import java.net.URLEncoder
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -64,7 +63,6 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.FormatUtils
 import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
-import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
 import com.woocommerce.android.ui.jitm.JitmTracker
+import com.woocommerce.android.ui.jitm.QueryParamsEncoder
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.IsJetPackCPEnabled
@@ -32,7 +33,6 @@ import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers.TopPerformerProduct
 import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.ui.jitm.QueryParamsEncoder
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -32,7 +32,7 @@ import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers.TopPerformerProduct
 import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.QueryParamsEncoder
+import com.woocommerce.android.ui.jitm.QueryParamsEncoder
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers.TopPerformerProduct
 import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.QueryParamsEncoder
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -84,6 +85,7 @@ class MyStoreViewModel @Inject constructor(
     private val jitmStore: JitmStore,
     private val jitmTracker: JitmTracker,
     private val myStoreUtmProvider: MyStoreUtmProvider,
+    private val queryParamsEncoder: QueryParamsEncoder,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
@@ -148,19 +150,10 @@ class MyStoreViewModel @Inject constructor(
             val response = jitmStore.fetchJitmMessage(
                 selectedSite.get(),
                 JITM_MESSAGE_PATH,
-                getEncodedQueryParams(),
+                queryParamsEncoder.getEncodedQueryParams(),
             )
             populateResultToUI(response)
         }
-    }
-
-    private fun getEncodedQueryParams(): String {
-        val query = if (BuildConfig.DEBUG) {
-            "build_type=developer&platform=android&version=${BuildConfig.VERSION_NAME}"
-        } else {
-            "platform=android&version=${BuildConfig.VERSION_NAME}"
-        }
-        return URLEncoder.encode(query, Charsets.UTF_8.name())
     }
 
     private fun populateResultToUI(response: WooResult<Array<JITMApiResponse>>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/QueryParamsEncoder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/QueryParamsEncoder.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.BuildConfig
+import java.net.URLEncoder
+import javax.inject.Inject
+
+class QueryParamsEncoder @Inject constructor() {
+    fun getEncodedQueryParams(): String {
+        val query = if (BuildConfig.DEBUG) {
+            "build_type=developer&platform=android&version=${BuildConfig.VERSION_NAME}"
+        } else {
+            "platform=android&version=${BuildConfig.VERSION_NAME}"
+        }
+        return URLEncoder.encode(query, Charsets.UTF_8.name())
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/QueryParamsEncoder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/QueryParamsEncoder.kt
@@ -4,9 +4,11 @@ import com.woocommerce.android.BuildConfig
 import java.net.URLEncoder
 import javax.inject.Inject
 
-class QueryParamsEncoder @Inject constructor() {
+class QueryParamsEncoder @Inject constructor(
+    private val buildConfigWrapper: BuildConfigWrapper
+) {
     fun getEncodedQueryParams(): String {
-        val query = if (BuildConfig.DEBUG) {
+        val query = if (buildConfigWrapper.debug) {
             "build_type=developer&platform=android&version=${BuildConfig.VERSION_NAME}"
         } else {
             "platform=android&version=${BuildConfig.VERSION_NAME}"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.jitm.JitmTracker
+import com.woocommerce.android.ui.jitm.QueryParamsEncoder
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.Companion.UTM_SOURCE
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.MyStoreEvent.OnJitmCtaClicked
 import com.woocommerce.android.ui.mystore.domain.GetStats
@@ -20,7 +21,6 @@ import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers.TopPerformerProduct
 import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.ui.jitm.QueryParamsEncoder
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -20,7 +20,7 @@ import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers.TopPerformerProduct
 import com.woocommerce.android.ui.payments.banner.BannerState
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.QueryParamsEncoder
+import com.woocommerce.android.ui.jitm.QueryParamsEncoder
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -51,7 +51,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMCta
 import org.wordpress.android.fluxc.store.JitmStore
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.net.URLEncoder
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/QueryParamsEncoderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/QueryParamsEncoderTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.ui.jitm.QueryParamsEncoder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/QueryParamsEncoderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/QueryParamsEncoderTest.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.BuildConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.net.URLEncoder
+
+class QueryParamsEncoderTest {
+    private val queryParramsEncoder = QueryParamsEncoder()
+    @Test
+    fun `when getEncodedQueryParams called, then proper encoded query params returned`() {
+        // WHEN
+        val encoderQueryParams = queryParramsEncoder.getEncodedQueryParams()
+
+        // THEN
+        if (BuildConfig.DEBUG) {
+            assertThat(encoderQueryParams).isEqualTo(
+                URLEncoder.encode(
+                    "build_type=developer&platform=android&version=${BuildConfig.VERSION_NAME}",
+                    Charsets.UTF_8.name()
+                )
+            )
+        } else {
+            assertThat(encoderQueryParams).isEqualTo(
+                URLEncoder.encode(
+                    "platform=android&version=${BuildConfig.VERSION_NAME}",
+                    Charsets.UTF_8.name()
+                )
+            )
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/QueryParamsEncoderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/QueryParamsEncoderTest.kt
@@ -3,30 +3,45 @@ package com.woocommerce.android.util
 import com.woocommerce.android.BuildConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.net.URLEncoder
 
 class QueryParamsEncoderTest {
-    private val queryParramsEncoder = QueryParamsEncoder()
+    private val buildConfigWrapper: BuildConfigWrapper = mock()
+    private val queryParramsEncoder = QueryParamsEncoder(buildConfigWrapper)
+
     @Test
-    fun `when getEncodedQueryParams called, then proper encoded query params returned`() {
+    fun `given debug build, when getEncodedQueryParams called, then proper encoded query params returned`() {
+        // GIVEN
+        whenever(buildConfigWrapper.debug).thenReturn(BuildConfig.DEBUG)
+
         // WHEN
         val encoderQueryParams = queryParramsEncoder.getEncodedQueryParams()
 
         // THEN
-        if (BuildConfig.DEBUG) {
-            assertThat(encoderQueryParams).isEqualTo(
-                URLEncoder.encode(
-                    "build_type=developer&platform=android&version=${BuildConfig.VERSION_NAME}",
-                    Charsets.UTF_8.name()
-                )
+        assertThat(encoderQueryParams).isEqualTo(
+            URLEncoder.encode(
+                "build_type=developer&platform=android&version=${BuildConfig.VERSION_NAME}",
+                Charsets.UTF_8.name()
             )
-        } else {
-            assertThat(encoderQueryParams).isEqualTo(
-                URLEncoder.encode(
-                    "platform=android&version=${BuildConfig.VERSION_NAME}",
-                    Charsets.UTF_8.name()
-                )
+        )
+    }
+
+    @Test
+    fun `given release build, when getEncodedQueryParams called, then proper encoded query params returned`() {
+        // GIVEN
+        whenever(buildConfigWrapper.debug).thenReturn(false)
+
+        // WHEN
+        val encoderQueryParams = queryParramsEncoder.getEncodedQueryParams()
+
+        // THEN
+        assertThat(encoderQueryParams).isEqualTo(
+            URLEncoder.encode(
+                "platform=android&version=${BuildConfig.VERSION_NAME}",
+                Charsets.UTF_8.name()
             )
-        }
+        )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8065 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR extracts the logic of encoding the query parameters before sending it to the JITM API call into a separate class so that it is reusable anywhere across the app.

Before this PR, the logic was present in `MyStoreViewModel`. In this PR, it's been moved into a separate `QueryParamsEncoder` class.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
**Pre-requisite**
As mentioned in this post (pdfdoF-1vt-p2) make sure you have installed any one of the mentioned barcode plugin installed on your store. For example - you can install [A4 Barcode Generator](https://wordpress.org/plugins/a4-barcode-generator/)

Your store must be set up in the US. JITM is not supported in any other country.

1. Visit the `MyStore` screen
2. Ensure you see the banner
3. In the `Flipper`, ensure the query params are being encoded while making a JITM API call

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->