### PR TITLE
Analytics Hub: Improve my store stats structure

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExt.kt
@@ -22,6 +22,9 @@ fun Double.formatToString(): String {
 
 fun Double?.isInteger() = this?.rem(1) == 0.0
 
+fun Double.limitTo(limit: Double) =
+    if (this > limit) limit else this
+
 infix fun <T> Comparable<T>?.greaterThan(other: T) =
     this?.let { it > other }
         ?: false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExt.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.extensions
 
+import java.text.DecimalFormat
 import kotlin.math.roundToInt
 
 fun Float.formatToString(): String {
@@ -22,9 +23,14 @@ fun Double.formatToString(): String {
 
 fun Double?.isInteger() = this?.rem(1) == 0.0
 
-fun Double.limitTo(limit: Double) =
-    if (this > limit) limit else this
+infix fun Number.convertedFrom(denominator: Number): String =
+    run { denominator.toDouble() }
+        .let { (if (it > 0) (this.toDouble() / it) * PERCENTAGE_BASE else 0.0) }
+        .coerceAtMost(PERCENTAGE_BASE)
+        .let { DecimalFormat("##.#").format(it) + "%" }
 
 infix fun <T> Comparable<T>?.greaterThan(other: T) =
     this?.let { it > other }
         ?: false
+
+const val PERCENTAGE_BASE = 100.0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SessionStat.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SessionStat.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.model
 
+import com.woocommerce.android.extensions.limitTo
 import java.text.DecimalFormat
 
 data class SessionStat(
@@ -8,15 +9,15 @@ data class SessionStat(
 ) {
     val conversionRate: String
         get() = when {
-            visitorsCount > 0 -> (ordersCount / visitorsCount.toFloat()) * PERCENT_BASE
-            else -> 0f
-        }.let { DecimalFormat("##.#").format(it) + "%" }
+            visitorsCount > 0 -> (ordersCount / visitorsCount.toDouble()) * PERCENT_BASE
+            else -> 0.0
+        }.limitTo(PERCENT_BASE).let { DecimalFormat("##.#").format(it) + "%" }
 
     companion object {
         val EMPTY = SessionStat(
             ordersCount = 0,
             visitorsCount = 0
         )
-        const val PERCENT_BASE = 100
+        const val PERCENT_BASE = 100.0
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SessionStat.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SessionStat.kt
@@ -1,23 +1,18 @@
 package com.woocommerce.android.model
 
-import com.woocommerce.android.extensions.limitTo
-import java.text.DecimalFormat
+import com.woocommerce.android.extensions.convertedFrom
 
 data class SessionStat(
     val ordersCount: Int,
     val visitorsCount: Int
 ) {
     val conversionRate: String
-        get() = when {
-            visitorsCount > 0 -> (ordersCount / visitorsCount.toDouble()) * PERCENT_BASE
-            else -> 0.0
-        }.limitTo(PERCENT_BASE).let { DecimalFormat("##.#").format(it) + "%" }
+        get() = ordersCount convertedFrom visitorsCount
 
     companion object {
         val EMPTY = SessionStat(
             ordersCount = 0,
             visitorsCount = 0
         )
-        const val PERCENT_BASE = 100.0
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/AnalyticsHubDateRangeSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/AnalyticsHubDateRangeSelection.kt
@@ -29,6 +29,7 @@ import java.io.Serializable
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 
 @Parcelize
 data class AnalyticsHubTimeRange(
@@ -157,6 +158,14 @@ class AnalyticsHubDateRangeSelection : Serializable {
             }
 
         companion object {
+            fun from(granularity: StatsGranularity) =
+                when (granularity) {
+                    StatsGranularity.DAYS -> TODAY
+                    StatsGranularity.WEEKS -> WEEK_TO_DATE
+                    StatsGranularity.MONTHS -> MONTH_TO_DATE
+                    StatsGranularity.YEARS -> YEAR_TO_DATE
+                }
+
             fun from(description: String): SelectionType {
                 return values().firstOrNull { it.toString() == description } ?: CUSTOM
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/AnalyticsHubDateRangeSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/AnalyticsHubDateRangeSelection.kt
@@ -25,11 +25,11 @@ import com.woocommerce.android.ui.analytics.ranges.data.WeekToDateRangeData
 import com.woocommerce.android.ui.analytics.ranges.data.YearToDateRangeData
 import com.woocommerce.android.ui.analytics.ranges.data.YesterdayRangeData
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import java.io.Serializable
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 
 @Parcelize
 data class AnalyticsHubTimeRange(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/sync/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/sync/AnalyticsRepository.kt
@@ -261,25 +261,12 @@ class AnalyticsRepository @Inject constructor(
         rangeSelection: AnalyticsHubDateRangeSelection,
         fetchStrategy: FetchStrategy
     ): Result<Map<String, Int>> = coroutineScope {
-        val isSelectionAvailableInMyStoreSection =
-            rangeSelection.selectionType == TODAY ||
-                rangeSelection.selectionType == WEEK_TO_DATE ||
-                rangeSelection.selectionType == MONTH_TO_DATE ||
-                rangeSelection.selectionType == YEAR_TO_DATE
-
-        if (isSelectionAvailableInMyStoreSection) {
-            statsRepository.fetchVisitorStats(
-                getGranularity(rangeSelection.selectionType),
-                fetchStrategy is FetchStrategy.ForceNew,
-            ).single()
-        } else {
-            statsRepository.fetchVisitorStats(
-                rangeSelection.currentRange.start.formatToYYYYmmDDhhmmss(),
-                rangeSelection.currentRange.end.formatToYYYYmmDDhhmmss(),
-                getGranularity(rangeSelection.selectionType),
-                fetchStrategy is FetchStrategy.ForceNew
-            )
-        }
+        statsRepository.fetchVisitorStats(
+            getGranularity(rangeSelection.selectionType),
+            fetchStrategy is FetchStrategy.ForceNew,
+            rangeSelection.currentRange.start.formatToYYYYmmDDhhmmss(),
+            rangeSelection.currentRange.end.formatToYYYYmmDDhhmmss()
+        ).single()
     }
 
     private fun getGranularity(selectionType: SelectionType) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/sync/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/sync/AnalyticsRepository.kt
@@ -304,8 +304,7 @@ class AnalyticsRepository @Inject constructor(
             granularity,
             fetchStrategy is FetchStrategy.ForceNew,
             startDate,
-            endDate,
-            true
+            endDate
         ).flowOn(dispatchers.io).single().mapCatching { it }
 
     private fun getCurrencyCode() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthYear
 import com.woocommerce.android.extensions.formatDateToYearMonth
 import com.woocommerce.android.extensions.formatToDateOnly
 import com.woocommerce.android.extensions.formatToMonthDateOnly
+import com.woocommerce.android.extensions.limitTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.MyStoreFragment.Companion.DEFAULT_STATS_GRANULARITY
 import com.woocommerce.android.util.CurrencyFormatter
@@ -427,6 +428,7 @@ class MyStoreStatsView @JvmOverloads constructor(
         binding.statsViewRow.visitorsValueTextview.isVisible = false
     }
 
+    @Suppress("MagicNumber")
     private fun updateConversionRate() {
         val ordersCount = ordersValue.text.toString().toIntOrNull()
         val visitorsCount = visitorsValue.text.toString().toIntOrNull()
@@ -440,7 +442,7 @@ class MyStoreStatsView @JvmOverloads constructor(
         val conversionRateDisplayValue = when (visitorsCount) {
             0 -> "0%"
             else -> {
-                val conversionRate = (ordersCount / visitorsCount.toFloat()) * 100
+                val conversionRate = ((ordersCount / visitorsCount.toDouble()) * 100).limitTo(100.0)
                 DecimalFormat("##.#").format(conversionRate) + "%"
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -30,13 +30,13 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.MyStoreStatsBinding
+import com.woocommerce.android.extensions.convertedFrom
 import com.woocommerce.android.extensions.formatDateToFriendlyDayHour
 import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthDate
 import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthYear
 import com.woocommerce.android.extensions.formatDateToYearMonth
 import com.woocommerce.android.extensions.formatToDateOnly
 import com.woocommerce.android.extensions.formatToMonthDateOnly
-import com.woocommerce.android.extensions.limitTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.MyStoreFragment.Companion.DEFAULT_STATS_GRANULARITY
 import com.woocommerce.android.util.CurrencyFormatter
@@ -53,7 +53,6 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DisplayUtils
-import java.text.DecimalFormat
 import java.util.Locale
 import kotlin.math.round
 
@@ -438,14 +437,7 @@ class MyStoreStatsView @JvmOverloads constructor(
             binding.statsViewRow.emptyConversionRateIndicator.isVisible = true
             return
         }
-
-        val conversionRateDisplayValue = when (visitorsCount) {
-            0 -> "0%"
-            else -> {
-                val conversionRate = ((ordersCount / visitorsCount.toDouble()) * 100).limitTo(100.0)
-                DecimalFormat("##.#").format(conversionRate) + "%"
-            }
-        }
+        val conversionRateDisplayValue = ordersCount convertedFrom visitorsCount
         val color = ContextCompat.getColor(context, R.color.color_on_surface_high)
         conversionValue.setTextColor(color)
         binding.statsViewRow.emptyConversionRateIndicator.isVisible = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
@@ -59,17 +59,12 @@ class StatsRepository @Inject constructor(
         granularity: StatsGranularity,
         forced: Boolean,
         startDate: String = "",
-        endDate: String = "",
-        forceSelectedDates: Boolean = false
+        endDate: String = ""
     ): Flow<Result<WCRevenueStatsModel?>> =
         flow {
-            val result = if (forceSelectedDates && startDate.isNotEmpty() && endDate.isNotEmpty()) {
-                wcStatsStore.fetchRevenueStats(selectedSite.get(), granularity, startDate, endDate, forced)
-            } else {
-                wcStatsStore.fetchRevenueStats(
-                    FetchRevenueStatsPayload(selectedSite.get(), granularity, startDate, endDate, forced)
-                )
-            }
+            val result = wcStatsStore.fetchRevenueStats(
+                FetchRevenueStatsPayload(selectedSite.get(), granularity, startDate, endDate, forced)
+            )
 
             if (!result.isError) {
                 val revenueStatsModel = wcStatsStore.getRawRevenueStats(
@@ -111,29 +106,6 @@ class StatsRepository @Inject constructor(
                 emit(Result.failure(Exception(errorMessage)))
             }
         }
-
-    suspend fun fetchVisitorStats(
-        startDate: String,
-        endDate: String,
-        granularity: StatsGranularity,
-        forced: Boolean
-    ): Result<Map<String, Int>> {
-        val result = FetchNewVisitorStatsPayload(
-            site = selectedSite.get(),
-            granularity = granularity,
-            forced = forced,
-            startDate = startDate,
-            endDate = endDate
-        ).let { wcStatsStore.fetchNewVisitorStats(it) }
-
-        if (result.isError) return Result.failure(Throwable(result.error?.message ?: "Timeout"))
-
-        val visitorStats = wcStatsStore.getNewVisitorStats(
-            selectedSite.get(), result.granularity, result.quantity, result.date, result.isCustomField
-        )
-
-        return Result.success(visitorStats)
-    }
 
     fun observeTopPerformers(
         granularity: StatsGranularity,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
@@ -88,9 +88,14 @@ class StatsRepository @Inject constructor(
             }
         }
 
-    suspend fun fetchVisitorStats(granularity: StatsGranularity, forced: Boolean): Flow<Result<Map<String, Int>>> =
+    suspend fun fetchVisitorStats(
+        granularity: StatsGranularity,
+        forced: Boolean,
+        startDate: String = "",
+        endDate: String = "",
+    ): Flow<Result<Map<String, Int>>> =
         flow {
-            val visitsPayload = FetchNewVisitorStatsPayload(selectedSite.get(), granularity, forced)
+            val visitsPayload = FetchNewVisitorStatsPayload(selectedSite.get(), granularity, forced, startDate, endDate)
             val result = wcStatsStore.fetchNewVisitorStats(visitsPayload)
             if (!result.isError) {
                 val visitorStats = wcStatsStore.getNewVisitorStats(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/GetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/GetStats.kt
@@ -72,11 +72,12 @@ class GetStats @Inject constructor(
         }
     }
 
-    private suspend fun visitorStats(forceRefresh: Boolean, granularity: StatsGranularity): Flow<LoadStatsResult> =
+    private suspend fun visitorStats(forceRefresh: Boolean, granularity: StatsGranularity): Flow<LoadStatsResult> {
+        val (startDate, endDate) = granularity.statsDateRange
         // Visitor stats are only available for Jetpack connected sites
-        when (selectedSite.connectionType) {
+        return when (selectedSite.connectionType) {
             SiteConnectionType.Jetpack -> {
-                statsRepository.fetchVisitorStats(granularity, forceRefresh)
+                statsRepository.fetchVisitorStats(granularity, forceRefresh, startDate, endDate)
                     .transform { result ->
                         result.fold(
                             onSuccess = { stats -> emit(LoadStatsResult.VisitorsStatsSuccess(stats)) },
@@ -88,6 +89,7 @@ class GetStats @Inject constructor(
                 flowOf(LoadStatsResult.VisitorStatUnavailable(it))
             } ?: emptyFlow()
         }
+    }
 
     private fun isPluginNotActiveError(error: Throwable): Boolean =
         (error as? StatsException)?.error?.type == OrderStatsErrorType.PLUGIN_NOT_ACTIVE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/GetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/GetStats.kt
@@ -9,9 +9,6 @@ import com.woocommerce.android.ui.mystore.data.StatsRepository
 import com.woocommerce.android.ui.mystore.data.StatsRepository.StatsException
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.locale.LocaleProvider
-import java.util.Calendar
-import java.util.Locale
-import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -21,6 +18,9 @@ import kotlinx.coroutines.flow.transform
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import java.util.Calendar
+import java.util.Locale
+import javax.inject.Inject
 
 class GetStats @Inject constructor(
     private val selectedSite: SelectedSite,
@@ -52,8 +52,7 @@ class GetStats @Inject constructor(
             granularity,
             forceRefresh,
             startDate,
-            endDate,
-            true
+            endDate
         ).transform { result ->
             result.fold(
                 onSuccess = { stats ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepositoryTest.kt
@@ -97,10 +97,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
     fun `given no currentPeriodRevenue, when fetchRevenueData, then result is RevenueError`() = runTest {
         // Given
         val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
             .thenReturn(listOf(Result.success(previousPeriodRevenue)).asFlow())
 
-        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
             .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
         // When
@@ -117,10 +117,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
     fun `given no currentPeriodRevenue when fetchOrderData result is RevenueError`() = runTest {
         // Given
         val previousPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
             .thenReturn(listOf(Result.success(previousPeriodOrdersStats)).asFlow())
 
-        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
             .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
         // When
@@ -137,10 +137,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
     fun `given no previousRevenuePeriod, when fetchRevenueData, then result is RevenueError`() = runTest {
         // Given
         val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
             .thenReturn(listOf(Result.success(currentPeriodRevenue)).asFlow())
 
-        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
             .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
         // When
@@ -158,10 +158,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(currentPeriodOrdersStats)).asFlow())
 
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
             // When
@@ -188,10 +188,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 netValue = 100.0,
                 itemsSold = 12
             )
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(currentRevenue)).asFlow())
 
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(previousRevenue)).asFlow())
 
             // When
@@ -230,10 +230,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 netValue = 159.4,
                 itemsSold = 12
             )
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(currentRevenue)).asFlow())
 
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(previousRevenue)).asFlow())
 
             // When
@@ -263,11 +263,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(ZERO_VALUE, ZERO_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(revenue)).asFlow())
 
             val previousRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(previousRevenue)).asFlow())
 
             // When
@@ -289,11 +289,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(revenue)).asFlow())
 
             val previousRevenue = givenARevenue(ZERO_VALUE, ZERO_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(previousRevenue)).asFlow())
 
             // When
@@ -312,10 +312,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val ordersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(ordersStats)).asFlow())
 
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(ordersStats)).asFlow())
 
             // When
@@ -337,10 +337,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val ordersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(ordersStats)).asFlow())
 
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(ordersStats)).asFlow())
 
             // When
@@ -360,11 +360,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(ZERO_VALUE, ZERO_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue)).asFlow())
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
@@ -385,11 +385,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(ZERO_VALUE.toInt(), ZERO_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats)).asFlow())
 
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodOrdersStats)).asFlow())
 
             // When
