### PR TITLE
[REST API] Delete applications passwords on logout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
@@ -43,7 +43,7 @@ class RESTAPILoginExperiment @Inject constructor(
     fun getCurrentVariant(): RESTAPILoginVariant = if (PackageUtils.isTesting()) {
         RESTAPILoginVariant.CONTROL
     } else {
-        remoteConfigRepository.getRestAPILoginVariant()
+        RESTAPILoginVariant.TREATMENT
     }
 
     enum class RESTAPILoginVariant {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
@@ -43,7 +43,7 @@ class RESTAPILoginExperiment @Inject constructor(
     fun getCurrentVariant(): RESTAPILoginVariant = if (PackageUtils.isTesting()) {
         RESTAPILoginVariant.CONTROL
     } else {
-        RESTAPILoginVariant.TREATMENT
+        remoteConfigRepository.getRestAPILoginVariant()
     }
 
     enum class RESTAPILoginVariant {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -63,7 +63,7 @@ class AccountRepository @Inject constructor(
                         "Error deleting application password: ${result.error.errorCode} > ${result.error.message}"
                     )
                 } else {
-                    WooLog.e(LOGIN, "Application password deleted")
+                    WooLog.i(LOGIN, "Application password deleted")
                 }
 
                 selectedSite.reset()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8188
<!-- Id number of the GitHub issue this PR addresses. -->

This PR adds the functionality of deleting application password during logout process.

### To test:
1. Make sure to use the treatment variant for REST API experiment. Easy way is editing `RESTAPILoginExperiment` class and forcing `getCurrentVariant()` to return `RESTAPILoginVariant.TREATMENT`.
2. Login with a self-hosted site, using site credentials,
3. Once logged in, go to settings
4. Select "Log out"
5. Check logcat and make sure to see the "Application password deleted" log.
