### PR TITLE
Issue/8197 disconnect builtin reader in hub screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -67,7 +67,7 @@ class CardReaderDetailViewModel @Inject constructor(
             cardReaderManager.readerStatus.collect { status ->
                 when (status) {
                     is Connected -> {
-                        if (isExternalCardReader(status)) {
+                        if (isExternalCardReader(status.cardReader)) {
                             triggerCardReaderConnectedEvent()
                             listenForSoftwareUpdateAvailability()
                             listenForBatteryStatus()
@@ -91,8 +91,8 @@ class CardReaderDetailViewModel @Inject constructor(
         }
     }
 
-    private fun isExternalCardReader(status: Connected) =
-        ReaderType.isExternalReaderType(status.cardReader.type)
+    private fun isExternalCardReader(cardReader: CardReader) =
+        ReaderType.isExternalReaderType(cardReader.type)
 
     private fun listenForBatteryStatus() {
         batteryStatusUpdateJob = launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -68,21 +68,9 @@ class CardReaderDetailViewModel @Inject constructor(
                 when (status) {
                     is Connected -> {
                         if (ReaderType.isExternalReaderType(status.cardReader.type)) {
-                            triggerEvent(
-                                CardReaderDetailEvent.CardReaderConnected(
-                                    R.string.card_reader_accessibility_reader_is_connected
-                                )
-                            )
-                            softwareUpdateAvailabilityJob = launch {
-                                cardReaderManager.softwareUpdateAvailability.collect(
-                                    ::handleSoftwareUpdateAvailability
-                                )
-                            }
-                            batteryStatusUpdateJob = launch {
-                                cardReaderManager.batteryStatus.collect(
-                                    ::handleBatteryStatusChange
-                                )
-                            }
+                            triggerCardReaderConnectedEvent()
+                            listenForSoftwareUpdateAvailability()
+                            listenForBatteryStatus()
                         } else {
                             disconnectReader()
                         }
@@ -101,6 +89,30 @@ class CardReaderDetailViewModel @Inject constructor(
                 }.exhaustive
             }
         }
+    }
+
+    private fun listenForBatteryStatus() {
+        batteryStatusUpdateJob = launch {
+            cardReaderManager.batteryStatus.collect(
+                ::handleBatteryStatusChange
+            )
+        }
+    }
+
+    private fun listenForSoftwareUpdateAvailability() {
+        softwareUpdateAvailabilityJob = launch {
+            cardReaderManager.softwareUpdateAvailability.collect(
+                ::handleSoftwareUpdateAvailability
+            )
+        }
+    }
+
+    private fun triggerCardReaderConnectedEvent() {
+        triggerEvent(
+            CardReaderDetailEvent.CardReaderConnected(
+                R.string.card_reader_accessibility_reader_is_connected
+            )
+        )
     }
 
     fun onUpdateReaderResult(updateResult: UpdateResult) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -191,11 +191,15 @@ class CardReaderDetailViewModel @Inject constructor(
         tracker.trackDisconnectTapped()
         launch {
             clearLastKnowReader()
-            val disconnectionResult = cardReaderManager.disconnectReader()
-            if (!disconnectionResult) {
-                WooLog.e(WooLog.T.CARD_READER, "Disconnection from reader has failed")
-                handleNotConnectedState()
-            }
+            disconnectReader()
+        }
+    }
+
+    private suspend fun disconnectReader() {
+        val disconnectionResult = cardReaderManager.disconnectReader()
+        if (!disconnectionResult) {
+            WooLog.e(WooLog.T.CARD_READER, "Disconnection from reader has failed")
+            handleNotConnectedState()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -67,7 +67,7 @@ class CardReaderDetailViewModel @Inject constructor(
             cardReaderManager.readerStatus.collect { status ->
                 when (status) {
                     is Connected -> {
-                        if (ReaderType.isExternalReaderType(status.cardReader.type)) {
+                        if (isExternalCardReader(status)) {
                             triggerCardReaderConnectedEvent()
                             listenForSoftwareUpdateAvailability()
                             listenForBatteryStatus()
@@ -90,6 +90,9 @@ class CardReaderDetailViewModel @Inject constructor(
             }
         }
     }
+
+    private fun isExternalCardReader(status: Connected) =
+        ReaderType.isExternalReaderType(status.cardReader.type)
 
     private fun listenForBatteryStatus() {
         batteryStatusUpdateJob = launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus.StatusChanged
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
@@ -66,20 +67,24 @@ class CardReaderDetailViewModel @Inject constructor(
             cardReaderManager.readerStatus.collect { status ->
                 when (status) {
                     is Connected -> {
-                        triggerEvent(
-                            CardReaderDetailEvent.CardReaderConnected(
-                                R.string.card_reader_accessibility_reader_is_connected
+                        if (ReaderType.isExternalReaderType(status.cardReader.type)) {
+                            triggerEvent(
+                                CardReaderDetailEvent.CardReaderConnected(
+                                    R.string.card_reader_accessibility_reader_is_connected
+                                )
                             )
-                        )
-                        softwareUpdateAvailabilityJob = launch {
-                            cardReaderManager.softwareUpdateAvailability.collect(
-                                ::handleSoftwareUpdateAvailability
-                            )
-                        }
-                        batteryStatusUpdateJob = launch {
-                            cardReaderManager.batteryStatus.collect(
-                                ::handleBatteryStatusChange
-                            )
+                            softwareUpdateAvailabilityJob = launch {
+                                cardReaderManager.softwareUpdateAvailability.collect(
+                                    ::handleSoftwareUpdateAvailability
+                                )
+                            }
+                            batteryStatusUpdateJob = launch {
+                                cardReaderManager.batteryStatus.collect(
+                                    ::handleBatteryStatusChange
+                                )
+                            }
+                        } else {
+                            disconnectReader()
                         }
                     }
                     is Connecting -> {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8197 
<!-- Id number of the GitHub issue this PR addresses. -->

🚨 ~~**This PR depends upon #8139. Please make sure to merge it before merging this one.**~~

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we add support for the built-in card reader, allowing merchants to take card payments using Tap to Pay on Android.

We can be connected to either the built-in reader, or a Bluetooth reader, but not both simultaneously.

There’s nothing to manage or view about the built-in reader, and from a user’s perspective there isn’t a reader at all, it’s just part of their phone.

Since we can’t connect to the Bluetooth reader until the built-in reader is disconnected, we just do that automatically for the user here. This saves us from updating the display of the connected reader to be suitable for the built-in reader too.

We can revisit this in the future, but for M1 it makes sense.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Navigate to Menu > Payments > Collect payment
2. Go through the payment flow, and select Card on the payment method screen
3. When asked for a reader type, tap Tap to Pay and connect to the reader
4. Take a payment.
5. When it's finished, repeat the above three steps to take another payment: observe that you don't need to connect to the reader and are not asked for a reader type.
6. Go to Menu > Payments > Manage Card Reader
7. Observe that there is no reader shown as connected
8. Repeat the above steps to take a payment: observe that you are asked to choose a reader type again, and can connect to the reader as the first time.


In general –

1. Observe that TTPoI connections persist as long as the app is in the foreground unless you tap Manage Card Reader
2. Observe that Bluetooth connections persist until you tap Disconnect in the Manage Card Reader screen.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->



https://user-images.githubusercontent.com/1331230/215082801-e9ceb5d5-4a15-44d2-80ff-8b3b56a0dca2.mp4






- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
