### PR TITLE
IPP feedback banner: user group detection rules update

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -316,7 +316,7 @@ class OrderListFragment :
                 }
                 is OrderListViewModel.OrderListEvent.OpenIPPFeedbackSurveyLink -> {
                     NavGraphMainDirections
-                        .actionGlobalFeedbackSurveyFragment(customUrll = event.url)
+                        .actionGlobalFeedbackSurveyFragment(customUrl = event.url)
                         .apply { findNavController().navigateSafely(this) }
                 }
                 is OrderListViewModel.OrderListEvent.NotifyOrderChanged -> {
@@ -399,7 +399,7 @@ class OrderListFragment :
     }
 
     private fun renderIPPBanner(bannerState: OrderListViewModel.IPPSurveyFeedbackBannerState) {
-        val isVisible = bannerState is OrderListViewModel.IPPSurveyFeedbackBannerState.Visible && isPortrait()
+        val isVisible = bannerState is OrderListViewModel.IPPSurveyFeedbackBannerState.Visible && !DisplayUtils.isLandscape(context)
 
         binding.ippFeedbackBanner.isVisible = isVisible
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
@@ -96,46 +96,56 @@ class GetIPPFeedbackBannerData @Inject constructor(
     data class IPPFeedbackBanner(
         @StringRes val title: Int,
         @StringRes val message: Int,
-        val url: String
+        val url: String,
+        val campaignName: String,
     ) : Parcelable
 
     companion object {
         private val IPP_NEWBIE_BANNER by lazy {
-            IPPFeedbackBanner(BANNER_TITLE_NEWBIE, BANNER_MESSAGE_NEWBIE, SURVEY_URL_IPP_NEWBIE)
+            IPPFeedbackBanner(
+                BANNER_TITLE_NEWBIE,
+                BANNER_MESSAGE_NEWBIE,
+                SURVEY_URL_IPP_NEWBIE,
+                CAMPAIGN_NAME_IPP_NEWBIE,
+            )
         }
 
         private val IPP_BEGINNER_BANNER by lazy {
             IPPFeedbackBanner(
                 BANNER_TITLE_BEGINNER,
                 BANNER_MESSAGE_BEGINNER,
-                SURVEY_URL_IPP_BEGINNER
+                SURVEY_URL_IPP_BEGINNER,
+                CAMPAIGN_NAME_IPP_BEGINNER,
             )
         }
 
         private val IPP_NINJA_BANNER by lazy {
-            IPPFeedbackBanner(BANNER_TITLE_NINJA, BANNER_MESSAGE_NINJA, SURVEY_URL_IPP_NINJA)
+            IPPFeedbackBanner(
+                BANNER_TITLE_NINJA,
+                BANNER_MESSAGE_NINJA,
+                SURVEY_URL_IPP_NINJA,
+                CAMPAIGN_NAME_IPP_NINJA,
+            )
         }
 
         private const val STATS_TIME_WINDOW_LENGTH_DAYS = 30
 
         private const val SURVEY_URL_IPP_NEWBIE = "https://automattic.survey.fm/woo-app-–-cod-survey"
-
         private const val SURVEY_URL_IPP_BEGINNER =
             "https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey"
-
         private const val SURVEY_URL_IPP_NINJA = "https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users"
 
         private const val BANNER_TITLE_NEWBIE = R.string.feedback_banner_ipp_title_newbie
-
         private const val BANNER_TITLE_BEGINNER = R.string.feedback_banner_ipp_title_beginner
-
         private const val BANNER_TITLE_NINJA = R.string.feedback_banner_ipp_title_ninja
 
         private const val BANNER_MESSAGE_NEWBIE = R.string.feedback_banner_ipp_message_newbie
-
         private const val BANNER_MESSAGE_BEGINNER = R.string.feedback_banner_ipp_message_beginner
-
         private const val BANNER_MESSAGE_NINJA = R.string.feedback_banner_ipp_message_ninja
+
+        private const val CAMPAIGN_NAME_IPP_NEWBIE = "ipp_not_user"
+        private const val CAMPAIGN_NAME_IPP_BEGINNER = "ipp_new_user"
+        private const val CAMPAIGN_NAME_IPP_NINJA = "ipp_heavy_user"
 
         private val IPP_BEGINNER_TRANSACTIONS_RANGE = 1..10
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
@@ -39,11 +39,11 @@ class GetIPPFeedbackBannerData @Inject constructor(
 
         requireSuccessfulTransactionsSummaryResponse(response)
 
-        val numberOfTransactions = requireTransactionsCount(response)
+        val numberOfTransactionsInLast30Days = requireTransactionsCount(response)
 
-        requirePositiveNumberOfTransactions(numberOfTransactions)
+        requirePositiveNumberOfTransactions(numberOfTransactionsInLast30Days)
 
-        return when (numberOfTransactions) {
+        return when (numberOfTransactionsInLast30Days) {
             0 -> if (hasUserEverMadeIppTransaction()) {
                 IPP_BEGINNER_BANNER
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBanner.kt
@@ -3,10 +3,8 @@ package com.woocommerce.android.ui.payments.feedback.ipp
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
-import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
 import com.woocommerce.android.ui.payments.cardreader.CashOnDeliverySettingsRepository
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
@@ -14,7 +12,6 @@ import javax.inject.Inject
 
 class ShouldShowFeedbackBanner @Inject constructor(
     private val prefs: AppPrefsWrapper,
-    private val getActivePaymentsPlugin: GetActivePaymentsPlugin,
     private val cashOnDeliverySettings: CashOnDeliverySettingsRepository,
     private val wooCommerceStore: WooCommerceStore,
     private val siteModel: SiteModel,
@@ -22,7 +19,7 @@ class ShouldShowFeedbackBanner @Inject constructor(
 ) {
     suspend operator fun invoke(): Boolean {
         return isStoreInSupportedCountry() &&
-            isIPPEnabled() &&
+            isCashOnDeliveryEnabled() &&
             !isSurveyCompletedOrDismissedForever() &&
             wasDismissedLongAgoEnoughToShowAgain()
     }
@@ -32,14 +29,11 @@ class ShouldShowFeedbackBanner @Inject constructor(
         return config is CardReaderConfigForSupportedCountry
     }
 
-    private suspend fun isIPPEnabled(): Boolean =
-        cashOnDeliverySettings.isCashOnDeliveryEnabled() && isWooCommercePaymentsPluginEnabled()
+    private suspend fun isCashOnDeliveryEnabled(): Boolean =
+        cashOnDeliverySettings.isCashOnDeliveryEnabled()
 
     private fun isSurveyCompletedOrDismissedForever(): Boolean =
         prefs.isIPPFeedbackSurveyCompleted() || prefs.isIPPFeedbackBannerDismissedForever()
-
-    private suspend fun isWooCommercePaymentsPluginEnabled() =
-        getActivePaymentsPlugin() == WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
 
     private fun wasDismissedLongAgoEnoughToShowAgain(): Boolean {
         val lastDismissed = prefs.getIPPFeedbackBannerLastDismissed()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -515,7 +515,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `given IPP banner is shown, then Orders banner should be hidden`() = testBlocking {
         // given
         whenever(shouldShowFeedbackBanner()).thenReturn(true)
-        val fakeBanner = GetIPPFeedbackBannerData.IPPFeedbackBanner(-1, -1, "")
+        val fakeBanner = GetIPPFeedbackBannerData.IPPFeedbackBanner(-1, -1, "", "")
         whenever(getIPPFeedbackBannerData()).thenReturn(fakeBanner)
 
         // when

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
@@ -97,6 +97,7 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result.url)
         assertEquals(R.string.feedback_banner_ipp_title_newbie, result.title)
         assertEquals(R.string.feedback_banner_ipp_message_newbie, result.message)
+        assertEquals("ipp_not_user", result.campaignName)
     }
 
     @Test
@@ -118,6 +119,7 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
             assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result.url)
             assertEquals(R.string.feedback_banner_ipp_message_beginner, result.message)
             assertEquals(R.string.feedback_banner_ipp_title_beginner, result.title)
+            assertEquals("ipp_new_user", result.campaignName)
         }
 
     @Test
@@ -144,6 +146,8 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
             assertEquals(R.string.feedback_banner_ipp_message_beginner, result.message)
             assertEquals(R.string.feedback_banner_ipp_title_beginner, result.title)
             assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result.url)
+            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result.url)
+            assertEquals("ipp_new_user", result.campaignName)
             assertNull(expectedTimeWindowCaptor.allValues.last())
             assertEquals(Date().daysAgo(30).formatToYYYYmmDD(), expectedTimeWindowCaptor.firstValue)
         }
@@ -167,6 +171,7 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
             assertEquals("https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users", result.url)
             assertEquals(R.string.feedback_banner_ipp_message_ninja, result.message)
             assertEquals(R.string.feedback_banner_ipp_title_ninja, result.title)
+            assertEquals("ipp_heavy_user", result.campaignName)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/ShouldShowFeedbackBannerTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.payments.feedback.ipp
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.extensions.daysAgo
-import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
 import com.woocommerce.android.ui.payments.cardreader.CashOnDeliverySettingsRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -15,7 +14,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCSettingsModel
-import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.util.Calendar
 import kotlin.test.assertFalse
@@ -24,7 +22,6 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class ShouldShowFeedbackBannerTest : BaseUnitTest() {
     private val appPrefs: AppPrefsWrapper = mock()
-    private val getActivePaymentsPlugin: GetActivePaymentsPlugin = mock()
     private val cashOnDeliverySettings: CashOnDeliverySettingsRepository = mock()
     private val siteModel: SiteModel = SiteModel()
     private val wooCommerceStore: WooCommerceStore = mock()
@@ -32,7 +29,6 @@ class ShouldShowFeedbackBannerTest : BaseUnitTest() {
 
     private val sut = ShouldShowFeedbackBanner(
         prefs = appPrefs,
-        getActivePaymentsPlugin = getActivePaymentsPlugin,
         cashOnDeliverySettings = cashOnDeliverySettings,
         wooCommerceStore = wooCommerceStore,
         siteModel = siteModel,
@@ -44,8 +40,6 @@ class ShouldShowFeedbackBannerTest : BaseUnitTest() {
         whenever(cashOnDeliverySettings.isCashOnDeliveryEnabled()).thenReturn(true)
         whenever(appPrefs.isIPPFeedbackSurveyCompleted()).thenReturn(false)
         whenever(appPrefs.isIPPFeedbackBannerDismissedForever()).thenReturn(false)
-        whenever(getActivePaymentsPlugin())
-            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
         whenever(siteSettings.countryCode).thenReturn("US")
         Unit
@@ -100,15 +94,15 @@ class ShouldShowFeedbackBannerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given Stripe plugin is used, then banner should not be shown`() = runBlocking {
+    fun `given COD is enabled, then banner should be shown`() = runBlocking {
         // given
-        whenever(getActivePaymentsPlugin()).thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.STRIPE)
+        whenever(cashOnDeliverySettings.isCashOnDeliveryEnabled()).thenReturn(true)
 
         // when
         val result = sut()
 
         // then
-        assertFalse(result)
+        assertTrue(result)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### IPP feedback banner: update of the rules for user group detection.

**🚨 Should be reviewed and merged after https://github.com/woocommerce/woocommerce-android/pull/8205** is merged.

**💡** This PR is part of the IPP in-app feedback banner project https://github.com/woocommerce/woocommerce-android/issues/8116. It targets the feature branch feature/8116-ipp-feedback-banner.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the rules of user group detection. Each [user group](pdfdoF-20T-p2) is served with a different banner and survey URL. What's changed:
- The condition for detecting user group 2. is now more complex. 
  -  COD is enabled + at least one IPP transaction ever completed +  less than 10 IPP transactions completed in last 30 days
- Stripe plugin users are now seeing the beginner-type banner. Previously they were ignored.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->