### PR TITLE
Remove portrait screen orientation requirement

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -7,10 +7,6 @@
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" /> <!-- Normal permissions, access automatically granted to app -->
-    <!--    Mark portrait orientation as optional, currently used for the bar code scanning activity -->
-    <uses-feature
-        android:name="android.hardware.screen.portrait"
-        android:required="false" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -134,6 +130,12 @@
         <activity
             android:name="org.wordpress.android.mediapicker.ui.MediaPickerActivity"
             android:theme="@style/Theme.Woo.DayNight" />
+        <!--        Make sure portrait screen orientation is not required for the installation of the app -->
+        <activity
+            android:name="com.google.mlkit.vision.codescanner.internal.GmsBarcodeScanningDelegateActivity"
+            android:screenOrientation="unspecified"
+            tools:replace="android:screenOrientation"/>
+
 
         <!-- Stats today app widget -->
         <meta-data


### PR DESCRIPTION
This is another iteration on ensuring portrait mode support is not required for the installation of the app. [The first attempt](https://github.com/woocommerce/woocommerce-android/pull/8163) turned out not to work as Google Play keeps excluding devices without portrait support.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open the app
2. Tap on "Continue with WordPress.com"
3. Enter mail
4. Tap on "Log in with magic link"
5. Tap on "Scan QR code to log in"
6. Assert there's not permission request
7. Scan a code that was sent to mail inbox
8. Assert successful log in

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
