### PR TITLE
TPP: handle specific tap on mobile errors from the stripe SDK

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentErrorMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentErrorMapper.kt
@@ -15,6 +15,13 @@ class CardReaderPaymentErrorMapper @Inject constructor() {
             CardPaymentStatus.CardPaymentStatusErrorType.CardReadTimeOut,
             CardPaymentStatus.CardPaymentStatusErrorType.Generic -> PaymentFlowError.Generic
             CardPaymentStatus.CardPaymentStatusErrorType.Server -> PaymentFlowError.Server
+            CardPaymentStatus.CardPaymentStatusErrorType.Canceled -> PaymentFlowError.Canceled
+            CardPaymentStatus.CardPaymentStatusErrorType.BuiltInReader.NfcDisabled ->
+                PaymentFlowError.BuiltInReader.NfcDisabled
+            CardPaymentStatus.CardPaymentStatusErrorType.BuiltInReader.DeviceIsNotSupported ->
+                PaymentFlowError.BuiltInReader.DeviceIsNotSupported
+            CardPaymentStatus.CardPaymentStatusErrorType.BuiltInReader.InvalidAppSetup ->
+                PaymentFlowError.BuiltInReader.InvalidAppSetup
             else -> PaymentFlowError.Generic
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
@@ -285,11 +285,11 @@ sealed class PaymentFlowError(@StringRes val message: Int) {
 
     sealed class BuiltInReader(message: Int) : PaymentFlowError(message) {
         object NfcDisabled : BuiltInReader(R.string.card_reader_payment_failed_nfc_disabled)
-        object DeviceIsNotSupported : BuiltInReader(R.string.card_reader_payment_failed_device_is_not_supported),
-            NonRetryableError
+        object DeviceIsNotSupported :
+            BuiltInReader(R.string.card_reader_payment_failed_device_is_not_supported), NonRetryableError
 
-        object InvalidAppSetup : BuiltInReader(R.string.card_reader_payment_failed_app_setup_is_invalid),
-            NonRetryableError
+        object InvalidAppSetup :
+            BuiltInReader(R.string.card_reader_payment_failed_app_setup_is_invalid), NonRetryableError
     }
 
     interface NonRetryableError

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
@@ -253,6 +253,7 @@ sealed class PaymentFlowError(@StringRes val message: Int) {
     object NoNetwork : PaymentFlowError(R.string.card_reader_payment_failed_no_network_state)
     object Server : PaymentFlowError(R.string.card_reader_payment_failed_server_error_state)
     object Generic : PaymentFlowError(R.string.card_reader_payment_failed_unexpected_error_state)
+    object Canceled : PaymentFlowError(R.string.card_reader_payment_failed_canceled)
     object AmountTooSmall : Declined(R.string.card_reader_payment_failed_amount_too_small), NonRetryableError
 
     object Unknown : Declined(R.string.card_reader_payment_failed_unknown)
@@ -280,6 +281,15 @@ sealed class PaymentFlowError(@StringRes val message: Int) {
         object TooManyPinTries : Declined(R.string.card_reader_payment_failed_too_many_pin_tries)
         object TestCard : Declined(R.string.card_reader_payment_failed_test_card)
         object TestModeLiveCard : Declined(R.string.card_reader_payment_failed_test_mode_live_card)
+    }
+
+    sealed class BuiltInReader(message: Int) : PaymentFlowError(message) {
+        object NfcDisabled : BuiltInReader(R.string.card_reader_payment_failed_nfc_disabled)
+        object DeviceIsNotSupported : BuiltInReader(R.string.card_reader_payment_failed_device_is_not_supported),
+            NonRetryableError
+
+        object InvalidAppSetup : BuiltInReader(R.string.card_reader_payment_failed_app_setup_is_invalid),
+            NonRetryableError
     }
 
     interface NonRetryableError

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1193,6 +1193,12 @@
     <string name="card_reader_payment_failed_test_card">System test cards are not permitted for payment</string>
     <string name="card_reader_payment_failed_test_mode_live_card">A live card was used on a site in test mode</string>
     <string name="card_reader_payment_failed_unknown">Payment was declined for an unknown reason</string>
+    <string name="card_reader_payment_failed_canceled">Transaction was canceled</string>
+
+    <string name="card_reader_payment_failed_nfc_disabled">The app could not enable the card reader, because the NFC chip is disabled</string>
+    <string name="card_reader_payment_failed_device_is_not_supported">Your device is not supported. Please contact support for more details</string>
+    <string name="card_reader_payment_failed_app_setup_is_invalid">Something went wrong with the app setup. Please contact support for more details</string>
+
 
     <string name="card_reader_payment_retry_card_prompt">Retry with the same card</string>
     <string name="card_reader_payment_remove_card_prompt">Remove the card</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentErrorMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentErrorMapperTest.kt
@@ -289,4 +289,60 @@ class CardReaderPaymentErrorMapperTest {
         assertThat((result as PaymentFlowError.Unknown).message)
             .isEqualTo(R.string.card_reader_payment_failed_unknown)
     }
+
+    @Test
+    fun `given Canceled error, when map to ui error, then Canceled error returned`() {
+        // GIVEN
+        val error = CardPaymentStatusErrorType.Canceled
+
+        // WHEN
+        val result = mapper.mapPaymentErrorToUiError(error)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentFlowError.Canceled)
+        assertThat((result as PaymentFlowError.Canceled).message)
+            .isEqualTo(R.string.card_reader_payment_failed_canceled)
+    }
+
+    @Test
+    fun `given NfcDisabled error, when map to ui error, then NfcDisable error returned`() {
+        // GIVEN
+        val error = CardPaymentStatusErrorType.BuiltInReader.NfcDisabled
+
+        // WHEN
+        val result = mapper.mapPaymentErrorToUiError(error)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentFlowError.BuiltInReader.NfcDisabled)
+        assertThat((result as PaymentFlowError.BuiltInReader.NfcDisabled).message)
+            .isEqualTo(R.string.card_reader_payment_failed_nfc_disabled)
+    }
+
+    @Test
+    fun `given DeviceIsNotSupported error, when map to ui error, then DeviceIsNotSupported error returned`() {
+        // GIVEN
+        val error = CardPaymentStatusErrorType.BuiltInReader.DeviceIsNotSupported
+
+        // WHEN
+        val result = mapper.mapPaymentErrorToUiError(error)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentFlowError.BuiltInReader.DeviceIsNotSupported)
+        assertThat((result as PaymentFlowError.BuiltInReader.DeviceIsNotSupported).message)
+            .isEqualTo(R.string.card_reader_payment_failed_device_is_not_supported)
+    }
+
+    @Test
+    fun `given InvalidAppSetup error, when map to ui error, then InvalidAppSetup error returned`() {
+        // GIVEN
+        val error = CardPaymentStatusErrorType.BuiltInReader.InvalidAppSetup
+
+        // WHEN
+        val result = mapper.mapPaymentErrorToUiError(error)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentFlowError.BuiltInReader.InvalidAppSetup)
+        assertThat((result as PaymentFlowError.BuiltInReader.InvalidAppSetup).message)
+            .isEqualTo(R.string.card_reader_payment_failed_app_setup_is_invalid)
+    }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapper.kt
@@ -7,9 +7,26 @@ import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.NetworkError
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.ServerError
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.BuiltInReader.DeviceIsNotSupported
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.BuiltInReader.InvalidAppSetup
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.BuiltInReader.NfcDisabled
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.Canceled
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.CardReadTimeOut
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError
-import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.*
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.CardNotSupported
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.CurrencyNotSupported
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.DuplicateTransaction
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.ExpiredCard
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.Fraud
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.IncorrectPostalCode
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.InsufficientFunds
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.InvalidAccount
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.InvalidAmount
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.PinRequired
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.Temporary
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.TestCard
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.TestModeLiveCard
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.TooManyPinTries
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.Generic
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.NoNetwork
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentFailed
@@ -27,6 +44,12 @@ internal class PaymentErrorMapper {
             TerminalErrorCode.CARD_READ_TIMED_OUT -> CardReadTimeOut
             TerminalErrorCode.DECLINED_BY_STRIPE_API -> mapDeclinedByStripeApiError(exception)
             TerminalErrorCode.REQUEST_TIMED_OUT -> NoNetwork
+            TerminalErrorCode.LOCAL_MOBILE_NFC_DISABLED -> NfcDisabled
+            TerminalErrorCode.LOCAL_MOBILE_UNSUPPORTED_DEVICE,
+            TerminalErrorCode.LOCAL_MOBILE_DEVICE_TAMPERED,
+            TerminalErrorCode.LOCAL_MOBILE_UNSUPPORTED_ANDROID_VERSION -> DeviceIsNotSupported
+            TerminalErrorCode.LOCAL_MOBILE_LIBRARY_NOT_INCLUDED -> InvalidAppSetup
+            TerminalErrorCode.CANCELED -> Canceled
             else -> Generic
         }
         return PaymentFailed(type, paymentData, exception.errorMessage)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/CardPaymentStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/CardPaymentStatus.kt
