### PR TITLE
[REST API] Reset tracks and preferences after application passwords logout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -305,18 +305,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged) {
         val isLoggedOut = event.causeOfChange == AccountAction.SIGN_OUT && event.error == null
-        if (!accountStore.hasAccessToken() && isLoggedOut) {
-            // Logged out
-            AnalyticsTracker.track(AnalyticsEvent.ACCOUNT_LOGOUT)
-
-            // Reset analytics
-            AnalyticsTracker.flush()
-            AnalyticsTracker.clearAllData()
-            zendeskHelper.reset()
-
-            // Wipe user-specific preferences
-            prefs.resetUserPreferences()
-        } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
+        if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
             // make sure local usage tracking matches the account setting
             val hasUserOptedOut = !AnalyticsTracker.sendUsageStats
             if (hasUserOptedOut != accountStore.account.tracksOptOut) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -304,8 +304,8 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged) {
-        val isLoggedOut = event.causeOfChange == null && event.error == null
-        if (!accountStore.hasAccessToken() && isLoggedOut) {
+        val isLoggedOut = event.causeOfChange == AccountAction.SIGN_OUT && event.error == null
+        if ((!accountStore.hasAccessToken() && isLoggedOut)) {
             // Logged out
             AnalyticsTracker.track(AnalyticsEvent.ACCOUNT_LOGOUT)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -305,7 +305,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged) {
         val isLoggedOut = event.causeOfChange == AccountAction.SIGN_OUT && event.error == null
-        if ((!accountStore.hasAccessToken() && isLoggedOut)) {
+        if (!accountStore.hasAccessToken() && isLoggedOut) {
             // Logged out
             AnalyticsTracker.track(AnalyticsEvent.ACCOUNT_LOGOUT)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -50,6 +50,7 @@ class AccountRepository @Inject constructor(
 
     suspend fun logout(): Boolean {
         return if (accountStore.hasAccessToken()) {
+            // WordPress.com account logout
             val event: OnAccountChanged = dispatcher.dispatchAndAwait(AccountActionBuilder.newSignOutAction())
             if (event.isError) {
                 WooLog.e(
@@ -57,12 +58,12 @@ class AccountRepository @Inject constructor(
                     "Account error [type = ${event.causeOfChange}] : " +
                         "${event.error.type} > ${event.error.message}"
                 )
-                return false
+                false
+            } else {
+                dispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction())
+                cleanup()
+                true
             }
-
-            dispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction())
-            cleanup()
-            true
         } else {
             // Application passwords logout
             appCoroutineScope.launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -60,7 +60,6 @@ class AccountRepository @Inject constructor(
                 )
                 false
             } else {
-                dispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction())
                 cleanup()
                 true
             }
@@ -94,5 +93,8 @@ class AccountRepository @Inject constructor(
 
         // Wipe user-specific preferences
         prefs.resetUserPreferences()
+
+        // Delete sites
+        dispatcher.dispatch(SiteActionBuilder.newRemoveAllSitesAction())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -58,6 +58,7 @@ class AccountRepository @Inject constructor(
                 true
             }
         } else {
+            dispatcher.dispatch(AccountActionBuilder.newSignOutAction())
             appCoroutineScope.launch {
                 val result = siteStore.deleteApplicationPassword(selectedSite.get())
                 if (result.isError) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8235
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures that analytics and prefs resetting are done both for wpcom-based and REST API-based account logout.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
