### PR TITLE
[Compose] Fix back button orientation in RTL languages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRScreen.kt
@@ -14,9 +14,7 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -28,6 +26,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.Toolbar
 
 @Composable
 fun SSRScreen(viewModel: SSRActivityViewModel) {
@@ -52,17 +51,9 @@ fun SSRScreen(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                backgroundColor = MaterialTheme.colors.surface,
-                title = { Text(stringResource(id = R.string.support_system_status_report)) },
-                navigationIcon = {
-                    IconButton(onClick = onBackPressed) {
-                        Icon(
-                            Icons.Filled.ArrowBack,
-                            contentDescription = stringResource(id = R.string.back)
-                        )
-                    }
-                },
+            Toolbar(
+                title = stringResource(id = R.string.support_system_status_report),
+                onNavigationButtonClick = onBackPressed,
                 actions = {
                     IconButton(onClick = onCopyButtonClick, enabled = !isLoading) {
                         Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -16,9 +16,7 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -29,6 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.util.RollingLogEntries
 import com.woocommerce.android.util.WooLog
 import java.lang.String.format
@@ -43,17 +42,9 @@ fun WooLogViewerScreen(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                backgroundColor = MaterialTheme.colors.surface,
-                title = { Text(stringResource(id = R.string.logviewer_activity_title)) },
-                navigationIcon = {
-                    IconButton(onClick = { onBackPress() }) {
-                        Icon(
-                            Icons.Filled.ArrowBack,
-                            contentDescription = stringResource(id = R.string.back)
-                        )
-                    }
-                },
+            Toolbar(
+                title = stringResource(id = R.string.logviewer_activity_title),
+                onNavigationButtonClick = onBackPress,
                 actions = {
                     IconButton(onClick = { onCopyButtonClick() }) {
                         Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/ModifierExts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/ModifierExts.kt
@@ -1,12 +1,17 @@
 package com.woocommerce.android.ui.compose
 
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 fun Modifier.drawShadow(
@@ -39,4 +44,12 @@ fun Modifier.drawShadow(
             paint
         )
     }
+}
+
+@Stable
+fun Modifier.autoMirror(): Modifier = composed {
+    if (LocalLayoutDirection.current == LayoutDirection.Rtl)
+        this.scale(scaleX = -1f, scaleY = 1f)
+    else
+        this
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
@@ -20,15 +20,53 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.autoMirror
 
 @Composable
+fun ToolbarWithHelpButton(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    onNavigationButtonClick: (() -> Unit)? = null,
+    navigationIcon: ImageVector? = Filled.ArrowBack,
+    navigationIconContentDescription: String = stringResource(id = string.back),
+    onHelpButtonClick: (() -> Unit)
+) {
+    Toolbar(
+        modifier = modifier,
+        title = title,
+        onNavigationButtonClick = onNavigationButtonClick,
+        navigationIcon = navigationIcon,
+        navigationIconContentDescription = navigationIconContentDescription,
+        actionButtonIcon = ImageVector.vectorResource(id = drawable.ic_help_24dp),
+        onActionButtonClick = onHelpButtonClick,
+        actionIconContentDescription = stringResource(id = string.help)
+    )
+}
+
+@Composable
 fun Toolbar(
     modifier: Modifier = Modifier,
     title: String = "",
     onNavigationButtonClick: (() -> Unit),
     navigationIcon: ImageVector = Filled.ArrowBack,
+    navigationIconContentDescription: String = stringResource(id = string.back)
+) {
+    Toolbar(
+        modifier = modifier,
+        title = { Text(title) },
+        onNavigationButtonClick = onNavigationButtonClick,
+        navigationIcon = navigationIcon,
+        navigationIconContentDescription = navigationIconContentDescription,
+    )
+}
+
+@Composable
+fun Toolbar(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    onNavigationButtonClick: (() -> Unit)? = null,
+    navigationIcon: ImageVector? = Filled.ArrowBack,
     navigationIconContentDescription: String = stringResource(id = string.back),
+    actionButtonIcon: ImageVector,
     onActionButtonClick: (() -> Unit),
-    actionButtonIcon: ImageVector = ImageVector.vectorResource(id = drawable.ic_help_24dp),
-    actionIconContentDescription: String = stringResource(id = string.help)
+    actionIconContentDescription: String
 ) {
     Toolbar(
         modifier = modifier,
@@ -51,11 +89,30 @@ fun Toolbar(
 fun Toolbar(
     modifier: Modifier = Modifier,
     title: String = "",
-    onNavigationButtonClick: (() -> Unit),
+    onNavigationButtonClick: (() -> Unit)? = null,
     navigationIcon: ImageVector? = Filled.ArrowBack,
     navigationIconContentDescription: String = stringResource(id = string.back),
-    onActionButtonClick: (() -> Unit)? = null,
-    actionButtonText: String? = null
+    actions: @Composable RowScope.() -> Unit = {}
+) {
+    Toolbar(
+        modifier = modifier,
+        title = { Text(title) },
+        onNavigationButtonClick = onNavigationButtonClick,
+        navigationIcon = navigationIcon,
+        navigationIconContentDescription = navigationIconContentDescription,
+        actions = actions
+    )
+}
+
+@Composable
+fun Toolbar(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    onNavigationButtonClick: (() -> Unit)? = null,
+    navigationIcon: ImageVector? = Filled.ArrowBack,
+    navigationIconContentDescription: String = stringResource(id = string.back),
+    onActionButtonClick: (() -> Unit),
+    actionButtonText: String
 ) {
     Toolbar(
         modifier = modifier,
@@ -64,12 +121,8 @@ fun Toolbar(
         navigationIcon = navigationIcon,
         navigationIconContentDescription = navigationIconContentDescription,
         actions = {
-            if (onActionButtonClick != null && actionButtonText != null) {
-                TextButton(onClick = onActionButtonClick) {
-                    Text(text = actionButtonText)
-                }
-            } else if (onActionButtonClick == null && actionButtonText != null || onActionButtonClick != null) {
-                error("Both actionButtonText and onActionButtonClick must be set")
+            TextButton(onClick = onActionButtonClick) {
+                Text(text = actionButtonText)
             }
         }
     )
@@ -88,7 +141,10 @@ fun Toolbar(
         backgroundColor = MaterialTheme.colors.surface,
         title = title,
         navigationIcon = {
-            if (onNavigationButtonClick != null && navigationIcon != null) {
+            if (navigationIcon != null) {
+                if (onNavigationButtonClick == null) {
+                    error("Please make sure to set onNavigationButtonClick when having a navigation icon")
+                }
                 IconButton(onClick = onNavigationButtonClick) {
                     Icon(
                         navigationIcon,
@@ -96,8 +152,6 @@ fun Toolbar(
                         modifier = Modifier.autoMirror()
                     )
                 }
-            } else if (onNavigationButtonClick == null && navigationIcon != null || onNavigationButtonClick != null) {
-                error("Both onNavigationButtonClick and navigationIcon must be set")
             }
         },
         actions = actions,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.compose.autoMirror
 
 @Composable
 fun Toolbar(
@@ -91,7 +92,8 @@ fun Toolbar(
                 IconButton(onClick = onNavigationButtonClick) {
                     Icon(
                         navigationIcon,
-                        contentDescription = navigationIconContentDescription
+                        contentDescription = navigationIconContentDescription,
+                        modifier = Modifier.autoMirror()
                     )
                 }
             } else if (onNavigationButtonClick == null && navigationIcon != null || onNavigationButtonClick != null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsScreen.kt
@@ -21,9 +21,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,6 +36,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.orNullIfEmpty
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.coupons.components.CouponExpirationLabel
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponDetailsState
 import com.woocommerce.android.ui.coupons.details.CouponDetailsViewModel.CouponPerformanceState
@@ -49,7 +48,7 @@ import com.woocommerce.android.util.FeatureFlag
 @Composable
 fun CouponDetailsScreen(
     viewModel: CouponDetailsViewModel,
-    onBackPress: () -> Boolean
+    onBackPress: () -> Unit
 ) {
     val couponSummaryState by viewModel.couponState.observeAsState(CouponDetailsState())
 
@@ -66,7 +65,7 @@ fun CouponDetailsScreen(
 @Composable
 fun CouponDetailsScreen(
     state: CouponDetailsState,
-    onBackPress: () -> Boolean,
+    onBackPress: () -> Unit,
     onCopyButtonClick: () -> Unit,
     onShareButtonClick: () -> Unit,
     onEditButtonClick: () -> Unit,
@@ -79,14 +78,9 @@ fun CouponDetailsScreen(
         var showMenu by remember { mutableStateOf(false) }
         var showDeleteDialog by remember { mutableStateOf(false) }
 
-        TopAppBar(
-            backgroundColor = MaterialTheme.colors.surface,
-            title = { Text(state.couponSummary?.code ?: "") },
-            navigationIcon = {
-                IconButton(onClick = { onBackPress() }) {
-                    Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
-                }
-            },
+        Toolbar(
+            title = state.couponSummary?.code ?: "",
+            onNavigationButtonClick = onBackPress,
             actions = {
                 IconButton(onClick = { showMenu = !showMenu }) {
                     Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -24,12 +24,9 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
@@ -47,7 +44,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest.Builder
 import com.woocommerce.android.AppUrls
@@ -56,6 +52,7 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
 import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.ProgressDialog
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
@@ -78,31 +75,20 @@ fun AccountMismatchErrorScreen(viewModel: AccountMismatchErrorViewModel) {
         BackHandler(onBack = viewState.onBackPressed)
 
         Scaffold(topBar = {
-            TopAppBar(
-                backgroundColor = MaterialTheme.colors.surface,
-                title = { },
-                navigationIcon = {
-                    if (viewState.showNavigationIcon) {
-                        IconButton(onClick = {
-                            if (webViewNavigator.canGoBack) {
-                                webViewNavigator.navigateBack()
-                            } else {
-                                viewState.onBackPressed()
-                            }
-                        }) {
-                            Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
-                        }
+            ToolbarWithHelpButton(
+                navigationIcon = if (viewState.showNavigationIcon) {
+                    Icons.Filled.ArrowBack
+                } else {
+                    null
+                },
+                onNavigationButtonClick = {
+                    if (webViewNavigator.canGoBack) {
+                        webViewNavigator.navigateBack()
+                    } else {
+                        viewState.onBackPressed()
                     }
                 },
-                actions = {
-                    IconButton(onClick = viewModel::onHelpButtonClick) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_help_24dp),
-                            contentDescription = stringResource(id = R.string.help)
-                        )
-                    }
-                },
-                elevation = 0.dp
+                onHelpButtonClick = viewModel::onHelpButtonClick
             )
         }) { paddingValues ->
             val transition = updateTransition(targetState = viewState, label = "state")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/base/LoginErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/base/LoginErrorScreen.kt
@@ -14,20 +14,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,7 +31,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -53,14 +49,10 @@ fun LoginErrorScreen(
 ) {
     Scaffold(
         topBar = {
-            Toolbar(actions = {
-                IconButton(onClick = onHelpButtonClick) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_help_24dp),
-                        contentDescription = stringResource(id = R.string.help)
-                    )
-                }
-            })
+            ToolbarWithHelpButton(
+                navigationIcon = null,
+                onHelpButtonClick = onHelpButtonClick
+            )
         }
     ) {
         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartScreen.kt
@@ -44,6 +44,7 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
 import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -72,11 +73,11 @@ fun JetpackActivationStartScreen(
     Scaffold(
         topBar = {
             if (!viewState.isConnectionDismissed) {
-                Toolbar(
+                ToolbarWithHelpButton(
                     title = stringResource(id = string.login_jetpack_installation_screen_title),
                     onNavigationButtonClick = onBackButtonClick,
                     navigationIcon = Icons.Filled.Clear,
-                    onActionButtonClick = onHelpButtonClick,
+                    onHelpButtonClick = onHelpButtonClick,
                 )
             } else {
                 Toolbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationErrorScreen.kt
@@ -8,13 +8,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons.Filled
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,10 +19,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -43,19 +38,7 @@ fun StoreCreationErrorScreen(
             .background(MaterialTheme.colors.surface)
             .fillMaxSize()
     ) {
-        TopAppBar(
-            backgroundColor = MaterialTheme.colors.surface,
-            title = {},
-            navigationIcon = {
-                IconButton(onClick = onArrowBackPressed) {
-                    Icon(
-                        Filled.ArrowBack,
-                        contentDescription = stringResource(id = string.back)
-                    )
-                }
-            },
-            elevation = 0.dp
-        )
+        Toolbar(onNavigationButtonClick = onArrowBackPressed)
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
@@ -23,16 +23,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.CountryPickerState
@@ -42,11 +40,9 @@ import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPicke
 fun CountryPickerScreen(viewModel: CountryPickerViewModel) {
     viewModel.countryPickerState.observeAsState().value?.let { countryPickerContent ->
         Scaffold(topBar = {
-            Toolbar(
+            ToolbarWithHelpButton(
                 onNavigationButtonClick = viewModel::onArrowBackPressed,
-                actionButtonIcon = ImageVector.vectorResource(id = R.drawable.ic_help_24dp),
-                actionIconContentDescription = stringResource(id = R.string.help),
-                onActionButtonClick = viewModel::onHelpPressed
+                onHelpButtonClick = viewModel::onHelpPressed
             )
         }) { padding ->
             CountryPickerForm(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerScreen.kt
@@ -48,7 +48,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCSearchField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -61,9 +61,9 @@ import com.woocommerce.android.ui.login.storecreation.domainpicker.DomainPickerV
 fun DomainPickerScreen(viewModel: DomainPickerViewModel) {
     viewModel.viewState.observeAsState(DomainPickerState()).value.let { viewState ->
         Scaffold(topBar = {
-            Toolbar(
+            ToolbarWithHelpButton(
                 onNavigationButtonClick = viewModel::onBackPressed,
-                onActionButtonClick = viewModel::onHelpPressed,
+                onHelpButtonClick = viewModel::onHelpPressed,
             )
         }) { padding ->
             DomainSearchForm(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/mystoresummary/MyStoreSummaryScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.mystoresummary.MyStoreSummaryViewModel.MyStoreSummaryState
@@ -41,9 +41,9 @@ import com.woocommerce.android.ui.login.storecreation.mystoresummary.MyStoreSumm
 fun MyStoreSummaryScreen(viewModel: MyStoreSummaryViewModel) {
     viewModel.viewState.observeAsState().value?.let { viewState ->
         Scaffold(topBar = {
-            Toolbar(
+            ToolbarWithHelpButton(
                 onNavigationButtonClick = viewModel::onBackPressed,
-                onActionButtonClick = viewModel::onHelpPressed,
+                onHelpButtonClick = viewModel::onHelpPressed,
             )
         }) { padding ->
             MyStoreSummaryScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -35,9 +35,9 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 fun StoreNamePickerScreen(viewModel: StoreNamePickerViewModel) {
     viewModel.storeName.observeAsState().value?.let { storeName ->
         Scaffold(topBar = {
-            Toolbar(
+            ToolbarWithHelpButton(
                 onNavigationButtonClick = viewModel::onCancelPressed,
-                onActionButtonClick = viewModel::onHelpPressed,
+                onHelpButtonClick = viewModel::onHelpPressed,
             )
         }) { padding ->
             NamePickerForm(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/webview/WebViewStoreCreationScreen.kt
@@ -10,15 +10,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons.Filled
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -34,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.AlertDialog
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCWebView
 import com.woocommerce.android.ui.login.storecreation.webview.WebViewStoreCreationViewModel.ViewState.ErrorState
@@ -49,15 +45,9 @@ fun WebViewStoreCreationScreen(viewModel: WebViewStoreCreationViewModel) {
     viewModel.viewState.observeAsState().value?.let { viewState ->
         BackHandler(onBack = viewModel::onBackPressed)
         Scaffold(topBar = {
-            TopAppBar(
-                backgroundColor = MaterialTheme.colors.surface,
-                title = { Text(stringResource(id = string.store_creation_create_new_store_label)) },
-                navigationIcon = {
-                    IconButton(onClick = viewModel::onBackPressed) {
-                        Icon(Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                elevation = 0.dp
+            Toolbar(
+                title = stringResource(id = string.store_creation_create_new_store_label),
+                onNavigationButtonClick = viewModel::onBackPressed
             )
         }) { paddingValues ->
             val transition = updateTransition(targetState = viewState, label = "state")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.window.Dialog
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.DialogButtonsRowLayout
 import com.woocommerce.android.ui.compose.component.ProgressDialog
-import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
@@ -45,10 +45,10 @@ import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscove
 fun SitePickerSiteDiscoveryScreen(viewModel: SitePickerSiteDiscoveryViewModel) {
     viewModel.viewState.observeAsState().value?.let { viewState ->
         Scaffold(topBar = {
-            Toolbar(
+            ToolbarWithHelpButton(
                 title = stringResource(id = R.string.login_site_picker_enter_site_address),
                 onNavigationButtonClick = viewModel::onBackButtonClick,
-                onActionButtonClick = viewModel::onHelpButtonClick
+                onHelpButtonClick = viewModel::onHelpButtonClick
             )
         }) { paddingValues ->
             val transition = updateTransition(viewState, label = "ViewStateTransition")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8252 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR aims at fixing the orientation of the back button in RTL languages, I did the fix in the `Toolbar` component, then I updated all of the Compose screens that weren't migrated last time to start using it.

When I wanted to start the migration, I found it hard to know which defaults the Toolbar would have, so I attempt a small refactor to the overloads to make it clear:
1. By default all of the `Toolbar` components have an optional navigation icon and its callback, and by default, it shows the back button.
2. We control the visibility of the navigation icon just with the `navigationIcon` property, meaning it's OK to have a non-null callback with a null `navigationIcon`. The goal of this is to make it easier to work with the component when the visibility of the button is conditional, so instead of having to remove the callback, we just nullify the `navigationIcon`. (check the comment for more clarification around the error check)
3. By default all of the `Toolbar` variants don't show any action button.
4. I removed the default help action button from the `Toolbar` component, and I created a new one called `ToolbarWithHelpButton`, this way it's clear when we want to use it.

All of this is done in the commit [c8647ef](https://github.com/woocommerce/woocommerce-android/pull/8257/commits/c8647ef9f4db2bd3a2a080a1e32d26946e7316c9), **please tell me what you think.**

### Testing instructions
1. Set the app's language to an RTL one (Arabit for example)
2. Open the app.
3. Open any Compose screen that uses the Compose toolbar (Signup screen or coupon details one)
4. Confirm the correct orientation of the back button.

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20230126_182927](https://user-images.githubusercontent.com/1657201/214907153-c603981e-e1e9-4519-83ca-1be10e033341.png) | ![Screenshot_20230126_183114](https://user-images.githubusercontent.com/1657201/214907188-e65342a1-5efa-4838-95d5-43a8af2ff6ff.png) |


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
