### PR TITLE
Business logic updates for IPP feedback survey banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.payments.feedback.ipp
 
+import androidx.annotation.StringRes
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.daysAgo
 import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
@@ -11,7 +13,10 @@ import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import java.util.Date
 import javax.inject.Inject
 
-class GetIPPFeedbackSurveyUrl @Inject constructor(
+/**
+ * Use case class to detect specific user group type and return the IPP feedback banner data: message and survey url.
+ */
+class GetIPPFeedbackBannerData @Inject constructor(
     private val shouldShowFeedbackBanner: ShouldShowFeedbackBanner,
     private val ippStore: WCInPersonPaymentsStore,
     private val siteModel: SiteModel,
@@ -19,7 +24,7 @@ class GetIPPFeedbackSurveyUrl @Inject constructor(
 ) {
     @Suppress("ReturnCount")
     @Throws(IllegalStateException::class)
-    suspend operator fun invoke(): String {
+    suspend operator fun invoke(): IPPFeedbackBanner {
         requireShouldShowFeedbackBanner()
 
         val activePaymentsPlugin = requireWooCommercePaymentsPlugin()
@@ -38,9 +43,9 @@ class GetIPPFeedbackSurveyUrl @Inject constructor(
         requirePositiveNumberOfTransactions(numberOfTransactions)
 
         return when (numberOfTransactions) {
-            0 -> SURVEY_URL_IPP_NEWBIE
-            in IPP_BEGINNER_TRANSACTIONS_RANGE -> SURVEY_URL_IPP_BEGINNER
-            else -> SURVEY_URL_IPP_NINJA
+            0 -> IPPFeedbackBanner(BANNER_MESSAGE_NEWBIE, SURVEY_URL_IPP_NEWBIE)
+            in IPP_BEGINNER_TRANSACTIONS_RANGE -> IPPFeedbackBanner(BANNER_MESSAGE_BEGINNER, SURVEY_URL_IPP_BEGINNER)
+            else -> IPPFeedbackBanner(BANNER_MESSAGE_NINJA, SURVEY_URL_IPP_NINJA)
         }
     }
 
@@ -67,6 +72,11 @@ class GetIPPFeedbackSurveyUrl @Inject constructor(
         }
     }
 
+    data class IPPFeedbackBanner(
+        @StringRes val message: Int,
+        val url: String
+    )
+
     companion object {
         @VisibleForTesting
         const val STATS_TIME_WINDOW_LENGTH_DAYS = 30
@@ -79,6 +89,15 @@ class GetIPPFeedbackSurveyUrl @Inject constructor(
 
         @VisibleForTesting
         const val SURVEY_URL_IPP_NINJA = "https://woocommerce.com/ninja"
+
+        @VisibleForTesting
+        const val BANNER_MESSAGE_NEWBIE = R.string.feedback_banner_ipp_message_newbie
+
+        @VisibleForTesting
+        const val BANNER_MESSAGE_BEGINNER = R.string.feedback_banner_ipp_message_beginner
+
+        @VisibleForTesting
+        const val BANNER_MESSAGE_NINJA = R.string.feedback_banner_ipp_message_ninja
 
         private val IPP_BEGINNER_TRANSACTIONS_RANGE = 1..10
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.payments.feedback.ipp
 
 import android.os.Parcelable
 import androidx.annotation.StringRes
-import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.daysAgo
 import com.woocommerce.android.extensions.formatToYYYYmmDD
@@ -85,14 +84,11 @@ class GetIPPFeedbackBannerData @Inject constructor(
 
         private const val SURVEY_URL_IPP_NINJA = "https://woocommerce.com/ninja"
 
-        @VisibleForTesting
-        const val BANNER_MESSAGE_NEWBIE = R.string.feedback_banner_ipp_message_newbie
+        private const val BANNER_MESSAGE_NEWBIE = R.string.feedback_banner_ipp_message_newbie
 
-        @VisibleForTesting
-        const val BANNER_MESSAGE_BEGINNER = R.string.feedback_banner_ipp_message_beginner
+        private const val BANNER_MESSAGE_BEGINNER = R.string.feedback_banner_ipp_message_beginner
 
-        @VisibleForTesting
-        const val BANNER_MESSAGE_NINJA = R.string.feedback_banner_ipp_message_ninja
+        private const val BANNER_MESSAGE_NINJA = R.string.feedback_banner_ipp_message_ninja
 
         private val IPP_BEGINNER_TRANSACTIONS_RANGE = 1..10
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.ui.payments.feedback.ipp
 
+import android.os.Parcelable
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.daysAgo
 import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
-import org.jetbrains.annotations.VisibleForTesting
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentTransactionsSummaryResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
@@ -23,7 +25,6 @@ class GetIPPFeedbackBannerData @Inject constructor(
     private val getActivePaymentsPlugin: GetActivePaymentsPlugin,
 ) {
     @Suppress("ReturnCount")
-    @Throws(IllegalStateException::class)
     suspend operator fun invoke(): IPPFeedbackBanner {
         requireShouldShowFeedbackBanner()
 
@@ -72,23 +73,20 @@ class GetIPPFeedbackBannerData @Inject constructor(
         }
     }
 
+    @Parcelize
     data class IPPFeedbackBanner(
         @StringRes val message: Int,
         val url: String
-    )
+    ) : Parcelable
 
     companion object {
-        @VisibleForTesting
-        const val STATS_TIME_WINDOW_LENGTH_DAYS = 30
+        private const val STATS_TIME_WINDOW_LENGTH_DAYS = 30
 
-        @VisibleForTesting
-        const val SURVEY_URL_IPP_NEWBIE = "https://woocommerce.com/newbie"
+        private const val SURVEY_URL_IPP_NEWBIE = "https://woocommerce.com/newbie"
 
-        @VisibleForTesting
-        const val SURVEY_URL_IPP_BEGINNER = "https://woocommerce.com/beginner"
+        private const val SURVEY_URL_IPP_BEGINNER = "https://woocommerce.com/beginner"
 
-        @VisibleForTesting
-        const val SURVEY_URL_IPP_NINJA = "https://woocommerce.com/ninja"
+        private const val SURVEY_URL_IPP_NINJA = "https://woocommerce.com/ninja"
 
         @VisibleForTesting
         const val BANNER_MESSAGE_NEWBIE = R.string.feedback_banner_ipp_message_newbie

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
@@ -15,9 +15,6 @@ import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import java.util.Date
 import javax.inject.Inject
 
-/**
- * Use case class to detect specific user group type and return the IPP feedback banner data: message and survey url.
- */
 class GetIPPFeedbackBannerData @Inject constructor(
     private val shouldShowFeedbackBanner: ShouldShowFeedbackBanner,
     private val ippStore: WCInPersonPaymentsStore,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
@@ -51,7 +51,7 @@ class GetIPPFeedbackBannerData @Inject constructor(
     }
 
     private fun requireTransactionsCount(response: WooPayload<WCPaymentTransactionsSummaryResult>): Int {
-        return response.result?.transactionsCount ?: throw IllegalStateException("Transactions count must not be null")
+        return checkNotNull(response.result?.transactionsCount) { "Transactions count must not be null" }
     }
 
     private fun requireSuccessfulTransactionsSummaryResponse(response: WooPayload<WCPaymentTransactionsSummaryResult>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkFeedbackBannerAsDismissed.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkFeedbackBannerAsDismissed.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.ui.payments.feedback.ipp
+
+import com.woocommerce.android.AppPrefsWrapper
+import java.util.Date
+import javax.inject.Inject
+
+/**
+ * This class is used to mark the IPP feedback banner as dismissed for now.
+ * If the user dismisses the banner, it will be shown again after a time interval defined
+ * in [ShouldShowFeedbackBanner.REMIND_LATER_INTERVAL_DAYS].
+ */
+class MarkFeedbackBannerAsDismissed @Inject constructor(
+    private val prefs: AppPrefsWrapper,
+) {
+    operator fun invoke() {
+        prefs.setIPPFeedbackBannerDismissedRemindLater(Date().time)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkFeedbackBannerAsDismissedForever.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkFeedbackBannerAsDismissedForever.kt
@@ -3,9 +3,6 @@ package com.woocommerce.android.ui.payments.feedback.ipp
 import com.woocommerce.android.AppPrefsWrapper
 import javax.inject.Inject
 
-/**
- * This class is used to mark the IPP feedback banner as dismissed forever.
- */
 class MarkFeedbackBannerAsDismissedForever @Inject constructor(
     private val prefs: AppPrefsWrapper,
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkFeedbackBannerAsDismissedForever.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkFeedbackBannerAsDismissedForever.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.payments.feedback.ipp
+
+import com.woocommerce.android.AppPrefsWrapper
+import javax.inject.Inject
+
+/**
+ * This class is used to mark the IPP feedback banner as dismissed forever.
+ */
+class MarkFeedbackBannerAsDismissedForever @Inject constructor(
+    private val prefs: AppPrefsWrapper,
+) {
+    operator fun invoke() {
+        prefs.setIPPFeedbackBannerDismissedForever(true)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkIPPFeedbackSurveyAsCompleted.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkIPPFeedbackSurveyAsCompleted.kt
@@ -3,9 +3,6 @@ package com.woocommerce.android.ui.payments.feedback.ipp
 import com.woocommerce.android.AppPrefsWrapper
 import javax.inject.Inject
 
-/**
- * This class is used to mark the IPP feedback banner as dismissed forever.
- */
 class MarkIPPFeedbackSurveyAsCompleted @Inject constructor(
     private val prefs: AppPrefsWrapper,
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkIPPFeedbackSurveyAsCompleted.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/MarkIPPFeedbackSurveyAsCompleted.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.payments.feedback.ipp
+
+import com.woocommerce.android.AppPrefsWrapper
+import javax.inject.Inject
+
+/**
+ * This class is used to mark the IPP feedback banner as dismissed forever.
+ */
+class MarkIPPFeedbackSurveyAsCompleted @Inject constructor(
+    private val prefs: AppPrefsWrapper,
+) {
+    operator fun invoke() {
+        prefs.setIPPFeedbackSurveyCompleted(true)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBanner.kt
@@ -3,7 +3,9 @@ package com.woocommerce.android.ui.payments.feedback.ipp
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
 import com.woocommerce.android.ui.payments.cardreader.CashOnDeliverySettingsRepository
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -15,18 +17,27 @@ class ShouldShowFeedbackBanner @Inject constructor(
     private val prefs: AppPrefsWrapper,
     private val getActivePaymentsPlugin: GetActivePaymentsPlugin,
     private val cashOnDeliverySettings: CashOnDeliverySettingsRepository,
+    private val wooCommerceStore: WooCommerceStore,
+    private val siteModel: SiteModel,
 ) {
     /**
-     * 1. Check if COD is enabled, if not return false.
-     * 2. Check if WCPay plugin is used if no, return false.
-     * 3. Check if survey has been already completed, if yes return false.
-     * 4. Check if survey has been dismissed forever, if yes return false,
+     * 1. Check if store's country code is US or CA, if not, return false
+     * 2. Check if COD is enabled, if not return false.
+     * 3. Check if WCPay plugin is used if no, return false.
+     * 4. Check if survey has been already completed, if yes return false.
+     * 5. Check if survey has been dismissed forever, if yes return false,
      * if not, check if it was last dismissed >= 7 days ago, if yes return true.
-     * 5. Return false.
+     * 6. Return false.
      */
     suspend operator fun invoke(): Boolean {
-        return isIPPEnabled() && !isSurveyCompletedOrDismissedForever() && wasDismissedLongAgoEnoughToShowAgain()
+        return isStoreInSupportedCountry() &&
+            isIPPEnabled() &&
+            !isSurveyCompletedOrDismissedForever() &&
+            wasDismissedLongAgoEnoughToShowAgain()
     }
+
+    private fun isStoreInSupportedCountry(): Boolean =
+        wooCommerceStore.getSiteSettings(siteModel)?.countryCode in SUPPORTED_COUNTRIES
 
     private suspend fun isIPPEnabled(): Boolean =
         cashOnDeliverySettings.isCashOnDeliveryEnabled() && isWooCommercePaymentsPluginEnabled()
@@ -46,5 +57,6 @@ class ShouldShowFeedbackBanner @Inject constructor(
 
     private companion object {
         private const val REMIND_LATER_INTERVAL_DAYS = 7
+        val SUPPORTED_COUNTRIES = listOf("US", "CA")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBanner.kt
@@ -12,9 +12,6 @@ import java.util.Calendar
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-/**
- * Use case to check if the IPP feedback banner should be shown to the user.
- */
 class ShouldShowFeedbackBanner @Inject constructor(
     private val prefs: AppPrefsWrapper,
     private val getActivePaymentsPlugin: GetActivePaymentsPlugin,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2117,6 +2117,12 @@
     <string name="feedback_completed_back_to_store_button_text">Back to store</string>
     <string name="feedback_product_give_feedback_button_text">Give Feedback</string>
 
+    <!-- In-person Payments feedback banner -->
+    <string name="feedback_banner_ipp_message_newbie">Do you sell in person?</string>
+    <string name="feedback_banner_ipp_message_beginner">Rate your first in-person payment experience.</string>
+    <string name="feedback_banner_ipp_message_ninja">Enjoy your in-person payments so far?</string>
+    <string name="feedback_banner_ipp_message_thank_you">Thank you for sharing your feedback about our feature. ♥️</string>
+
     <!-- permissions -->
     <string name="permissions_denied_title">Permissions</string>
     <string name="permissions_denied_message">It looks like you turned off permissions required for this feature.&lt;br/&gt;&lt;br/&gt;To change this, edit your permissions and make sure &lt;strong&gt;%s&lt;/strong&gt; is enabled.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
@@ -3,10 +3,13 @@ package com.woocommerce.android.ui.payments.feedback.ipp
 import com.woocommerce.android.extensions.daysAgo
 import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackSurveyUrl.Companion.STATS_TIME_WINDOW_LENGTH_DAYS
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackSurveyUrl.Companion.SURVEY_URL_IPP_BEGINNER
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackSurveyUrl.Companion.SURVEY_URL_IPP_NEWBIE
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackSurveyUrl.Companion.SURVEY_URL_IPP_NINJA
+import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_BEGINNER
+import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_NEWBIE
+import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_NINJA
+import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.STATS_TIME_WINDOW_LENGTH_DAYS
+import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.SURVEY_URL_IPP_BEGINNER
+import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.SURVEY_URL_IPP_NEWBIE
+import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.SURVEY_URL_IPP_NINJA
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -30,13 +33,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class GetIPPFeedbackSurveyUrlTest : BaseUnitTest() {
+class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     private val shouldShowFeedbackBanner: ShouldShowFeedbackBanner = mock()
     private val ippStore: WCInPersonPaymentsStore = mock()
     private val siteModel: SiteModel = mock()
     private val getActivePaymentsPlugin: GetActivePaymentsPlugin = mock()
 
-    private val sut = GetIPPFeedbackSurveyUrl(
+    private val sut = GetIPPFeedbackBannerData(
         shouldShowFeedbackBanner = shouldShowFeedbackBanner,
         ippStore = ippStore,
         siteModel = siteModel,
@@ -95,7 +98,7 @@ class GetIPPFeedbackSurveyUrlTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(SURVEY_URL_IPP_NEWBIE, result)
+        assertEquals(SURVEY_URL_IPP_NEWBIE, result.url)
     }
 
     @Test
@@ -114,7 +117,7 @@ class GetIPPFeedbackSurveyUrlTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(SURVEY_URL_IPP_BEGINNER, result)
+        assertEquals(SURVEY_URL_IPP_BEGINNER, result.url)
     }
 
     @Test
@@ -132,7 +135,61 @@ class GetIPPFeedbackSurveyUrlTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(SURVEY_URL_IPP_NINJA, result)
+        assertEquals(SURVEY_URL_IPP_NINJA, result.url)
+    }
+
+    @Test
+    fun `given banner should be displayed and user is a newbie, then should display correct message`() = runBlocking {
+        // given
+        whenever(shouldShowFeedbackBanner()) doReturn true
+        whenever(getActivePaymentsPlugin()) doReturn
+            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+
+        val fakeNinjaTransactionsSummary = WCPaymentTransactionsSummaryResult(0, "", 0, 0, 0, null, null)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn
+            WooPayload(fakeNinjaTransactionsSummary)
+
+        // when
+        val result = sut()
+
+        // then
+        assertEquals(BANNER_MESSAGE_NEWBIE, result.message)
+    }
+
+    @Test
+    fun `given banner should be displayed and user is a beginner, then should display correct message`() = runBlocking {
+        // given
+        whenever(shouldShowFeedbackBanner()) doReturn true
+        whenever(getActivePaymentsPlugin()) doReturn
+            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+
+        val fakeNinjaTransactionsSummary = WCPaymentTransactionsSummaryResult(1, "", 0, 0, 0, null, null)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn
+            WooPayload(fakeNinjaTransactionsSummary)
+
+        // when
+        val result = sut()
+
+        // then
+        assertEquals(BANNER_MESSAGE_BEGINNER, result.message)
+    }
+
+    @Test
+    fun `given banner should be displayed and user is a ninja, then should display correct message`() = runBlocking {
+        // given
+        whenever(shouldShowFeedbackBanner()) doReturn true
+        whenever(getActivePaymentsPlugin()) doReturn
+            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+
+        val fakeNinjaTransactionsSummary = WCPaymentTransactionsSummaryResult(11, "", 0, 0, 0, null, null)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn
+            WooPayload(fakeNinjaTransactionsSummary)
+
+        // when
+        val result = sut()
+
+        // then
+        assertEquals(BANNER_MESSAGE_NINJA, result.message)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
@@ -1,11 +1,9 @@
 package com.woocommerce.android.ui.payments.feedback.ipp
 
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.daysAgo
 import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_BEGINNER
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_NEWBIE
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_NINJA
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -146,7 +144,7 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(BANNER_MESSAGE_NEWBIE, result.message)
+        assertEquals(R.string.feedback_banner_ipp_message_newbie, result.message)
     }
 
     @Test
@@ -164,7 +162,7 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(BANNER_MESSAGE_BEGINNER, result.message)
+        assertEquals(R.string.feedback_banner_ipp_message_beginner, result.message)
     }
 
     @Test
@@ -182,7 +180,7 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(BANNER_MESSAGE_NINJA, result.message)
+        assertEquals(R.string.feedback_banner_ipp_message_ninja, result.message)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
@@ -6,10 +6,6 @@ import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
 import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_BEGINNER
 import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_NEWBIE
 import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.BANNER_MESSAGE_NINJA
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.STATS_TIME_WINDOW_LENGTH_DAYS
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.SURVEY_URL_IPP_BEGINNER
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.SURVEY_URL_IPP_NEWBIE
-import com.woocommerce.android.ui.payments.feedback.ipp.GetIPPFeedbackBannerData.Companion.SURVEY_URL_IPP_NINJA
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -17,7 +13,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -50,14 +45,14 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     fun setup() {
         val fakeSummary = WCPaymentTransactionsSummaryResult(99, "", 0, 0, 0, null, null)
         runBlocking {
-            whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn WooPayload(fakeSummary)
+            whenever(ippStore.fetchTransactionsSummary(any(), any(), any())).thenReturn(WooPayload(fakeSummary))
         }
     }
 
     @Test
     fun `given banner should not be displayed, then should throw exception`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn false
+        whenever(shouldShowFeedbackBanner()).thenReturn(false)
 
         // then
         assertFailsWith(IllegalStateException::class) {
@@ -70,8 +65,8 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     @Test
     fun `given no active payments plugin found, then should throw exception`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn null
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin()).thenReturn(null)
 
         // then
         assertFailsWith(IllegalStateException::class) {
@@ -84,70 +79,68 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     @Test
     fun `given banner should be displayed and user is a newbie, then should return correct url`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
 
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
         val fakeNewbieTransactionsSummary = WCPaymentTransactionsSummaryResult(0, "", 0, 0, 0, null, null)
-        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn WooPayload(
-            fakeNewbieTransactionsSummary
-        )
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any()))
+            .thenReturn(WooPayload(fakeNewbieTransactionsSummary))
 
         // when
         val result = sut()
 
         // then
-        assertEquals(SURVEY_URL_IPP_NEWBIE, result.url)
+        assertEquals("https://woocommerce.com/newbie", result.url)
     }
 
     @Test
     fun `given banner should be displayed and user is a beginner, then should return correct url`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
         val fakeBeginnerTransactionsSummary = WCPaymentTransactionsSummaryResult(2, "", 0, 0, 0, null, null)
-        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn WooPayload(
-            fakeBeginnerTransactionsSummary
-        )
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any()))
+            .thenReturn(WooPayload(fakeBeginnerTransactionsSummary))
 
         // when
         val result = sut()
 
         // then
-        assertEquals(SURVEY_URL_IPP_BEGINNER, result.url)
+        assertEquals("https://woocommerce.com/beginner", result.url)
     }
 
     @Test
     fun `given banner should be displayed and user is a ninja, then should return correct url`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
         val fakeNinjaTransactionsSummary = WCPaymentTransactionsSummaryResult(11, "", 0, 0, 0, null, null)
-        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn
-            WooPayload(fakeNinjaTransactionsSummary)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any()))
+            .thenReturn(WooPayload(fakeNinjaTransactionsSummary))
 
         // when
         val result = sut()
 
         // then
-        assertEquals(SURVEY_URL_IPP_NINJA, result.url)
+        assertEquals("https://woocommerce.com/ninja", result.url)
     }
 
     @Test
     fun `given banner should be displayed and user is a newbie, then should display correct message`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
         val fakeNinjaTransactionsSummary = WCPaymentTransactionsSummaryResult(0, "", 0, 0, 0, null, null)
-        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn
-            WooPayload(fakeNinjaTransactionsSummary)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any()))
+            .thenReturn(WooPayload(fakeNinjaTransactionsSummary))
 
         // when
         val result = sut()
@@ -159,13 +152,13 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     @Test
     fun `given banner should be displayed and user is a beginner, then should display correct message`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
         val fakeNinjaTransactionsSummary = WCPaymentTransactionsSummaryResult(1, "", 0, 0, 0, null, null)
-        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn
-            WooPayload(fakeNinjaTransactionsSummary)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any()))
+            .thenReturn(WooPayload(fakeNinjaTransactionsSummary))
 
         // when
         val result = sut()
@@ -177,13 +170,13 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     @Test
     fun `given banner should be displayed and user is a ninja, then should display correct message`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
         val fakeNinjaTransactionsSummary = WCPaymentTransactionsSummaryResult(11, "", 0, 0, 0, null, null)
-        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn
-            WooPayload(fakeNinjaTransactionsSummary)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any()))
+            .thenReturn(WooPayload(fakeNinjaTransactionsSummary))
 
         // when
         val result = sut()
@@ -195,9 +188,9 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     @Test
     fun `given banner should be displayed, then should analyze IPP stats from the correct time window`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
         val expectedTimeWindowCaptor = ArgumentCaptor.forClass(String::class.java)
 
@@ -210,19 +203,20 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         )
 
         // then
-        val desiredTimeWindowStart = Date().daysAgo(STATS_TIME_WINDOW_LENGTH_DAYS).formatToYYYYmmDD()
+        val timeWindowLengthDays = 30
+        val desiredTimeWindowStart = Date().daysAgo(timeWindowLengthDays).formatToYYYYmmDD()
         assertEquals(desiredTimeWindowStart, expectedTimeWindowCaptor.value)
     }
 
     @Test
     fun `given endpoint returns error, then should throw error`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
         val error = WooError(WooErrorType.API_ERROR, BaseRequest.GenericErrorType.NO_CONNECTION, "error")
-        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn WooPayload(error)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())).thenReturn(WooPayload(error))
 
         // then
         assertFailsWith(IllegalStateException::class) {
@@ -235,11 +229,11 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     @Test
     fun `given endpoint returns null response, then should throw exception`() = runBlocking {
         // given
-        whenever(shouldShowFeedbackBanner()) doReturn true
-        whenever(getActivePaymentsPlugin()) doReturn
-            WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+        whenever(shouldShowFeedbackBanner()).thenReturn(true)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
-        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())) doReturn WooPayload(null)
+        whenever(ippStore.fetchTransactionsSummary(any(), any(), any())).thenReturn(WooPayload(null))
 
         // then
         assertFailsWith(IllegalStateException::class) {
@@ -253,9 +247,9 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     fun `given successful endpoint response, when transactions count is negative, then should throw exception `() =
         runBlocking {
             // given
-            whenever(shouldShowFeedbackBanner()) doReturn true
-            whenever(getActivePaymentsPlugin()) doReturn
-                WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
+            whenever(shouldShowFeedbackBanner()).thenReturn(true)
+            whenever(getActivePaymentsPlugin())
+                .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
             val fakeTransactionsSummary = WCPaymentTransactionsSummaryResult(-1, "", 0, 0, 0, null, null)
             whenever(
@@ -264,7 +258,7 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
                     any(),
                     any()
                 )
-            ) doReturn WooPayload(fakeTransactionsSummary)
+            ).thenReturn(WooPayload(fakeTransactionsSummary))
 
             // then
             assertFailsWith(IllegalStateException::class) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBannerTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.payments.feedback.ipp
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.extensions.daysAgo
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
 import com.woocommerce.android.ui.payments.cardreader.CashOnDeliverySettingsRepository
@@ -10,7 +11,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -36,24 +36,25 @@ class ShouldShowFeedbackBannerTest : BaseUnitTest() {
         cashOnDeliverySettings = cashOnDeliverySettings,
         wooCommerceStore = wooCommerceStore,
         siteModel = siteModel,
+        cardReaderConfig = CardReaderConfigFactory()
     )
 
     @Before
     fun setup() = runBlocking {
-        whenever(cashOnDeliverySettings.isCashOnDeliveryEnabled()) doReturn (true)
-        whenever(appPrefs.isIPPFeedbackSurveyCompleted()) doReturn (false)
-        whenever(appPrefs.isIPPFeedbackBannerDismissedForever()) doReturn (false)
-        whenever(getActivePaymentsPlugin()) doReturn
-            (WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
-        whenever(wooCommerceStore.getSiteSettings(any())) doReturn (siteSettings)
-        whenever(siteSettings.countryCode) doReturn ("US")
+        whenever(cashOnDeliverySettings.isCashOnDeliveryEnabled()).thenReturn(true)
+        whenever(appPrefs.isIPPFeedbackSurveyCompleted()).thenReturn(false)
+        whenever(appPrefs.isIPPFeedbackBannerDismissedForever()).thenReturn(false)
+        whenever(getActivePaymentsPlugin())
+            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        whenever(siteSettings.countryCode).thenReturn("US")
         Unit
     }
 
     @Test
     fun `given the store's country code is not US or CA, then the banner should not be shown`() = runBlocking {
         // given
-        whenever(wooCommerceStore.getSiteSettings(siteModel)?.countryCode) doReturn ("GB")
+        whenever(wooCommerceStore.getSiteSettings(siteModel)?.countryCode).thenReturn("GB")
 
         // when
         val result = sut()
@@ -65,7 +66,7 @@ class ShouldShowFeedbackBannerTest : BaseUnitTest() {
     @Test
     fun `given the store's country code is US, then the banner should be shown`() = runBlocking {
         // given
-        whenever(wooCommerceStore.getSiteSettings(siteModel)?.countryCode) doReturn ("US")
+        whenever(wooCommerceStore.getSiteSettings(siteModel)?.countryCode).thenReturn("US")
 
         // when
         val result = sut()
@@ -77,7 +78,7 @@ class ShouldShowFeedbackBannerTest : BaseUnitTest() {
     @Test
     fun `given the store's country code is CA, then the banner should be shown`() = runBlocking {
         // given
-        whenever(wooCommerceStore.getSiteSettings(siteModel)?.countryCode) doReturn ("CA")
+        whenever(wooCommerceStore.getSiteSettings(siteModel)?.countryCode).thenReturn("CA")
 
         // when
         val result = sut()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
#### Business logic updates for IPP feedback survey banner

**Note:** This PR is part of the IPP in-app feedback banner project https://github.com/woocommerce/woocommerce-android/issues/8116. It targets the feature branch feature/8116-ipp-feedback-banner.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduces the following new use case classes:
* `MarkFeedbackBannerAsDismissed`
* `MarkFeedbackBannerAsDismissedForever`
* `MarkIPPFeedbackSurveyAsCompleted`

that are responsible for storing banner actions in `SharedPreferences`.

It also adds the following updates to existing use cases:
* `GetIPPFeedbackBannerData` - renamed from `GetIPPFeedbackSurveyUrl` and modified to return banner message along with survey url. These values are wrapped up by `IPPFeedbackBanner ` data class.
* `ShouldShowFeedbackBanner` - updated to limit showing the banner only to stores in CA and US.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

There is no UI part associated with the use cases yet, so I just recommend reviewing unit tests: `ShouldShowFeedbackBannerTest` and `GetIPPFeedbackBannerDataTest` and make sure they are complete.

### Roadmap
In the next PR, I'll add a feature flag and UI for the banner.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
