### PR TITLE
Domain change: Make the Learn more link interactive

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/CurrentDomainsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/CurrentDomainsFragment.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.prefs.domain.DomainChangeViewModel.ShowMoreAboutDomains
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -44,6 +46,7 @@ class CurrentDomainsFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is MultiLiveEvent.Event.NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
+                is ShowMoreAboutDomains -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/CurrentDomainsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/CurrentDomainsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -40,11 +40,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -53,6 +49,8 @@ import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
+import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.ProgressIndicator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -131,41 +129,29 @@ private fun DomainChange(
                 Text(text = stringResource(id = string.domains_search_for_domain_button_title))
             }
             Row(
-                Modifier
-                    .padding(
-                        start = dimensionResource(id = dimen.major_100),
-                        end = dimensionResource(id = dimen.major_100),
-                        top = dimensionResource(id = dimen.minor_50),
-                        bottom = dimensionResource(id = dimen.major_100)
-                    )
-                    .clickable {
-                        onLearnMoreButtonTapped()
-                    }
+                modifier = Modifier.padding(
+                    start = dimensionResource(id = dimen.major_100),
+                    end = dimensionResource(id = dimen.major_100),
+                    top = dimensionResource(id = dimen.minor_50),
+                    bottom = dimensionResource(id = dimen.major_100)
+                )
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(id = drawable.ic_info_outline_20dp),
-                    contentDescription = stringResource(string.learn_more)
+                    contentDescription = stringResource(string.domains_learn_more)
                 )
