### PR TITLE
Storage for IPP feedback banner and survey events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -163,6 +163,15 @@ object AppPrefs {
         WC_SHIPPING_BANNER_DISMISSED,
 
         ONBOARDING_CAROUSEL_DISPLAYED,
+
+        // If the IPP feedback survey was completed
+        IPP_FEEDBACK_SURVEY_COMPLETED,
+
+        // Timestamp of when the IPP feedback request banner was last dismissed
+        IPP_FEEDBACK_SURVEY_BANNER_LAST_DISMISSED,
+
+        // Was the IPP feedback survey banner dismissed forever
+        IPP_FEEDBACK_SURVEY_BANNER_DISMISSED_FOREVER,
     }
 
     fun init(context: Context) {
@@ -884,6 +893,28 @@ object AppPrefs {
 
     private fun getActiveStatsGranularityFilterKey(currentSiteId: Int) =
         PrefKeyString("${DeletablePrefKey.ACTIVE_STATS_GRANULARITY}:$currentSiteId")
+
+    /**
+     * Used for storing IPP feedback banner interaction data.
+     */
+    fun isIPPFeedbackSurveyCompleted() = getBoolean(UndeletablePrefKey.IPP_FEEDBACK_SURVEY_COMPLETED, false)
+
+    fun setIPPFeedbackSurveyCompleted(completed: Boolean) {
+        setBoolean(UndeletablePrefKey.IPP_FEEDBACK_SURVEY_COMPLETED, completed)
+    }
+
+    fun getIPPFeedbackBannerLastDismissed() = getLong(UndeletablePrefKey.IPP_FEEDBACK_SURVEY_BANNER_LAST_DISMISSED, -1L)
+
+    fun setIPPFeedbackBannerDismissedRemindLater(dismissDateTime: Long) {
+        setLong(UndeletablePrefKey.IPP_FEEDBACK_SURVEY_BANNER_LAST_DISMISSED, dismissDateTime)
+    }
+
+    fun isIPPFeedbackBannerDismissedForever() =
+        getBoolean(UndeletablePrefKey.IPP_FEEDBACK_SURVEY_BANNER_DISMISSED_FOREVER, false)
+
+    fun setIPPFeedbackBannerDismissedForever(dismissedForever: Boolean) {
+        setBoolean(UndeletablePrefKey.IPP_FEEDBACK_SURVEY_BANNER_DISMISSED_FOREVER, dismissedForever)
+    }
 
     /**
      * Remove all user and site-related preferences.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -278,6 +278,23 @@ class AppPrefsWrapper @Inject constructor() {
     fun isV4StatsSupported() = AppPrefs.isV4StatsSupported()
 
     /**
+     * Used for storing IPP feedback banner interaction data.
+     */
+    fun isIPPFeedbackSurveyCompleted() = AppPrefs.isIPPFeedbackSurveyCompleted()
+
+    fun setIPPFeedbackSurveyCompleted(completed: Boolean) = AppPrefs.setIPPFeedbackSurveyCompleted(completed)
+
+    fun getIPPFeedbackBannerLastDismissed() = AppPrefs.getIPPFeedbackBannerLastDismissed()
+
+    fun setIPPFeedbackBannerDismissedRemindLater(dismissDateTime: Long) =
+        AppPrefs.setIPPFeedbackBannerDismissedRemindLater(dismissDateTime)
+
+    fun isIPPFeedbackBannerDismissedForever() = AppPrefs.isIPPFeedbackBannerDismissedForever()
+
+    fun setIPPFeedbackBannerDismissedForever(dismissedForever: Boolean) =
+        AppPrefs.setIPPFeedbackBannerDismissedForever(dismissedForever)
+
+    /**
      * Observes changes to the preferences
      */
     fun observePrefs(): Flow<Unit> {


### PR DESCRIPTION
Storage for IPP feedback banner and survey events

This PR is part of the **IPP in-app feedback banner project** https://github.com/woocommerce/woocommerce-android/issues/8116. It targets the feature branch `feature/8116-ipp-feedback-banner`.

### Description
Added new methods to store the following events:
* Survey completed
* Banner dismissed timestamp
* Banner dismissed forever

### Testing instructions
There is nothing to test at the moment. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
