### PR TITLE
Fix/remove dependency from debug sourceset

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InAppPurchasesModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InAppPurchasesModule.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.woocommerce.android.iap.pub.IAPSitePurchasePlanFactory
 import com.woocommerce.android.iap.pub.PurchaseWPComPlanActions
 import com.woocommerce.android.iap.pub.PurchaseWpComPlanSupportChecker
-import com.woocommerce.android.iapshowcase.purchase.IAPShowcaseMobilePayAPIProvider
+import com.woocommerce.android.ui.login.storecreation.iap.IapMobilePayApiProvider
 import com.woocommerce.android.ui.login.storecreation.iap.WooIapLogWrapper
 import dagger.Module
 import dagger.Provides
@@ -19,7 +19,7 @@ class InAppPurchasesModule {
     @Provides
     fun providePurchaseWPComPlanActions(
         context: Application,
-        mobilePayAPIProvider: IAPShowcaseMobilePayAPIProvider
+        mobilePayAPIProvider: IapMobilePayApiProvider
     ): PurchaseWPComPlanActions =
         IAPSitePurchasePlanFactory.createIAPSitePurchasePlan(
             context,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/iap/IapMobilePayApiProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/iap/IapMobilePayApiProvider.kt
@@ -6,6 +6,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.mobilepay.MobilePayRestCli
 import org.wordpress.android.fluxc.store.MobilePayStore
 import javax.inject.Inject
 
+/**
+ * This class provides a default implementation of IAPMobilePayAPI for store creation flow. It duplicates
+ * code from IAPShowcaseMobilePayAPIProvider. We should double check if we need this duplication to remove
+ * one of the files and move the other to the correct package.
+ * Github issue: https://github.com/woocommerce/woocommerce-android/issues/8148
+ */
 class IapMobilePayApiProvider @Inject constructor(private val mobilePayStore: MobilePayStore) {
     fun buildMobilePayAPI(customUrl: String?) = object : IAPMobilePayAPI {
         override suspend fun createAndConfirmOrder(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/iap/IapMobilePayApiProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/iap/IapMobilePayApiProvider.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.ui.login.storecreation.iap
+
+import com.woocommerce.android.iap.pub.network.IAPMobilePayAPI
+import com.woocommerce.android.iap.pub.network.model.CreateAndConfirmOrderResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.mobilepay.MobilePayRestClient
+import org.wordpress.android.fluxc.store.MobilePayStore
+import javax.inject.Inject
+
+class IapMobilePayApiProvider @Inject constructor(private val mobilePayStore: MobilePayStore) {
+    fun buildMobilePayAPI(customUrl: String?) = object : IAPMobilePayAPI {
+        override suspend fun createAndConfirmOrder(
+            remoteSiteId: Long,
+            productIdentifier: String,
+            priceInCents: Int,
+            currency: String,
+            purchaseToken: String,
+            appId: String
+        ): CreateAndConfirmOrderResponse {
+            val response = mobilePayStore.createOrder(
+                productIdentifier,
+                priceInCents,
+                currency,
+                purchaseToken,
+                appId,
+                remoteSiteId,
+                customUrl = customUrl
+            )
+            return when (response) {
+                is MobilePayRestClient.CreateOrderResponse.Success -> {
+                    CreateAndConfirmOrderResponse.Success(response.orderId)
+                }
+                is MobilePayRestClient.CreateOrderResponse.Error -> {
+                    when (response.type) {
+                        MobilePayRestClient.CreateOrderErrorType.API_ERROR,
+                        MobilePayRestClient.CreateOrderErrorType.AUTH_ERROR,
+                        MobilePayRestClient.CreateOrderErrorType.GENERIC_ERROR,
+                        MobilePayRestClient.CreateOrderErrorType.INVALID_RESPONSE ->
+                            CreateAndConfirmOrderResponse.Server(response.message ?: "Reason is not provided")
+                        MobilePayRestClient.CreateOrderErrorType.TIMEOUT -> CreateAndConfirmOrderResponse.Network
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description 
This PR removes the use of `IAPShowcaseMobilePayAPIProvider` in production code to fix `release` build compile issues. Instead, it adds new `IapMobilePayApiProvider` file available for `release` source sets that copies the code we had in `IAPShowcaseMobilePayAPIProvider`. This is enough for now, as IAP feature is still under development and we might refactor this code later on.

Keep in mind that In-App Purchases code is under a feature flag that only enables the feature for `debug` builds, so these are production safe changes.

Compiling the app for `release` using `./gradlew assembleVanillaRelease` should be enough to check the problem is fixed. 

Sorry for the trouble caused for generating the release.