### PR TITLE
[Build] Remove Vector Drawables Use Support Library Configuration

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -84,8 +84,6 @@ android {
         // P.S. Update the targetSdkVersion in all the modules, otherwise static analysis tools won't give you a heads-up about potential issues.
         targetSdkVersion gradle.ext.targetSdkVersion
 
-        vectorDrawables.useSupportLibrary = true
-
         testInstrumentationRunner 'com.woocommerce.android.WooCommerceTestRunner'
         // TODO remove this once the hilt migration is complete
         javaCompileOptions.annotationProcessorOptions.arguments['dagger.hilt.disableModulesHaveInstallInCheck'] = 'true'


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR is mainly about removing the no longer necessary `vectorDrawables.useSupportLibrary = true` configuration from this project. Since the `minSdkVersion` of this project is currently on `24`, this vector drawables backward compatibility solution is no longer required.

For more info see:
- [Vector drawables backward compatibility solution](https://developer.android.com/develop/ui/views/graphics/vector-drawable-resources#vector-drawables-backward-solution)
- [androidx.vectordrawable.graphics.drawable.VectorDrawableCompat](https://developer.android.com/reference/androidx/vectordrawable/graphics/drawable/VectorDrawableCompat)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could quickly smoke test the WooCommerce app and see if it works as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
