### PR TITLE
Update of RELEASE-NOTES.txt about IPP feedback banner

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 12.1
 -----
-
+- [*] Adds an In-Person Payments survey banner on top of the Orders view [https://github.com/woocommerce/woocommerce-android/pull/8247]
 
 12.0
 -----


### PR DESCRIPTION
### Update of `RELEASE-NOTES.txt` about the IPP feedback banner 

The final [PR](https://github.com/woocommerce/woocommerce-android/pull/8247) with the project is merged and targets the 12.1 milestone.

This PR updates `RELEASE-NOTES.txt` about this feature.


