### PR TITLE
Issue/8178 fix user role fetch

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -109,13 +109,11 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
             selectedSite.getIfExists()?.let {
                 appCoroutineScope.launch {
                     wooCommerceStore.fetchWooCommerceSite(it).let {
-                        if (it.model?.hasWooCommerce == false &&
-                            ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(STARTED)
-                        ) {
+                        if (it.model?.hasWooCommerce == false) {
                             // The previously selected site is not connected anymore, take the user to the site picker
                             WooLog.w(T.LOGIN, "Selected site no longer has WooCommerce")
                             selectedSite.reset()
-                            openMainActivity()
+                            restartMainActivity()
                         }
                     }
                     wooCommerceStore.fetchSiteGeneralSettings(it)
@@ -207,12 +205,11 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                 // Added to fix this crash
                 // https://github.com/woocommerce/woocommerce-android/issues/4842
                 if (selectedSite.getSelectedSiteId() != -1 &&
-                    !selectedSite.exists() &&
-                    ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(STARTED)
+                    !selectedSite.exists()
                 ) {
                     // The previously selected site is not connected anymore, take the user to the site picker
                     WooLog.i(DASHBOARD, "Selected site no longer exists, showing site picker")
-                    openMainActivity()
+                    restartMainActivity()
                 }
             }
 
@@ -222,7 +219,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                     userEligibilityFetcher.fetchUserInfo()?.let {
                         if (!it.isUserEligible()) {
                             WooLog.w(T.LOGIN, "Current user is not eligible to access the current site")
-                            openMainActivity()
+                            restartMainActivity()
                         }
                     }
                 }
@@ -239,10 +236,12 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         }
     }
 
