### PR TITLE
Crash reporting: some fixes to improve reporting when no WPCom account is present

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 12.0
 -----
 - [**] Add a feature of duplicating products [https://github.com/woocommerce/woocommerce-android/pull/8164]
+- [*] [Internal] Improve crash reporting for logged out state and for site credentials login [https://github.com/woocommerce/woocommerce-android/pull/8233]
 
 11.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/MapExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/MapExt.kt
@@ -1,0 +1,4 @@
+package com.woocommerce.android.extensions
+
+@Suppress("UNCHECKED_CAST")
+fun <K, V : Any> Map<out K, V?>.filterNotNull(): Map<K, V> = filterValues { it != null } as Map<K, V>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
@@ -113,11 +113,15 @@ class WCCrashLoggingDataProvider @Inject constructor(
         return false
     }
 
-    private fun AccountModel.toCrashLoggingUser() = CrashLoggingUser(
-        userID = userId.toString(),
-        email = email,
-        username = userName
-    )
+    private fun AccountModel.toCrashLoggingUser(): CrashLoggingUser? {
+        if (userId == 0L) return null
+
+        return CrashLoggingUser(
+            userID = userId.toString(),
+            email = email,
+            username = userName
+        )
+    }
 
     companion object {
         const val SITE_ID_KEY = "site_id"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
@@ -7,6 +7,7 @@ import com.automattic.android.tracks.crashlogging.ExtraKnownKey
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.locale.LocaleProvider
@@ -56,9 +57,10 @@ class WCCrashLoggingDataProvider @Inject constructor(
         .map { site ->
             site?.let {
                 mapOf(
-                    SITE_ID_KEY to site.siteId.toString(),
+                    SITE_ID_KEY to site.siteId.takeIf { it != 0L }?.toString(),
                     SITE_URL_KEY to site.url
                 )
+                    .filterNotNull()
             }.orEmpty()
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProviderTest.kt
@@ -91,6 +91,16 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
     }
 
     @Test
+    fun `should not send site id if it has the default value`() = testBlocking {
+        whenever(selectedSite.observe()).thenReturn(flowOf(SiteModel()))
+        reinitialize()
+
+        val appContext = sut.applicationContextProvider.single()
+
+        assertThat(appContext).doesNotContainKey(SITE_ID_KEY)
+    }
+
+    @Test
     fun `should provide empty apps context if selected site does not exist`() = testBlocking {
         whenever(selectedSite.observe()).thenReturn(flowOf(null))
         reinitialize()
@@ -136,6 +146,16 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
     @Test
     fun `should not provide user if user does not exist`() = testBlocking {
         whenever(accountStore.account).thenReturn(null)
+        reinitialize()
+
+        val user = sut.user.first()
+
+        assertThat(user).isNull()
+    }
+
+    @Test
+    fun `should not provide user if the account is the default one`() = testBlocking {
+        whenever(accountStore.account).thenReturn(DEFAULT_TEST_ACCOUNT)
         reinitialize()
 
         val user = sut.user.first()
@@ -230,6 +250,8 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
             email = "mail@a8c.com"
             userName = "username"
         }
+
+        val DEFAULT_TEST_ACCOUNT = AccountModel()
 
         val TEST_SITE_MODEL = SiteModel().apply {
             siteId = 7L


### PR DESCRIPTION
Closes: #8232 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Currently, we use the `AccountModel` that we get from the `AccountStore` as the Sentry's user, but the logic doesn't take into account the logged-out state, where the `AccountStore` would return a [default value](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/2bb7fe8e003587ab2010e7150ad706d5011186bc/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java#L1256).

This was impacting the error reports in the logged out state, and more importantly it would impact the reports after the REST API project.

This PR aims to make sure we don't set Sentry's user unless we have a valid account, and in the other cases, we pass `null` which would mean using the `installationId` by the SDK (https://docs.sentry.io/platforms/android/enriching-events/identify-user/).

### Testing instructions
Apply the patch from below, then test the following scenarios:

##### Logged out state
1. Clear the app's data.
2. Open the app.
3. Open Sentry, and check for an error report with the wording: `Test`
4. Check the user details, and confirm that there is a UUID in the user's ID.

##### WPCom login
1. Open the app.
2. Enter the address of a WPCom site.
3. You will be asked for the WordPress.com credentials, enter them.
4. When the login finished, open Sentry and check for the error report.
5. Check the user details and confirm that the user details match your WPCom account details.

##### Site credentials login
1. Open the app.
2. Enter the address of a selfhosted site.
3. You will be asked for the site credentials, enter them.
4. When the login finished, open Sentry and check for the error report.
5. Check the user details, and confirm that there is a UUID in the user's ID.

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt	(revision 931a5dc876444bf26234eb69582e1d91b747d0b2)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt	(date 1674232031203)
@@ -43,7 +43,7 @@
     fun getCurrentVariant(): RESTAPILoginVariant = if (PackageUtils.isTesting()) {
         RESTAPILoginVariant.CONTROL
     } else {
-        remoteConfigRepository.getRestAPILoginVariant()
+        RESTAPILoginVariant.TREATMENT
     }
 
     enum class RESTAPILoginVariant {
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt	(revision 931a5dc876444bf26234eb69582e1d91b747d0b2)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt	(date 1674231697972)
@@ -224,6 +224,7 @@
         installSplashScreen()
 
         super.onCreate(savedInstanceState)
+        crashLogging.sendReport(Exception("Test"))
 
         // Verify authenticated session
         if (!presenter.userIsLoggedIn()) {
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt	(revision 931a5dc876444bf26234eb69582e1d91b747d0b2)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt	(date 1674231697992)
@@ -422,7 +422,7 @@
 
     fun isCrashReportingEnabled(): Boolean {
         // default to False for debug builds
-        val default = !BuildConfig.DEBUG
+        val default = true//!BuildConfig.DEBUG
         return getBoolean(UndeletablePrefKey.ENABLE_CRASH_REPORTING, default)
     }
 
```

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