@@ -411,11 +411,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, ZERO_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue)).asFlow())
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
@@ -435,11 +435,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), ZERO_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats)).asFlow())
 
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodOrdersStats)).asFlow())
 
             // When
@@ -459,11 +459,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(null, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue)).asFlow())
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
@@ -482,11 +482,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(null, TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats)).asFlow())
 
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodOrdersStats)).asFlow())
 
             // When
@@ -506,11 +506,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, null, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue)).asFlow())
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
@@ -530,11 +530,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), null)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats)).asFlow())
 
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodOrdersStats)).asFlow())
 
             // When
@@ -553,11 +553,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue)).asFlow())
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
@@ -577,11 +577,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats)).asFlow())
 
             val currentPeriodRevenue = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue)).asFlow())
 
             // When
@@ -601,10 +601,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(previousPeriodRevenue)).asFlow())
 
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -628,11 +628,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
     fun `given no previousPeriodRevenue, when fetchProductsData, then result is ProductsError`() =
         runTest {
             // Given
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(currentPeriodRevenue)).asFlow())
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -657,10 +657,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(previousPeriodRevenue)).asFlow())
 
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null))).asFlow())
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -685,11 +685,11 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(previousStart), eq(previousEnd)))
                 .thenReturn(listOf(Result.success(previousPeriodRevenue)).asFlow())
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, null)
-            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), eq(currentStart), eq(currentEnd)))
                 .thenReturn(listOf(Result.success(currentPeriodRevenue)).asFlow())
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -714,7 +714,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
                 .thenReturn(listOf(Result.success(revenue)).asFlow())
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -735,7 +735,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
                 .thenReturn(listOf(Result.success(revenue)).asFlow())
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -763,7 +763,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
                 .thenReturn(listOf(Result.success(revenue)).asFlow())
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -789,10 +789,10 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
 
             // Then
             verify(statsRepository, times(1)).fetchRevenueStats(
-                any(), any(), eq(previousStart), eq(previousEnd), any()
+                any(), any(), eq(previousStart), eq(previousEnd)
             )
             verify(statsRepository, times(1)).fetchRevenueStats(
-                any(), any(), eq(currentStart), eq(currentEnd), any()
+                any(), any(), eq(currentStart), eq(currentEnd)
             )
         }
 
