### PR TITLE
Fix/crash on profiler industries step

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
@@ -52,12 +52,12 @@ class StoreProfilerIndustriesViewModel @Inject constructor(
         resourceProvider.getString(R.string.store_creation_store_profiler_industries_title)
 
     override fun onContinueClicked() {
-        val selectedOptionKey = profilerOptions.value.firstOrNull { it.isSelected }?.key
-        val selectedIndustry = industries.firstOrNull { selectedOptionKey == it.key }
+        val selectedOption = profilerOptions.value.firstOrNull { it.isSelected }
+        val selectedIndustry = industries.firstOrNull { selectedOption?.key == it.key }
         newStore.update(
             profilerData = (newStore.data.profilerData ?: ProfilerData())
                 .copy(
-                    industryLabel = selectedIndustry?.label,
+                    industryLabel = selectedOption?.name,
                     industryKey = selectedIndustry?.key,
                     industryGroupKey = selectedIndustry?.tracks
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
@@ -52,14 +52,14 @@ class StoreProfilerIndustriesViewModel @Inject constructor(
         resourceProvider.getString(R.string.store_creation_store_profiler_industries_title)
 
     override fun onContinueClicked() {
-        val selectedOptionName = profilerOptions.value.firstOrNull { it.isSelected }?.name
-        val selectedIndustry = industries.first { selectedOptionName == it.label }
+        val selectedOptionKey = profilerOptions.value.firstOrNull { it.isSelected }?.key
+        val selectedIndustry = industries.firstOrNull { selectedOptionKey == it.key }
         newStore.update(
             profilerData = (newStore.data.profilerData ?: ProfilerData())
                 .copy(
-                    industryLabel = selectedIndustry.label,
-                    industryKey = selectedIndustry.key,
-                    industryGroupKey = selectedIndustry.tracks
+                    industryLabel = selectedIndustry?.label,
+                    industryKey = selectedIndustry?.key,
+                    industryGroupKey = selectedIndustry?.tracks
                 )
         )
         triggerEvent(NavigateToNextStep)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #8276
Sentry Issue: [WOOCOMMERCE-ANDROID-5VA](https://sentry.io/organizations/a8c/issues/3905445632/?referrer=github_integration)

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Fixes a crash in store profiler industry step. 

When selecting an industry from store profiler step and clicking continue button if the device is set to a different language from English the app will crash. 

### Testing instructions
- Trigger store creation flow 
- Pick a language different from English for the device
- Navigate to store profiler 
- Select an industry
- Click continue
- Verify the selected industry is displayed in the Store Summary screen in the correct language


https://user-images.githubusercontent.com/2663464/215837056-cf9dc8c2-1c13-4370-9d56-4ecd88706469.mp4


I think this fix should be a hotfix in `v12.0` as this will crash for all users triggering store creation flow, selecting an industry and clicking continue, if their device is set to a language different from English. So far, the number of users impacted is low (only 16) due to the low adoption of `v12.0`, but is increasing fast. I'm basing the PR in `release/12.1` branch. But I presume if we want to release this as a hotfix I had to do something else. Wdyt about how critical this is @pmusolino ?

**UPDATE**: We decided to apply this as a hotfix and thus it will be merged to `release/12.0.1`. Discussion: p1675240923074989-slack-C6H8C3G23

cc: @ParaskP7