### PR TITLE
[REST API] Add an API to allow checking the type of connection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -2,8 +2,10 @@ package com.woocommerce.android.tools
 
 import android.content.Context
 import androidx.preference.PreferenceManager
+import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.util.PreferenceUtils
+import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.greenrobot.eventbus.EventBus
@@ -27,6 +29,30 @@ class SelectedSite(
     }
 
     private val state: MutableStateFlow<SiteModel?> = MutableStateFlow(getSelectedSiteFromPersistance())
+
+    val connectionType: SiteConnectionType?
+        get() = getIfExists()?.let { site ->
+            when {
+                site.origin != SiteModel.ORIGIN_WPCOM_REST -> SiteConnectionType.ApplicationPasswords
+                site.isJetpackConnected -> SiteConnectionType.Jetpack
+                site.isJetpackCPConnected -> SiteConnectionType.JetpackConnectionPackage
+                else -> {
+                    if (BuildConfig.DEBUG) {
+                        error("Can't determine site connection status")
+                    } else {
+                        WooLog.w(
+                            WooLog.T.UTILS,
+                            "Can't determine site connection status: \n" +
+                                "Origin: ${site.origin}, Jetpack Connected: ${site.isJetpackConnected}, " +
+                                "Jetpack CP Connected: ${site.isJetpackCPConnected}"
+                        )
+                        // A site that doesn't fall into the above conditions, it shouldn't happen,
+                        // but if it does in production, pretend it's a Jetpack connection
+                        SiteConnectionType.Jetpack
+                    }
+                }
+            }
+        }
 
     fun observe(): Flow<SiteModel?> = state
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SiteConnectionType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SiteConnectionType.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android.tools
+
+enum class SiteConnectionType {
+    Jetpack, JetpackConnectionPackage, ApplicationPasswords
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.StringUtils
@@ -54,9 +55,10 @@ class MainSettingsPresenter @Inject constructor(
     }
 
     override fun setupJetpackInstallOption() {
-        appSettingsFragmentView?.handleJetpackInstallOption(selectedSite.get().isJetpackCPConnected)
+        val isJetpackCPConnection = selectedSite.connectionType == SiteConnectionType.JetpackConnectionPackage
+        appSettingsFragmentView?.handleJetpackInstallOption(isJetpackCPSite = isJetpackCPConnection)
         jetpackMonitoringJob?.cancel()
-        if (selectedSite.get().isJetpackCPConnected) {
+        if (isJetpackCPConnection) {
             jetpackMonitoringJob = coroutineScope.launch {
                 selectedSite.observe()
                     .filter { it?.isJetpackConnected == true }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.mystore.domain
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.mystore.data.StatsRepository
 import com.woocommerce.android.ui.mystore.data.StatsRepository.StatsException
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -19,7 +20,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.WCStatsStore
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
@@ -175,9 +175,10 @@ class GetStatsTest : BaseUnitTest() {
     }
 
     private fun givenIsJetpackConnected(isJetPackConnected: Boolean) {
-        val siteModel = SiteModel()
-        siteModel.setIsJetpackCPConnected(isJetPackConnected)
-        whenever(selectedSite.getIfExists()).thenReturn(siteModel)
+        whenever(selectedSite.connectionType).thenReturn(
+            if (isJetPackConnected) SiteConnectionType.JetpackConnectionPackage
+            else SiteConnectionType.Jetpack
+        )
     }
 
     private suspend fun givenFetchVisitorStats(result: Result<Map<String, Int>>) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8095 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds a property to `SelectedSite` to return the type of connection of the given site:
1. Jetpack
2. Jetpack Connection Package
3. Application Passwords

This is useful to simplify the checks when we want to decide whether to hide a feature that's not available for a given site.
And it's needed also since the `isJetpackConnected` and `isJetpackCPConnected` are not enough by themselves, we need always to check the `origin` property too. This is because these properties represent whether the site has Jetpack and is connected, but they don't necessarily mean that the user is connected using the WordPress.com account (the XMLRPC site fetching logic check for Jetpack connection status, so we can have a site with `isJetpackConnected == true` while being connected using site credentials).

If you have any remarks or a better idea of how to architect the API, please share them 🙏.

### Testing instructions
For non-regression:

1. Make sure a Jetpack CP site is connected to your account (a site that uses WCPay or Jetpack backup instead of the full Jetpack plugin).
2. Open the app then sign to this site.
3. Confirm the visitors stats are hidden and the Jetpack banner is shown.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
