### PR TITLE
[REST API] Hide "Password protected" product visibility option

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -40,6 +40,8 @@ import com.woocommerce.android.model.addTags
 import com.woocommerce.android.model.sortCategories
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.getMediaUploadErrorMessage
 import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.ProductDetailBottomSheetUiItem
@@ -112,6 +114,7 @@ class ProductDetailViewModel @Inject constructor(
     private val addonRepository: AddonRepository,
     private val duplicateProduct: DuplicateProduct,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val selectedSite: SelectedSite,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
@@ -861,7 +864,13 @@ class ProductDetailViewModel @Inject constructor(
     fun onSettingsVisibilityButtonClicked() {
         val visibility = getProductVisibility()
         val password = viewState.draftPassword ?: viewState.storedPassword
-        triggerEvent(ProductNavigationTarget.ViewProductVisibility(visibility, password))
+        triggerEvent(
+            ProductNavigationTarget.ViewProductVisibility(
+                selectedSite.connectionType == SiteConnectionType.ApplicationPasswords,
+                visibility,
+                password
+            )
+        )
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -57,6 +57,7 @@ sealed class ProductNavigationTarget : Event() {
         ProductNavigationTarget()
 
     data class ViewProductVisibility(
+        val isApplicationPasswordsLogin: Boolean,
         val visibility: ProductVisibility?,
         val password: String?
     ) : ProductNavigationTarget()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -188,7 +188,11 @@ class ProductNavigator @Inject constructor() {
             is ViewProductVisibility -> {
                 val visibility = target.visibility.toString()
                 val action = ProductSettingsFragmentDirections
-                    .actionProductSettingsFragmentToProductVisibilityFragment(visibility, target.password)
+                    .actionProductSettingsFragmentToProductVisibilityFragment(
+                        target.isApplicationPasswordsLogin,
+                        visibility,
+                        target.password
+                    )
                 fragment.findNavController().navigateSafely(action)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
@@ -46,6 +46,8 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
         binding.btnPasswordProtected.setOnClickListener(this)
         binding.btnPrivate.setOnClickListener(this)
 
+        handlePasswordProtectedSetting(navArgs.isApplicationPasswordsLogin)
+
         if (selectedVisibility == PASSWORD_PROTECTED.toString()) {
             (savedInstanceState?.getString(ARG_PASSWORD) ?: navArgs.password)?.let { password ->
                 binding.editPassword.text = password
@@ -57,6 +59,22 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
             if (it.toString().isNotBlank()) {
                 binding.editPassword.clearError()
             }
+        }
+
+        // Hide "Password protected" visibility setting on login with application passwords,
+        // because this feature specifically uses WP.com API.
+        if (navArgs.isApplicationPasswordsLogin) {
+            binding.btnPasswordProtected.visibility = View.GONE
+        } else {
+            binding.btnPasswordProtected.visibility = View.VISIBLE
+        }
+    }
+
+    private fun handlePasswordProtectedSetting(isApplicationPasswordsLogin: Boolean) {
+        if (isApplicationPasswordsLogin) {
+            binding.btnPasswordProtected.visibility = View.GONE
+        } else {
+            binding.btnPasswordProtected.visibility = View.VISIBLE
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
@@ -43,38 +43,39 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
         }
 
         binding.btnPublic.setOnClickListener(this)
-        binding.btnPasswordProtected.setOnClickListener(this)
         binding.btnPrivate.setOnClickListener(this)
 
-        handlePasswordProtectedSetting(navArgs.isApplicationPasswordsLogin)
-
-        if (selectedVisibility == PASSWORD_PROTECTED.toString()) {
-            (savedInstanceState?.getString(ARG_PASSWORD) ?: navArgs.password)?.let { password ->
-                binding.editPassword.text = password
-                showPassword(password.isNotBlank())
-            }
-        }
-
-        binding.editPassword.setOnTextChangedListener {
-            if (it.toString().isNotBlank()) {
-                binding.editPassword.clearError()
-            }
-        }
-
-        // Hide "Password protected" visibility setting on login with application passwords,
-        // because this feature specifically uses WP.com API.
-        if (navArgs.isApplicationPasswordsLogin) {
-            binding.btnPasswordProtected.visibility = View.GONE
-        } else {
-            binding.btnPasswordProtected.visibility = View.VISIBLE
-        }
+        val password = savedInstanceState?.getString(ARG_PASSWORD) ?: navArgs.password
+        setupPasswordProtectedSetting(
+            isApplicationPasswordsLogin = navArgs.isApplicationPasswordsLogin,
+            selectedVisibility = selectedVisibility,
+            password = password
+        )
     }
 
-    private fun handlePasswordProtectedSetting(isApplicationPasswordsLogin: Boolean) {
+    private fun setupPasswordProtectedSetting(
+        isApplicationPasswordsLogin: Boolean,
+        selectedVisibility: String?,
+        password: String?
+    ) {
         if (isApplicationPasswordsLogin) {
+            // Hide "Password protected" visibility setting on login with application passwords,
+            // because this feature specifically uses WP.com API.
             binding.btnPasswordProtected.visibility = View.GONE
         } else {
+            if (selectedVisibility == PASSWORD_PROTECTED.toString()) {
+                password?.let {
+                    binding.editPassword.text = it
+                    showPassword(it.isNotBlank())
+                }
+            }
+            binding.btnPasswordProtected.setOnClickListener(this)
             binding.btnPasswordProtected.visibility = View.VISIBLE
+            binding.editPassword.setOnTextChangedListener {
+                if (it.toString().isNotBlank()) {
+                    binding.editPassword.clearError()
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_settings.xml
@@ -62,6 +62,10 @@
         android:name="com.woocommerce.android.ui.products.settings.ProductVisibilityFragment"
         tools:layout="@layout/fragment_product_visibility">
         <argument
+            android:name="isApplicationPasswordsLogin"
+            app:argType="boolean"
+            app:nullable="false" />
+        <argument
             android:name="visibility"
             app:argType="string"
             app:nullable="true" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.MediaFileUploadHandler.ProductImageUploadData
 import com.woocommerce.android.ui.media.MediaFileUploadHandler.UploadStatus
@@ -76,6 +77,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     private val productTagsRepository: ProductTagsRepository = mock()
     private val mediaFilesRepository: MediaFilesRepository = mock()
     private val variationRepository: VariationRepository = mock()
+    private val selectedSite: SelectedSite = mock()
     private val resources: ResourceProvider = mock {
         on(it.getString(any())).thenAnswer { i -> i.arguments[0].toString() }
         on(it.getString(any(), any())).thenAnswer { i -> i.arguments[0].toString() }
@@ -241,7 +243,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 prefsWrapper,
                 addonRepository,
                 mock(),
-                mock()
+                mock(),
+                selectedSite
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductDetailViewModel.MenuButtonsState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
@@ -60,6 +61,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     private val productTagsRepository: ProductTagsRepository = mock()
     private val mediaFilesRepository: MediaFilesRepository = mock()
     private val variationRepository: VariationRepository = mock()
+    private val selectedSite: SelectedSite = mock()
     private val resources: ResourceProvider = mock {
         on(it.getString(any())).thenAnswer { i -> i.arguments[0].toString() }
         on(it.getString(any(), any())).thenAnswer { i -> i.arguments[0].toString() }
@@ -168,7 +170,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 prefs,
                 addonRepository,
                 mock(),
-                mock()
+                mock(),
+                selectedSite
             )
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8107
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR hides the "Password protected" option in Visibility area in Product details for logins using Application Passwords.

### Testing instructions
1. login using a self-hosted site credentials,
2. go to Products and open a Product,
3. go to triple-dot menu on top right, select Product Settings,
4. Select "Visibility",
5. Make sure the only shown options are "Public" and "Private"

