### PR TITLE
fix: make StatsTimeRangeSelection parcelable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelection.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.ui.analytics.ranges.data.YearToDateRangeData
 import com.woocommerce.android.ui.analytics.ranges.data.YesterdayRangeData
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
-import java.io.Serializable
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
@@ -45,65 +44,68 @@ data class AnalyticsHubTimeRange(
  *
  * When creating the object through the available constructor, the Selection will be set as [CUSTOM]
  */
-class StatsTimeRangeSelection : Serializable {
-    val selectionType: SelectionType
-    val currentRange: AnalyticsHubTimeRange
-    val previousRange: AnalyticsHubTimeRange
-    val currentRangeDescription: String
-    val previousRangeDescription: String
+@Parcelize
+class StatsTimeRangeSelection private constructor(
+    val selectionType: SelectionType,
+    val currentRange: AnalyticsHubTimeRange,
+    val previousRange: AnalyticsHubTimeRange,
+    val currentRangeDescription: String,
+    val previousRangeDescription: String,
+) : Parcelable {
 
-    private constructor(
-        rangeStart: Date,
-        rangeEnd: Date,
-        calendar: Calendar,
-        locale: Locale,
-    ) {
-        val rangeData = CustomRangeData(rangeStart, rangeEnd, locale, calendar)
-        selectionType = CUSTOM
-        currentRange = rangeData.currentRange
-        previousRange = rangeData.previousRange
-        currentRangeDescription = rangeData.formattedCurrentRange
-        previousRangeDescription = rangeData.formattedPreviousRange
-    }
-
-    private constructor(
-        selectionType: SelectionType,
-        referenceDate: Date,
-        calendar: Calendar,
-        locale: Locale
-    ) {
-        val rangeData = generateTimeRangeData(selectionType, referenceDate, locale, calendar)
-        this.selectionType = selectionType
-        currentRange = rangeData.currentRange
-        previousRange = rangeData.previousRange
-        currentRangeDescription = rangeData.formattedCurrentRange
-        previousRangeDescription = rangeData.formattedPreviousRange
-    }
-
-    private fun generateTimeRangeData(
-        selectionType: SelectionType,
-        referenceDate: Date,
-        locale: Locale,
-        calendar: Calendar
-    ): StatsTimeRangeData {
-        return when (selectionType) {
-            TODAY -> TodayRangeData(referenceDate, locale, calendar)
-            YESTERDAY -> YesterdayRangeData(referenceDate, locale, calendar)
-            WEEK_TO_DATE -> WeekToDateRangeData(referenceDate, locale, calendar)
-            LAST_WEEK -> LastWeekRangeData(referenceDate, locale, calendar)
-            MONTH_TO_DATE -> MonthToDateRangeData(referenceDate, locale, calendar)
-            LAST_MONTH -> LastMonthRangeData(referenceDate, locale, calendar)
-            QUARTER_TO_DATE -> QuarterToDateRangeData(referenceDate, locale, calendar)
-            LAST_QUARTER -> LastQuarterRangeData(referenceDate, locale, calendar)
-            YEAR_TO_DATE -> YearToDateRangeData(referenceDate, locale, calendar)
-            LAST_YEAR -> LastYearRangeData(referenceDate, locale, calendar)
-            else -> throw IllegalStateException("Custom selection type should use the correct constructor")
+    companion object Factory {
+        fun build(
+            rangeStart: Date,
+            rangeEnd: Date,
+            calendar: Calendar,
+            locale: Locale,
+        ): StatsTimeRangeSelection {
+            val rangeData = CustomRangeData(rangeStart, rangeEnd, locale, calendar)
+            return StatsTimeRangeSelection(
+                selectionType = CUSTOM,
+                currentRange = rangeData.currentRange,
+                previousRange = rangeData.previousRange,
+                currentRangeDescription = rangeData.formattedCurrentRange,
+                previousRangeDescription = rangeData.formattedPreviousRange,
+            )
         }
-    }
 
-    companion object {
-        // Needed to avoid the [SerialVersionUIDInSerializableClass] warning from detekt
-        const val serialVersionUID = 1L
+        fun build(
+            selectionType: SelectionType,
+            referenceDate: Date,
+            calendar: Calendar,
+            locale: Locale
+        ): StatsTimeRangeSelection {
+            val rangeData = generateTimeRangeData(selectionType, referenceDate, locale, calendar)
+            return StatsTimeRangeSelection(
+                selectionType = selectionType,
+                currentRange = rangeData.currentRange,
+                previousRange = rangeData.previousRange,
+                currentRangeDescription = rangeData.formattedCurrentRange,
+                previousRangeDescription = rangeData.formattedPreviousRange,
+            )
+        }
+
+        private fun generateTimeRangeData(
+            selectionType: SelectionType,
+            referenceDate: Date,
+            locale: Locale,
+            calendar: Calendar
+        ): StatsTimeRangeData {
+            return when (selectionType) {
+                TODAY -> TodayRangeData(referenceDate, locale, calendar)
+                YESTERDAY -> YesterdayRangeData(referenceDate, locale, calendar)
+                WEEK_TO_DATE -> WeekToDateRangeData(referenceDate, locale, calendar)
+                LAST_WEEK -> LastWeekRangeData(referenceDate, locale, calendar)
+                MONTH_TO_DATE -> MonthToDateRangeData(referenceDate, locale, calendar)
+                LAST_MONTH -> LastMonthRangeData(referenceDate, locale, calendar)
+                QUARTER_TO_DATE -> QuarterToDateRangeData(referenceDate, locale, calendar)
+                LAST_QUARTER -> LastQuarterRangeData(referenceDate, locale, calendar)
+                YEAR_TO_DATE -> YearToDateRangeData(referenceDate, locale, calendar)
+                LAST_YEAR -> LastYearRangeData(referenceDate, locale, calendar)
+                else -> throw IllegalStateException("Custom selection type should use the correct constructor")
+            }
+        }
     }
 
     enum class SelectionType(val localizedResourceId: Int) {
@@ -126,14 +128,14 @@ class StatsTimeRangeSelection : Serializable {
             locale: Locale
         ): StatsTimeRangeSelection {
             return if (this == CUSTOM) {
-                StatsTimeRangeSelection(
+                build(
                     rangeStart = referenceStartDate,
                     rangeEnd = referenceEndDate,
                     calendar = calendar,
                     locale = locale
                 )
             } else {
-                StatsTimeRangeSelection(
+                build(
                     selectionType = this,
                     referenceDate = referenceStartDate,
                     calendar = calendar,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8245 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the issue of the app crashing when saving the state of the Analytics Hub screen (when e.g. app goes to background). The problem was with `AnalyticsHubTimeRange` class - it was part of class `StatsTimeRangeSelection` which was `Serializable`. `Serializable` requires its members to be `Serializable` too (if they're objects) but `AnalyticsHubTimeRange` was not `Serializable` - it was `Parcelable`.

I've decided to make `StatsTimeRangeSelection` a `Parcelable` to fix this issue and improve performance (although it probably won't be visible to users).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### First, reproduce the issue
1. Checkout `release/12.0`
2. Connect the phone to Flipper (Android won't always display a dialog about the crash)
3. Open Analytics Hub
4. Go to the phone's main screen
5. **Assert there was a crash** (Flipper should report it)

#### Check the fix
1. Checkout `issue/8245_fix_analytics_background_crash`
2. Connect the phone to Flipper (Android won't always display a dialog about the crash)
3. Open Analytics Hub
4. Go to the phone's main screen
5. **Assert there was not crash**

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
