### PR TITLE
[REST API] Offer WPCom login as alternative if Application Passwords are disabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
@@ -40,6 +40,10 @@ class RESTAPILoginExperiment @Inject constructor(
         )
     }
 
+    fun trackSuccess() {
+        experimentTracker.log(ExperimentTracker.MYSTORE_DISPLAYED_EVENT)
+    }
+
     fun getCurrentVariant(): RESTAPILoginVariant = if (PackageUtils.isTesting()) {
         RESTAPILoginVariant.CONTROL
     } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SiteConnectionType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SiteConnectionType.kt
@@ -1,11 +1,17 @@
 package com.woocommerce.android.tools
 
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.tools.AuthenticationType.SiteCredentials
+import com.woocommerce.android.tools.AuthenticationType.WPCom
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.model.SiteModel
 
-enum class SiteConnectionType {
-    Jetpack, JetpackConnectionPackage, ApplicationPasswords
+enum class SiteConnectionType(val authenticationType: AuthenticationType) {
+    Jetpack(WPCom), JetpackConnectionPackage(WPCom), ApplicationPasswords(SiteCredentials)
+}
+
+enum class AuthenticationType {
+    WPCom, SiteCredentials
 }
 
 val SiteModel.connectionType

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -28,8 +28,6 @@ import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.ActivityLoginBinding
 import com.woocommerce.android.experiment.RESTAPILoginExperiment
 import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant
-import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant.CONTROL
-import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant.TREATMENT
 import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.support.ZendeskExtraTags
 import com.woocommerce.android.support.ZendeskHelper
@@ -564,8 +562,8 @@ class LoginActivity :
         AppPrefs.setLoginSiteAddress(siteAddressClean)
 
         val shouldUseEmailLogin = when (restApiLoginExperiment.getCurrentVariant()) {
-            CONTROL -> hasJetpack
-            TREATMENT -> connectSiteInfo?.isWPCom == true
+            RESTAPILoginVariant.CONTROL -> hasJetpack
+            RESTAPILoginVariant.TREATMENT -> connectSiteInfo?.isWPCom == true
         }
 
         if (shouldUseEmailLogin) {
@@ -831,6 +829,7 @@ class LoginActivity :
             Pair(
                 LoginSiteCredentialsFragment.newInstance(
                     siteAddress = requireNotNull(siteAddress),
+                    isJetpackConnected = connectSiteInfo?.isJetpackConnected ?: false,
                     username = inputUsername,
                     password = inputPassword
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/ApplicationPasswordsDisabledDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/ApplicationPasswordsDisabledDialogFragment.kt
@@ -11,13 +11,20 @@ class ApplicationPasswordsDisabledDialogFragment : LoginBaseErrorDialogFragment(
     companion object {
         const val RETRY_RESULT = "retry"
         private const val SITE_URL_KEY = "site-url"
+        private const val IS_JETPACK_CONNECTED_KEY = "is-jetpack-connected"
         private const val APPLICATION_PASSWORDS_GUIDE =
             "https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/"
 
-        fun newInstance(siteUrl: String) = ApplicationPasswordsDisabledDialogFragment().apply {
-            arguments = bundleOf(SITE_URL_KEY to siteUrl)
-        }
+        fun newInstance(siteUrl: String, isJetpackConnected: Boolean) =
+            ApplicationPasswordsDisabledDialogFragment().apply {
+                arguments = bundleOf(
+                    SITE_URL_KEY to siteUrl,
+                    IS_JETPACK_CONNECTED_KEY to isJetpackConnected
+                )
+            }
     }
+
+    private val isJetpackConnected by lazy { requireArguments().getBoolean(IS_JETPACK_CONNECTED_KEY) }
 
     override val text: CharSequence
         get() = getString(R.string.login_application_passwords_unavailable, requireArguments().getString(SITE_URL_KEY))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/ApplicationPasswordsDisabledDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/ApplicationPasswordsDisabledDialogFragment.kt
@@ -4,6 +4,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
 import com.woocommerce.android.R
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.error.base.LoginBaseErrorDialogFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 
@@ -42,11 +43,21 @@ class ApplicationPasswordsDisabledDialogFragment : LoginBaseErrorDialogFragment(
         )
 
     override val primaryButton: LoginErrorButton
-        get() = LoginErrorButton(
-            title = R.string.retry,
-            onClick = {
-                setFragmentResult(RETRY_RESULT, bundleOf())
-                dismiss()
-            }
-        )
+        get() = if (isJetpackConnected) {
+            LoginErrorButton(
+                title = R.string.login_with_wordpress,
+                onClick = {
+                    dismiss()
+                    (requireActivity() as LoginActivity).showEmailLoginScreen()
+                }
+            )
+        } else {
+            LoginErrorButton(
+                title = R.string.retry,
+                onClick = {
+                    setFragmentResult(RETRY_RESULT, bundleOf())
+                    dismiss()
+                }
+            )
+        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
@@ -28,10 +28,11 @@ import javax.inject.Inject
 class LoginSiteCredentialsFragment : Fragment() {
     companion object {
         const val TAG = "LoginSiteCredentialsFragment"
-        fun newInstance(siteAddress: String, username: String?, password: String?) =
+        fun newInstance(siteAddress: String, isJetpackConnected: Boolean, username: String?, password: String?) =
             LoginSiteCredentialsFragment().apply {
                 arguments = bundleOf(
                     LoginSiteCredentialsViewModel.SITE_ADDRESS_KEY to siteAddress,
+                    LoginSiteCredentialsViewModel.IS_JETPACK_CONNECTED_KEY to isJetpackConnected,
                     LoginSiteCredentialsViewModel.USERNAME_KEY to username.orEmpty(),
                     LoginSiteCredentialsViewModel.PASSWORD_KEY to password.orEmpty()
                 )
@@ -72,7 +73,7 @@ class LoginSiteCredentialsFragment : Fragment() {
                 is ShowNonWooErrorScreen -> LoginNotWooDialogFragment.newInstance(it.siteAddress)
                     .show(childFragmentManager, LoginNotWooDialogFragment.TAG)
                 is ShowApplicationPasswordsUnavailableScreen ->
-                    ApplicationPasswordsDisabledDialogFragment.newInstance(it.siteAddress)
+                    ApplicationPasswordsDisabledDialogFragment.newInstance(it.siteAddress, it.isJetpackConnected)
                         .show(childFragmentManager, LoginNotWooDialogFragment.TAG)
                 is ShowSnackbar -> uiMessageResolver.showSnack(it.message)
                 is ShowUiStringSnackbar -> uiMessageResolver.showSnack(it.message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -58,6 +58,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         const val SITE_ADDRESS_KEY = "site-address"
         const val USERNAME_KEY = "username"
         const val PASSWORD_KEY = "password"
+        const val IS_JETPACK_CONNECTED_KEY = "is-jetpack-connected"
     }
 
     private val siteAddress: String = savedStateHandle[SITE_ADDRESS_KEY]!!
@@ -85,7 +86,12 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         loginAnalyticsListener.trackUsernamePasswordFormViewed()
         applicationPasswordsNotifier.featureUnavailableEvents
             .onEach {
-                triggerEvent(ShowApplicationPasswordsUnavailableScreen(siteAddress))
+                triggerEvent(
+                    ShowApplicationPasswordsUnavailableScreen(
+                        siteAddress = siteAddress,
+                        isJetpackConnected = savedStateHandle[IS_JETPACK_CONNECTED_KEY]!!
+                    )
+                )
             }
             .launchIn(this)
     }
@@ -228,5 +234,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     data class LoggedIn(val localSiteId: Int) : MultiLiveEvent.Event()
     data class ShowResetPasswordScreen(val siteAddress: String) : MultiLiveEvent.Event()
     data class ShowNonWooErrorScreen(val siteAddress: String) : MultiLiveEvent.Event()
-    data class ShowApplicationPasswordsUnavailableScreen(val siteAddress: String) : MultiLiveEvent.Event()
+    data class ShowApplicationPasswordsUnavailableScreen(
+        val siteAddress: String,
+        val isJetpackConnected: Boolean
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -23,7 +23,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.attr
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.FragmentMyStoreBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
@@ -83,7 +82,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var dateUtils: DateUtils
     @Inject lateinit var usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter
-    @Inject lateinit var experimentTracker: ExperimentTracker
 
     private var _binding: FragmentMyStoreBinding? = null
     private val binding get() = _binding!!
@@ -172,9 +170,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         binding.statsScrollView.scrollStartEvents()
             .onEach { usageTracksEventEmitter.interacted() }
             .launchIn(viewLifecycleOwner.lifecycleScope)
-
-        // Successful event for REST API A/B testing.
-        experimentTracker.log(ExperimentTracker.MYSTORE_DISPLAYED_EVENT)
 
         setupStateObservers()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -13,9 +13,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.experiment.RESTAPILoginExperiment
+import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
+import com.woocommerce.android.tools.AuthenticationType
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
@@ -86,6 +89,7 @@ class MyStoreViewModel @Inject constructor(
     private val jitmTracker: JitmTracker,
     private val myStoreUtmProvider: MyStoreUtmProvider,
     private val queryParamsEncoder: QueryParamsEncoder,
+    private val restAPILoginExperiment: RESTAPILoginExperiment
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
@@ -143,6 +147,10 @@ class MyStoreViewModel @Inject constructor(
             }
         }
         observeTopPerformerUpdates()
+
+        if (selectedSite.exists()) {
+            trackRESTAPIExperimentSuccess()
+        }
     }
 
     private fun fetchJitms() {
@@ -477,6 +485,17 @@ class MyStoreViewModel @Inject constructor(
         val previouslySelectedGranularity = appPrefsWrapper.getActiveStatsGranularity(selectedSite.getSelectedSiteId())
         return runCatching { StatsGranularity.valueOf(previouslySelectedGranularity.uppercase()) }
             .getOrElse { StatsGranularity.DAYS }
+    }
+
+    private fun trackRESTAPIExperimentSuccess() {
+        // Log success unless: the user is in the treatment group and the sign in used WordPress.com
+        // for a self-hosted site
+        val isTreatmentGroup = restAPILoginExperiment.getCurrentVariant() == RESTAPILoginVariant.TREATMENT
+        val isWPComLogin = selectedSite.connectionType?.authenticationType == AuthenticationType.WPCom
+        val isSelfHostedSite = !selectedSite.get().isWPComAtomic
+        if (isTreatmentGroup && isWPComLogin && isSelfHostedSite) return
+
+        restAPILoginExperiment.trackSuccess()
     }
 
     private fun StatsGranularity.toAnalyticTimePeriod() = when (this) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -46,6 +46,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         onBlocking { checkWooStatus(testSite) } doReturn Result.success(true)
         onBlocking { getSiteByUrl(siteAddress) } doReturn testSite
     }
+    private var isJetpackConnected: Boolean = false
     private val selectedSite: SelectedSite = mock {
         on { exists() } doReturn false
     }
@@ -64,7 +65,12 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         prepareMocks()
 
         viewModel = LoginSiteCredentialsViewModel(
-            savedStateHandle = SavedStateHandle(mapOf(LoginSiteCredentialsViewModel.SITE_ADDRESS_KEY to siteAddress)),
+            savedStateHandle = SavedStateHandle(
+                mapOf(
+                    LoginSiteCredentialsViewModel.SITE_ADDRESS_KEY to siteAddress,
+                    LoginSiteCredentialsViewModel.IS_JETPACK_CONNECTED_KEY to isJetpackConnected
+                )
+            ),
             wpApiSiteRepository = wpApiSiteRepository,
             selectedSite = selectedSite,
             loginAnalyticsListener = loginAnalyticsListener,
@@ -204,7 +210,8 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             applicationPasswordsUnavailableEvents.tryEmit(mock())
         }
 
-        assertThat(viewModel.event.value).isEqualTo(ShowApplicationPasswordsUnavailableScreen(siteAddress))
+        assertThat(viewModel.event.value)
+            .isEqualTo(ShowApplicationPasswordsUnavailableScreen(siteAddress, isJetpackConnected))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.experiment.RESTAPILoginExperiment
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -71,6 +72,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
     private val jitmTracker: JitmTracker = mock()
     private val utmProvider: MyStoreUtmProvider = mock()
     private val queryParamsEncoder: QueryParamsEncoder = mock()
+    private val restAPILoginExperiment: RESTAPILoginExperiment = mock()
 
     private lateinit var sut: MyStoreViewModel
 
@@ -1373,7 +1375,8 @@ class MyStoreViewModelTest : BaseUnitTest() {
             jitmStore,
             jitmTracker,
             utmProvider,
-            queryParamsEncoder
+            queryParamsEncoder,
+            restAPILoginExperiment
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8228
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the Application Passwords error screen to allow switching to WordPress.com login if the site is connected to Jetpack.

In addition to this, it makes sure that the success in this case is not counted in the A/B test results, this is needed because we want to measure the real success using Application Passwords and not when using the workaround ([c3bd5d6](https://github.com/woocommerce/woocommerce-android/pull/8231/commits/c3bd5d6cb2ccc54f51201745ca28932cdfa4e016))

### Testing instructions
1. Prepare a self-hosted sites with the following conditions:
    - Application Passwords disabled (you can use this [plugin](https://wordpress.org/plugins/disable-application-passwords/))
    - Has Jetpack and it's connected.
2. Make sure you are assigned the Treatment variant of the REST API experiment (either by [hardcoding](https://github.com/woocommerce/woocommerce-android/blob/9841083ed877c1846ca66d43a44841ecfb320837/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt#L43) it or by setting a test device)
3. Open the app, then enter you site's address
4. Enter site credentials.
5. Notice the "Sign in with WordPress.com" button in the error screen.
6. Click on the button.
7. Complete the sign using WordPress.com.
8. Confirm that you don't see the following in logcat: ```Logging event: origin=app,name=my_store_displayed``` (make sure to disable all filters, as the `package` filter hides the entry also).

### Images/gif

https://user-images.githubusercontent.com/1657201/213683984-7711437f-7dd5-47cf-a886-dc9fe96c5ca7.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