-    private fun openMainActivity() {
-        val intent = Intent(application, MainActivity::class.java)
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-        application.startActivity(intent)
+    private fun restartMainActivity() {
+        if (ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(STARTED)) {
+            val intent = Intent(application, MainActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            application.startActivity(intent)
+        }
     }
 
     private fun monitorApplicationPasswordsStatus() {
@@ -252,7 +251,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                 if (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords) {
                     WooLog.w(T.LOGIN, "Application Passwords support has been disabled in the current site")
                     selectedSite.reset()
-                    openMainActivity()
+                    restartMainActivity()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -218,7 +218,14 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
 
             // Update the user info
             if (selectedSite.exists()) {
-                userEligibilityFetcher.fetchUserEligibility()
+                appCoroutineScope.launch {
+                    userEligibilityFetcher.fetchUserInfo()?.let {
+                        if (!it.isUserEligible()) {
+                            WooLog.w(T.LOGIN, "Current user is not eligible to access the current site")
+                            openMainActivity()
+                        }
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
@@ -49,7 +49,6 @@ class UserEligibilityErrorViewModel @Inject constructor(
             val userModel = userEligibilityFetcher.fetchUserInfo()
             userModel?.let {
                 val isUserEligible = it.isUserEligible()
-                userEligibilityFetcher.updateUserInfo(it)
 
                 if (isUserEligible) {
                     triggerEvent(Exit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcher.kt
@@ -2,37 +2,26 @@ package com.woocommerce.android.ui.common
 
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.user.WCUserModel
 import org.wordpress.android.fluxc.store.WCUserStore
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 @Singleton
 class UserEligibilityFetcher @Inject constructor(
     private val appPrefs: AppPrefs,
     private val userStore: WCUserStore,
     private val selectedSite: SelectedSite
-) : CoroutineScope {
-    private val job: Job = Job()
-    override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main + job
-
-    fun fetchUserEligibility() {
-        launch(Dispatchers.Default) {
-            fetchUserInfo()?.let { updateUserInfo(it) }
+) {
+    suspend fun fetchUserInfo(): WCUserModel? {
+        return userStore.fetchUserRole(selectedSite.get()).model?.also {
+            updateUserInfo(it)
         }
     }
 
-    suspend fun fetchUserInfo(): WCUserModel? = userStore.fetchUserRole(selectedSite.get()).model
-
     fun getUserByEmail(email: String) = userStore.getUserByEmail(selectedSite.get(), email)
 
-    fun updateUserInfo(user: WCUserModel) {
+    private fun updateUserInfo(user: WCUserModel) {
         appPrefs.setIsUserEligible(user.isUserEligible())
         appPrefs.setUserEmail(user.email)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -173,7 +173,6 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         isLoading.value = true
         val userInfo = userEligibilityFetcher.fetchUserInfo()
         if (userInfo != null) {
-            userEligibilityFetcher.updateUserInfo(userInfo)
             triggerEvent(LoggedIn(selectedSite.getSelectedSiteId()))
         } else {
             triggerEvent(ShowSnackbar(R.string.error_generic))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -486,9 +486,8 @@ class SitePickerViewModel @Inject constructor(
                         siteVerificationResult.model?.apiVersion == WooCommerceStore.WOO_API_NAMESPACE_V3 -> {
                             experimentTracker.log(ExperimentTracker.SITE_VERIFICATION_SUCCESSFUL_EVENT)
                             selectedSite.set(it.site)
-                            userEligibilityFetcher.fetchUserInfo()?.let { userModel ->
+                            userEligibilityFetcher.fetchUserInfo()?.let {
                                 sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
-                                userEligibilityFetcher.updateUserInfo(userModel)
 
                                 trackLoginEvent(currentStep = UnifiedLoginTracker.Step.SUCCESS)
                                 appPrefsWrapper.removeLoginSiteAddress()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
@@ -89,7 +89,6 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
             viewModel.onRetryButtonClicked()
 
             verify(userEligibilityFetcher, times(1)).fetchUserInfo()
-            verify(userEligibilityFetcher, times(1)).updateUserInfo(any())
 
             assertFalse(appPrefsWrapper.isUserEligible())
             assertThat(snackbar).isEqualTo(ShowSnackbar(string.user_role_access_error_retry))
@@ -119,7 +118,6 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
         viewModel.onRetryButtonClicked()
 
         verify(userEligibilityFetcher, times(1)).fetchUserInfo()
-        verify(userEligibilityFetcher, times(1)).updateUserInfo(any())
 
         assertTrue(appPrefsWrapper.isUserEligible())
         assertThat(snackbar).isNull()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -405,7 +405,6 @@ class SitePickerViewModelTest : BaseUnitTest() {
         verify(repository, times(1)).verifySiteWooAPIVersion(any())
         verify(selectedSite, times(1)).set(any())
         verify(userEligibilityFetcher, times(1)).fetchUserInfo()
-        verify(userEligibilityFetcher, times(1)).updateUserInfo(any())
         verify(appPrefsWrapper, times(1)).removeLoginSiteAddress()
 
         assertThat(view).isEqualTo(NavigateToMainActivityEvent)
@@ -439,7 +438,6 @@ class SitePickerViewModelTest : BaseUnitTest() {
             verify(repository, times(1)).verifySiteWooAPIVersion(any())
             verify(selectedSite, times(0)).set(any())
             verify(userEligibilityFetcher, times(0)).fetchUserInfo()
-            verify(userEligibilityFetcher, times(0)).updateUserInfo(any())
             verify(appPrefsWrapper, times(0)).removeLoginSiteAddress()
 
             assertThat(view).isEqualTo(ShowWooUpgradeDialogEvent)


### PR DESCRIPTION
Closes: #8178 

### Description
This PR fixes the above issue by making sure we re-open the MainActivity after the fetch if the user is ineligible.

### Testing instructions

1. Sign in to the app using a user that has a valid role.
2. Close the app.
3. Open the website then update the role to a role other than "admin" and "shop manager".
4. Re-open the app.
5. Confirm the app shows an error screen.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
