### PR TITLE
[REST API] Hide "Manage notifications" option in the Settings area

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -11,11 +11,13 @@ interface MainSettingsContract {
         fun hasMultipleStores(): Boolean
         fun setupAnnouncementOption()
         fun setupJetpackInstallOption()
+        fun setupApplicationPasswordsSettings()
     }
 
     interface View : BaseView<Presenter> {
         fun showDeviceAppNotificationSettings()
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
         fun handleJetpackInstallOption(isJetpackCPSite: Boolean)
+        fun handleApplicationPasswordsSettings()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_WE_ARE_HIRING_B
 import com.woocommerce.android.analytics.AnalyticsEvent.SETTING_CHANGE
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSettingsMainBinding
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.FeatureAnnouncement
@@ -205,6 +206,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
         presenter.setupAnnouncementOption()
         presenter.setupJetpackInstallOption()
+        presenter.setupApplicationPasswordsSettings()
     }
 
     override fun onResume() {
@@ -266,6 +268,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                     )
                 )
         }
+    }
+
+    override fun handleApplicationPasswordsSettings() {
+        binding.optionNotifications.hide()
     }
 
     private fun updateStoreSettings() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -67,4 +67,10 @@ class MainSettingsPresenter @Inject constructor(
             }
         }
     }
+
+    override fun setupApplicationPasswordsSettings() {
+        if (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords) {
+            appSettingsFragmentView?.handleApplicationPasswordsSettings()
+        }
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8107
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR hides the "Manage notifications" option in Settings area for logins using Application Passwords.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. login using a self-hosted site credentials,
2. go to Settings,
3. make sure "Manage notifications" setting item is not shown.