-                val learnMoreColor = colorResource(id = color.color_primary)
-                val learnMore = stringResource(id = string.learn_more)
-                val learnMoreContinued = stringResource(id = string.domains_learn_more)
-                Text(
-                    modifier = Modifier.padding(start = dimensionResource(id = dimen.major_100)),
-                    text = buildAnnotatedString {
-                        withStyle(
-                            style = SpanStyle(
-                                color = learnMoreColor,
-                                textDecoration = TextDecoration.Underline
-                            )
-                        ) {
-                            append(learnMore)
-                        }
-                        append(" ")
-                        append(learnMoreContinued)
-                    },
-                    style = MaterialTheme.typography.caption,
-                    color = colorResource(id = color.color_on_surface_medium)
-                )
+                val text = annotatedStringRes(stringResId = string.domains_learn_more)
+                ClickableText(
+                    modifier = Modifier.padding(start = dimensionResource(id = dimen.minor_100)),
+                    text = text,
+                    style = MaterialTheme.typography.caption.copy(
+                        color = colorResource(id = color.color_on_surface_medium)
+                    ),
+                ) {
+                    text.getStringAnnotations(tag = URL_ANNOTATION_TAG, start = it, end = it)
+                        .firstOrNull()
+                        ?.let { onLearnMoreButtonTapped() }
+                }
             }
         } else {
             LazyColumn(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/CurrentDomainsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/CurrentDomainsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,7 +40,11 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -64,7 +69,7 @@ fun CurrentDomainsScreen(viewModel: DomainChangeViewModel) {
                 Toolbar(
                     title = stringResource(id = string.domains),
                     onNavigationButtonClick = viewModel::onCancelPressed,
-                    onActionButtonClick = viewModel::onHelpPressed,
+                    onActionButtonClick = viewModel::onHelpPressed
                 )
             }) { padding ->
                 when (viewState) {
@@ -73,6 +78,7 @@ fun CurrentDomainsScreen(viewModel: DomainChangeViewModel) {
                             domainsState = viewState,
                             onFindDomainButtonTapped = viewModel::onFindDomainButtonTapped,
                             onDismissBannerButtonTapped = viewModel::onDismissBannerButtonTapped,
+                            onLearnMoreButtonTapped = viewModel::onLearnMoreButtonTapped,
                             modifier = Modifier
                                 .background(MaterialTheme.colors.surface)
                                 .fillMaxSize()
@@ -92,6 +98,7 @@ private fun DomainChange(
     domainsState: DomainsState,
     onFindDomainButtonTapped: () -> Unit,
     onDismissBannerButtonTapped: () -> Unit,
+    onLearnMoreButtonTapped: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
@@ -124,18 +131,38 @@ private fun DomainChange(
                 Text(text = stringResource(id = string.domains_search_for_domain_button_title))
             }
             Row(
-                Modifier.padding(
-                    horizontal = dimensionResource(id = dimen.major_100),
-                    vertical = dimensionResource(id = dimen.minor_50)
-                )
+                Modifier
+                    .padding(
+                        start = dimensionResource(id = dimen.major_100),
+                        end = dimensionResource(id = dimen.major_100),
+                        top = dimensionResource(id = dimen.minor_50),
+                        bottom = dimensionResource(id = dimen.major_100)
+                    )
+                    .clickable {
+                        onLearnMoreButtonTapped()
+                    }
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(id = drawable.ic_info_outline_20dp),
-                    contentDescription = stringResource(string.domains_learn_more)
+                    contentDescription = stringResource(string.learn_more)
                 )
+                val learnMoreColor = colorResource(id = color.color_primary)
+                val learnMore = stringResource(id = string.learn_more)
+                val learnMoreContinued = stringResource(id = string.domains_learn_more)
                 Text(
                     modifier = Modifier.padding(start = dimensionResource(id = dimen.major_100)),
-                    text = stringResource(id = string.domains_learn_more),
+                    text = buildAnnotatedString {
+                        withStyle(
+                            style = SpanStyle(
+                                color = learnMoreColor,
+                                textDecoration = TextDecoration.Underline
+                            )
+                        ) {
+                            append(learnMore)
+                        }
+                        append(" ")
+                        append(learnMoreContinued)
+                    },
                     style = MaterialTheme.typography.caption,
                     color = colorResource(id = color.color_on_surface_medium)
                 )
@@ -356,7 +383,31 @@ fun NamePickerPreview() {
                 ),
             ),
             onFindDomainButtonTapped = {},
-            onDismissBannerButtonTapped = {}
+            onDismissBannerButtonTapped = {},
+            onLearnMoreButtonTapped = {}
+        )
+    }
+}
+
+@ExperimentalFoundationApi
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Composable
+fun NoDomainsPickerPreview() {
+    WooThemeWithBackground {
+        DomainChange(
+            domainsState = DomainsState(
+                wpComDomain = DomainsState.Domain(
+                    url = "www.test.com",
+                    renewalDate = "Renewal date: 12/12/2020",
+                    isPrimary = true
+                ),
+                isDomainClaimBannerVisible = true,
+                paidDomains = listOf(),
+            ),
+            onFindDomainButtonTapped = {},
+            onDismissBannerButtonTapped = {},
+            onLearnMoreButtonTapped = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainChangeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainChangeViewModel.kt
@@ -26,6 +26,10 @@ class DomainChangeViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        private const val LEARN_MORE_URL = "https://wordpress.com/go/tutorials/what-is-a-domain-name/"
+    }
+
     private val _viewState = savedStateHandle.getStateFlow<ViewState>(this, LoadingState)
     val viewState = _viewState.asLiveData()
 
@@ -45,11 +49,6 @@ class DomainChangeViewModel @Inject constructor(
                         isPrimary = true
                     ),
                     paidDomains = listOf(
-                        DomainsState.Domain(
-                            url = "www.cnn.com",
-                            renewalDate = "Renewal date: 12/12/2020",
-                            isPrimary = false
-                        )
                     ),
                     isDomainClaimBannerVisible = true
                 )
@@ -77,6 +76,10 @@ class DomainChangeViewModel @Inject constructor(
         }
     }
 
+    fun onLearnMoreButtonTapped() {
+        triggerEvent(ShowMoreAboutDomains(LEARN_MORE_URL))
+    }
+    
     sealed interface ViewState : Parcelable {
         @Parcelize
         object LoadingState : ViewState
@@ -97,4 +100,5 @@ class DomainChangeViewModel @Inject constructor(
     }
 
     object NavigateToNextStep : MultiLiveEvent.Event()
+    data class ShowMoreAboutDomains(val url: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainChangeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainChangeViewModel.kt
@@ -48,8 +48,7 @@ class DomainChangeViewModel @Inject constructor(
                         url = selectedSite.get().url,
                         isPrimary = true
                     ),
-                    paidDomains = listOf(
-                    ),
+                    paidDomains = emptyList(),
                     isDomainClaimBannerVisible = true
                 )
             }
@@ -79,7 +78,7 @@ class DomainChangeViewModel @Inject constructor(
     fun onLearnMoreButtonTapped() {
         triggerEvent(ShowMoreAboutDomains(LEARN_MORE_URL))
     }
-    
+
     sealed interface ViewState : Parcelable {
         @Parcelize
         object LoadingState : ViewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -34,9 +34,9 @@ enum class FeatureFlag {
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
+            IAP_FOR_STORE_CREATION,
             IPP_TAP_TO_PAY,
             DOMAIN_CHANGE -> PackageUtils.isDebugBuild()
-            IAP_FOR_STORE_CREATION -> false
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -34,9 +34,9 @@ enum class FeatureFlag {
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            IAP_FOR_STORE_CREATION,
             IPP_TAP_TO_PAY,
             DOMAIN_CHANGE -> PackageUtils.isDebugBuild()
+            IAP_FOR_STORE_CREATION -> false
         }
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -538,7 +538,7 @@
     <string name="domains_claim_your_free_domain_link">Claim Domain</string>
     <string name="domains_purchase_redirect_notice">The domain purchased will redirect users to your primary address.</string>
     <string name="domains_search_for_domain_button_title">Search for a domain</string>
-    <string name="domains_learn_more">Learn more about domains and how to take domain-related actions.</string>
+    <string name="domains_learn_more">about domains and how to take domain-related actions.</string>
     <string name="domains_primary_address">Primary site address</string>
     <string name="domains_your_domains">Your site domains</string>
     <string name="domains_add_domain_button_title">Add a domain</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -538,7 +538,7 @@
     <string name="domains_claim_your_free_domain_link">Claim Domain</string>
     <string name="domains_purchase_redirect_notice">The domain purchased will redirect users to your primary address.</string>
     <string name="domains_search_for_domain_button_title">Search for a domain</string>
-    <string name="domains_learn_more">about domains and how to take domain-related actions.</string>
+    <string name="domains_learn_more">&lt;a href=\'\'&gt;&lt;u&gt;Learn more&lt;/u&gt;&lt;/a&gt; about domains and how to take domain-related actions.</string>
     <string name="domains_primary_address">Primary site address</string>
     <string name="domains_your_domains">Your site domains</string>
     <string name="domains_add_domain_button_title">Add a domain</string>


### PR DESCRIPTION
Fixes #8274, a subtask of #8238.

**To test:**
1. Go to Preferences -> Domains
2. Tap on the `Learn more` link under the CTA
3. Verify a browser is opened with this URL: `https://wordpress.com/go/tutorials/what-is-a-domain-name/`