@@ -20,6 +20,7 @@ sealed class CardPaymentStatus {
         object NoNetwork : CardPaymentStatusErrorType()
         object Server : CardPaymentStatusErrorType()
         object Generic : CardPaymentStatusErrorType()
+        object Canceled : CardPaymentStatusErrorType()
 
         sealed class DeclinedByBackendError : CardPaymentStatusErrorType() {
             /**
@@ -127,6 +128,12 @@ sealed class CardPaymentStatus {
                  */
                 object TestModeLiveCard : CardDeclined()
             }
+        }
+
+        sealed class BuiltInReader : CardPaymentStatusErrorType() {
+            object NfcDisabled : BuiltInReader()
+            object DeviceIsNotSupported : BuiltInReader()
+            object InvalidAppSetup: BuiltInReader()
         }
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/CardPaymentStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/CardPaymentStatus.kt
@@ -133,7 +133,7 @@ sealed class CardPaymentStatus {
         sealed class BuiltInReader : CardPaymentStatusErrorType() {
             object NfcDisabled : BuiltInReader()
             object DeviceIsNotSupported : BuiltInReader()
-            object InvalidAppSetup: BuiltInReader()
+            object InvalidAppSetup : BuiltInReader()
         }
     }
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapperTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapperTest.kt
@@ -6,6 +6,8 @@ import com.stripe.stripeterminal.external.models.TerminalException.TerminalError
 import com.stripe.stripeterminal.external.models.TerminalException.TerminalErrorCode.DECLINED_BY_READER
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.BuiltInReader
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.Canceled
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.CardReadTimeOut
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.DeclinedByBackendError
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.Generic
@@ -534,6 +536,60 @@ class PaymentErrorMapperTest : CardReaderBaseUnitTest() {
         val result = mapper.mapTerminalError(mock(), terminalException)
 
         assertThat(result.type).isEqualTo(DeclinedByBackendError.Unknown)
+    }
+
+    @Test
+    fun `given local_mobile_nfc_disabled, when terminal exception thrown, then nfc disabled type returned`() {
+        whenever(terminalException.errorCode).thenReturn(TerminalErrorCode.LOCAL_MOBILE_NFC_DISABLED)
+
+        val result = mapper.mapTerminalError(mock(), terminalException)
+
+        assertThat(result.type).isEqualTo(BuiltInReader.NfcDisabled)
+    }
+
+    @Test
+    fun `given local_mobile_library_not_included, when terminal exception thrown, then invalid app setup returned`() {
+        whenever(terminalException.errorCode).thenReturn(TerminalErrorCode.LOCAL_MOBILE_LIBRARY_NOT_INCLUDED)
+
+        val result = mapper.mapTerminalError(mock(), terminalException)
+
+        assertThat(result.type).isEqualTo(BuiltInReader.InvalidAppSetup)
+    }
+
+    @Test
+    fun `given local_mobile_unsupported_device, when terminal exception thrown, then device unsupported returned`() {
+        whenever(terminalException.errorCode).thenReturn(TerminalErrorCode.LOCAL_MOBILE_UNSUPPORTED_DEVICE)
+
+        val result = mapper.mapTerminalError(mock(), terminalException)
+
+        assertThat(result.type).isEqualTo(BuiltInReader.DeviceIsNotSupported)
+    }
+
+    @Test
+    fun `given local_mobile_unsupported_android_version, when terminal exception thrown, then device unsupported`() {
+        whenever(terminalException.errorCode).thenReturn(TerminalErrorCode.LOCAL_MOBILE_UNSUPPORTED_ANDROID_VERSION)
+
+        val result = mapper.mapTerminalError(mock(), terminalException)
+
+        assertThat(result.type).isEqualTo(BuiltInReader.DeviceIsNotSupported)
+    }
+
+    @Test
+    fun `given local_mobile_device_tampered, when terminal exception thrown, then device unsupported returned`() {
+        whenever(terminalException.errorCode).thenReturn(TerminalErrorCode.LOCAL_MOBILE_DEVICE_TAMPERED)
+
+        val result = mapper.mapTerminalError(mock(), terminalException)
+
+        assertThat(result.type).isEqualTo(BuiltInReader.DeviceIsNotSupported)
+    }
+
+    @Test
+    fun `given canceled, when terminal exception thrown, then canceled returned`() {
+        whenever(terminalException.errorCode).thenReturn(TerminalErrorCode.CANCELED)
+
+        val result = mapper.mapTerminalError(mock(), terminalException)
+
+        assertThat(result.type).isEqualTo(Canceled)
     }
 
     private fun setupStripeApiCardDeclined(declineCode: String?) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8136
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds handling of the following errors from the SDK:
```
            TerminalErrorCode.LOCAL_MOBILE_NFC_DISABLED
            TerminalErrorCode.LOCAL_MOBILE_UNSUPPORTED_DEVICE
            TerminalErrorCode.LOCAL_MOBILE_DEVICE_TAMPERED
            TerminalErrorCode.LOCAL_MOBILE_UNSUPPORTED_ANDROID_VERSION
            TerminalErrorCode.LOCAL_MOBILE_LIBRARY_NOT_INCLUDED
            TerminalErrorCode.CANCELED 
```

The list of the error they provide is pretty basic compared to iOS. This might be due to the beta status though

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Enable beta sdk on your build
* Go to the payments and select TPP
* `Canceled` can be tested by canceling transaction on the Stripe screen
* `NFC_DISABLED` can be tested by disabling NFC on your device
* The rest can be tested with code altering. For instance, disable NFC and change the returned error type in the `PaymentErrorMapper::47`  on the error type you want to test

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


<img src="https://user-images.githubusercontent.com/4923871/216025248-baa0025e-1ca3-4ce3-84fd-1a757bda8e68.png" width="300">

<img src="https://user-images.githubusercontent.com/4923871/216025262-e91efa88-0f22-4fa0-a57b-6f2ee5384138.png" width="300">

<img src="https://user-images.githubusercontent.com/4923871/216025266-70b794cd-62b6-4f77-b8fa-cf7e7bf0c979.png" width="300">

<img src="https://user-images.githubusercontent.com/4923871/216025274-79f8886b-a75c-40d5-a987-30df9a98088c.png" width="300">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
