### PR TITLE
[REST API] Update FluxC to align with Addons changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
@@ -29,7 +29,7 @@ class AddonRepository @Inject constructor(
 
     fun observeProductSpecificAddons(productRemoteID: Long): Flow<List<Addon>> =
         addonsStore.observeProductSpecificAddons(
-            selectedSite.get().siteId,
+            selectedSite.get(),
             productRemoteId = productRemoteID
         )
 
@@ -58,6 +58,6 @@ class AddonRepository @Inject constructor(
 
     private suspend fun getAddonsFrom(productID: Long) =
         productStore.getProductByRemoteId(selectedSite.get(), productID)
-            ?.let { addonsStore.observeAllAddonsForProduct(selectedSite.get().siteId, it) }
+            ?.let { addonsStore.observeAllAddonsForProduct(selectedSite.get(), it) }
             ?.firstOrNull()
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -39,9 +39,8 @@ class AddonRepositoryTest : BaseUnitTest() {
     private lateinit var productStoreMock: WCProductStore
     private lateinit var addonStoreMock: WCAddonsStore
     private lateinit var selectedSiteMock: SelectedSite
-    private lateinit var siteModelMock: SiteModel
+    private lateinit var testSite: SiteModel
 
-    private val localSiteID = 321
     private val remoteOrderID = 123L
     private val remoteProductID = 333L
 
@@ -53,11 +52,9 @@ class AddonRepositoryTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        siteModelMock = mock {
-            on { siteId }.doReturn(321)
-        }
+        testSite = SiteModel()
         selectedSiteMock = mock {
-            on { get() }.doReturn(siteModelMock)
+            on { get() }.doReturn(testSite)
         }
         orderStoreMock = mock()
         productStoreMock = mock()
@@ -80,10 +77,10 @@ class AddonRepositoryTest : BaseUnitTest() {
             ?.let { (productAddons, orderAddons) ->
 
                 verify(orderStoreMock, times(1))
-                    .getOrderByIdAndSite(123L, siteModelMock)
+                    .getOrderByIdAndSite(123L, testSite)
 
                 verify(productStoreMock, times(1))
-                    .getProductByRemoteId(siteModelMock, 333)
+                    .getProductByRemoteId(testSite, 333)
 
                 assertThat(productAddons).isNotEmpty
                 assertThat(orderAddons).isNotEmpty
@@ -101,10 +98,10 @@ class AddonRepositoryTest : BaseUnitTest() {
             ?.let { (_, orderAddons) ->
 
                 verify(orderStoreMock, times(1))
-                    .getOrderByIdAndSite(123L, siteModelMock)
+                    .getOrderByIdAndSite(123L, testSite)
 
                 verify(productStoreMock, times(1))
-                    .getProductByRemoteId(siteModelMock, 333)
+                    .getProductByRemoteId(testSite, 333)
 
                 assertThat(orderAddons).isEqualTo(expectedAddons)
             } ?: fail("non-null Pair with valid data was expected")
@@ -121,10 +118,10 @@ class AddonRepositoryTest : BaseUnitTest() {
             ?.let { (productAddons, _) ->
 
                 verify(productStoreMock, times(1))
-                    .getProductByRemoteId(siteModelMock, 333)
+                    .getProductByRemoteId(testSite, 333)
 
                 verify(addonStoreMock, times(1))
-                    .observeAllAddonsForProduct(siteModelMock.siteId, defaultWCProductModel)
+                    .observeAllAddonsForProduct(testSite, defaultWCProductModel)
 
                 assertThat(productAddons).isEqualTo(expectedAddons)
             } ?: fail("non-null Pair with valid data was expected")
@@ -194,7 +191,7 @@ class AddonRepositoryTest : BaseUnitTest() {
             whenever(getLineItemList()).thenReturn(defaultWCOrderItemList)
         }.let {
             whenever(
-                orderStoreMock.getOrderByIdAndSite(remoteOrderID, siteModelMock)
+                orderStoreMock.getOrderByIdAndSite(remoteOrderID, testSite)
             ).thenReturn(it)
         }
     }
@@ -202,12 +199,12 @@ class AddonRepositoryTest : BaseUnitTest() {
     private fun configureSuccessfulAddonResponse() {
         whenever(
             productStoreMock.getProductByRemoteId(
-                siteModelMock, remoteProductID
+                testSite, remoteProductID
             )
         ).thenReturn(defaultWCProductModel)
 
         whenever(
-            addonStoreMock.observeAllAddonsForProduct(localSiteID.toLong(), defaultWCProductModel)
+            addonStoreMock.observeAllAddonsForProduct(testSite, defaultWCProductModel)
         ).thenReturn(MutableStateFlow(defaultAddonsList))
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-94601a5d4c1c98068adde0352ecc25e6d0046f35'
+    fluxCVersion = '2617-fa762318536752e5113222aacab3a5f518e49a86'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #8079 

⚠️ Please don't merge.

### Description
This PR updates FluxC to align with the changes done in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2617

### Testing instructions
The Addons part should have been tested and confirmed in the FluxC PR.

For the `Inbox` testing steps:
1. Open the app then sign in.
2. Click on More.
3. Click on Inbox.
4. Check the different scenarios (action, dismiss, dismiss all).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
