### PR TITLE
Send `customer_id` when creating a new order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -46,7 +46,8 @@ data class Order(
     val chargeId: String?,
     val shippingPhone: String,
     val paymentUrl: String,
-    val isEditable: Boolean
+    val isEditable: Boolean,
+    val customerId: Long?,
 ) : Parcelable {
     @IgnoredOnParcel
     val isOrderPaid = datePaid != null
@@ -334,7 +335,8 @@ data class Order(
                 taxLines = emptyList(),
                 shippingPhone = "",
                 paymentUrl = "",
-                isEditable = true
+                isEditable = true,
+                customerId = null,
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -52,7 +52,8 @@ class OrderMapper @Inject constructor(private val getLocations: GetLocations) {
             chargeId = metaDataList.getOrNull(CHARGE_ID_KEY),
             shippingPhone = metaDataList.getOrEmpty(SHIPPING_PHONE_KEY),
             paymentUrl = databaseEntity.paymentUrl,
-            isEditable = databaseEntity.isEditable
+            isEditable = databaseEntity.isEditable,
+            customerId = null
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
@@ -121,6 +121,7 @@ class OrderCreateEditCustomerAddFragment :
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> {
                     sharedViewModel.onCustomerAddressEdited(
+                        customerId = event.customerId,
                         billingAddress = event.addresses.getValue(BILLING),
                         shippingAddress = event.addresses.getValue(SHIPPING)
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -39,6 +39,7 @@ class OrderCreateEditRepository @Inject constructor(
 ) {
     suspend fun placeOrder(order: Order): Result<Order> {
         val request = UpdateOrderRequest(
+            customerId = order.customerId,
             status = order.status.toDataModel(),
             lineItems = order.items.map { item ->
                 LineItem(
@@ -98,6 +99,7 @@ class OrderCreateEditRepository @Inject constructor(
 
     suspend fun createOrUpdateDraft(order: Order): Result<Order> {
         val request = UpdateOrderRequest(
+            customerId = order.customerId,
             status = order.status.toDataModel(),
             lineItems = order.items.map { item ->
                 LineItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -248,7 +248,7 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
-    fun onCustomerAddressEdited(billingAddress: Address, shippingAddress: Address) {
+    fun onCustomerAddressEdited(customerId: Long, billingAddress: Address, shippingAddress: Address) {
         val hasDifferentShippingDetails = _orderDraft.value.shippingAddress != _orderDraft.value.billingAddress
         tracker.track(
             ORDER_CUSTOMER_ADD,
@@ -260,6 +260,7 @@ class OrderCreateEditViewModel @Inject constructor(
 
         _orderDraft.update { order ->
             order.copy(
+                customerId = customerId,
                 billingAddress = billingAddress,
                 shippingAddress = shippingAddress.takeIf { it != Address.EMPTY } ?: billingAddress
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -248,7 +248,7 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
-    fun onCustomerAddressEdited(customerId: Long, billingAddress: Address, shippingAddress: Address) {
+    fun onCustomerAddressEdited(customerId: Long?, billingAddress: Address, shippingAddress: Address) {
         val hasDifferentShippingDetails = _orderDraft.value.shippingAddress != _orderDraft.value.billingAddress
         tracker.track(
             ORDER_CUSTOMER_ADD,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
@@ -60,6 +60,7 @@ class CustomerListFragment :
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is CustomerListViewModel.CustomerSelected -> {
                     addressViewModel.onAddressesChanged(
+                        customerId = event.customerId,
                         billingAddress = event.billingAddress,
                         shippingAddress = event.shippingAddress
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListViewModel.kt
@@ -80,6 +80,7 @@ class CustomerListViewModel @Inject constructor(
 
                 triggerEvent(
                     CustomerSelected(
+                        customerId = customerRemoteId,
                         shippingAddress = shippingAddress.toAddressModel(shippingCountry, shippingState),
                         billingAddress = billingAddress.toAddressModel(billingCountry, billingState)
                     )
@@ -169,6 +170,7 @@ class CustomerListViewModel @Inject constructor(
     ) : Parcelable
 
     data class CustomerSelected(
+        val customerId: Long,
         val billingAddress: Address,
         val shippingAddress: Address
     ) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -199,6 +199,7 @@ class AddressViewModel @Inject constructor(
 
         triggerEvent(
             Exit(
+                customerId = viewState.customerId,
                 viewState.addressSelectionStates.mapValues { statePair ->
                     if (addDifferentShippingChecked == false && statePair.key == AddressType.SHIPPING) {
                         Address.EMPTY
@@ -240,10 +241,12 @@ class AddressViewModel @Inject constructor(
     }
 
     fun onAddressesChanged(
+        customerId: Long,
         billingAddress: Address,
         shippingAddress: Address
     ) {
         viewState = viewState.copy(
+            customerId = customerId,
             addressSelectionStates = mapOf(
                 AddressType.BILLING to AddressSelectionState(
                     billingAddress,
@@ -259,6 +262,7 @@ class AddressViewModel @Inject constructor(
 
     @Parcelize
     data class ViewState(
+        val customerId: Long = 0,
         val addressSelectionStates: Map<AddressType, AddressSelectionState> = emptyMap(),
         val isLoading: Boolean = false,
     ) : Parcelable
@@ -288,6 +292,7 @@ class AddressViewModel @Inject constructor(
     ) : MultiLiveEvent.Event()
 
     data class Exit(
+        val customerId: Long,
         val addresses: Map<AddressType, Address>
     ) : MultiLiveEvent.Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -262,7 +262,7 @@ class AddressViewModel @Inject constructor(
 
     @Parcelize
     data class ViewState(
-        val customerId: Long = 0,
+        val customerId: Long? = null,
         val addressSelectionStates: Map<AddressType, AddressSelectionState> = emptyMap(),
         val isLoading: Boolean = false,
     ) : Parcelable
@@ -292,7 +292,7 @@ class AddressViewModel @Inject constructor(
     ) : MultiLiveEvent.Event()
 
     data class Exit(
-        val customerId: Long,
+        val customerId: Long?,
         val addresses: Map<AddressType, Address>
     ) : MultiLiveEvent.Event()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -41,6 +41,10 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     override val mode: Mode = Creation
     override val tracksFlow: String = VALUE_FLOW_CREATION
 
+    companion object {
+        private const val DEFAULT_CUSTOMER_ID = 0L
+    }
+
     override fun initMocksForAnalyticsWithOrder(order: Order) {
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
@@ -93,7 +97,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         val defaultBillingAddress = Address.EMPTY.copy(firstName = "Test", lastName = "Billing")
         val defaultShippingAddress = Address.EMPTY.copy(firstName = "Test", lastName = "Shipping")
 
-        sut.onCustomerAddressEdited(defaultBillingAddress, defaultShippingAddress)
+        sut.onCustomerAddressEdited(DEFAULT_CUSTOMER_ID, defaultBillingAddress, defaultShippingAddress)
 
         assertThat(orderDraft?.billingAddress).isEqualTo(defaultBillingAddress)
         assertThat(orderDraft?.shippingAddress).isEqualTo(defaultShippingAddress)
@@ -108,7 +112,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         val defaultBillingAddress = Address.EMPTY.copy(firstName = "Test", lastName = "Billing")
         val defaultShippingAddress = Address.EMPTY
 
-        sut.onCustomerAddressEdited(defaultBillingAddress, defaultShippingAddress)
+        sut.onCustomerAddressEdited(DEFAULT_CUSTOMER_ID, defaultBillingAddress, defaultShippingAddress)
 
         assertThat(orderDraft?.billingAddress).isEqualTo(defaultBillingAddress)
         assertThat(orderDraft?.shippingAddress).isEqualTo(defaultBillingAddress)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -120,7 +120,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when customer address edited, send tracks event`() {
-        sut.onCustomerAddressEdited(Address.EMPTY, Address.EMPTY)
+        sut.onCustomerAddressEdited(0, Address.EMPTY, Address.EMPTY)
 
         verify(tracker).track(
             AnalyticsEvent.ORDER_CUSTOMER_ADD,

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2609-a2191b5200f6793af6f63572245663683bac0895'
+    fluxCVersion = 'trunk-30b4719077c9d94496d24b506a8ea45fcb590c8e'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-a0e76ec7a4948baba2c77a05f5c5d6ade3b1f84e'
+    fluxCVersion = '2609-a2191b5200f6793af6f63572245663683bac0895'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7968 
Closes https://github.com/woocommerce/woocommerce-android/issues/8117
<!-- Id number of the GitHub issue this PR addresses. -->

Review & merge FluxC PR first: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2609

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR supports adding the `customer_id` property to the Order Creation payload if a user was selected. This way we'll identify correct user in Woo Core. See attached issue for more details.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### TC1 Add a customer

1. Open the order creation screen
2. In `Customer` section tap `Edit` and search for any customer
3. Select a customer
4. Create the order
5. **Assert that in details of order in Woo Core the customer is assigned like below:**

<img width="667" alt="image" src="https://user-images.githubusercontent.com/5845095/210537811-500972ea-12d6-43b8-80b8-db3922a50742.png">


#### TC2 Do not add customer
1. Open the order creation screen
2. In `Customer` section tap `Edit` and enter some random values
3. Create the order
4. **Assert that in details of order in Woo Core the customer is not assigned**


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
