### PR TITLE
Feature/search bar store profiler

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.login.storecreation.profiler
 
-import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -9,27 +8,30 @@ import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
-import kotlinx.parcelize.Parcelize
 
 abstract class BaseStoreProfilerViewModel(
     savedStateHandle: SavedStateHandle,
     private val newStore: NewStore,
 ) : ScopedViewModel(savedStateHandle) {
+    abstract val hasSearchableContent: Boolean
     protected val profilerOptions = MutableStateFlow(emptyList<StoreProfilerOptionUi>())
-    val storeProfilerContent: LiveData<ViewState> = profilerOptions
-        .map { options ->
-            if (options.isEmpty()) {
-                LoadingState
-            } else {
-                StoreProfilerContent(
-                    storeName = newStore.data.name ?: "",
-                    title = getProfilerStepTitle(),
-                    description = getProfilerStepDescription(),
-                    options = options
-                )
-            }
+    protected val isLoading = MutableStateFlow(false)
+
+    val storeProfilerState: LiveData<StoreProfilerState> =
+        combine(
+            profilerOptions,
+            isLoading
+        ) { options, isLoading ->
+            StoreProfilerState(
+                storeName = newStore.data.name ?: "",
+                title = getProfilerStepTitle(),
+                description = getProfilerStepDescription(),
+                options = options,
+                isSearchableContent = hasSearchableContent,
+                isLoading = isLoading
+            )
         }.asLiveData()
 
     protected abstract fun getProfilerStepDescription(): String
@@ -37,6 +39,8 @@ abstract class BaseStoreProfilerViewModel(
     protected abstract fun getProfilerStepTitle(): String
 
     abstract fun onContinueClicked()
+
+    open fun onSearchQueryChanged(query: String) {}
 
     fun onSkipPressed() {
         triggerEvent(NavigateToCountryPickerStep)
@@ -59,25 +63,20 @@ abstract class BaseStoreProfilerViewModel(
         triggerEvent(MultiLiveEvent.Event.NavigateToHelpScreen(HelpOrigin.STORE_CREATION))
     }
 
-    sealed class ViewState : Parcelable
-
-    @Parcelize
-    object LoadingState : ViewState()
-
-    @Parcelize
-    data class StoreProfilerContent(
+    data class StoreProfilerState(
         val storeName: String,
         val title: String,
         val description: String,
-        val options: List<StoreProfilerOptionUi> = emptyList()
-    ) : ViewState(), Parcelable
+        val options: List<StoreProfilerOptionUi> = emptyList(),
+        val isSearchableContent: Boolean,
+        val isLoading: Boolean
+    )
 
-    @Parcelize
     data class StoreProfilerOptionUi(
         val name: String,
         val key: String,
         val isSelected: Boolean,
-    ) : Parcelable
+    )
 
     object NavigateToCountryPickerStep : MultiLiveEvent.Event()
     object NavigateToCommerceJourneyStep : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerCommerceJourneyViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerCommerceJourneyViewModel.kt
@@ -21,6 +21,8 @@ class StoreProfilerCommerceJourneyViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
 ) : BaseStoreProfilerViewModel(savedStateHandle, newStore) {
     private var alreadySellingOnlineOption: StoreProfilerOptionUi? = null
+    override val hasSearchableContent: Boolean
+        get() = false
 
     init {
         analyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerEcommercePlatformsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerEcommercePlatformsViewModel.kt
@@ -20,6 +20,9 @@ class StoreProfilerEcommercePlatformsViewModel @Inject constructor(
     private val storeProfilerRepository: StoreProfilerRepository,
     private val resourceProvider: ResourceProvider,
 ) : BaseStoreProfilerViewModel(savedStateHandle, newStore) {
+    override val hasSearchableContent: Boolean
+        get() = false
+
     init {
         analyticsTracker.track(
             AnalyticsEvent.SITE_CREATION_STEP,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
@@ -33,13 +33,11 @@ class StoreProfilerIndustriesViewModel @Inject constructor(
             )
         )
         launch {
-            isLoading.value = true
             val fetchedOptions = storeProfilerRepository.fetchProfilerOptions()
             industries = fetchedOptions.industries
             profilerOptions.update {
                 industries.map { it.toStoreProfilerOptionUi() }
             }
-            isLoading.value = false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
@@ -61,17 +61,6 @@ class StoreProfilerIndustriesViewModel @Inject constructor(
         triggerEvent(NavigateToCommerceJourneyStep)
     }
 
-    override fun onSearchQueryChanged(query: String) {
-        profilerOptions.update {
-            if (query.isBlank()) industries.map { it.toStoreProfilerOptionUi() }
-            industries
-                .filter { industry ->
-                    industry.label.contains(query, ignoreCase = true)
-                }
-                .map { it.toStoreProfilerOptionUi() }
-        }
-    }
-
     private fun Industry.toStoreProfilerOptionUi() = StoreProfilerOptionUi(
         name = label,
         key = key,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -37,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -107,39 +109,43 @@ private fun ProfilerContent(
             modifier = Modifier
                 .fillMaxSize()
                 .weight(1f)
-                .padding(dimensionResource(id = R.dimen.major_100)),
-            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+                .padding(
+                    start = dimensionResource(id = R.dimen.major_100),
+                    end = dimensionResource(id = R.dimen.major_100)
+                )
         ) {
-            Text(
-                text = profilerStepContent.storeName.uppercase(),
-                style = MaterialTheme.typography.caption,
-                color = colorResource(id = R.color.color_on_surface_medium)
-            )
-            Text(
-                text = profilerStepContent.title,
-                style = MaterialTheme.typography.h5,
-            )
-            Text(
-                text = profilerStepContent.description,
-                style = MaterialTheme.typography.subtitle1,
-                color = colorResource(id = R.color.color_on_surface_medium)
-            )
-            if (profilerStepContent.isSearchableContent)
-                SearchBar(
-                    profilerStepContent.searchQuery,
-                    onSearchQueryChanged
-                )
-            if (profilerStepContent.options.isEmpty() && profilerStepContent.isSearchableContent) {
-                Text(
-                    modifier = Modifier.align(alignment = Alignment.CenterHorizontally),
-                    text = stringResource(id = R.string.store_creation_store_profiler_industries_search_empty_results)
-                )
-            } else {
-                CategoryList(
-                    categories = profilerStepContent.options,
-                    onCategorySelected = onCategorySelected,
-                    modifier = Modifier.fillMaxWidth()
-                )
+            val configuration = LocalConfiguration.current
+            if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                HeaderContent(profilerStepContent, onSearchQueryChanged)
+            }
+            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                    item {
+                        HeaderContent(profilerStepContent, onSearchQueryChanged)
+                    }
+                }
+                if (profilerStepContent.options.isEmpty()) {
+                    item {
+                        Text(
+                            modifier = Modifier
+                                .align(alignment = Alignment.CenterHorizontally)
+                                .padding(top = dimensionResource(id = R.dimen.major_100)),
+                            text = stringResource(id = R.string.store_creation_profiler_options_search_empty)
+                        )
+                    }
+                }
+                itemsIndexed(profilerStepContent.options) { index, category ->
+                    if (index == 0)
+                        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+
+                    ProfilerOptionItem(
+                        category = category,
+                        onCategorySelected = onCategorySelected,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = dimensionResource(id = R.dimen.major_100))
+                    )
+                }
             }
         }
         Divider(
@@ -155,6 +161,38 @@ private fun ProfilerContent(
         ) {
             Text(text = stringResource(id = R.string.continue_button))
         }
+    }
+}
+
+@Composable
+private fun HeaderContent(
+    profilerStepContent: StoreProfilerState,
+    onSearchQueryChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+    ) {
+        Text(
+            text = profilerStepContent.storeName.uppercase(),
+            style = MaterialTheme.typography.caption,
+            color = colorResource(id = R.color.color_on_surface_medium)
+        )
+        Text(
+            text = profilerStepContent.title,
+            style = MaterialTheme.typography.h5,
+        )
+        Text(
+            text = profilerStepContent.description,
+            style = MaterialTheme.typography.subtitle1,
+            color = colorResource(id = R.color.color_on_surface_medium)
+        )
+        if (profilerStepContent.isSearchableContent)
+            SearchBar(
+                profilerStepContent.searchQuery,
+                onSearchQueryChanged
+            )
     }
 }
 
@@ -186,26 +224,7 @@ private fun SearchBar(
 }
 
 @Composable
-private fun CategoryList(
-    categories: List<StoreProfilerOptionUi>,
-    onCategorySelected: (StoreProfilerOptionUi) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    LazyColumn(modifier = modifier) {
-        itemsIndexed(categories) { _, category ->
-            CategoryItem(
-                category = category,
-                onCategorySelected = onCategorySelected,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = dimensionResource(id = R.dimen.major_100))
-            )
-        }
-    }
-}
-
-@Composable
-private fun CategoryItem(
+private fun ProfilerOptionItem(
     category: StoreProfilerOptionUi,
     onCategorySelected: (StoreProfilerOptionUi) -> Unit,
     modifier: Modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerScreen.kt
@@ -32,11 +32,7 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -128,7 +124,11 @@ private fun ProfilerContent(
                 style = MaterialTheme.typography.subtitle1,
                 color = colorResource(id = R.color.color_on_surface_medium)
             )
-            if (profilerStepContent.isSearchableContent) SearchBar(onSearchQueryChanged)
+            if (profilerStepContent.isSearchableContent)
+                SearchBar(
+                    profilerStepContent.searchQuery,
+                    onSearchQueryChanged
+                )
             if (profilerStepContent.options.isEmpty() && profilerStepContent.isSearchableContent) {
                 Text(
                     modifier = Modifier.align(alignment = Alignment.CenterHorizontally),
@@ -159,17 +159,17 @@ private fun ProfilerContent(
 }
 
 @Composable
-private fun SearchBar(onSearchQueryChanged: (String) -> Unit) {
+private fun SearchBar(
+    searchQuery: String,
+    onSearchQueryChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
     val keyboardController = LocalSoftwareKeyboardController.current
-    var searchQuery by remember { mutableStateOf("") }
     WCSearchField(
         value = searchQuery,
-        onValueChange = {
-            searchQuery = it
-            onSearchQueryChanged.invoke(it)
-        },
+        onValueChange = onSearchQueryChanged,
         hint = stringResource(id = string.store_creation_store_profiler_industries_search_hint),
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(52.dp)
             .border(
@@ -292,7 +292,8 @@ fun CategoriesContentPreview() {
                     )
                 ),
                 isSearchableContent = true,
-                isLoading = false
+                isLoading = false,
+                searchQuery = ""
             ),
             onContinueClicked = {},
             onCategorySelected = {},

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2829,7 +2829,7 @@
     <string name="store_creation_store_profiler_industries_title">What will you be selling?</string>
     <string name="store_creation_store_profiler_industries_description">Choose a category that best fits your business.</string>
     <string name="store_creation_store_profiler_industries_search_hint">Type a category</string>
-    <string name="store_creation_store_profiler_industries_search_empty_results">No available results for this search</string>
+    <string name="store_creation_profiler_options_search_empty">No available results for this search</string>
     <string name="store_creation_store_profiler_journey_title">Where are you on your commerce journey?</string>
     <string name="store_creation_store_profiler_journey_description">To speed things up, we’ll tailor your WooCommerce experience for you based on your response.</string>
     <string name="store_creation_store_profiler_platforms_title">In which platform are you currently selling?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2828,6 +2828,8 @@
 
     <string name="store_creation_store_profiler_industries_title">What will you be selling?</string>
     <string name="store_creation_store_profiler_industries_description">Choose a category that best fits your business.</string>
+    <string name="store_creation_store_profiler_industries_search_hint">Type a category</string>
+    <string name="store_creation_store_profiler_industries_search_empty_results">No available results for this search</string>
     <string name="store_creation_store_profiler_journey_title">Where are you on your commerce journey?</string>
     <string name="store_creation_store_profiler_journey_description">To speed things up, we’ll tailor your WooCommerce experience for you based on your response.</string>
     <string name="store_creation_store_profiler_platforms_title">In which platform are you currently selling?</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
Adds a search bar for the long industries list of store profiler steps. 

This PR also handles configuration changes so that all the content is scrollable when screen is landscape mode

### Testing instructions

Note: To trigger the store creation flow you'll need to compile `vanillaDebug` flavour, and if the Google account you've set on your device is not US located you'll also need to disable the feature flag IAP_FOR_STORE_CREATION for debug builds.

- Trigger store creation flow
- Navigate to store profiler steps
- Search different industries in store profiler and check that results are refreshed accordingly

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2663464/213238738-bf35e84b-fc5c-4334-a85f-f1dea473fd99.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
