### PR TITLE
TPP: Set platform = android key-value on the payment intent metadata

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
@@ -49,7 +49,12 @@ internal enum class MetaDataKeys(val key: String) {
     /**
      * Model name of a reader which is used to collect the payment
      */
-    READER_MODEL("reader_model");
+    READER_MODEL("reader_model"),
+
+    /**
+     * The platform used to collect the payment, `android` in our case
+     */
+    PLATFORM("platform");
 
     enum class PaymentTypes(val key: String) {
         /**

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -106,9 +106,14 @@ internal class CreatePaymentAction(
         }
 
         map[MetaDataKeys.ORDER_ID.key] = paymentInfo.orderId.toString()
+        map[MetaDataKeys.PLATFORM.key] = PLATFORM
 
         // TODO cardreader Needs to be fixed when we add support for recurring payments
         map[MetaDataKeys.PAYMENT_TYPE.key] = MetaDataKeys.PaymentTypes.SINGLE.key
         return map
+    }
+
+    companion object {
+        private const val PLATFORM = "android"
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -415,7 +415,7 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
         action.createPaymentIntent(createPaymentInfo()).toList()
         verify(intentParametersBuilder).setMetadata(captor.capture())
 
-        assertThat(captor.firstValue[MetaDataKeys.PLATFORM.key]).isEqualTo("android")
+        assertThat(captor.firstValue["platform"]).isEqualTo("android")
     }
 
     private fun createPaymentInfo(

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -408,6 +408,16 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
         verify(paymentIntentParametersFactory).createBuilder(expectedPaymentMethod)
     }
 
+    @Test
+    fun `when creating payment intent, then platform set to android`() = testBlocking {
+        val captor = argumentCaptor<Map<String, String>>()
+
+        action.createPaymentIntent(createPaymentInfo()).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.PLATFORM.key]).isEqualTo("android")
+    }
+
     private fun createPaymentInfo(
         paymentDescription: String = "",
         orderId: Long = 1L,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8155
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds another key to the metadata of the payment intents. It's needed so the backend can figure out fees

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Perform TPP or IPP transaction
* Open stripe dashboard and find this transaction
* Notice new key and it's value `platform=android`

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="689" alt="image" src="https://user-images.githubusercontent.com/4923871/216259730-fab70ae2-a7ae-489a-9d37-a252984c5128.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
