### PR TITLE
Quick fix: Add missing nav graph argument

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -62,6 +62,11 @@
             android:name="surveyType"
             android:defaultValue='MAIN'
             app:argType="com.woocommerce.android.ui.feedback.SurveyType" />
+        <argument
+            android:name="customUrl"
+            app:argType="string"
+            android:defaultValue="@null"
+            app:nullable="true" />
         <action
             android:id="@+id/action_feedbackSurveyFragment_to_feedbackCompletedFragment"
             app:destination="@id/feedbackCompletedFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### This PR adds a missing nav graph argument

The bug was introduced in my previous PR: https://github.com/woocommerce/woocommerce-android/pull/8247/commits/c31837848ef7c548d99cbccf810b953add67eef4 and had effect in `trunk` build failing randomly.

Thank you @hichamboushaba for [identifying this](https://github.com/woocommerce/woocommerce-android/pull/8222#discussion_r1087908237):
> This new nav graph argument was added in the commit https://github.com/woocommerce/woocommerce-android/commit/4eeb55aefde344ac31d78d6d45cee7d1f7ab210e, but it was added only in the main_nav_graph.
> Given that this destination is declared in two navgraphs, we need to make sure the arguments are kept in sync, otherwise the build fails randomly (like this [build](https://buildkite.com/automattic/woocommerce-android/builds/9272#0185ee5e-2e1a-4f0f-af6b-c03523e7e7f1)), this is a known [bug](https://issuetracker.google.com/issues/80332455), and we faced it before p1646845001099659-slack-C6H8C3G23

I decided to fix this in a separate PR to fix the trunk's failing build faster.