### PR TITLE
Exclude assertj testing library from dependabot automatic upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,7 @@ updates:
       - dependency-name: "org.wordpress:login"
       - dependency-name: "com.automattic:Automattic-Tracks-Android"
       - dependency-name: "com.automattic.tracks:experimentation"
+      # Assertj is a java first library only used for testing. It has caused troubles several times due to library
+      # updates with Kotlin breaking changes. For that it has been decided to update this library on a manual basis
+      - dependency-name: "org.assertj:assertj-core"
+


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Excludes `assertj` testing library  from dependabot automatic upgrades.

I haven't tested if this config file change will work. Is there any way to test this? Or we just have to wait and check that no more dependabot PR are opened for upgrading asserj libray? 