### PR TITLE
[REST API] Hide visitor stats

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -2,10 +2,8 @@ package com.woocommerce.android.tools
 
 import android.content.Context
 import androidx.preference.PreferenceManager
-import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.util.PreferenceUtils
-import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.greenrobot.eventbus.EventBus
@@ -31,28 +29,7 @@ class SelectedSite(
     private val state: MutableStateFlow<SiteModel?> = MutableStateFlow(getSelectedSiteFromPersistance())
 
     val connectionType: SiteConnectionType?
-        get() = getIfExists()?.let { site ->
-            when {
-                site.origin != SiteModel.ORIGIN_WPCOM_REST -> SiteConnectionType.ApplicationPasswords
-                site.isJetpackConnected -> SiteConnectionType.Jetpack
-                site.isJetpackCPConnected -> SiteConnectionType.JetpackConnectionPackage
-                else -> {
-                    if (BuildConfig.DEBUG) {
-                        error("Can't determine site connection status")
-                    } else {
-                        WooLog.w(
-                            WooLog.T.UTILS,
-                            "Can't determine site connection status: \n" +
-                                "Origin: ${site.origin}, Jetpack Connected: ${site.isJetpackConnected}, " +
-                                "Jetpack CP Connected: ${site.isJetpackCPConnected}"
-                        )
-                        // A site that doesn't fall into the above conditions, it shouldn't happen,
-                        // but if it does in production, pretend it's a Jetpack connection
-                        SiteConnectionType.Jetpack
-                    }
-                }
-            }
-        }
+        get() = getIfExists()?.connectionType
 
     fun observe(): Flow<SiteModel?> = state
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SiteConnectionType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SiteConnectionType.kt
@@ -1,5 +1,31 @@
 package com.woocommerce.android.tools
 
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.util.WooLog
+import org.wordpress.android.fluxc.model.SiteModel
+
 enum class SiteConnectionType {
     Jetpack, JetpackConnectionPackage, ApplicationPasswords
 }
+
+val SiteModel.connectionType
+    get() = when {
+        origin != SiteModel.ORIGIN_WPCOM_REST -> SiteConnectionType.ApplicationPasswords
+        isJetpackConnected -> SiteConnectionType.Jetpack
+        isJetpackCPConnected -> SiteConnectionType.JetpackConnectionPackage
+        else -> {
+            if (BuildConfig.DEBUG) {
+                error("Can't determine site connection status")
+            } else {
+                WooLog.w(
+                    WooLog.T.UTILS,
+                    """Can't determine site connection status:
+                        "Origin: $origin, Jetpack Connected: $isJetpackConnected,
+                        "Jetpack CP Connected: $isJetpackCPConnected"""
+                )
+                // A site that doesn't fall into the above conditions, it shouldn't happen,
+                // but if it does in production, pretend it's a Jetpack connection
+                SiteConnectionType.Jetpack
+            }
+        }
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -222,7 +222,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                     binding.jetpackBenefitsBanner.root.isVisible = false
                     binding.myStoreStats.showVisitorStatsError()
                 }
-                is VisitorStatsViewState.JetpackCpConnected -> onJetpackCpConnected(stats.benefitsBanner)
+                is VisitorStatsViewState.Unavailable -> onVisitorStatsUnavailable(stats)
             }
         }
         viewModel.topPerformersState.observe(viewLifecycleOwner) { topPerformers ->
@@ -265,20 +265,22 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         }
     }
 
