### PR TITLE
Fix/ecommerce platform step multichoice

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/NewStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/NewStore.kt
@@ -52,6 +52,6 @@ class NewStore @Inject constructor() {
         val industryKey: String? = null,
         val industryGroupKey: String? = null,
         val userCommerceJourneyKey: String? = null,
-        val eCommercePlatformKey: String? = null,
+        val eCommercePlatformKeys: List<String> = emptyList(),
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryViewModel.kt
@@ -49,7 +49,7 @@ class MyStoreSummaryViewModel @Inject constructor(
                 AnalyticsTracker.KEY_INDUSTRY_GROUP to newStoreProfilerData?.industryGroupKey,
                 AnalyticsTracker.KEY_INDUSTRY to newStoreProfilerData?.industryKey,
                 AnalyticsTracker.KEY_USER_COMMERCE_JOURNEY to newStoreProfilerData?.userCommerceJourneyKey,
-                AnalyticsTracker.KEY_ECOMMERCE_PLATFORMS to newStoreProfilerData?.eCommercePlatformKey,
+                AnalyticsTracker.KEY_ECOMMERCE_PLATFORMS to newStoreProfilerData?.eCommercePlatformKeys?.joinToString(),
                 AnalyticsTracker.KEY_COUNTRY_CODE to newStore.data.country?.code,
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
@@ -46,7 +46,7 @@ abstract class BaseStoreProfilerViewModel(
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
-    fun onOptionSelected(option: StoreProfilerOptionUi) {
+    open fun onOptionSelected(option: StoreProfilerOptionUi) {
         profilerOptions.update { currentOptions ->
             currentOptions.map {
                 if (option.name == it.name) it.copy(isSelected = true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerCommerceJourneyViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerCommerceJourneyViewModel.kt
@@ -62,7 +62,7 @@ class StoreProfilerCommerceJourneyViewModel @Inject constructor(
     private fun AboutMerchant.toStoreProfilerOptionUi() = StoreProfilerOptionUi(
         name = value,
         key = tracks,
-        isSelected = newStore.data.profilerData?.eCommercePlatformKey == tracks,
+        isSelected = newStore.data.profilerData?.userCommerceJourneyKey == tracks,
     )
 
     private fun alreadySellingOnlineSelected() = profilerOptions.value

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerEcommercePlatformsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerEcommercePlatformsViewModel.kt
@@ -42,7 +42,7 @@ class StoreProfilerEcommercePlatformsViewModel @Inject constructor(
         StoreProfilerOptionUi(
             name = label,
             key = value,
-            isSelected = newStore.data.profilerData?.eCommercePlatformKey == value
+            isSelected = newStore.data.profilerData?.eCommercePlatformKeys?.any { it == value } == true
         )
 
     override fun getProfilerStepDescription(): String =
@@ -51,11 +51,22 @@ class StoreProfilerEcommercePlatformsViewModel @Inject constructor(
     override fun getProfilerStepTitle(): String =
         resourceProvider.getString(R.string.store_creation_store_profiler_platforms_title)
 
+    override fun onOptionSelected(option: StoreProfilerOptionUi) {
+        profilerOptions.update { currentOptions ->
+            currentOptions.map {
+                if (option.name == it.name) it.copy(isSelected = !it.isSelected)
+                else it
+            }
+        }
+    }
+
     override fun onContinueClicked() {
         newStore.update(
             profilerData = (newStore.data.profilerData ?: NewStore.ProfilerData())
                 .copy(
-                    eCommercePlatformKey = profilerOptions.value.firstOrNull { it.isSelected }?.key
+                    eCommercePlatformKeys = profilerOptions.value
+                        .filter { it.isSelected }
+                        .map { it.key }
                 )
         )
         triggerEvent(NavigateToCountryPickerStep)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
Fix ecommerce platform profiler step, currently is single choice, but according to the designs this step must be multi choice. 

Also, added a small fix, to recover the correct selected profiler value when opening `StoreProfilerCommerceJourney` step. 

### Testing instructions

To trigger the store creation flow you'll need to compile `vanillaDebug` flavor, and if the google account you've set on your device is not US located you'll also need to disable the feature flag `IAP_FOR_STORE_CREATION` for `debug` builds.

- Trigger store creation flow
- Go over the profiler steps. In the `StoreProfilerCommerceJourney` select: "I'm already selling online" 
- In the ecommerce platforms step, select multiple choices. 
- Navigate to store summary step and check that the following event is tracked with your previously selected values: 
``` 
Tracked: site_creation_profiler_data, Properties: {"industry_group":"construction_industrial","industry":"carpentry_contractors","user_commerce_journey":"im_already_selling_online","ecommerce_platforms":"big-cartel, big-commerce, etsy, pinterest, wix","country_code":"AI","is_debug":true}
```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
