### PR TITLE
[REST API] Handle duplicate passwords

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/ApplicationPasswordsNotifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/ApplicationPasswordsNotifier.kt
@@ -31,7 +31,7 @@ class ApplicationPasswordsNotifier @Inject constructor(
         _featureUnavailableEvents.tryEmit(networkError)
     }
 
-    override fun onNewPasswordCreated() {
+    override fun onNewPasswordCreated(isPasswordRegenerated: Boolean) {
         analyticsTrackerWrapper.track(stat = AnalyticsEvent.APPLICATION_PASSWORDS_NEW_PASSWORD_CREATED)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-5b0c7cf987471ad7460e87f9212f01d7ac89f52e'
+    fluxCVersion = '2638-86eda124d89db8958fb37b5ce128fac53976dce9'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
### Description
This PR includes the changes of the FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2638, it aims at fixing the logic of deleting passwords when a duplicate one is detected.

### Testing instructions
The test steps of the FluxC PR should cover what's needed.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