-    private fun onJetpackCpConnected(benefitsBanner: BenefitsBannerUiModel) {
-        showEmptyVisitorStatsForJetpackCP()
-        if (benefitsBanner.show) {
+    private fun onVisitorStatsUnavailable(state: VisitorStatsViewState.Unavailable) {
+        handleUnavailableVisitorStats()
+
+        val jetpackBenefitsBanner = state.benefitsBanner
+        if (jetpackBenefitsBanner.show) {
             binding.jetpackBenefitsBanner.dismissButton.setOnClickListener {
-                benefitsBanner.onDismiss()
+                jetpackBenefitsBanner.onDismiss()
             }
         }
-        if (benefitsBanner.show && !binding.jetpackBenefitsBanner.root.isVisible) {
+        if (jetpackBenefitsBanner.show && !binding.jetpackBenefitsBanner.root.isVisible) {
             AnalyticsTracker.track(
                 stat = AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER,
                 properties = mapOf(AnalyticsTracker.KEY_JETPACK_BENEFITS_BANNER_ACTION to "shown")
             )
         }
-        binding.jetpackBenefitsBanner.root.isVisible = benefitsBanner.show
+        binding.jetpackBenefitsBanner.root.isVisible = jetpackBenefitsBanner.show
     }
 
     private fun showTopPerformersLoading() {
@@ -386,8 +388,8 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         binding.myStoreStats.showVisitorStats(visitorStats)
     }
 
-    private fun showEmptyVisitorStatsForJetpackCP() {
-        binding.myStoreStats.showEmptyVisitorStatsForJetpackCP()
+    private fun handleUnavailableVisitorStats() {
+        binding.myStoreStats.handleUnavailableVisitorStats()
     }
 
     private fun showErrorSnack() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -422,7 +422,7 @@ class MyStoreStatsView @JvmOverloads constructor(
         binding.statsViewRow.visitorsValueTextview.isVisible = false
     }
 
-    fun showEmptyVisitorStatsForJetpackCP() {
+    fun handleUnavailableVisitorStats() {
         binding.statsViewRow.emptyVisitorsStatsGroup.isVisible = true
         binding.statsViewRow.visitorsValueTextview.isVisible = false
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreUiModels.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.mystore
 
-data class BenefitsBannerUiModel(
+data class JetpackBenefitsBannerUiModel(
     val show: Boolean = false,
     val onDismiss: () -> Unit = {}
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -18,15 +18,17 @@ import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.analytics.daterangeselector.AnalyticTimePeriod
 import com.woocommerce.android.ui.jitm.JitmTracker
 import com.woocommerce.android.ui.jitm.QueryParamsEncoder
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders
-import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.IsJetPackCPEnabled
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.PluginNotActive
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.RevenueStatsError
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.RevenueStatsSuccess
+import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.VisitorStatUnavailable
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.VisitorsStatsError
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.VisitorsStatsSuccess
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
@@ -315,7 +317,7 @@ class MyStoreViewModel @Inject constructor(
                     PluginNotActive -> _revenueStatsState.value = RevenueStatsViewState.PluginNotActiveError
                     is VisitorsStatsSuccess -> _visitorStatsState.value = VisitorStatsViewState.Content(it.stats)
                     is VisitorsStatsError -> _visitorStatsState.value = VisitorStatsViewState.Error
-                    IsJetPackCPEnabled -> onJetPackCpConnected()
+                    is VisitorStatUnavailable -> onVisitorStatsUnavailable(it.connectionType)
                     is HasOrders -> _hasOrders.value = if (it.hasOrder) OrderState.AtLeastOne else OrderState.Empty
                 }
                 myStoreTransactionLauncher.onStoreStatisticsFetched()
@@ -336,25 +338,26 @@ class MyStoreViewModel @Inject constructor(
         )
     }
 
-    private fun onJetPackCpConnected() {
+    private fun onVisitorStatsUnavailable(connectionType: SiteConnectionType) {
         val daysSinceDismissal = TimeUnit.MILLISECONDS.toDays(
             System.currentTimeMillis() - appPrefsWrapper.getJetpackBenefitsDismissalDate()
         )
-        val showBanner = daysSinceDismissal >= DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER
-        val benefitsBanner =
-            BenefitsBannerUiModel(
-                show = showBanner,
-                onDismiss = {
-                    _visitorStatsState.value =
-                        VisitorStatsViewState.JetpackCpConnected(BenefitsBannerUiModel(show = false))
-                    appPrefsWrapper.recordJetpackBenefitsDismissal()
-                    analyticsTrackerWrapper.track(
-                        stat = AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER,
-                        properties = mapOf(AnalyticsTracker.KEY_JETPACK_BENEFITS_BANNER_ACTION to "dismissed")
-                    )
-                }
-            )
-        _visitorStatsState.value = VisitorStatsViewState.JetpackCpConnected(benefitsBanner)
+        // For now, the banner is shown only when the site is a Jetpack CP site
+        val showBanner = connectionType == SiteConnectionType.JetpackConnectionPackage &&
+            daysSinceDismissal >= DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER
+        val benefitsBanner = JetpackBenefitsBannerUiModel(
+            show = showBanner,
+            onDismiss = {
+                _visitorStatsState.value =
+                    VisitorStatsViewState.Unavailable(JetpackBenefitsBannerUiModel(show = false))
+                appPrefsWrapper.recordJetpackBenefitsDismissal()
+                analyticsTrackerWrapper.track(
+                    stat = AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER,
+                    properties = mapOf(AnalyticsTracker.KEY_JETPACK_BENEFITS_BANNER_ACTION to "dismissed")
+                )
+            }
+        )
+        _visitorStatsState.value = VisitorStatsViewState.Unavailable(benefitsBanner)
         monitorJetpackInstallation()
     }
 
@@ -362,7 +365,7 @@ class MyStoreViewModel @Inject constructor(
         jetpackMonitoringJob?.cancel()
         jetpackMonitoringJob = viewModelScope.launch {
             selectedSite.observe()
-                .filter { it?.isJetpackConnected == true }
+                .filter { it?.connectionType == SiteConnectionType.Jetpack }
                 .take(1)
                 .collect {
                     loadStoreStats(_activeStatsGranularity.value)
@@ -495,8 +498,8 @@ class MyStoreViewModel @Inject constructor(
 
     sealed class VisitorStatsViewState {
         object Error : VisitorStatsViewState()
-        data class JetpackCpConnected(
-            val benefitsBanner: BenefitsBannerUiModel
+        data class Unavailable(
+            val benefitsBanner: JetpackBenefitsBannerUiModel
         ) : VisitorStatsViewState()
 
         data class Content(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
@@ -157,10 +157,14 @@ class GetStatsTest : BaseUnitTest() {
             givenIsJetpackConnected(true)
 
             val result = getStats(refresh = false, granularity = ANY_GRANULARITY)
-                .filter { it is GetStats.LoadStatsResult.IsJetPackCPEnabled }
+                .filter { it is GetStats.LoadStatsResult.VisitorStatUnavailable }
                 .first()
 
-            assertThat(result).isEqualTo(GetStats.LoadStatsResult.IsJetPackCPEnabled)
+            assertThat(result).isEqualTo(
+                GetStats.LoadStatsResult.VisitorStatUnavailable(
+                    connectionType = SiteConnectionType.JetpackConnectionPackage
+                )
+            )
         }
 
     private suspend fun givenCheckIfStoreHasNoOrdersFlow(result: Result<Boolean>) {


### PR DESCRIPTION
Part of: #8107 

### Description
This PR refactors the visitor stats loading to allow exposing the cause of the "unavailability" represented by the connection type.
This will allow customizing the UI shown when needed (for now we are keeping the same UI as Jetpack CP, just without the Jetpack banner).

The first commit in the PR dc4a186923259bb02468c15dfff6dffa62d10b7c is something that should've been part of #8095, but I didn't think about the need of the observability before, so I added it now. 

### Testing instructions
1. Open the app.
2. Sign in using site credentials.
3. Confirm the visitor stats are hidden (ignore the Snackbar errors for now, the cause is that the top performers endpoint is not migrated in `trunk` yet)

### Images/gif
<img width=400 src="https://user-images.githubusercontent.com/1657201/210552765-58c737a6-5164-4a3d-9f47-a9f9aba5b49a.png"/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
