### PR TITLE
Remove portrait screen orientation requirement

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -7,6 +7,11 @@
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" /> <!-- Normal permissions, access automatically granted to app -->
+    <!--    Mark portrait orientation as optional, currently used for the bar code scanning activity -->
+    <uses-feature
+        android:name="android.hardware.screen.portrait"
+        android:required="false" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -23,11 +28,11 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
+        android:localeConfig="@xml/locales_config"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Woo.DayNight"
-        android:localeConfig="@xml/locales_config"
         tools:ignore="UnusedAttribute">
 
         <!-- TODO: we eventually want to drop support for Apache, but for now it's used by FluxC -->
@@ -53,14 +58,14 @@
                 <category android:name="android.intent.category.DEFAULT" />
 
                 <data
-                    android:scheme="https"
                     android:host="woocommerce.com"
-                    android:pathPattern="/mobile/orders/details" />
+                    android:pathPattern="/mobile/orders/details"
+                    android:scheme="https" />
 
                 <data
-                    android:scheme="https"
                     android:host="woocommerce.com"
-                    android:pathPattern="/mobile/payments" />
+                    android:pathPattern="/mobile/payments"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
### Description
When releasing the new version of the app @ParaskP7 noticed the new version excludes support for some devices. 

After investigation we discovered that this requirement is merged into the AndroidManifest from Google's barcode scanning library which was introduced [here](https://github.com/woocommerce/woocommerce-android/pull/8059).

This is where the portrait orientation comes from. I've run some tests and I didn't encounter any issues.

<img width="680" alt="Screenshot 2023-01-11 at 13 34 51" src="https://user-images.githubusercontent.com/2261188/211807658-5cfd53da-e58c-4f8d-9c3b-8d87f7223117.png">

This PR explicitly declares that the portrait mode is not a hard requirement for the installation of the app.

After discussing this with Petros we decided to target this change in the 11.8 release.

### Testing instructions

2. Open the app
3. Tap on "Continue with WordPress.com"
4. Enter mail
5. Tap on "Log in with magic link"
6. Tap on "Scan QR code to log in"
7. Assert there's not permission request
8. Scan a code that was sent to mail inbox
9. Assert successful log in

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
