### PR TITLE
Remove outdated Simple Payments feedback survey

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -32,8 +32,6 @@ object AppUrls {
     const val CROWDSIGNAL_SHIPPING_LABELS_SURVEY =
         "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
 
-    const val SIMPLE_PAYMENTS_SURVEY = "https://automattic.survey.fm/woo-app-quick-order-production"
-
     const val ORDER_CREATION_SURVEY = "https://automattic.survey.fm/woo-app-order-creation-production"
 
     const val ADDONS_SURVEY = "https://automattic.survey.fm/woo-app-addons-production"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -22,7 +22,6 @@ data class FeatureFeedbackSettings(
         SHIPPING_LABEL_M4,
         PRODUCT_VARIATIONS,
         PRODUCT_ADDONS,
-        SIMPLE_PAYMENTS,
         SIMPLE_PAYMENTS_AND_ORDER_CREATION,
         COUPONS
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.BuildConfig
 enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
     SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY, 4),
-    SIMPLE_PAYMENTS(AppUrls.SIMPLE_PAYMENTS_SURVEY, 1),
     ORDER_CREATION(AppUrls.ORDER_CREATION_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
     COUPONS(AppUrls.COUPONS_SURVEY),


### PR DESCRIPTION
### Description
The Simple Payments survey [was replaced with a new survey](https://href.li/?https://github.com/woocommerce/woocommerce-android/pull/6092) shared between Order Creation and Simple Payments features back in April 2022. This PR only removes a deadcode from the codebase.

### Testing instructions
No testing needed - CI checks are enough.

### Images/gif
No UI changes


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
