### PR TITLE
[REST API] Check Application Passwords status

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android
 
 import android.app.Application
 import android.appwidget.AppWidgetManager
-import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
@@ -10,8 +9,6 @@ import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.automattic.android.experimentation.ExPlat
 import com.automattic.android.tracks.crashlogging.CrashLogging
-import com.google.android.gms.common.ConnectionResult
-import com.google.android.gms.common.GoogleApiAvailability
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
@@ -246,22 +243,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                     selectedSite.reset()
                     openMainActivity()
                 }
-            }
-        }
-    }
-
-    private fun isGooglePlayServicesAvailable(context: Context): Boolean {
-        val googleApiAvailability = GoogleApiAvailability.getInstance()
-
-        return when (val connectionResult = googleApiAvailability.isGooglePlayServicesAvailable(context)) {
-            ConnectionResult.SUCCESS -> true
-            else -> {
-                WooLog.w(
-                    T.NOTIFS,
-                    "Google Play Services unavailable, connection result: " +
-                        googleApiAvailability.getErrorString(connectionResult)
-                )
-                return false
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/ApplicationPasswordsDisabledDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/ApplicationPasswordsDisabledDialogFragment.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 
 class ApplicationPasswordsDisabledDialogFragment : LoginBaseErrorDialogFragment() {
     companion object {
+        const val RETRY_RESULT = "retry"
         private const val SITE_URL_KEY = "site-url"
         private const val APPLICATION_PASSWORDS_GUIDE =
             "https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/"
@@ -31,5 +32,14 @@ class ApplicationPasswordsDisabledDialogFragment : LoginBaseErrorDialogFragment(
                     ChromeCustomTabUtils.launchUrl(requireContext(), APPLICATION_PASSWORDS_GUIDE)
                 }
             )
+        )
+
+    override val primaryButton: LoginErrorButton
+        get() = LoginErrorButton(
+            title = R.string.retry,
+            onClick = {
+                setFragmentResult(RETRY_RESULT, bundleOf())
+                dismiss()
+            }
         )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/ApplicationPasswordsDisabledDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/ApplicationPasswordsDisabledDialogFragment.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.ui.login.error
+
+import androidx.core.os.bundleOf
+import androidx.fragment.app.setFragmentResult
+import com.woocommerce.android.R
+import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.ui.login.error.base.LoginBaseErrorDialogFragment
+import com.woocommerce.android.util.ChromeCustomTabUtils
+
+class ApplicationPasswordsDisabledDialogFragment : LoginBaseErrorDialogFragment() {
+    companion object {
+        private const val SITE_URL_KEY = "site-url"
+        private const val APPLICATION_PASSWORDS_GUIDE =
+            "https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/"
+
+        fun newInstance(siteUrl: String) = ApplicationPasswordsDisabledDialogFragment().apply {
+            arguments = bundleOf(SITE_URL_KEY to siteUrl)
+        }
+    }
+
+    override val text: CharSequence
+        get() = getString(R.string.login_application_passwords_unavailable, requireArguments().getString(SITE_URL_KEY))
+    override val helpOrigin: HelpOrigin
+        get() = HelpOrigin.LOGIN_SITE_ADDRESS
+
+    override val inlineButtons: List<LoginErrorButton>
+        get() = listOf(
+            LoginErrorButton(
+                title = R.string.login_application_passwords_help,
+                onClick = {
+                    ChromeCustomTabUtils.launchUrl(requireContext(), APPLICATION_PASSWORDS_GUIDE)
+                }
+            )
+        )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
@@ -11,8 +11,10 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.error.ApplicationPasswordsDisabledDialogFragment
 import com.woocommerce.android.ui.login.error.notwoo.LoginNotWooDialogFragment
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.LoggedIn
+import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowApplicationPasswordsUnavailableScreen
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowNonWooErrorScreen
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowResetPasswordScreen
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -68,6 +70,9 @@ class LoginSiteCredentialsFragment : Fragment() {
                 is LoggedIn -> loginListener.loggedInViaUsernamePassword(arrayListOf(it.localSiteId))
                 is ShowResetPasswordScreen -> loginListener.forgotPassword(it.siteAddress)
                 is ShowNonWooErrorScreen -> LoginNotWooDialogFragment.newInstance(it.siteAddress)
+                    .show(childFragmentManager, LoginNotWooDialogFragment.TAG)
+                is ShowApplicationPasswordsUnavailableScreen -> ApplicationPasswordsDisabledDialogFragment
+                    .newInstance(it.siteAddress)
                     .show(childFragmentManager, LoginNotWooDialogFragment.TAG)
                 is ShowSnackbar -> uiMessageResolver.showSnack(it.message)
                 is ShowUiStringSnackbar -> uiMessageResolver.showSnack(it.message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
@@ -71,9 +71,9 @@ class LoginSiteCredentialsFragment : Fragment() {
                 is ShowResetPasswordScreen -> loginListener.forgotPassword(it.siteAddress)
                 is ShowNonWooErrorScreen -> LoginNotWooDialogFragment.newInstance(it.siteAddress)
                     .show(childFragmentManager, LoginNotWooDialogFragment.TAG)
-                is ShowApplicationPasswordsUnavailableScreen -> ApplicationPasswordsDisabledDialogFragment
-                    .newInstance(it.siteAddress)
-                    .show(childFragmentManager, LoginNotWooDialogFragment.TAG)
+                is ShowApplicationPasswordsUnavailableScreen ->
+                    ApplicationPasswordsDisabledDialogFragment.newInstance(it.siteAddress)
+                        .show(childFragmentManager, LoginNotWooDialogFragment.TAG)
                 is ShowSnackbar -> uiMessageResolver.showSnack(it.message)
                 is ShowUiStringSnackbar -> uiMessageResolver.showSnack(it.message)
                 is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
@@ -87,6 +87,13 @@ class LoginSiteCredentialsFragment : Fragment() {
             viewLifecycleOwner
         ) { _, _ ->
             viewModel.onWooInstallationAttempted()
+        }
+
+        childFragmentManager.setFragmentResultListener(
+            ApplicationPasswordsDisabledDialogFragment.RETRY_RESULT,
+            viewLifecycleOwner
+        ) { _, _ ->
+            viewModel.retryApplicationPasswordsCheck()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -22,7 +22,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -46,7 +48,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     private val wpApiSiteRepository: WPApiSiteRepository,
     private val selectedSite: SelectedSite,
     private val loginAnalyticsListener: LoginAnalyticsListener,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val applicationPasswordsNotifier: ApplicationPasswordsNotifier
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         const val SITE_ADDRESS_KEY = "site-address"
@@ -77,6 +80,11 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     init {
         loginAnalyticsListener.trackUsernamePasswordFormViewed()
+        applicationPasswordsNotifier.featureUnavailableEvents
+            .onEach {
+                triggerEvent(ShowApplicationPasswordsUnavailableScreen(siteAddress))
+            }
+            .launchIn(this)
     }
 
     fun onUsernameChanged(username: String) {
@@ -193,4 +201,5 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     data class LoggedIn(val localSiteId: Int) : MultiLiveEvent.Event()
     data class ShowResetPasswordScreen(val siteAddress: String) : MultiLiveEvent.Event()
     data class ShowNonWooErrorScreen(val siteAddress: String) : MultiLiveEvent.Event()
+    data class ShowApplicationPasswordsUnavailableScreen(val siteAddress: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -335,6 +335,7 @@
     <string name="login_jetpack_installation_connection_dismissed_explanation">Try connecting again to access your store.</string>
     <string name="login_jetpack_installation_continue_connection">Continue connection</string>
     <string name="login_jetpack_installation_exit_without_connection">Exit Without Connecting</string>
+    <string name="login_application_passwords_unavailable">It looks like Application Passwords feature is disabled in your site %1$s.\n Please enable it to use the WooCommerce app.</string>
 
     <!--
         My Store View
@@ -2814,4 +2815,5 @@
 
     <string name="store_creation_store_categories_title">What’s your business about?</string>
     <string name="store_creation_store_categories_subtitle">Choose a category that defines your business the best.</string><string name="not_a_valid_qr_code">Scanned Qr code is not a WooCommerce code</string>
+    <string name="login_application_passwords_help">What are Application Passwords?</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8110
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
#### Login
1. Install a plugin that disables application passwords (I use this [one](https://wordpress.org/plugins/disable-application-passwords/))
2. Open the app
3. Sign in using site credentials.
4. Confirm that the error screen is shown.
5. Go back to the site, and deactivate the plugin.
6. Click on Retry.
7. Confirm the login continues.

#### Check when using the app
1. After sign in, go to your site, then re-install/re-activate the plugin.
2. Start using the app (open orders or products then force fetching, the same would happen when relaunching the app).
3. Notice the app will log you out.

Note: regarding the last test, we can probably do better, but for now this will do, the user will see the correct error message if they try to sign in to the same site. We'll add some tracking to track the number of cases where this happens, and decide if it's worth improvement or not.

### Images/gif
The recording is choppy, I don't know why 😕 

https://user-images.githubusercontent.com/1657201/211362352-273228f9-e9bb-4361-ad22-5b4646b9bdf2.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
