### PR TITLE
REST API: update FluxC to bring last migrations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-94601a5d4c1c98068adde0352ecc25e6d0046f35'
+    fluxCVersion = '2606-cfb84ac6fd9d7ea3de917ab5dd1bec8722607e23'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #8012 Closes: #8014 Closes: #8015

⚠️ Please don't merge until we update the commit hash with a `trunk` one.

### Description
This PR simply updates FluxC to bring the last migrations:
1. Reviews (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2601)
2. Products (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2602 and https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2603)
3. Order Stats (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2606)

### Testing instructions
Repeat the following for WordPress.com and site credentials logins:
1. Open the app, then sign in to the app.
2. Smoke test products
3. Smoke test reviews.
4. Smoke test stats (for site credentials login, only revenue stats will work).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
