### PR TITLE
TPP: Handle manual cancellation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModel.kt
@@ -93,10 +93,10 @@ class CardReaderStatusCheckerViewModel
     }
 
     private fun CardReader.toCardReaderType() =
-        if (type.equals(ReaderType.BuildInReader.CotsDevice.name, ignoreCase = true)) {
-            CardReaderType.BUILT_IN
-        } else {
+        if (ReaderType.isExternalReaderType(type)) {
             CardReaderType.EXTERNAL
+        } else {
+            CardReaderType.BUILT_IN
         }
 
     sealed class StatusCheckerEvent : MultiLiveEvent.Event() {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderType.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderType.kt
@@ -15,6 +15,23 @@ sealed class ReaderType(val name: String) {
     sealed class BuildInReader(buildInReaderName: String) : ReaderType(buildInReaderName) {
         object CotsDevice : BuildInReader("COTS_DEVICE")
     }
+
+    object Unknown : ReaderType("UNKNOWN")
+
+    companion object {
+        private fun fromName(name: String): ReaderType =
+            when (name.uppercase()) {
+                "CHIPPER_2X" -> ExternalReader.Chipper2X
+                "STRIPE_M2" -> ExternalReader.StripeM2
+                "VERIFONE_P400" -> ExternalReader.VerifoneP400
+                "WISEPAD_3" -> ExternalReader.WisePade3
+                "WISEPOS_E" -> ExternalReader.WisePadeE
+                "COTS_DEVICE" -> BuildInReader.CotsDevice
+                else -> Unknown
+            }
+
+        fun isExternalReaderType(name: String?): Boolean = name?.let { fromName(name) is ExternalReader } ?: false
+    }
 }
 
 sealed class CardReaderTypesToDiscover {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -63,7 +63,7 @@ internal class PaymentManager(
 
     private fun processPaymentIntent(orderId: Long, data: PaymentIntent) = flow {
         var paymentIntent = data
-        if (paymentIntent.status == null && paymentIntent.status == CANCELED) {
+        if (paymentIntent.status == null || paymentIntent.status == CANCELED) {
             emit(errorMapper.mapError(errorMessage = "Cannot retry paymentIntent with status ${paymentIntent.status}"))
             return@flow
         }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.cardreader.internal.payments.actions
 
 import com.stripe.stripeterminal.external.callable.Callback
+import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.PaymentIntentCallback
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.cardreader.internal.LOG_TAG
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.Failure
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.Success
@@ -39,9 +41,20 @@ internal class CollectPaymentAction(private val terminal: TerminalWrapper, priva
                 }
             )
             awaitClose {
-                if (!cancelable.isCompleted) cancelable.cancel(noop)
+                cancelIfExternalReaderUsed(cancelable)
             }
         }
+    }
+
+    /** In the current version of the Local Mobile SDK manual cancellation throws an exception:
+     *  > com.stripe.stripeterminal.external.models.TerminalException:
+     *  > Cancellation of a Tap to Pay transaction can only happen from the activity
+     *
+     * That's why we cancel only if external reader is used
+     **/
+    private fun cancelIfExternalReaderUsed(cancelable: Cancelable) {
+        val externalReaderUsed = ReaderType.isExternalReaderType(terminal.getConnectedReader()?.type)
+        if (!cancelable.isCompleted && externalReaderUsed) cancelable.cancel(noop)
     }
 }
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -547,6 +547,32 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
 
             assertThat(result).isInstanceOf(CapturingPayment::class.java)
         }
+
+    @Test
+    fun `given PaymentStatus CANCELED, when retrying payment, then PaymentFailed is emitted`() =
+        testBlocking {
+            val paymentIntent = createPaymentIntent(CANCELED)
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            val result = manager
+                .retryPayment(1, paymentData).toList()
+
+            assertThat(result.last()).isInstanceOf(PaymentFailed::class.java)
+        }
+
+    @Test
+    fun `given PaymentStatus null, when retrying payment, then PaymentFailed is emitted`() =
+        testBlocking {
+            val paymentIntent = mock<PaymentIntent>().also {
+                whenever(it.status).thenReturn(null)
+            }
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            val result = manager
+                .retryPayment(1, paymentData).toList()
+
+            assertThat(result.last()).isInstanceOf(PaymentFailed::class.java)
+        }
     // END - Retry
 
     // BEGIN - Cancel

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentActionTest.kt
@@ -113,7 +113,7 @@ internal class CollectPaymentActionTest : CardReaderBaseUnitTest() {
         }
 
     @Test
-    fun `given flow not terminated built int reader, when job canceled, then collect payment not canceled`() =
+    fun `given flow not terminated built in reader, when job canceled, then collect payment not canceled`() =
         testBlocking {
             val cancelable = mock<Cancelable>()
             whenever(cancelable.isCompleted).thenReturn(false)

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentActionTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader.internal.payments.actions
 import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.PaymentIntentCallback
 import com.stripe.stripeterminal.external.models.PaymentIntent
+import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.Failure
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.Success
@@ -92,17 +93,39 @@ internal class CollectPaymentActionTest : CardReaderBaseUnitTest() {
     }
 
     @Test
-    fun `given flow not terminated, when job canceled, then collect payment gets canceled`() = testBlocking {
-        val cancelable = mock<Cancelable>()
-        whenever(cancelable.isCompleted).thenReturn(false)
-        whenever(terminal.collectPaymentMethod(any(), any())).thenAnswer { cancelable }
-        val job = launch {
-            action.collectPayment(mock()).collect { }
+    fun `given flow not terminated external reader, when job canceled, then collect payment gets canceled`() =
+        testBlocking {
+            val cancelable = mock<Cancelable>()
+            whenever(cancelable.isCompleted).thenReturn(false)
+            whenever(terminal.collectPaymentMethod(any(), any())).thenAnswer { cancelable }
+
+            val cardReader = mock<CardReader> { on { type }.thenReturn("STRIPE_M2") }
+            whenever(terminal.getConnectedReader()).thenReturn(cardReader)
+            val job = launch {
+                action.collectPayment(mock()).collect { }
+            }
+
+            job.cancel()
+            joinAll(job)
+
+            verify(cancelable).cancel(any())
         }
 
-        job.cancel()
-        joinAll(job)
+    @Test
+    fun `given flow not terminated built int reader, when job canceled, then collect payment not canceled`() =
+        testBlocking {
+            val cancelable = mock<Cancelable>()
+            whenever(cancelable.isCompleted).thenReturn(false)
+            whenever(terminal.collectPaymentMethod(any(), any())).thenAnswer { cancelable }
+            val cardReader = mock<CardReader> { on { type }.thenReturn("COTS_DEVICE") }
+            whenever(terminal.getConnectedReader()).thenReturn(cardReader)
+            val job = launch {
+                action.collectPayment(mock()).collect { }
+            }
 
-        verify(cancelable).cancel(any())
-    }
+            job.cancel()
+            joinAll(job)
+
+            verify(cancelable).isCompleted
+        }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentActionTest.kt
@@ -18,6 +18,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -126,6 +127,6 @@ internal class CollectPaymentActionTest : CardReaderBaseUnitTest() {
             job.cancel()
             joinAll(job)
 
-            verify(cancelable).isCompleted
+            verify(cancelable, never()).cancel(any())
         }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8139
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The SDK throws an exception if we manually try to cancel the payment:

```
com.stripe.stripeterminal.external.models.TerminalException: Cancellation of a Tap to Pay transaction can only happen from the activity
```

It's might a bug in there because weirdly `cancelable.isCompleted` returns false in this case. The PR removes the cancelation of the built-in readers as the exception suggests
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* During TPP full-screen activity click on "cross"
* Notice that an error is shown to a user and the crash doesn't happen anymore 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->



https://user-images.githubusercontent.com/4923871/213161754-2cf1a5af-0f3b-48a7-9d1c-4b688de89a80.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