@@ -801,7 +801,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
                 .thenReturn(listOf(Result.success(revenue)).asFlow())
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -830,15 +830,13 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 any(),
                 any(),
                 eq(previousStart),
-                eq(previousEnd),
-                any()
+                eq(previousEnd)
             )
             verify(statsRepository, times(2)).fetchRevenueStats(
                 any(),
                 any(),
                 eq(currentStart),
-                eq(currentEnd),
-                any()
+                eq(currentEnd)
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
@@ -34,6 +34,7 @@ class GetStatsTest : BaseUnitTest() {
 
     private val getStats = GetStats(
         selectedSite,
+        mock(),
         statsRepository,
         appPrefsWrapper,
         coroutinesTestRule.testDispatchers
@@ -174,7 +175,7 @@ class GetStatsTest : BaseUnitTest() {
     }
 
     private suspend fun givenFetchRevenueStats(result: Result<WCRevenueStatsModel?>) {
-        whenever(statsRepository.fetchRevenueStats(any(), anyBoolean(), anyString(), anyString(), anyBoolean()))
+        whenever(statsRepository.fetchRevenueStats(any(), anyBoolean(), anyString(), anyString()))
             .thenReturn(flow { emit(result) })
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/domain/GetStatsTest.kt
@@ -187,7 +187,7 @@ class GetStatsTest : BaseUnitTest() {
     }
 
     private suspend fun givenFetchVisitorStats(result: Result<Map<String, Int>>) {
-        whenever(statsRepository.fetchVisitorStats(any(), anyBoolean()))
+        whenever(statsRepository.fetchVisitorStats(any(), anyBoolean(), anyString(), anyString()))
             .thenReturn(flow { emit(result) })
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2630-0819be8e724333ee1b408f2ce4c4343752473e15'
+    fluxCVersion = '2630-3d2d51f1dde14ef29b47c5df753dc3fd4ef2d75a'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
### ⚠️ Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2630 and should be reviewed alongside it.

Changelog
==========
This PR syncs the My Store and Analytics Hub to use the same data source, enforcing the same data structure between them.

Disclaimer
==========
Since it will take a bunch of changes to achieve the complete scope, this PR is targeted to a feature branch called `improve/analytics-hub` that will aggregate everything, this way we can review piece by piece while keeping the production version intact.

How to Test
==========
1. Open the app and go to the My Store section. Verify that every single data between the My Store section and the Hub are in sync.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
