### PR TITLE
Fix crash when logging in with site address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -143,35 +143,16 @@ class LoginActivity :
         }
     }
 
-    @Inject
-    internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
-
-    @Inject
-    internal lateinit var loginAnalyticsListener: LoginAnalyticsListener
-
-    @Inject
-    internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
-
-    @Inject
-    internal lateinit var zendeskHelper: ZendeskHelper
-
-    @Inject
-    internal lateinit var urlUtils: UrlUtils
-
-    @Inject
-    internal lateinit var experimentTracker: ExperimentTracker
-
-    @Inject
-    internal lateinit var appPrefsWrapper: AppPrefsWrapper
-
-    @Inject
-    internal lateinit var dispatcher: Dispatcher
-
-    @Inject
-    internal lateinit var loginNotificationScheduler: LoginNotificationScheduler
-
-    @Inject
-    internal lateinit var uiMessageResolver: UIMessageResolver
+    @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
+    @Inject internal lateinit var loginAnalyticsListener: LoginAnalyticsListener
+    @Inject internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
+    @Inject internal lateinit var zendeskHelper: ZendeskHelper
+    @Inject internal lateinit var urlUtils: UrlUtils
+    @Inject internal lateinit var experimentTracker: ExperimentTracker
+    @Inject internal lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var loginNotificationScheduler: LoginNotificationScheduler
+    @Inject internal lateinit var uiMessageResolver: UIMessageResolver
 
     private var loginMode: LoginMode? = null
     private lateinit var binding: ActivityLoginBinding
@@ -203,7 +184,6 @@ class LoginActivity :
                 val email = intent.extras!!.getString(EMAIL_PARAMETER)
                 gotWpcomEmail(email, verifyEmail = true, null)
             }
-
             hasJetpackConnectedIntent() -> {
                 AnalyticsTracker.track(
                     stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_COMPLETED,
@@ -211,15 +191,12 @@ class LoginActivity :
                 )
                 startLoginViaWPCom()
             }
-
             hasMagicLinkLoginIntent() -> {
                 getAuthTokenFromIntent()?.let { showMagicLinkInterceptFragment(it) }
             }
-
             !loginHelpNotification.isNullOrBlank() -> {
                 processLoginHelpNotification(loginHelpNotification)
             }
-
             savedInstanceState == null -> {
                 loginAnalyticsListener.trackLoginAccessed()
                 showPrologue()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -65,6 +65,7 @@ import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UrlUtils
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.sanitiseUrl
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
@@ -144,22 +145,31 @@ class LoginActivity :
 
     @Inject
     internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
     @Inject
     internal lateinit var loginAnalyticsListener: LoginAnalyticsListener
+
     @Inject
     internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
+
     @Inject
     internal lateinit var zendeskHelper: ZendeskHelper
+
     @Inject
     internal lateinit var urlUtils: UrlUtils
+
     @Inject
     internal lateinit var experimentTracker: ExperimentTracker
+
     @Inject
     internal lateinit var appPrefsWrapper: AppPrefsWrapper
+
     @Inject
     internal lateinit var dispatcher: Dispatcher
+
     @Inject
     internal lateinit var loginNotificationScheduler: LoginNotificationScheduler
+
     @Inject
     internal lateinit var uiMessageResolver: UIMessageResolver
 
@@ -193,6 +203,7 @@ class LoginActivity :
                 val email = intent.extras!!.getString(EMAIL_PARAMETER)
                 gotWpcomEmail(email, verifyEmail = true, null)
             }
+
             hasJetpackConnectedIntent() -> {
                 AnalyticsTracker.track(
                     stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_COMPLETED,
@@ -200,12 +211,15 @@ class LoginActivity :
                 )
                 startLoginViaWPCom()
             }
+
             hasMagicLinkLoginIntent() -> {
                 getAuthTokenFromIntent()?.let { showMagicLinkInterceptFragment(it) }
             }
+
             !loginHelpNotification.isNullOrBlank() -> {
                 processLoginHelpNotification(loginHelpNotification)
             }
