### PR TITLE
[REST API] A/B test: update eligibility event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/ExperimentTracker.kt
@@ -7,7 +7,7 @@ interface ExperimentTracker {
         const val PROLOGUE_EXPERIMENT_ELIGIBLE_EVENT = "prologue_carousel_displayed"
         const val LOGIN_SUCCESSFUL_EVENT = "login_successful"
         const val SITE_VERIFICATION_SUCCESSFUL_EVENT = "site_verification_successful"
-        const val REST_API_ELIGIBLE_EVENT = "simplified_login_experiment_eligible"
+        const val REST_API_ELIGIBLE_EVENT = "wcandroid_rest_api_experiment_eligible"
         const val MYSTORE_DISPLAYED_EVENT = "my_store_displayed"
     }
 


### PR DESCRIPTION
### Description
This PR just updates the A/B test eligibility event to a value different than the previous one, I did this because the previous value was used for the experiment 1, and I'm worried this might cause a lower success rate if users of previous app versions get included in the A/B test results calculation.

@hafizrahman sorry for missing this until you merged the previous PR 🙏 .

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
