### PR TITLE
[REST API] A/B test

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -783,4 +783,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
 
     APPLICATION_PASSWORDS_NEW_PASSWORD_CREATED,
     APPLICATION_PASSWORDS_NOT_AVAILABLE,
+
+    // Experiments (A/B test variants)
+    REST_API_LOGIN_EXPERIMENT
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
@@ -8,6 +8,7 @@ interface ExperimentTracker {
         const val LOGIN_SUCCESSFUL_EVENT = "login_successful"
         const val SITE_VERIFICATION_SUCCESSFUL_EVENT = "site_verification_successful"
         const val REST_API_ELIGIBLE_EVENT = "simplified_login_experiment_eligible"
+        const val MYSTORE_DISPLAYED_EVENT = "my_store_displayed"
     }
 
     fun log(event: String, block: (ParametersBuilder.() -> Unit)? = null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
@@ -7,6 +7,7 @@ interface ExperimentTracker {
         const val PROLOGUE_EXPERIMENT_ELIGIBLE_EVENT = "prologue_carousel_displayed"
         const val LOGIN_SUCCESSFUL_EVENT = "login_successful"
         const val SITE_VERIFICATION_SUCCESSFUL_EVENT = "site_verification_successful"
+        const val REST_API_ELIGIBLE_EVENT = "simplified_login_experiment_eligible"
     }
 
     fun log(event: String, block: (ParametersBuilder.() -> Unit)? = null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -4,7 +4,7 @@ import androidx.annotation.VisibleForTesting
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
-import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
+import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -43,7 +43,7 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     private val defaultValues by lazy {
         @Suppress("RemoveExplicitTypeArguments")
         mapOf<String, String>(
-            REST_API_LOGIN_VARIANT_KEY to RestAPILoginVariant.CONTROL.name
+            REST_API_LOGIN_VARIANT_KEY to RESTAPILoginVariant.CONTROL.name
         )
     }
 
@@ -77,12 +77,12 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     override fun getPerformanceMonitoringSampleRate(): Double =
         remoteConfig.getDouble(PERFORMANCE_MONITORING_SAMPLE_RATE_KEY)
 
-    override fun getRestAPILoginVariant(): RestAPILoginVariant {
+    override fun getRestAPILoginVariant(): RESTAPILoginVariant {
         return try {
-            RestAPILoginVariant.valueOf(remoteConfig.getString(REST_API_LOGIN_VARIANT_KEY).uppercase())
+            RESTAPILoginVariant.valueOf(remoteConfig.getString(REST_API_LOGIN_VARIANT_KEY).uppercase())
         } catch (e: IllegalArgumentException) {
             crashLogging.get().recordException(e)
-            RestAPILoginVariant.valueOf(defaultValues[REST_API_LOGIN_VARIANT_KEY]!!)
+            RESTAPILoginVariant.valueOf(defaultValues[REST_API_LOGIN_VARIANT_KEY]!!)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -1,22 +1,27 @@
 package com.woocommerce.android.config
 
 import androidx.annotation.VisibleForTesting
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
+import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Singleton
 class FirebaseRemoteConfigRepository @Inject constructor(
-    private val remoteConfig: FirebaseRemoteConfig
+    private val remoteConfig: FirebaseRemoteConfig,
+    private val crashLogging: Provider<CrashLogging>
 ) : RemoteConfigRepository {
     companion object {
         private const val PERFORMANCE_MONITORING_SAMPLE_RATE_KEY = "wc_android_performance_monitoring_sample_rate"
+        private const val REST_API_LOGIN_VARIANT_KEY = "wcandroid_rest_api_login_variant"
         private const val DEBUG_INTERVAL = 10L
         private const val RELEASE_INTERVAL = 31200L
     }
@@ -30,7 +35,10 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     private val changesTrigger = MutableSharedFlow<Unit>(replay = 1)
 
     private val defaultValues by lazy {
-        mapOf<String, String>()
+        @Suppress("RemoveExplicitTypeArguments")
+        mapOf<String, String>(
+            REST_API_LOGIN_VARIANT_KEY to RestAPILoginVariant.CONTROL.name
+        )
     }
 
     init {
@@ -60,6 +68,15 @@ class FirebaseRemoteConfigRepository @Inject constructor(
 
     override fun getPerformanceMonitoringSampleRate(): Double =
         remoteConfig.getDouble(PERFORMANCE_MONITORING_SAMPLE_RATE_KEY)
+
+    override fun getRestAPILoginVariant(): RestAPILoginVariant {
+        return try {
+            RestAPILoginVariant.valueOf(remoteConfig.getString(REST_API_LOGIN_VARIANT_KEY).uppercase())
+        } catch (e: IllegalArgumentException) {
+            crashLogging.get().recordException(e)
+            RestAPILoginVariant.valueOf(defaultValues[REST_API_LOGIN_VARIANT_KEY]!!)
+        }
+    }
 
     @VisibleForTesting
     fun observeStringRemoteValue(key: String) = changesTrigger

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -1,12 +1,12 @@
 package com.woocommerce.android.config
 
-import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
+import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant
 import kotlinx.coroutines.flow.Flow
 
 interface RemoteConfigRepository {
     val fetchStatus: Flow<RemoteConfigFetchStatus>
     fun fetchRemoteConfig()
-    fun getRestAPILoginVariant(): RestAPILoginVariant
+    fun getRestAPILoginVariant(): RESTAPILoginVariant
     fun getPerformanceMonitoringSampleRate(): Double
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.config
 
+import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
+
 interface RemoteConfigRepository {
     fun fetchRemoteConfig()
+    fun getRestAPILoginVariant(): RestAPILoginVariant
     fun getPerformanceMonitoringSampleRate(): Double
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -1,9 +1,15 @@
 package com.woocommerce.android.config
 
 import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
+import kotlinx.coroutines.flow.Flow
 
 interface RemoteConfigRepository {
+    val fetchStatus: Flow<RemoteConfigFetchStatus>
     fun fetchRemoteConfig()
     fun getRestAPILoginVariant(): RestAPILoginVariant
     fun getPerformanceMonitoringSampleRate(): Double
+}
+
+enum class RemoteConfigFetchStatus {
+    Pending, Success, Failure
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
-class RestAPILoginExperiment @Inject constructor(
+class RESTAPILoginExperiment @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val experimentTracker: ExperimentTracker,
     private val remoteConfigRepository: RemoteConfigRepository,
@@ -40,13 +40,13 @@ class RestAPILoginExperiment @Inject constructor(
         )
     }
 
-    fun getCurrentVariant(): RestAPILoginVariant = if (PackageUtils.isTesting()) {
-        RestAPILoginVariant.CONTROL
+    fun getCurrentVariant(): RESTAPILoginVariant = if (PackageUtils.isTesting()) {
+        RESTAPILoginVariant.CONTROL
     } else {
         remoteConfigRepository.getRestAPILoginVariant()
     }
 
-    enum class RestAPILoginVariant {
+    enum class RESTAPILoginVariant {
         CONTROL,
         TREATMENT
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RestAPILoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RestAPILoginExperiment.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.config.RemoteConfigRepository
+import com.woocommerce.android.util.PackageUtils
 import javax.inject.Inject
 
 class RestAPILoginExperiment @Inject constructor(
@@ -25,7 +26,11 @@ class RestAPILoginExperiment @Inject constructor(
         )
     }
 
-    fun getCurrentVariant(): RestAPILoginVariant = remoteConfigRepository.getRestAPILoginVariant()
+    fun getCurrentVariant(): RestAPILoginVariant = if (PackageUtils.isTesting()) {
+        RestAPILoginVariant.CONTROL
+    } else {
+        remoteConfigRepository.getRestAPILoginVariant()
+    }
 
     enum class RestAPILoginVariant {
         CONTROL,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RestAPILoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RestAPILoginExperiment.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.experiment
+
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.analytics.ExperimentTracker
+import com.woocommerce.android.config.RemoteConfigRepository
+import javax.inject.Inject
+
+class RestAPILoginExperiment @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val experimentTracker: ExperimentTracker,
+    private val remoteConfigRepository: RemoteConfigRepository,
+) {
+
+    fun activate() {
+        // Track Firebase's activation event for the A/B testing.
+        experimentTracker.log(ExperimentTracker.REST_API_ELIGIBLE_EVENT)
+
+        // Track used variant
+        val variant = getCurrentVariant()
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.REST_API_LOGIN_EXPERIMENT,
+            mapOf(Pair(AnalyticsTracker.KEY_EXPERIMENT_VARIANT, variant.name))
+        )
+    }
+
+    fun getCurrentVariant(): RestAPILoginVariant = remoteConfigRepository.getRestAPILoginVariant()
+
+    enum class RestAPILoginVariant {
+        CONTROL,
+        TREATMENT
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/RegisterDevice.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.push
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.GetDeviceRegistrationStatus
 import javax.inject.Inject
@@ -12,6 +14,9 @@ class RegisterDevice @Inject constructor(
     private val getDeviceRegistrationStatus: GetDeviceRegistrationStatus,
 ) {
     suspend operator fun invoke(mode: Mode) {
+        if (BuildConfig.DEBUG) {
+            WooLog.d(WooLog.T.UTILS, "Current FCM token: ${appPrefsWrapper.getFCMToken()}")
+        }
         when (mode) {
             Mode.IF_NEEDED -> {
                 if (getDeviceRegistrationStatus() == GetDeviceRegistrationStatus.Status.UNREGISTERED) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -26,10 +26,10 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_JETPAC
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_LOGIN_WITH_WORDPRESS_COM
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.ActivityLoginBinding
-import com.woocommerce.android.experiment.RestAPILoginExperiment
-import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
-import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant.CONTROL
-import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant.TREATMENT
+import com.woocommerce.android.experiment.RESTAPILoginExperiment
+import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant
+import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant.CONTROL
+import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant.TREATMENT
 import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.support.ZendeskExtraTags
 import com.woocommerce.android.support.ZendeskHelper
@@ -158,7 +158,7 @@ class LoginActivity :
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var loginNotificationScheduler: LoginNotificationScheduler
     @Inject internal lateinit var uiMessageResolver: UIMessageResolver
-    @Inject internal lateinit var restApiLoginExperiment: RestAPILoginExperiment
+    @Inject internal lateinit var restApiLoginExperiment: RESTAPILoginExperiment
 
     private var loginMode: LoginMode? = null
     private lateinit var binding: ActivityLoginBinding
@@ -827,7 +827,7 @@ class LoginActivity :
         inputUsername: String?,
         inputPassword: String?
     ) {
-        val (fragment, tag) = if (restApiLoginExperiment.getCurrentVariant() == RestAPILoginVariant.TREATMENT) {
+        val (fragment, tag) = if (restApiLoginExperiment.getCurrentVariant() == RESTAPILoginVariant.TREATMENT) {
             Pair(
                 LoginSiteCredentialsFragment.newInstance(
                     siteAddress = requireNotNull(siteAddress),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -26,6 +26,10 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_JETPAC
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_LOGIN_WITH_WORDPRESS_COM
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.ActivityLoginBinding
+import com.woocommerce.android.experiment.RestAPILoginExperiment
+import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
+import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant.CONTROL
+import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant.TREATMENT
 import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.support.ZendeskExtraTags
 import com.woocommerce.android.support.ZendeskHelper
@@ -63,7 +67,6 @@ import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsFrag
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.UrlUtils
 import com.woocommerce.android.util.WooLog
 import dagger.android.AndroidInjector
@@ -155,6 +158,7 @@ class LoginActivity :
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var loginNotificationScheduler: LoginNotificationScheduler
     @Inject internal lateinit var uiMessageResolver: UIMessageResolver
+    @Inject internal lateinit var restApiLoginExperiment: RestAPILoginExperiment
 
     private var loginMode: LoginMode? = null
     private lateinit var binding: ActivityLoginBinding
@@ -559,7 +563,12 @@ class LoginActivity :
         val siteAddressClean = inputSiteAddress.replaceFirst(protocolRegex, "")
         AppPrefs.setLoginSiteAddress(siteAddressClean)
 
-        if (hasJetpack) {
+        val shouldUseEmailLogin = when (restApiLoginExperiment.getCurrentVariant()) {
+            CONTROL -> hasJetpack
+            TREATMENT -> connectSiteInfo?.isWPCom == true
+        }
+
+        if (shouldUseEmailLogin) {
             showEmailLoginScreen(inputSiteAddress.takeIf { connectSiteInfo?.isWPCom != true })
         } else {
             // Let user log in via site credentials first before showing Jetpack missing screen.
@@ -818,7 +827,7 @@ class LoginActivity :
         inputUsername: String?,
         inputPassword: String?
     ) {
-        val (fragment, tag) = if (FeatureFlag.REST_API.isEnabled()) {
+        val (fragment, tag) = if (restApiLoginExperiment.getCurrentVariant() == RestAPILoginVariant.TREATMENT) {
             Pair(
                 LoginSiteCredentialsFragment.newInstance(
                     siteAddress = requireNotNull(siteAddress),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.FragmentLoginPrologueBinding
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.FragmentLoginPrologueBinding
+import com.woocommerce.android.experiment.RestAPILoginExperiment
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,6 +33,8 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
     constructor() : this(R.layout.fragment_login_prologue)
 
     @Inject lateinit var unifiedLoginTracker: UnifiedLoginTracker
+    @Inject lateinit var restAPILoginExperiment: RestAPILoginExperiment
+
     private var prologueFinishedListener: PrologueFinishedListener? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -50,6 +53,7 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
         }
 
         if (savedInstanceState == null) {
+            restAPILoginExperiment.activate()
             unifiedLoginTracker.track(Flow.PROLOGUE, Step.PROLOGUE)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -4,17 +4,23 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.LayoutRes
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.FragmentLoginPrologueBinding
 import com.woocommerce.android.experiment.RestAPILoginExperiment
+import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -32,10 +38,19 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
 
     constructor() : this(R.layout.fragment_login_prologue)
 
-    @Inject lateinit var unifiedLoginTracker: UnifiedLoginTracker
-    @Inject lateinit var restAPILoginExperiment: RestAPILoginExperiment
+    @Inject
+    lateinit var unifiedLoginTracker: UnifiedLoginTracker
+
+    @Inject
+    lateinit var restAPILoginExperiment: RestAPILoginExperiment
 
     private var prologueFinishedListener: PrologueFinishedListener? = null
+
+    private val loadingIndicator by lazy {
+        CircularProgressIndicator(requireActivity()).apply {
+            isIndeterminate = true
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val binding = FragmentLoginPrologueBinding.bind(view)
@@ -52,16 +67,59 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
             prologueFinishedListener?.onSecondaryButtonClicked()
         }
 
-        if (savedInstanceState == null) {
-            restAPILoginExperiment.activate()
-            unifiedLoginTracker.track(Flow.PROLOGUE, Step.PROLOGUE)
-        }
-
         binding.buttonGetStarted.setOnClickListener {
             AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
             AnalyticsTracker.track(stat = AnalyticsEvent.LOGIN_PROLOGUE_CREATE_SITE_TAPPED)
             prologueFinishedListener?.onGetStartedClicked()
         }
+
+        if (savedInstanceState == null) {
+            unifiedLoginTracker.track(Flow.PROLOGUE, Step.PROLOGUE)
+
+            binding.showLoadingIndicator()
+
+            lifecycleScope.launch {
+                restAPILoginExperiment.activate()
+                binding.removeLoadingIndicator()
+                binding.handleRestLoginExperiment()
+            }
+        } else {
+            binding.handleRestLoginExperiment()
+        }
+    }
+
+    private fun FragmentLoginPrologueBinding.handleRestLoginExperiment() {
+        // Override behavior for REST API treatment experiment
+        if (restAPILoginExperiment.getCurrentVariant() == RestAPILoginVariant.TREATMENT) {
+            // Since Android doesn't allow changing view's styles, we will just swap buttons in order to have the store
+            // button primary
+            buttonLoginStore.hide()
+            buttonLoginWpcom.text = buttonLoginStore.text
+            buttonLoginWpcom.setOnClickListener {
+                // Forward click to site address button
+                buttonLoginStore.performClick()
+            }
+        }
+    }
+
+    private fun FragmentLoginPrologueBinding.showLoadingIndicator() {
+        loadingIndicator.layoutParams = ConstraintLayout.LayoutParams(
+            ConstraintLayout.LayoutParams.WRAP_CONTENT,
+            ConstraintLayout.LayoutParams.WRAP_CONTENT
+        ).apply {
+            startToStart = ConstraintLayout.LayoutParams.PARENT_ID
+            endToEnd = ConstraintLayout.LayoutParams.PARENT_ID
+            topToTop = loginButtons.id
+            bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+        }
+
+        root.addView(loadingIndicator)
+        loginButtons.visibility = View.INVISIBLE
+    }
+
+    private fun FragmentLoginPrologueBinding.removeLoadingIndicator() {
+        root.removeView(loadingIndicator)
+        loginButtons.show()
     }
 
     override fun onAttach(context: Context) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -95,6 +95,7 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
             // button primary
             buttonLoginStore.hide()
             buttonLoginWpcom.text = buttonLoginStore.text
+            buttonLoginWpcom.layoutParams = buttonLoginStore.layoutParams
             buttonLoginWpcom.setOnClickListener {
                 // Forward click to site address button
                 buttonLoginStore.performClick()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -13,8 +13,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentLoginPrologueBinding
-import com.woocommerce.android.experiment.RestAPILoginExperiment
-import com.woocommerce.android.experiment.RestAPILoginExperiment.RestAPILoginVariant
+import com.woocommerce.android.experiment.RESTAPILoginExperiment
+import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
@@ -42,7 +42,7 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
     lateinit var unifiedLoginTracker: UnifiedLoginTracker
 
     @Inject
-    lateinit var restAPILoginExperiment: RestAPILoginExperiment
+    lateinit var restAPILoginExperiment: RESTAPILoginExperiment
 
     private var prologueFinishedListener: PrologueFinishedListener? = null
 
@@ -90,7 +90,7 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
 
     private fun FragmentLoginPrologueBinding.handleRestLoginExperiment() {
         // Override behavior for REST API treatment experiment
-        if (restAPILoginExperiment.getCurrentVariant() == RestAPILoginVariant.TREATMENT) {
+        if (restAPILoginExperiment.getCurrentVariant() == RESTAPILoginVariant.TREATMENT) {
             // Since Android doesn't allow changing view's styles, we will just swap buttons in order to have the store
             // button primary
             buttonLoginStore.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -173,6 +173,9 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
             .onEach { usageTracksEventEmitter.interacted() }
             .launchIn(viewLifecycleOwner.lifecycleScope)
 
+        // Successful event for REST API A/B testing.
+        experimentTracker.log(ExperimentTracker.MYSTORE_DISPLAYED_EVENT)
+
         setupStateObservers()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,7 +14,6 @@ enum class FeatureFlag {
     UNIFIED_ORDER_EDITING,
     ORDER_CREATION_CUSTOMER_SEARCH,
     NATIVE_STORE_CREATION_FLOW,
-    REST_API,
     IAP_FOR_STORE_CREATION,
     IPP_TAP_TO_PAY;
 
@@ -32,7 +31,6 @@ enum class FeatureFlag {
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            REST_API,
             IAP_FOR_STORE_CREATION,
             IPP_TAP_TO_PAY -> PackageUtils.isDebugBuild()
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepositoryTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepositoryTests.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.config
 
 import android.app.Activity
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.gms.tasks.OnCompleteListener
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
@@ -9,6 +10,7 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -20,6 +22,7 @@ import java.util.concurrent.Executor
 @OptIn(ExperimentalCoroutinesApi::class)
 class FirebaseRemoteConfigRepositoryTests : BaseUnitTest() {
     private val remoteConfig = mock<FirebaseRemoteConfig>()
+    private val crashLogging = mock<CrashLogging>()
 
     lateinit var repository: FirebaseRemoteConfigRepository
 
@@ -34,7 +37,8 @@ class FirebaseRemoteConfigRepositoryTests : BaseUnitTest() {
             .thenReturn(StaticTask(null))
 
         repository = FirebaseRemoteConfigRepository(
-            remoteConfig = remoteConfig
+            remoteConfig = remoteConfig,
+            crashLogging = { crashLogging }
         )
     }
 
@@ -82,9 +86,46 @@ class FirebaseRemoteConfigRepositoryTests : BaseUnitTest() {
 
             assertThat(values.size).isEqualTo(1)
         }
+
+    @Test
+    fun `when remote config is initiated, then expose a pending fetch status`() = testBlocking {
+        setup()
+
+        val status = repository.fetchStatus.first()
+
+        assertThat(status).isEqualTo(RemoteConfigFetchStatus.Pending)
+    }
+
+    @Test
+    fun `when remote config fetch succeeds, then expose a success fetch status`() = testBlocking {
+        setup {
+            whenever(remoteConfig.fetchAndActivate())
+                .thenReturn(StaticTask(false))
+        }
+
+        val status = repository.fetchStatus.runAndCaptureValues {
+            repository.fetchRemoteConfig()
+        }.last()
+
+        assertThat(status).isEqualTo(RemoteConfigFetchStatus.Success)
+    }
+
+    @Test
+    fun `when remote config fetch fails, then expose a failure fetch status`() = testBlocking {
+        setup {
+            whenever(remoteConfig.fetchAndActivate())
+                .thenReturn(StaticTask(false, Exception()))
+        }
+
+        val status = repository.fetchStatus.runAndCaptureValues {
+            repository.fetchRemoteConfig()
+        }.last()
+
+        assertThat(status).isEqualTo(RemoteConfigFetchStatus.Failure)
+    }
 }
 
-class StaticTask<T>(private val value: T) : Task<T>() {
+class StaticTask<T>(private val value: T, private val exception: Exception? = null) : Task<T>() {
     override fun addOnCompleteListener(p0: OnCompleteListener<T>): Task<T> {
         p0.onComplete(this)
         return this
@@ -94,11 +135,14 @@ class StaticTask<T>(private val value: T) : Task<T>() {
         return addOnCompleteListener(p1)
     }
 
-    override fun addOnFailureListener(p0: OnFailureListener): Task<T> = this
+    override fun addOnFailureListener(p0: OnFailureListener): Task<T> {
+        exception?.let { p0.onFailure(it) }
+        return this
+    }
 
-    override fun addOnFailureListener(p0: Executor, p1: OnFailureListener): Task<T> = this
+    override fun addOnFailureListener(p0: Executor, p1: OnFailureListener): Task<T> = addOnFailureListener(p1)
 
-    override fun addOnFailureListener(p0: Activity, p1: OnFailureListener): Task<T> = this
+    override fun addOnFailureListener(p0: Activity, p1: OnFailureListener): Task<T> = addOnFailureListener(p1)
 
     override fun addOnSuccessListener(p0: OnSuccessListener<in T>): Task<T> {
         p0.onSuccess(value)
@@ -109,7 +153,7 @@ class StaticTask<T>(private val value: T) : Task<T>() {
 
     override fun addOnSuccessListener(p0: Activity, p1: OnSuccessListener<in T>): Task<T> = addOnSuccessListener(p1)
 
-    override fun getException(): Exception? = null
+    override fun getException(): Exception? = exception
 
     override fun getResult(): T = value
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8174
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the A/B test logic for the REST API project, this got more complicated than the past experiments because I found out an issue with our past implementation, and let me explain in steps what happens sometimes:
1. We open the app then we trigger a fetch of the remote config data, let's suppose it takes a while.
2. The prologue screen is opened, then we attempt to activate the A/B test and track its variant, at this step, since the fetch didn't finish yet, remote config SDK will give us the default value.
3. The remote config fetch finishes, and the variant was updated.
4. The remaining steps of login flow won't match the variant that we showed in the prologue.
5. The A/B test success status will be assigned to the wrong variant.

To fix this issue, I updated the logic of the RemoteConfigRepository to expose the status of the fetch, and I made the `activate` function of the experiment suspendable to make it possible to wait for the fetch to finish, before tracking the current variant and sending the activation event, and if the fetch **fails**, we won't send the activation event, meaning this user will be excluded from the A/B test results.

### Testing instructions
For assigning yourself a variant, you have the choice between:
1. Going to the Firebase Console and adding your device to the test devices, you can use the FCM token to do so, it's printed to the logcat when opening the app.
2. Hardcode the value in code.

#### Control variant
For the tests below, please force the Control variant

##### WPCom site
1. Open the app, then click on "Enter site address"
2. Enter the address of a WPCom site.
3. Confirm the WPCom email login screen is shown.

##### Selfhosted Jetpack site
1. Open the app, then click on "Enter site address"
2. Enter the address of a selfhosted Jetpack site (connected to a WPCom account).
3. Confirm the WPCom email login screen is shown.

##### Selfhosted non-Jetpack site
1. Open the app, then click on "Enter site address"
2. Enter the address of a selfhosted site without Jetpack (either uninstalled or non-connected).
3. Confirm the site credentials screen is shown.
4. Enter site credentials.
5. Confirm the Jetpack error screen is shown.

#### Treatment variant
##### WPCom site
1. Open the app, then click on "Enter site address"
2. Enter the address of a WPCom site.
3. Confirm the WPCom email login screen is shown.

##### Selfhosted Jetpack site
1. Open the app, then click on "Enter site address"
2. Enter the address of a selfhosted Jetpack site (connected to a WPCom account).
3. Confirm the site credentials screen is shown.

##### Selfhosted non-Jetpack site
1. Open the app, then click on "Enter site address"
2. Enter the address of a selfhosted site without Jetpack (either uninstalled or non-connected).
3. Confirm the site credentials screen is shown.

### Screenshots

| Control | Treatment |
| --- | --- |
| ![Screenshot_20230117_150843](https://user-images.githubusercontent.com/1657201/212920266-dac3ea1f-b052-419d-9293-889c607d18fc.png) |![Screenshot_20230117_150909](https://user-images.githubusercontent.com/1657201/212920284-f980b474-9ea1-4507-a64c-da7809e33d8e.png) |



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