+
             savedInstanceState == null -> {
                 loginAnalyticsListener.trackLoginAccessed()
                 showPrologue()
@@ -556,7 +570,7 @@ class LoginActivity :
     override fun gotConnectedSiteInfo(siteAddress: String, redirectUrl: String?, hasJetpack: Boolean) {
         // If the redirect url is available, use that as the preferred url. Pass this url to the other fragments
         // with the protocol since it is needed for initiating forgot password flow etc in the login process.
-        val inputSiteAddress = redirectUrl ?: siteAddress
+        val inputSiteAddress = (redirectUrl ?: siteAddress).sanitiseUrl()
 
         // Save site address to app prefs so it's available to MainActivity regardless of how the user
         // logs into the app. Strip the protocol from this url string prior to saving to AppPrefs since it's
@@ -931,6 +945,7 @@ class LoginActivity :
         val notificationType = when {
             !appPrefsWrapper.getLoginSiteAddress()
                 .isNullOrBlank() -> LOGIN_SITE_ADDRESS_PASSWORD_ERROR
+
             else -> LOGIN_WPCOM_PASSWORD_ERROR
         }
         loginNotificationScheduler.scheduleNotification(notificationType)
@@ -949,6 +964,7 @@ class LoginActivity :
             LOGIN_SITE_ADDRESS_ERROR -> startLoginViaWPCom()
             LOGIN_SITE_ADDRESS_PASSWORD_ERROR,
             LOGIN_WPCOM_PASSWORD_ERROR -> useMagicLinkInstead(appPrefsWrapper.getLoginEmail(), verifyEmail = false)
+
             LOGIN_WPCOM_EMAIL_ERROR,
             LOGIN_SITE_ADDRESS_EMAIL_ERROR,
             DEFAULT_HELP ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -65,7 +65,6 @@ import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UrlUtils
 import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.sanitiseUrl
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
@@ -547,7 +546,7 @@ class LoginActivity :
     override fun gotConnectedSiteInfo(siteAddress: String, redirectUrl: String?, hasJetpack: Boolean) {
         // If the redirect url is available, use that as the preferred url. Pass this url to the other fragments
         // with the protocol since it is needed for initiating forgot password flow etc in the login process.
-        val inputSiteAddress = (redirectUrl ?: siteAddress).sanitiseUrl()
+        val inputSiteAddress = urlUtils.sanitiseUrl(redirectUrl ?: siteAddress)
 
         // Save site address to app prefs so it's available to MainActivity regardless of how the user
         // logs into the app. Strip the protocol from this url string prior to saving to AppPrefs since it's

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.experiment.JetpackInstallationExperiment
 import com.woocommerce.android.experiment.JetpackInstallationExperiment.JetpackInstallationVariant
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
+import com.woocommerce.android.util.sanitiseUrl
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -35,8 +36,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.flow.zip
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.network.discovery.DiscoveryUtils
-import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
 
@@ -269,22 +268,6 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    /**
-     * Basic sanitization of the URL based on the same logic we use in the XMLRPC discovery
-     * see: https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/94601a5d4c1c98068adde0352ecc25e6d0046f35/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java#L292
-     */
-    private fun String.sanitiseUrl(): String {
-        return trim()
-            .trimEnd('/')
-            .let {
-                // Convert IDN names to punycode if necessary
-                UrlUtils.convertUrlToPunycodeIfNeeded(it)
-            }.let {
-                // Strip url from known usual trailing paths
-                DiscoveryUtils.stripKnownPaths(it)
-            }
     }
 
     private enum class Step {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.experiment.JetpackInstallationExperiment
 import com.woocommerce.android.experiment.JetpackInstallationExperiment.JetpackInstallationVariant
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
-import com.woocommerce.android.util.sanitiseUrl
+import com.woocommerce.android.util.UrlUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -46,7 +46,8 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
     private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val jetpackInstallationExperiment: JetpackInstallationExperiment
+    private val jetpackInstallationExperiment: JetpackInstallationExperiment,
+    private val urlUtils: UrlUtils
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val FETCHED_URL_KEY = "fetched_url"
@@ -173,7 +174,7 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
 
         sitePickRepository.fetchSiteInfo(siteAddressFlow.value).fold(
             onSuccess = {
-                val siteAddress = (it.urlAfterRedirects ?: it.url).sanitiseUrl()
+                val siteAddress = urlUtils.sanitiseUrl(it.urlAfterRedirects ?: it.url)
                 // Remove protocol prefix
                 val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
                 fetchedSiteUrl = siteAddress.replaceFirst(protocolRegex, "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
@@ -3,7 +3,9 @@ package com.woocommerce.android.util
 import android.content.Context
 import com.woocommerce.android.AppUrls
 import dagger.Reusable
+import org.wordpress.android.fluxc.network.discovery.DiscoveryUtils
 import org.wordpress.android.util.LanguageUtils
+import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
 @Reusable
@@ -13,4 +15,20 @@ class UrlUtils @Inject constructor(
     val tosUrlWithLocale by lazy {
         "${AppUrls.AUTOMATTIC_TOS}?locale=${LanguageUtils.getPatchedCurrentDeviceLanguage(context)}"
     }
+}
+
+/**
+ * Basic sanitization of the URL based on the same logic we use in the XMLRPC discovery
+ * see: https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/94601a5d4c1c98068adde0352ecc25e6d0046f35/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java#L292
+ */
+fun String.sanitiseUrl(): String {
+    return trim()
+        .trimEnd('/')
+        .let {
+            // Convert IDN names to punycode if necessary
+            UrlUtils.convertUrlToPunycodeIfNeeded(it)
+        }.let {
+            // Strip url from known usual trailing paths
+            DiscoveryUtils.stripKnownPaths(it)
+        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
@@ -15,20 +15,21 @@ class UrlUtils @Inject constructor(
     val tosUrlWithLocale by lazy {
         "${AppUrls.AUTOMATTIC_TOS}?locale=${LanguageUtils.getPatchedCurrentDeviceLanguage(context)}"
     }
-}
 
-/**
- * Basic sanitization of the URL based on the same logic we use in the XMLRPC discovery
- * see: https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/94601a5d4c1c98068adde0352ecc25e6d0046f35/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java#L292
- */
-fun String.sanitiseUrl(): String {
-    return trim()
-        .trimEnd('/')
-        .let {
-            // Convert IDN names to punycode if necessary
-            UrlUtils.convertUrlToPunycodeIfNeeded(it)
-        }.let {
-            // Strip url from known usual trailing paths
-            DiscoveryUtils.stripKnownPaths(it)
-        }
+    /**
+     * Basic sanitization of the URL based on the same logic we use in the XMLRPC discovery
+     * see: https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/94601a5d4c1c98068adde0352ecc25e6d0046f35/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java#L292
+     */
+    fun sanitiseUrl(url: String): String {
+        return url
+            .trim()
+            .trimEnd('/')
+            .let {
+                // Convert IDN names to punycode if necessary
+                UrlUtils.convertUrlToPunycodeIfNeeded(it)
+            }.let {
+                // Strip url from known usual trailing paths
+                DiscoveryUtils.stripKnownPaths(it)
+            }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
     mediapickerVersion = '0.1.1'
-    wordPressLoginVersion = '107-3a1adf7fcfc5b346479c5fb1028d6b18dc3bd8ad'
+    wordPressLoginVersion = '0.21.0'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
     mediapickerVersion = '0.1.1'
-    wordPressLoginVersion = '0.21.0'
+    wordPressLoginVersion = '107-3a1adf7fcfc5b346479c5fb1028d6b18dc3bd8ad'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #8056
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Fixes crash when trying to log in using their site address if the site address contains suffixes like wp-admin or wp-login.php

### Testing instructions
Log into the app using site address with `wp-admin` suffix and check that the app doesn't crash. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
