### PR TITLE
[REST API] Hide "Switch Store" Option

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -152,7 +152,7 @@ private fun MoreMenuHeader(
             userAvatarUrl = state.userAvatarUrl,
             siteName = state.siteName,
             siteUrl = state.siteUrl,
-            showStoreSwitcher = true
+            showStoreSwitcher = state.showStoreSwitcher
         )
         SettingsButton(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -199,7 +199,7 @@ private fun StoreDetailsHeader(
                 style = MaterialTheme.typography.body2,
                 modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_50))
             )
-            if(showStoreSwitcher) {
+            if (showStoreSwitcher) {
                 Text(
                     text = stringResource(string.settings_switch_store),
                     color = MaterialTheme.colors.secondary,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -151,7 +151,8 @@ private fun MoreMenuHeader(
                 ),
             userAvatarUrl = state.userAvatarUrl,
             siteName = state.siteName,
-            siteUrl = state.siteUrl
+            siteUrl = state.siteUrl,
+            showStoreSwitcher = true
         )
         SettingsButton(
             modifier = Modifier
@@ -181,7 +182,8 @@ private fun StoreDetailsHeader(
     modifier: Modifier,
     userAvatarUrl: String,
     siteName: String,
-    siteUrl: String
+    siteUrl: String,
+    showStoreSwitcher: Boolean
 ) {
     Row(modifier = modifier) {
         MoreMenuUserAvatar(avatarUrl = userAvatarUrl)
@@ -197,11 +199,13 @@ private fun StoreDetailsHeader(
                 style = MaterialTheme.typography.body2,
                 modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_50))
             )
-            Text(
-                text = stringResource(string.settings_switch_store),
-                color = MaterialTheme.colors.secondary,
-                style = MaterialTheme.typography.body2,
-            )
+            if(showStoreSwitcher) {
+                Text(
+                    text = stringResource(string.settings_switch_store),
+                    color = MaterialTheme.colors.secondary,
+                    style = MaterialTheme.typography.body2,
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -132,7 +132,7 @@ private fun MoreMenuHeader(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(
-                enabled = true,
+                enabled = state.isStoreSwitcherEnabled,
                 onClickLabel = stringResource(id = string.settings_switch_store),
                 role = Role.Button,
                 onClick = onSwitchStore
@@ -152,7 +152,7 @@ private fun MoreMenuHeader(
             userAvatarUrl = state.userAvatarUrl,
             siteName = state.siteName,
             siteUrl = state.siteUrl,
-            showStoreSwitcher = state.showStoreSwitcher
+            isStoreSwitcherEnabled = state.isStoreSwitcherEnabled
         )
         SettingsButton(
             modifier = Modifier
@@ -183,7 +183,7 @@ private fun StoreDetailsHeader(
     userAvatarUrl: String,
     siteName: String,
     siteUrl: String,
-    showStoreSwitcher: Boolean
+    isStoreSwitcherEnabled: Boolean
 ) {
     Row(modifier = modifier) {
         MoreMenuUserAvatar(avatarUrl = userAvatarUrl)
@@ -199,7 +199,7 @@ private fun StoreDetailsHeader(
                 style = MaterialTheme.typography.body2,
                 modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_50))
             )
-            if (showStoreSwitcher) {
+            if (isStoreSwitcherEnabled) {
                 Text(
                     text = stringResource(string.settings_switch_store),
                     color = MaterialTheme.colors.secondary,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -16,6 +16,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_M
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_VIEW_STORE
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -49,7 +51,8 @@ class MoreMenuViewModel @Inject constructor(
                 ),
                 siteName = selectedSite.getSelectedSiteName(),
                 siteUrl = selectedSite.getSelectedSiteAbsoluteUrl(),
-                userAvatarUrl = accountStore.account.avatarUrl
+                userAvatarUrl = accountStore.account.avatarUrl,
+                showStoreSwitcher = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
             )
         }.asLiveData()
 
@@ -176,7 +179,8 @@ class MoreMenuViewModel @Inject constructor(
         val moreMenuItems: List<MenuUiButton> = emptyList(),
         val siteName: String = "",
         val siteUrl: String = "",
-        val userAvatarUrl: String = ""
+        val userAvatarUrl: String = "",
+        val showStoreSwitcher: Boolean = false
     )
 
     sealed class MoreMenuEvent : MultiLiveEvent.Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -52,7 +52,7 @@ class MoreMenuViewModel @Inject constructor(
                 siteName = selectedSite.getSelectedSiteName(),
                 siteUrl = selectedSite.getSelectedSiteAbsoluteUrl(),
                 userAvatarUrl = accountStore.account.avatarUrl,
-                showStoreSwitcher = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords
+                isStoreSwitcherEnabled = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords
             )
         }.asLiveData()
 
@@ -180,7 +180,7 @@ class MoreMenuViewModel @Inject constructor(
         val siteName: String = "",
         val siteUrl: String = "",
         val userAvatarUrl: String = "",
-        val showStoreSwitcher: Boolean = false
+        val isStoreSwitcherEnabled: Boolean = false
     )
 
     sealed class MoreMenuEvent : MultiLiveEvent.Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -52,7 +52,7 @@ class MoreMenuViewModel @Inject constructor(
                 siteName = selectedSite.getSelectedSiteName(),
                 siteUrl = selectedSite.getSelectedSiteAbsoluteUrl(),
                 userAvatarUrl = accountStore.account.avatarUrl,
-                showStoreSwitcher = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
+                showStoreSwitcher = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords
             )
         }.asLiveData()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -133,4 +133,44 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             // THEN
             assertThat(states.last().isStoreSwitcherEnabled).isEqualTo(false)
         }
+
+    @Test
+    fun `given wpcom login on Jetpack connected site, when building state, then store switcher state is enabled `() =
+        testBlocking {
+            // GIVEN
+            selectedSiteFlow.update {
+                it.apply {
+                    origin = SiteModel.ORIGIN_WPCOM_REST
+                }
+            }
+            selectedSiteFlow.value.setIsJetpackConnected(true)
+
+            setup()
+
+            // WHEN
+            val states = viewModel.moreMenuViewState.captureValues()
+
+            // THEN
+            assertThat(states.last().isStoreSwitcherEnabled).isEqualTo(true)
+        }
+
+    @Test
+    fun `given wpcom login on Jetpack CP site, when building state, then store switcher state is enabled `() =
+        testBlocking {
+            // GIVEN
+            selectedSiteFlow.update {
+                it.apply {
+                    origin = SiteModel.ORIGIN_WPCOM_REST
+                }
+            }
+            selectedSiteFlow.value.setIsJetpackCPConnected(true)
+
+            setup()
+
+            // WHEN
+            val states = viewModel.moreMenuViewState.captureValues()
+
+            // THEN
+            assertThat(states.last().isStoreSwitcherEnabled).isEqualTo(true)
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -116,4 +116,21 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         assertThat(reviewsButton.badgeState?.textState?.fontSize)
             .isEqualTo(R.dimen.text_minor_80)
     }
+
+    @Test
+    fun `given application passwords login, when building state, then store switcher state is disabled `() =
+        testBlocking {
+            // GIVEN
+            setup {
+                val siteModel: SiteModel = mock()
+                whenever(selectedSite.get()).thenReturn(siteModel)
+                whenever(selectedSite.get().origin).thenReturn(SiteModel.ORIGIN_XMLRPC)
+            }
+
+            // WHEN
+            val states = viewModel.moreMenuViewState.captureValues()
+
+            // THEN
+            assertThat(states.last().isStoreSwitcherEnabled).isEqualTo(false)
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -141,9 +141,9 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             selectedSiteFlow.update {
                 it.apply {
                     origin = SiteModel.ORIGIN_WPCOM_REST
+                    setIsJetpackConnected(true)
                 }
             }
-            selectedSiteFlow.value.setIsJetpackConnected(true)
 
             setup()
 
@@ -161,9 +161,9 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             selectedSiteFlow.update {
                 it.apply {
                     origin = SiteModel.ORIGIN_WPCOM_REST
+                    setIsJetpackCPConnected(true)
                 }
             }
-            selectedSiteFlow.value.setIsJetpackCPConnected(true)
 
             setup()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -122,9 +123,9 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         testBlocking {
             // GIVEN
             setup {
-                val siteModel: SiteModel = mock()
-                whenever(selectedSite.get()).thenReturn(siteModel)
-                whenever(selectedSite.get().origin).thenReturn(SiteModel.ORIGIN_XMLRPC)
+                whenever(selectedSite.connectionType).thenReturn(
+                    SiteConnectionType.ApplicationPasswords
+                )
             }
 
             // WHEN


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8107
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Switch Store functionality is not supported on application passwords login, so we're removing it in this case.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. login using a self-hosted site credentials,
2. go to More menu,
3. make sure "Switch Store" option at the top, under site address, is not shown.