### PR TITLE
Bump FluxC to 2.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-2bb7fe8e003587ab2010e7150ad706d5011186bc'
+    fluxCVersion = '2.13'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
To continue with https://github.com/woocommerce/woocommerce-android/pull/8249, this PR points to the new release version of FluxC  (2.13) instead of the trunk version.

Nothing to test aside from making sure building works.