### PR TITLE
[REST API] Check user role

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -192,11 +192,15 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     }
 
     override fun onFirstActivityResumed() {
-        // Update the WP.com account details, settings, and site list every time the app is completely restarted,
-        // only if the logged in
-        if (networkStatus.isConnected() && accountStore.hasAccessToken()) {
-            dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
-            dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
+        // App is completely restarted
+        if (networkStatus.isConnected()) {
+            if (accountStore.hasAccessToken()) {
+                // Update the WPCom account if the user is signed in using a WPCom account
+                dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
+                dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
+            }
+
+            // Update the list of sites
             appCoroutineScope.launch {
                 wooCommerceStore.fetchWooCommerceSites()
 
@@ -212,7 +216,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                 }
             }
 
-            // Update the user info for the currently logged in user
+            // Update the user info
             if (selectedSite.exists()) {
                 userEligibilityFetcher.fetchUserEligibility()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/User.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/User.kt
@@ -14,7 +14,7 @@ data class User(
     val roles: List<String>
 ) : Parcelable {
     fun getUserNameForDisplay(): String {
-        val name = "$firstName $lastName"
+        val name = "$firstName $lastName".trim()
         return when {
             name.isEmpty() && username.isEmpty() -> email
             name.isEmpty() && username.isNotEmpty() -> username

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/User.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/User.kt
@@ -16,9 +16,9 @@ data class User(
     fun getUserNameForDisplay(): String {
         val name = "$firstName $lastName".trim()
         return when {
-            name.isEmpty() && username.isEmpty() -> email
-            name.isEmpty() && username.isNotEmpty() -> username
-            else -> name
+            name.isNotEmpty() -> name
+            username.isNotEmpty() -> username
+            else -> email
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -50,7 +51,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val loginAnalyticsListener: LoginAnalyticsListener,
     private val resourceProvider: ResourceProvider,
-    applicationPasswordsNotifier: ApplicationPasswordsNotifier
+    applicationPasswordsNotifier: ApplicationPasswordsNotifier,
+    private val userEligibilityFetcher: UserEligibilityFetcher
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         const val SITE_ADDRESS_KEY = "site-address"
@@ -100,8 +102,17 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     fun onContinueClick() = launch {
         loginAnalyticsListener.trackSubmitClicked()
-        isLoading.value = true
+        if (selectedSite.exists()) {
+            // The login already succeeded, proceed to fetching user info
+            fetchUserInfo()
+        } else {
+            login()
+        }
+    }
+
+    private suspend fun login() {
         val state = requireNotNull(this@LoginSiteCredentialsViewModel.state.value)
+        isLoading.value = true
         wpApiSiteRepository.login(
             url = siteAddress,
             username = state.username,
@@ -146,15 +157,27 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 if (isWooInstalled) {
                     loginAnalyticsListener.trackAnalyticsSignIn(false)
                     selectedSite.set(site)
-                    triggerEvent(LoggedIn(site.id))
+                    fetchUserInfo()
                 } else {
                     triggerEvent(ShowNonWooErrorScreen(siteAddress))
                 }
             },
             onFailure = {
+                isLoading.value = false
                 triggerEvent(ShowSnackbar(R.string.error_generic))
             }
         )
+    }
+
+    private suspend fun fetchUserInfo() {
+        isLoading.value = true
+        val userInfo = userEligibilityFetcher.fetchUserInfo()
+        if (userInfo != null) {
+            userEligibilityFetcher.updateUserInfo(userInfo)
+            triggerEvent(LoggedIn(selectedSite.getSelectedSiteId()))
+        } else {
+            triggerEvent(ShowSnackbar(R.string.error_generic))
+        }
         isLoading.value = false
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -122,7 +122,6 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 checkWooStatus(it)
             },
             onFailure = { exception ->
-                isLoading.value = false
                 var errorMessage: Int? = null
                 if (exception is OnChangedException && exception.error is AuthenticationError) {
                     errorMessage = exception.error.toErrorMessage()
@@ -148,6 +147,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 )
             }
         )
+        isLoading.value = false
     }
 
     private suspend fun checkWooStatus(site: SiteModel) {
@@ -163,10 +163,10 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 }
             },
             onFailure = {
-                isLoading.value = false
                 triggerEvent(ShowSnackbar(R.string.error_generic))
             }
         )
+        isLoading.value = false
     }
 
     private suspend fun fetchUserInfo() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
@@ -6,42 +6,32 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.ui.common.UserEligibilityErrorViewModel.ViewState
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.AccountAction.SIGN_OUT
-import org.wordpress.android.fluxc.action.SiteAction
-import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.user.WCUserModel
-import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     private val appPrefsWrapper: AppPrefs = mock()
-    private val dispatcher: Dispatcher = mock()
-    private val accountStore: AccountStore = mock()
+    private val accountRepository: AccountRepository = mock()
     private val userEligibilityFetcher: UserEligibilityFetcher = mock()
 
     private lateinit var viewModel: UserEligibilityErrorViewModel
-    private lateinit var actionCaptor: KArgumentCaptor<Action<*>>
 
     private val testUser = WCUserModel().apply {
         remoteUserId = 1L
@@ -56,22 +46,11 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        actionCaptor = argumentCaptor()
-
-        viewModel = spy(
-            UserEligibilityErrorViewModel(
-                SavedStateHandle(),
-                appPrefsWrapper,
-                dispatcher,
-                accountStore,
-                userEligibilityFetcher
-            )
-        )
-
-        clearInvocations(
-            viewModel,
-            userEligibilityFetcher,
-            appPrefsWrapper
+        viewModel = UserEligibilityErrorViewModel(
+            SavedStateHandle(),
+            appPrefsWrapper,
+            accountRepository,
+            userEligibilityFetcher
         )
     }
 
@@ -149,23 +128,17 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Handles logout button click correctly`() {
-        doReturn(false).whenever(accountStore).hasAccessToken()
+    fun `Handles logout button click correctly`() = testBlocking {
+        doReturn(true).whenever(accountRepository).logout()
 
         var logoutEvent: Logout? = null
         viewModel.event.observeForever {
-            if (it is Logout) logoutEvent = it
+            logoutEvent = it as? Logout
         }
 
         viewModel.onLogoutButtonClicked()
 
-        // note that we expect two dispatches because there's one to sign out the user and
-        // the other to remove WPcom and Jetpack sites from local db
-        verify(dispatcher, times(2)).dispatch(actionCaptor.capture())
-        assertEquals(SIGN_OUT, actionCaptor.firstValue.type)
-        assertEquals(SiteAction.REMOVE_WPCOM_AND_JETPACK_SITES, actionCaptor.secondValue.type)
-
-        viewModel.onAccountChanged(OnAccountChanged())
+        verify(accountRepository).logout()
         assertThat(logoutEvent).isNotNull
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.10.0'
+    fluxCVersion = '2628-ed3c683cbcd857e5700b77545d0e21976f3f25cf'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2628-ed3c683cbcd857e5700b77545d0e21976f3f25cf'
+    fluxCVersion = 'trunk-463c753ae48797fd0543f237f668b322345eb69b'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8110 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds user role fetching logic during the site credentials login.
While working on it, I found out that the Woo detection logic we have only works for users who have a valid user role, which prevents showing the correct error message.
So I updated the logic in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2628, please check it before this PR.

### Testing instructions
#### Login
1. Create a user with a role other than "admin" and "shop manager".
2. Open the app, then sign using site credentials with the new user.
3. Notice that after the login, the app shows an error screen about the user role.

#### App Startup
1. Finish login using a user that has a valid role.
2. Close the app.
3. Open the website then update the role to a role other than "admin" and "shop manager".
4. Re-open the app.
5. Confirm the app shows an error screen. 

### Images/gif
https://user-images.githubusercontent.com/1657201/211609250-89941395-90c5-41f6-b028-9b2f63942d58.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
