### PR TITLE
Update the FluxC reference to the latest trunk commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2638-86eda124d89db8958fb37b5ce128fac53976dce9'
+    fluxCVersion = 'trunk-e844ae56793e2d5340995caf50da100c66099505'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
This PR just updates the FluxC reference to the latest `trunk` commit.