### PR TITLE
Product selection with Talkback enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -626,8 +626,22 @@ class ProductListFragment :
         }
     }
 
+    //  Some edge cases in product selection mode, like tapping the screen with 4 fingers or using TalkBack,
+    //  cause the product's onClick listener to gain focus over the selection tracker.
+    //  This quick fix will prevent the app from entering an unexpected status when the app is in selection mode.
+    private fun shouldPreventDetailNavigation(remoteProductId: Long): Boolean {
+        if (viewModel.isSelecting()) {
+            tracker?.let { selectionTracker ->
+                if (selectionTracker.isSelected(remoteProductId)) selectionTracker.deselect(remoteProductId)
+                else selectionTracker.select(remoteProductId)
+            }
+            return true
+        }
+        return false
+    }
+
     private fun onProductClick(remoteProductId: Long, sharedView: View?) {
-        if (viewModel.isSelecting()) return
+        if (shouldPreventDetailNavigation(remoteProductId)) return
         (activity as? MainNavigationRouter)?.let { router ->
             if (sharedView == null) {
                 router.showProductDetail(remoteProductId, enableTrash = true)


### PR DESCRIPTION
### Why 
When the view is in selection mode and TalkBack is enabled, TalkBack passes all product list items interaction directly to the view and not to the selection tracker. The result of this behavior is that it is very hard for merchants with TalkBack active to deselect a product from the selected product list.

### Description
This PR adds the `shouldPreventDetailNavigation` function that checks if the view is in selection mode before navigating to the product details screen. If the view is in selection mode and receives a product list item tap it would handle item selection as expected. This scenario could happen because of one of the edges cases mentioned before:
 1. [Touching the screen with 4 fingers ](https://github.com/woocommerce/woocommerce-android/pull/7971#issuecomment-1344642475)
 3. TalkBack enabled


### Testing instructions
1. Enable TalkBack on the device settings
2. Open Woo App
3. Navigate to the Products screen
4. Enter selection mode by double tapping a product (the second tap should be a long tap until the screen enters the selection mode)
5. Check that double tapping an unselected product selects that product
6. Check that double tapping a selected product unselects that product
7. Check that unselecting all selected products exits the selection mode

### Images/gif

https://user-images.githubusercontent.com/18119390/211676370-ccfb78e1-6195-469c-bacd-8a9e5f3e926a.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
