### PR TITLE
UI to display a list of onboarding tasks inside my Store tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -65,7 +65,7 @@ fun OnboardingTaskList(
                     modifier = Modifier.fillMaxHeight(),
                     painter = painterResource(id = task.icon),
                     contentDescription = "",
-                    colorFilter = ColorFilter.tint(color = MaterialTheme.colors.onSurface)
+                    colorFilter = ColorFilter.tint(color = colorResource(id = R.color.color_icon))
                 )
                 Column(modifier = Modifier.weight(1f)) {
                     Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding
 
 import android.content.res.Configuration
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -9,11 +10,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProgressIndicatorDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -25,8 +32,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.OnboardingTask
 
 @Composable
+@Suppress("MagicNumber")
 fun StoreOnboardingScreen(
     onboardingState: StoreOnboardingViewModel.OnboardingState
 ) {
@@ -40,6 +49,12 @@ fun StoreOnboardingScreen(
             text = stringResource(id = onboardingState.title),
             style = MaterialTheme.typography.h6,
         )
+        OnboardingTaskLinearProgress(
+            tasks = onboardingState.tasks,
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.major_100))
+                .fillMaxWidth(0.5f)
+        )
         OnboardingTaskList(
             tasks = onboardingState.tasks,
             modifier = Modifier
@@ -51,7 +66,7 @@ fun StoreOnboardingScreen(
 
 @Composable
 fun OnboardingTaskList(
-    tasks: List<StoreOnboardingViewModel.OnboardingTask>,
+    tasks: List<OnboardingTask>,
     modifier: Modifier = Modifier
 ) {
     Column(modifier) {
@@ -93,12 +108,42 @@ fun OnboardingTaskList(
     }
 }
 
+@Composable
+fun OnboardingTaskLinearProgress(
+    tasks: List<OnboardingTask>,
+    modifier: Modifier = Modifier
+) {
+    val completedTasks = tasks.count { it.isCompleted }
+    val totalTasks = tasks.count()
+    val progress by remember { mutableStateOf(completedTasks / totalTasks.toFloat()) }
+    val animatedProgress = animateFloatAsState(
+        targetValue = progress,
+        animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
+    ).value
+    Column(modifier) {
+        LinearProgressIndicator(
+            progress = animatedProgress,
+            modifier = with(Modifier) {
+                height(dimensionResource(id = R.dimen.minor_100))
+            },
+            color = MaterialTheme.colors.primary,
+            backgroundColor = colorResource(id = R.color.divider_color)
+        )
+        Text(
+            modifier = Modifier.padding(top = dimensionResource(id = R.dimen.minor_100)),
+            text = stringResource(R.string.store_onboarding_completed_tasks_status, completedTasks, totalTasks),
+            style = MaterialTheme.typography.body2,
+        )
+    }
+}
+
 @ExperimentalFoundationApi
 @Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "small screen", device = Devices.PIXEL)
 @Preview(name = "mid screen", device = Devices.PIXEL_4)
 @Preview(name = "large screen", device = Devices.NEXUS_10)
+@Suppress("unused")
 @Composable
 private fun OnboardingPreview() {
     StoreOnboardingScreen(
@@ -106,23 +151,23 @@ private fun OnboardingPreview() {
             show = true,
             title = R.string.store_onboarding_title,
             tasks = listOf(
-                StoreOnboardingViewModel.OnboardingTask(
+                OnboardingTask(
                     icon = R.drawable.ic_product,
                     title = R.string.store_onboarding_task_add_product_title,
                     description = R.string.store_onboarding_task_add_product_description,
-                    status = StoreOnboardingViewModel.OnboardingTaskStatus.UNDONE
+                    isCompleted = false
                 ),
-                StoreOnboardingViewModel.OnboardingTask(
+                OnboardingTask(
                     icon = R.drawable.ic_product,
                     title = R.string.store_onboarding_task_launch_store_title,
                     description = R.string.store_onboarding_task_launch_store_description,
-                    status = StoreOnboardingViewModel.OnboardingTaskStatus.UNDONE
+                    isCompleted = false
                 ),
-                StoreOnboardingViewModel.OnboardingTask(
+                OnboardingTask(
                     icon = R.drawable.ic_product,
                     title = R.string.store_onboarding_task_change_domain_title,
                     description = R.string.store_onboarding_task_change_domain_description,
-                    status = StoreOnboardingViewModel.OnboardingTaskStatus.UNDONE
+                    isCompleted = false
                 )
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
@@ -23,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -130,11 +132,11 @@ fun OnboardingTaskLinearProgress(
     Column(modifier) {
         LinearProgressIndicator(
             progress = animatedProgress,
-            modifier = with(Modifier) {
-                height(dimensionResource(id = R.dimen.minor_100))
-            },
+            modifier = Modifier
+                .height(dimensionResource(id = R.dimen.minor_100))
+                .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
             color = MaterialTheme.colors.primary,
-            backgroundColor = colorResource(id = R.color.divider_color)
+            backgroundColor = colorResource(id = R.color.divider_color),
         )
         Text(
             modifier = Modifier.padding(top = dimensionResource(id = R.dimen.minor_100)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -78,9 +78,16 @@ fun OnboardingTaskList(
             ) {
                 Image(
                     modifier = Modifier.fillMaxHeight(),
-                    painter = painterResource(id = task.icon),
+                    painter = painterResource(
+                        id = if (task.isCompleted)
+                            R.drawable.ic_onboarding_task_completed
+                        else task.icon
+                    ),
                     contentDescription = "",
-                    colorFilter = ColorFilter.tint(color = colorResource(id = R.color.color_icon))
+                    colorFilter =
+                    if (!task.isCompleted)
+                        ColorFilter.tint(color = colorResource(id = R.color.color_icon))
+                    else null
                 )
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
@@ -161,7 +168,7 @@ private fun OnboardingPreview() {
                     icon = R.drawable.ic_product,
                     title = R.string.store_onboarding_task_launch_store_title,
                     description = R.string.store_onboarding_task_launch_store_description,
-                    isCompleted = false
+                    isCompleted = true
                 ),
                 OnboardingTask(
                     icon = R.drawable.ic_product,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.login.storecreation.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
+
+@Composable
+fun StoreOnboardingScreen(
+    onboardingState: StoreOnboardingViewModel.OnboardingState
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colors.surface)
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Text(text = stringResource(id = onboardingState.title))
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -1,15 +1,29 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding
 
+import android.content.res.Configuration
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 
 @Composable
@@ -22,6 +36,95 @@ fun StoreOnboardingScreen(
             .background(MaterialTheme.colors.surface)
             .padding(dimensionResource(id = R.dimen.major_100))
     ) {
-        Text(text = stringResource(id = onboardingState.title))
+        Text(
+            text = stringResource(id = onboardingState.title),
+            style = MaterialTheme.typography.h6,
+        )
+        OnboardingTaskList(
+            tasks = onboardingState.tasks,
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.major_100))
+                .fillMaxWidth()
+        )
     }
+}
+
+@Composable
+fun OnboardingTaskList(
+    tasks: List<StoreOnboardingViewModel.OnboardingTask>,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        tasks.forEachIndexed { index, task ->
+            Row(
+                modifier = modifier.padding(bottom = dimensionResource(id = R.dimen.major_100)),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+            ) {
+                Image(
+                    modifier = Modifier.fillMaxHeight(),
+                    painter = painterResource(id = task.icon),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(color = MaterialTheme.colors.onSurface)
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(id = task.title),
+                        style = MaterialTheme.typography.subtitle1,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        modifier = Modifier.padding(top = dimensionResource(id = R.dimen.minor_75)),
+                        text = stringResource(id = task.description),
+                        style = MaterialTheme.typography.body1,
+                    )
+                }
+                Image(
+                    painter = painterResource(R.drawable.ic_arrow_right),
+                    contentDescription = ""
+                )
+            }
+            if (index < tasks.lastIndex)
+                Divider(
+                    color = colorResource(id = R.color.divider_color),
+                    thickness = dimensionResource(id = R.dimen.minor_10)
+                )
+        }
+    }
+}
+
+@ExperimentalFoundationApi
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "small screen", device = Devices.PIXEL)
+@Preview(name = "mid screen", device = Devices.PIXEL_4)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
+@Composable
+private fun OnboardingPreview() {
+    StoreOnboardingScreen(
+        StoreOnboardingViewModel.OnboardingState(
+            show = true,
+            title = R.string.store_onboarding_title,
+            tasks = listOf(
+                StoreOnboardingViewModel.OnboardingTask(
+                    icon = R.drawable.ic_product,
+                    title = R.string.store_onboarding_task_add_product_title,
+                    description = R.string.store_onboarding_task_add_product_description,
+                    status = StoreOnboardingViewModel.OnboardingTaskStatus.UNDONE
+                ),
+                StoreOnboardingViewModel.OnboardingTask(
+                    icon = R.drawable.ic_product,
+                    title = R.string.store_onboarding_task_launch_store_title,
+                    description = R.string.store_onboarding_task_launch_store_description,
+                    status = StoreOnboardingViewModel.OnboardingTaskStatus.UNDONE
+                ),
+                StoreOnboardingViewModel.OnboardingTask(
+                    icon = R.drawable.ic_product,
+                    title = R.string.store_onboarding_task_change_domain_title,
+                    description = R.string.store_onboarding_task_change_domain_description,
+                    status = StoreOnboardingViewModel.OnboardingTaskStatus.UNDONE
+                )
+            )
+        )
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -24,19 +24,19 @@ class StoreOnboardingViewModel @Inject constructor(
             title = R.string.store_onboarding_title,
             tasks = listOf(
                 OnboardingTask(
-                    icon = R.drawable.ic_product,
+                    icon = R.drawable.ic_product_onboarding_list,
                     title = R.string.store_onboarding_task_add_product_title,
                     description = R.string.store_onboarding_task_add_product_description,
                     status = OnboardingTaskStatus.UNDONE
                 ),
                 OnboardingTask(
-                    icon = R.drawable.ic_product,
+                    icon = R.drawable.ic_store_onboarding_list,
                     title = R.string.store_onboarding_task_launch_store_title,
                     description = R.string.store_onboarding_task_launch_store_description,
                     status = OnboardingTaskStatus.UNDONE
                 ),
                 OnboardingTask(
-                    icon = R.drawable.ic_product,
+                    icon = R.drawable.ic_globe_onboarding_list,
                     title = R.string.store_onboarding_task_change_domain_title,
                     description = R.string.store_onboarding_task_change_domain_description,
                     status = OnboardingTaskStatus.UNDONE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.ui.login.storecreation.onboarding
+
+import android.os.Parcelable
+import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
+
+@HiltViewModel
+class StoreOnboardingViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ScopedViewModel(savedStateHandle) {
+    private val _viewState = savedState.getStateFlow(
+        this,
+        OnboardingState(
+            show = FeatureFlag.STORE_CREATION_ONBOARDING.isEnabled(),
+            title = R.string.store_onboarding_title,
+            tasks = emptyList()
+        )
+    )
+    val viewState = _viewState.asLiveData()
+
+    @Parcelize
+    data class OnboardingState(
+        val show: Boolean,
+        @StringRes val title: Int,
+        val tasks: List<OnboardingTask>
+    ) : Parcelable
+
+    @Parcelize
+    data class OnboardingTask(
+        val name: String,
+        val description: String,
+        val status: OnboardingTaskStatus
+    ) : Parcelable
+
+    enum class OnboardingTaskStatus {
+        TODO,
+        COMPLETED
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -27,19 +27,19 @@ class StoreOnboardingViewModel @Inject constructor(
                     icon = R.drawable.ic_product_onboarding_list,
                     title = R.string.store_onboarding_task_add_product_title,
                     description = R.string.store_onboarding_task_add_product_description,
-                    status = OnboardingTaskStatus.UNDONE
+                    isCompleted = false
                 ),
                 OnboardingTask(
                     icon = R.drawable.ic_store_onboarding_list,
                     title = R.string.store_onboarding_task_launch_store_title,
                     description = R.string.store_onboarding_task_launch_store_description,
-                    status = OnboardingTaskStatus.UNDONE
+                    isCompleted = true
                 ),
                 OnboardingTask(
                     icon = R.drawable.ic_globe_onboarding_list,
                     title = R.string.store_onboarding_task_change_domain_title,
                     description = R.string.store_onboarding_task_change_domain_description,
-                    status = OnboardingTaskStatus.UNDONE
+                    isCompleted = false
                 )
             )
         )
@@ -58,11 +58,6 @@ class StoreOnboardingViewModel @Inject constructor(
         @DrawableRes val icon: Int,
         @StringRes val title: Int,
         @StringRes val description: Int,
-        val status: OnboardingTaskStatus
+        val isCompleted: Boolean
     ) : Parcelable
-
-    enum class OnboardingTaskStatus {
-        UNDONE,
-        COMPLETED
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding
 
 import android.os.Parcelable
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -21,7 +22,26 @@ class StoreOnboardingViewModel @Inject constructor(
         OnboardingState(
             show = FeatureFlag.STORE_CREATION_ONBOARDING.isEnabled(),
             title = R.string.store_onboarding_title,
-            tasks = emptyList()
+            tasks = listOf(
+                OnboardingTask(
+                    icon = R.drawable.ic_product,
+                    title = R.string.store_onboarding_task_add_product_title,
+                    description = R.string.store_onboarding_task_add_product_description,
+                    status = OnboardingTaskStatus.UNDONE
+                ),
+                OnboardingTask(
+                    icon = R.drawable.ic_product,
+                    title = R.string.store_onboarding_task_launch_store_title,
+                    description = R.string.store_onboarding_task_launch_store_description,
+                    status = OnboardingTaskStatus.UNDONE
+                ),
+                OnboardingTask(
+                    icon = R.drawable.ic_product,
+                    title = R.string.store_onboarding_task_change_domain_title,
+                    description = R.string.store_onboarding_task_change_domain_description,
+                    status = OnboardingTaskStatus.UNDONE
+                )
+            )
         )
     )
     val viewState = _viewState.asLiveData()
@@ -35,13 +55,14 @@ class StoreOnboardingViewModel @Inject constructor(
 
     @Parcelize
     data class OnboardingTask(
-        val name: String,
-        val description: String,
+        @DrawableRes val icon: Int,
+        @StringRes val title: Int,
+        @StringRes val description: Int,
         val status: OnboardingTaskStatus
     ) : Parcelable
 
     enum class OnboardingTaskStatus {
-        TODO,
+        UNDONE,
         COMPLETED
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingScreen
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel
-import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.*
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -5,9 +5,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.View
 import android.view.ViewGroup.LayoutParams
-import androidx.compose.material.Text
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.res.stringResource
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -38,6 +36,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingScreen
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.*
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -177,6 +176,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
             .launchIn(viewLifecycleOwner.lifecycleScope)
 
         setupStateObservers()
+        setupOnboardingView()
     }
 
     private fun applyBannerComposeUI(state: BannerState) {
@@ -196,17 +196,19 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         }
     }
 
-    private fun showStoreOnboardingView(state: OnboardingState) {
-        when (state.show) {
-            false -> binding.storeOnboardingView.hide()
-            else -> {
-                binding.storeOnboardingView.apply {
-                    binding.storeOnboardingView.show()
-                    // Dispose of the Composition when the view's LifecycleOwner is destroyed
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                    setContent {
-                        WooThemeWithBackground {
-                            Text(stringResource(id = state.title))
+    private fun setupOnboardingView() {
+        storeOnboardingViewModel.viewState.observe(viewLifecycleOwner) { state ->
+            when (state.show) {
+                false -> binding.storeOnboardingView.hide()
+                else -> {
+                    binding.storeOnboardingView.apply {
+                        binding.storeOnboardingView.show()
+                        // Dispose of the Composition when the view's LifecycleOwner is destroyed
+                        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                        setContent {
+                            WooThemeWithBackground {
+                                StoreOnboardingScreen(onboardingState = state)
+                            }
                         }
                     }
                 }
@@ -280,9 +282,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                 }
                 else -> event.isHandled = false
             }
-        }
-        storeOnboardingViewModel.viewState.observe(viewLifecycleOwner) { onboardingState ->
-            showStoreOnboardingView(onboardingState)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -5,7 +5,9 @@ import android.os.Handler
 import android.os.Looper
 import android.view.View
 import android.view.ViewGroup.LayoutParams
+import androidx.compose.material.Text
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -36,6 +38,8 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.*
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
@@ -75,7 +79,8 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         val DEFAULT_STATS_GRANULARITY = StatsGranularity.DAYS
     }
 
-    private val viewModel: MyStoreViewModel by viewModels()
+    private val myStoreViewModel: MyStoreViewModel by viewModels()
+    private val storeOnboardingViewModel: StoreOnboardingViewModel by viewModels()
 
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var currencyFormatter: CurrencyFormatter
@@ -109,7 +114,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     private val tabSelectedListener = object : TabLayout.OnTabSelectedListener {
         override fun onTabSelected(tab: TabLayout.Tab) {
-            viewModel.onStatsGranularityChanged(tab.tag as StatsGranularity)
+            myStoreViewModel.onStatsGranularityChanged(tab.tag as StatsGranularity)
         }
 
         override fun onTabUnselected(tab: TabLayout.Tab) {}
@@ -120,7 +125,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     private val handler = Handler(Looper.getMainLooper())
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        lifecycle.addObserver(viewModel.performanceObserver)
+        lifecycle.addObserver(myStoreViewModel.performanceObserver)
         super.onCreate(savedInstanceState)
     }
 
@@ -131,7 +136,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
         binding.myStoreRefreshLayout.setOnRefreshListener {
             binding.myStoreRefreshLayout.isRefreshing = false
-            viewModel.onSwipeToRefresh()
+            myStoreViewModel.onSwipeToRefresh()
             binding.myStoreStats.clearStatsHeaderValues()
             binding.myStoreStats.clearChartData()
         }
@@ -146,13 +151,13 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         }
 
         binding.myStoreStats.initView(
-            viewModel.activeStatsGranularity.value ?: DEFAULT_STATS_GRANULARITY,
+            myStoreViewModel.activeStatsGranularity.value ?: DEFAULT_STATS_GRANULARITY,
             selectedSite,
             dateUtils,
             currencyFormatter,
             usageTracksEventEmitter,
             viewLifecycleOwner.lifecycleScope
-        ) { viewModel.onViewAnalyticsClicked() }
+        ) { myStoreViewModel.onViewAnalyticsClicked() }
 
         binding.myStoreTopPerformers.initView(selectedSite)
 
@@ -191,9 +196,27 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         }
     }
 
+    private fun showStoreOnboardingView(state: OnboardingState) {
+        when (state.show) {
+            false -> binding.storeOnboardingView.hide()
+            else -> {
+                binding.storeOnboardingView.apply {
+                    binding.storeOnboardingView.show()
+                    // Dispose of the Composition when the view's LifecycleOwner is destroyed
+                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                    setContent {
+                        WooThemeWithBackground {
+                            Text(stringResource(id = state.title))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     @Suppress("ComplexMethod", "MagicNumber", "LongMethod")
     private fun setupStateObservers() {
-        viewModel.activeStatsGranularity.observe(viewLifecycleOwner) { activeGranularity ->
+        myStoreViewModel.activeStatsGranularity.observe(viewLifecycleOwner) { activeGranularity ->
             if (tabLayout.getTabAt(tabLayout.selectedTabPosition)?.tag != activeGranularity) {
                 val index = StatsGranularity.values().indexOf(activeGranularity)
                 // Small delay needed to ensure tablayout scrolls to the selected tab if tab is not visible on screen.
@@ -202,7 +225,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
             binding.myStoreStats.loadDashboardStats(activeGranularity)
             binding.myStoreTopPerformers.onDateGranularityChanged(activeGranularity)
         }
-        viewModel.revenueStatsState.observe(viewLifecycleOwner) { revenueStats ->
+        myStoreViewModel.revenueStatsState.observe(viewLifecycleOwner) { revenueStats ->
             when (revenueStats) {
                 is RevenueStatsViewState.Content -> showStats(revenueStats.revenueStats)
                 RevenueStatsViewState.GenericError -> showStatsError()
@@ -210,7 +233,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                 RevenueStatsViewState.PluginNotActiveError -> updateStatsAvailabilityError()
             }
         }
-        viewModel.visitorStatsState.observe(viewLifecycleOwner) { stats ->
+        myStoreViewModel.visitorStatsState.observe(viewLifecycleOwner) { stats ->
             when (stats) {
                 is VisitorStatsViewState.Content -> showVisitorStats(stats.stats)
                 VisitorStatsViewState.Error -> {
@@ -220,23 +243,23 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                 is VisitorStatsViewState.Unavailable -> onVisitorStatsUnavailable(stats)
             }
         }
-        viewModel.topPerformersState.observe(viewLifecycleOwner) { topPerformers ->
+        myStoreViewModel.topPerformersState.observe(viewLifecycleOwner) { topPerformers ->
             when {
                 topPerformers.isLoading -> showTopPerformersLoading()
                 topPerformers.isError -> showTopPerformersError()
                 else -> showTopPerformers(topPerformers.topPerformers)
             }
         }
-        viewModel.hasOrders.observe(viewLifecycleOwner) { newValue ->
+        myStoreViewModel.hasOrders.observe(viewLifecycleOwner) { newValue ->
             when (newValue) {
                 OrderState.Empty -> showEmptyView(true)
                 OrderState.AtLeastOne -> showEmptyView(false)
             }
         }
-        viewModel.bannerState.observe(viewLifecycleOwner) { bannerState ->
+        myStoreViewModel.bannerState.observe(viewLifecycleOwner) { bannerState ->
             applyBannerComposeUI(bannerState)
         }
-        viewModel.event.observe(viewLifecycleOwner) { event ->
+        myStoreViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is OpenTopPerformer -> findNavController().navigateSafely(
                     NavGraphMainDirections.actionGlobalProductDetailFragment(
@@ -257,6 +280,9 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                 }
                 else -> event.isHandled = false
             }
+        }
+        storeOnboardingViewModel.viewState.observe(viewLifecycleOwner) { onboardingState ->
+            showStoreOnboardingView(onboardingState)
         }
     }
 
@@ -348,7 +374,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         binding.myStoreStats.updateView(revenueStatsModel)
 
         // update the stats today widget if we're viewing today's stats
-        if (viewModel.activeStatsGranularity.value == StatsGranularity.DAYS) {
+        if (myStoreViewModel.activeStatsGranularity.value == StatsGranularity.DAYS) {
             (activity as? MainActivity)?.updateStatsWidgets()
         }
     }
@@ -396,7 +422,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     override fun getFragmentTitle() = getString(R.string.my_store)
 
-    override fun getFragmentSubtitle(): String = viewModel.getSelectedSiteName()
+    override fun getFragmentSubtitle(): String = myStoreViewModel.getSelectedSiteName()
 
     override fun scrollToTop() {
         binding.statsScrollView.smoothScrollTo(0, 0)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -17,7 +17,8 @@ enum class FeatureFlag {
     IAP_FOR_STORE_CREATION,
     IPP_TAP_TO_PAY,
     DOMAIN_CHANGE,
-    IPP_FEEDBACK_BANNER;
+    IPP_FEEDBACK_BANNER,
+    STORE_CREATION_ONBOARDING;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -36,7 +37,8 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             IAP_FOR_STORE_CREATION,
             IPP_TAP_TO_PAY,
-            DOMAIN_CHANGE -> PackageUtils.isDebugBuild()
+            DOMAIN_CHANGE,
+            STORE_CREATION_ONBOARDING -> PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/main/res/drawable/ic_globe_onboarding_list.xml
+++ b/WooCommerce/src/main/res/drawable/ic_globe_onboarding_list.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:autoMirrored="true"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+    <path
+        android:pathData="M14.001,14m-9.333,0a9.333,9.333 0,1 1,18.667 0a9.333,9.333 0,1 1,-18.667 0"
+        android:strokeWidth="1.5"
+        android:strokeColor="#000000" />
+    <path
+        android:pathData="M14.001,5.094C11.635,6.283 9.918,9.821 9.918,14C9.918,18.269 11.71,21.869 14.155,22.979"
+        android:strokeWidth="1.5"
+        android:strokeColor="#000000" />
+    <path
+        android:pathData="M13.999,5.094C16.365,6.283 18.082,9.821 18.082,14C18.082,18.179 16.365,21.717 13.999,22.906"
+        android:strokeWidth="1.5"
+        android:strokeColor="#000000" />
+    <path
+        android:pathData="M23.332,16.792L4.665,16.792"
+        android:strokeWidth="1.5"
+        android:strokeColor="#000000" />
+    <path
+        android:pathData="M4.668,11.208L23.335,11.208"
+        android:strokeWidth="1.5"
+        android:strokeColor="#000000" />
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_onboarding_task_completed.xml
+++ b/WooCommerce/src/main/res/drawable/ic_onboarding_task_completed.xml
@@ -1,0 +1,19 @@
+<vector android:autoMirrored="true"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="#674399"
+        android:pathData="M12,1L12,1A11,11 0,0 1,23 12L23,12A11,11 0,0 1,12 23L12,23A11,11 0,0 1,1 12L1,12A11,11 0,0 1,12 1z" />
+    <path
+        android:fillColor="#ffffff"
+        android:fillType="evenOdd"
+        android:pathData="M10.94,17.5C11.262,17.5 11.54,17.352 11.748,17.031L17.587,7.882C17.717,7.69 17.83,7.456 17.83,7.247C17.83,6.787 17.422,6.5 16.996,6.5C16.744,6.5 16.492,6.648 16.301,6.943L10.896,15.536L8.021,11.931C7.795,11.644 7.56,11.54 7.282,11.54C6.856,11.54 6.5,11.878 6.5,12.339C6.5,12.556 6.587,12.791 6.735,12.973L10.089,17.039C10.358,17.37 10.618,17.5 10.94,17.5Z" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M12,1L12,1A11,11 0,0 1,23 12L23,12A11,11 0,0 1,12 23L12,23A11,11 0,0 1,1 12L1,12A11,11 0,0 1,12 1z"
+        android:strokeColor="#674399"
+        android:strokeWidth="1.5" />
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_product_onboarding_list.xml
+++ b/WooCommerce/src/main/res/drawable/ic_product_onboarding_list.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:pathData="M 0 0 H 24 V 24 H 0 V 0 Z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M22 3H2v6h1v11c0 1.105 0.895 2 2 2h14c1.105 0 2-0.895 2-2V9h1V3zM4 5h16v2H4V5zm15 15H5V9h14v11zM9 11h6c0 1.105-0.895 2-2 2h-2c-1.105 0-2-0.895-2-2z" />
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_store_onboarding_list.xml
+++ b/WooCommerce/src/main/res/drawable/ic_store_onboarding_list.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M21.167,10.633H2.833V9.081L3.9,4.833H20.1L21.167,9.081V10.633Z"
+        android:strokeWidth="1.66667"
+        android:strokeColor="#000000" />
+    <path
+        android:pathData="M4.223,10.402V16.802V20.002H19.778V16.802V10.402"
+        android:strokeWidth="1.66667"
+        android:strokeColor="#000000" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9.777,13.602h4.444v6.4h-4.444z" />
+    <path
+        android:pathData="M8.107,5.07L7.497,8.985L7.441,10.404"
+        android:strokeWidth="1.66667"
+        android:strokeColor="#000000" />
+    <path
+        android:pathData="M15.893,5.07L16.503,8.985L16.559,10.404"
+        android:strokeWidth="1.66667"
+        android:strokeColor="#000000" />
+    <path
+        android:pathData="M12,5.07V10.404"
+        android:strokeWidth="1.66667"
+        android:strokeColor="#000000" />
+</vector>

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -35,7 +35,13 @@
                         android:id="@+id/jitmView"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_100"/>
+                        android:layout_marginBottom="@dimen/minor_100" />
+
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/store_onboarding_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100" />
 
                     <com.woocommerce.android.widgets.WCEmptyView
                         android:id="@+id/empty_view"
@@ -109,8 +115,8 @@
                 android:id="@+id/stats_availability_image"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:importantForAccessibility="no"
                 android:layout_marginTop="@dimen/major_250"
+                android:importantForAccessibility="no"
                 android:src="@drawable/img_empty_search"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -41,7 +41,8 @@
                         android:id="@+id/store_onboarding_view"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_100" />
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:visibility="gone" />
 
                     <com.woocommerce.android.widgets.WCEmptyView
                         android:id="@+id/empty_view"

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -41,7 +41,8 @@
                         android:id="@+id/store_onboarding_view"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_100"
+                        android:layout_marginBottom="@dimen/major_100"
+                        android:layout_marginTop="@dimen/major_100"
                         android:visibility="gone" />
 
                     <com.woocommerce.android.widgets.WCEmptyView

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3032,4 +3032,10 @@
     Store onboarding
     -->
     <string name="store_onboarding_title">Store setup</string>
+    <string name="store_onboarding_task_add_product_title">Add your first product </string>
+    <string name="store_onboarding_task_add_product_description">Start selling by adding products or services to your store.</string>
+    <string name="store_onboarding_task_launch_store_title">Launch your store</string>
+    <string name="store_onboarding_task_launch_store_description">Publish your site to the world anytime you want!</string>
+    <string name="store_onboarding_task_change_domain_title">Customize your domain</string>
+    <string name="store_onboarding_task_change_domain_description">Have a custom URL to host your store.</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3038,4 +3038,6 @@
     <string name="store_onboarding_task_launch_store_description">Publish your site to the world anytime you want!</string>
     <string name="store_onboarding_task_change_domain_title">Customize your domain</string>
     <string name="store_onboarding_task_change_domain_description">Have a custom URL to host your store.</string>
+    <string name="store_onboarding_completed_tasks_status">%1$d/%2$d completed</string>
+
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3027,4 +3027,9 @@
     <string name="store_creation_profiler_merchant_journey_starting_business">I\'m just starting my business</string>
     <string name="store_creation_profiler_merchant_journey_selling_not_online">I\'m already selling, but not online</string>
     <string name="store_creation_profiler_merchant_journey_selling_online">I\'m already selling online</string>
+
+    <!--
+    Store onboarding
+    -->
+    <string name="store_onboarding_title">Store setup</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8260 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

UI to display a list of onboarding tasks inside my Store tab. Plain UI that doesn't support any interactions for now. The feature is under a feature flag that is only enabled for `debug` builds.

I've opened a discussion in design P2 pecCkj-kA-p2 about the following: 
- Where should we place the new onboarding tasks list: nested inside the tabs or outside the tabs. 
- Overflow button at the top right corner to display a single option, doesn't seem to make much sense. 

Until those 2 points are clarified I've added the list nested inside the tabs in My Store screen and also have not added the overflow menu.

### Testing instructions
Just launch the app and check that the UI matches design (with the expected differences between iOS and Android platforms): VyLr7LvKodHE4kINfBE7Lw-fi-1264%3A69768

![Screenshot 2023-01-30 at 12 56 04](https://user-images.githubusercontent.com/2663464/215470454-1a466db7-7fb7-4541-8d52-54c3c3950a00.png)