### PR TITLE
Issue/8282 remove xmlrpc checks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 12.4
 -----
-
+- [***] [Internal] Remove XMRPC discovery steps from the REST API login [https://github.com/woocommerce/woocommerce-android/pull/8289]
 
 12.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityFetcher.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.WooException
 import com.woocommerce.android.model.User
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCUserStore
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,8 +16,10 @@ class UserEligibilityFetcher @Inject constructor(
     private val userStore: WCUserStore,
     private val selectedSite: SelectedSite
 ) {
-    suspend fun fetchUserInfo(): Result<User> {
-        return userStore.fetchUserRole(selectedSite.get()).let {
+    suspend fun fetchUserInfo(): Result<User> = fetchUserInfo(selectedSite.get())
+
+    suspend fun fetchUserInfo(site: SiteModel): Result<User> {
+        return userStore.fetchUserRole(site).let {
             when {
                 it.isError -> Result.failure(WooException(it.error))
                 it.model != null -> Result.success(it.model!!.toAppModel())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -56,14 +56,14 @@ class WPApiSiteRepository @Inject constructor(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    suspend fun checkIfUserIsEligible(): Result<Boolean> = coroutineScope {
+    suspend fun checkIfUserIsEligible(site: SiteModel): Result<Boolean> = coroutineScope {
         WooLog.d(WooLog.T.LOGIN, "Fetch user info to check if user is eligible for using the API")
 
         val applicationPasswordErrorTask = async {
             applicationPasswordsNotifier.passwordGenerationFailures.first()
         }
 
-        return@coroutineScope userEligibilityFetcher.fetchUserInfo()
+        return@coroutineScope userEligibilityFetcher.fetchUserInfo(site)
             .recoverCatching { exception ->
                 @Suppress("MagicNumber")
                 withTimeoutOrNull(100L) { applicationPasswordErrorTask.join() }
@@ -81,5 +81,9 @@ class WPApiSiteRepository @Inject constructor(
 
     suspend fun getSiteByUrl(siteUrl: String): SiteModel? = withContext(Dispatchers.IO) {
         SiteUtils.getSiteByMatchingUrl(siteStore, siteUrl)
+    }
+
+    suspend fun getSiteByLocalId(id: Int): SiteModel? = withContext(Dispatchers.IO) {
+        siteStore.getSiteByLocalId(id)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -4,8 +4,6 @@ import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.WooException
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
 import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.awaitEvent
-import com.woocommerce.android.util.dispatchAndAwait
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -14,12 +12,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
-import org.wordpress.android.fluxc.store.AccountStore.OnDiscoveryResponse
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload
+import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.login.util.SiteUtils
 import javax.inject.Inject
@@ -34,16 +29,33 @@ class WPApiSiteRepository @Inject constructor(
      * Handles authentication to the given [url] using wp-admin credentials.
      * After calling this, and if the authentication is successful, a [SiteModel] matching this site will be persisted
      * in the DB.
-     *
-     * Note: this function uses XMLRPC behind the scenes
      */
     suspend fun login(url: String, username: String, password: String): Result<SiteModel> {
         WooLog.d(WooLog.T.LOGIN, "Authenticating in to site $url using site credentials")
 
-        return discoverXMLRPCAddress(url)
-            .mapCatching { xmlrpcEndpoint ->
-                fetchXMLRPCSite(url, xmlrpcEndpoint, username, password).getOrThrow()
+        return siteStore.fetchWPAPISite(
+            FetchWPAPISitePayload(
+                url = url,
+                username = username,
+                password = password
+            )
+        ).let { result ->
+            when {
+                result.isError -> {
+                    WooLog.w(
+                        tag = WooLog.T.LOGIN,
+                        message = "Fetching site $url failed, error: ${result.error.type}, ${result.error.message}"
+                    )
+
+                    Result.failure(OnChangedException(result.error))
+                }
+                else -> {
+                    WooLog.d(WooLog.T.LOGIN, "Site $url fetch succeeded")
+                    val site = getSiteByUrl(url)!!
+                    Result.success(site)
+                }
             }
+        }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -79,92 +91,6 @@ class WPApiSiteRepository @Inject constructor(
     }
 
     suspend fun getSiteByUrl(siteUrl: String): SiteModel? = withContext(Dispatchers.IO) {
-        SiteUtils.getXMLRPCSiteByUrl(siteStore, siteUrl)
-    }
-
-    private suspend fun discoverXMLRPCAddress(siteUrl: String): Result<String> {
-        WooLog.d(WooLog.T.LOGIN, "Running discovery to fetch XMLRPC endpoint for site $siteUrl")
-
-        val action = AuthenticationActionBuilder.newDiscoverEndpointAction(siteUrl)
-        val event: OnDiscoveryResponse = dispatcher.dispatchAndAwait(action)
-
-        return if (event.isError) {
-            WooLog.w(WooLog.T.LOGIN, "XMLRPC Discovery failed, error: ${event.error}")
-            Result.failure(OnChangedException(event.error, event.error.name))
-        } else {
-            WooLog.d(
-                tag = WooLog.T.LOGIN,
-                message = "XMLRPC Discovery succeeded, xmrlpc endpoint: ${event.xmlRpcEndpoint}"
-            )
-            Result.success(event.xmlRpcEndpoint)
-        }
-    }
-
-    @Suppress("ReturnCount")
-    private suspend fun fetchXMLRPCSite(
-        siteUrl: String,
-        xmlrpcEndpoint: String,
-        username: String,
-        password: String
-    ): Result<SiteModel> = coroutineScope {
-        val authenticationTask = async {
-            dispatcher.awaitEvent<OnAuthenticationChanged>().also { event ->
-                if (event.isError) {
-                    WooLog.w(
-                        tag = WooLog.T.LOGIN,
-                        message = "Authenticating to XMLRPC site $xmlrpcEndpoint failed, " +
-                            "error: ${event.error.message}"
-                    )
-                }
-            }
-        }
-        val siteTask = async(Dispatchers.IO) {
-            siteStore.fetchSitesXmlRpc(
-                RefreshSitesXMLRPCPayload(
-                    username = username,
-                    password = password,
-                    url = xmlrpcEndpoint
-                )
-            ).also { event ->
-                if (event.isError) {
-                    WooLog.w(
-                        tag = WooLog.T.LOGIN,
-                        message = "XMLRPC site $xmlrpcEndpoint fetch failed, error: ${event.error.message}"
-                    )
-                } else {
-                    WooLog.d(WooLog.T.LOGIN, "XMLRPC site $xmlrpcEndpoint fetch succeeded")
-                }
-            }
-        }
-
-        val fetchEvent = siteTask.await()
-
-        val event = if (!fetchEvent.isError) {
-            // In case of success, continue directly
-            fetchEvent
-        } else {
-            // If there is an error, prefer passing the authentication error instead of the fetch error
-            // This allows having a better error message in the UI
-            val authenticationError = if (fetchEvent.isError) {
-                @Suppress("MagicNumber")
-                withTimeoutOrNull(100) {
-                    authenticationTask.await()
-                }
-            } else null
-
-            authenticationError ?: fetchEvent
-        }
-
-        // Make sure to cancel the task if no event was sent
-        if (authenticationTask.isActive) authenticationTask.cancel()
-
-        return@coroutineScope when {
-            event.isError -> Result.failure(OnChangedException(event.error))
-            else -> {
-                WooLog.d(WooLog.T.LOGIN, "XMLRPC site $siteUrl fetch succeeded")
-                val site = getSiteByUrl(siteUrl)!!
-                return@coroutineScope Result.success(site)
-            }
-        }
+        SiteUtils.getSiteByMatchingUrl(siteStore, siteUrl)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -15,12 +15,14 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
 import org.wordpress.android.login.util.SiteUtils
+import java.net.CookieManager
 import javax.inject.Inject
 
 class WPApiSiteRepository @Inject constructor(
     private val siteStore: SiteStore,
     private val userEligibilityFetcher: UserEligibilityFetcher,
-    private val applicationPasswordsNotifier: ApplicationPasswordsNotifier
+    private val applicationPasswordsNotifier: ApplicationPasswordsNotifier,
+    private val cookieManager: CookieManager
 ) {
     /**
      * Handles authentication to the given [url] using wp-admin credentials.
@@ -29,6 +31,9 @@ class WPApiSiteRepository @Inject constructor(
      */
     suspend fun login(url: String, username: String, password: String): Result<SiteModel> {
         WooLog.d(WooLog.T.LOGIN, "Authenticating in to site $url using site credentials")
+
+        // Clear cookies to make sure the new credentials are correctly checked
+        cookieManager.cookieStore.removeAll()
 
         return siteStore.fetchWPAPISite(
             FetchWPAPISitePayload(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -70,6 +70,8 @@ class WPApiSiteRepository @Inject constructor(
 
         return@coroutineScope userEligibilityFetcher.fetchUserInfo(site)
             .recoverCatching { exception ->
+                // Wait for any potential application password generation error and report it as the cause of failure
+                // We use the 100L waiting time just to make sure it's correctly reported before the network failure
                 @Suppress("MagicNumber")
                 withTimeoutOrNull(100L) { applicationPasswordErrorTask.join() }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -98,11 +98,13 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     fun onUsernameChanged(username: String) {
         savedState[USERNAME_KEY] = username
         errorMessage.value = 0
+        fetchedSiteId.value = -1
     }
 
     fun onPasswordChanged(password: String) {
         savedState[PASSWORD_KEY] = password
         errorMessage.value = 0
+        fetchedSiteId.value = -1
     }
 
     fun onContinueClick() = launch {

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
     mediapickerVersion = '0.1.1'
-    wordPressLoginVersion = '0.21.0'
+    wordPressLoginVersion = '109-ef17de3b9151074ac5da9ffb1da9f3d6b6636163'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
     mediapickerVersion = '0.1.1'
-    wordPressLoginVersion = '109-ef17de3b9151074ac5da9ffb1da9f3d6b6636163'
+    wordPressLoginVersion = 'trunk-8a6e41fa5db0e82a1d6d8da54cdb1fdb5d21bca2'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8282 

### Description
This PR updates the REST API login to use Cookie Nonce authentication instead of doing the XMLRPC discovery and authentication first.
It builds on top of the following PRs:
1. https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2643
2. https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2649
3. https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/109

The FluxC changes were already merged and are part of the app's current version.

### Testing instructions
All of the tests below require the `treatment` variant of the REST API experiment, so please make sure you change the returned variant [here](https://github.com/woocommerce/woocommerce-android/blob/c3bd5d6cb2ccc54f51201745ca28932cdfa4e016/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt#L47) accordingly.
##### Happy path
1. Open the app and click on "Enter site address".
2. Enter the site address.
3. Enter the site credentials.
5. Confirm the login succeeds.

##### Wrong credentials
1. Open the app and click on "Enter site address".
2. Enter the site address.
3. Enter some wrong site credentials.
4. Confirm the correct error message is shown.

##### WooCommerce not installed
1. Disable or uninstall WooCommerce from your site.
2. Open the app and click on "Enter site address".
3. Enter the site address.
4. Enter the site credentials.
6. Confirm the WooCommerce Not Installed error screen is shown.

##### Application Passwords disabled
1. Install this [plugin ](https://wordpress.org/plugins/disable-application-passwords/) to disable Application Passwords.
2. Open the app and click on "Enter site address".
3. Enter the site address.
4. Enter the site credentials.
5. Confirm the Application Passwords error screen is shown.

##### User role not eligible
1. Update or create a new user with a role other than `admin` and `show-manager`.
2. Open the app and click on "Enter site address".
3. Enter the site address.
4. Enter the site credentials.
5. Confirm the user role error is shown.

##### XMLRPC disabled
1. Install this [plugin](https://wordpress.org/plugins/manage-xml-rpc/), then check "Disable XML-RPC" in XML-RPC settings page.
2. Open the app and click on "Enter site address".
3. Enter the site address.
4. Enter the site credentials.
5. Confirm the login succeeds.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
