### PR TITLE
Add a new Domain option to Settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -12,6 +12,8 @@ interface MainSettingsContract {
         fun setupAnnouncementOption()
         fun setupJetpackInstallOption()
         fun setupApplicationPasswordsSettings()
+
+        val isDomainOptionVisible: Boolean
     }
 
     interface View : BaseView<Presenter> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -203,6 +204,9 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             // FIXME AMANDA tracks event
             showThemeChooser()
         }
+
+        binding.categoryStoreSettings.isVisible = presenter.isDomainOptionVisible
+        binding.optionDomain.isVisible = presenter.isDomainOptionVisible
 
         presenter.setupAnnouncementOption()
         presenter.setupJetpackInstallOption()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
@@ -73,4 +74,7 @@ class MainSettingsPresenter @Inject constructor(
             appSettingsFragmentView?.handleApplicationPasswordsSettings()
         }
     }
+
+    override val isDomainOptionVisible: Boolean
+        get() = selectedSite.get().isWPComAtomic && FeatureFlag.DOMAIN_CHANGE.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -16,7 +16,8 @@ enum class FeatureFlag {
     NATIVE_STORE_CREATION_FLOW,
     REST_API,
     IAP_FOR_STORE_CREATION,
-    IPP_TAP_TO_PAY;
+    IPP_TAP_TO_PAY,
+    DOMAIN_CHANGE;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -34,7 +35,8 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             REST_API,
             IAP_FOR_STORE_CREATION,
-            IPP_TAP_TO_PAY -> PackageUtils.isDebugBuild()
+            IPP_TAP_TO_PAY,
+            DOMAIN_CHANGE -> PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -174,6 +174,23 @@
         <View style="@style/Woo.Divider" />
 
         <!--
+            Store settings
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+            android:id="@+id/category_store_settings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_store" />
+
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_domain"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/domain" />
+
+        <View style="@style/Woo.Divider" />
+
+        <!--
             About
         -->
         <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="discard">Discard</string>
     <string name="products">Products</string>
     <string name="refunds">Refunds</string>
+    <string name="domain">Domain</string>
     <string name="shipping_labels">Shipping Labels</string>
     <string name="product_variations">Variations</string>
     <string name="product_variation_options">%1$s (%2$s options)</string>


### PR DESCRIPTION
This PR adds a new `Domain` option under the `Store settings` category, which will be the entry point to the domain change feature.

The option is displayed only for Atomic sites and it's under a feature flag (Debug build).

<img src="https://user-images.githubusercontent.com/1522856/213300320-e26ed0c7-91b9-40cd-bc8a-bc38dd41abb0.png" width="300" />
