### PR TITLE
Fix logout crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -45,7 +45,7 @@ class AccountRepository @Inject constructor(
 
     fun isUserLoggedIn(): Boolean {
         return accountStore.hasAccessToken() ||
-            (selectedSite.exists() && selectedSite.get().origin != SiteModel.ORIGIN_WPCOM_REST)
+            (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords)
     }
 
     suspend fun logout(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -49,6 +49,7 @@ class AccountRepository @Inject constructor(
     }
 
     suspend fun logout(): Boolean {
+        if (!isUserLoggedIn()) return true
         return if (accountStore.hasAccessToken()) {
             // WordPress.com account logout
             val event: OnAccountChanged = dispatcher.dispatchAndAwait(AccountActionBuilder.newSignOutAction())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.LOGIN
 import com.woocommerce.android.util.dispatchAndAwait
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
@@ -67,8 +66,9 @@ class AccountRepository @Inject constructor(
             }
         } else {
             // Application passwords logout
-            appCoroutineScope.launch(Dispatchers.Main.immediate) {
-                val result = siteStore.deleteApplicationPassword(selectedSite.get())
+            val site = selectedSite.get()
+            appCoroutineScope.launch {
+                val result = siteStore.deleteApplicationPassword(site)
                 if (result.isError) {
                     WooLog.e(
                         LOGIN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -7,16 +7,17 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.LOGIN
 import com.woocommerce.android.util.dispatchAndAwait
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.AccountModel
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
@@ -66,7 +67,7 @@ class AccountRepository @Inject constructor(
             }
         } else {
             // Application passwords logout
-            appCoroutineScope.launch {
+            appCoroutineScope.launch(Dispatchers.Main.immediate) {
                 val result = siteStore.deleteApplicationPassword(selectedSite.get())
                 if (result.isError) {
                     WooLog.e(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8295 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR is an attempt to fix the linked issue.
While I couldn't reproduce it, I see from some of the logs that the cause is a double click on the "Try another account" button:
```
[Feb-02 04:16 UTILS i] 🔵 Tracked: unified_login_interaction, Properties: {"source":"default","flow":"epilogue","step":"start","click":"try_another_account","is_debug":false}
[Feb-02 04:16 WP d] API Dispatching action: AccountAction-SIGN_OUT
[Feb-02 04:16 UTILS i] 🔵 Tracked: unified_login_interaction, Properties: {"source":"default","flow":"epilogue","step":"start","click":"try_another_account","is_debug":false}
``` 
This triggers two calls to the `logout` function, and in the second call, we will fall in the `else` branch since we don't have an access token, which causes the crash:
https://github.com/woocommerce/woocommerce-android/blob/e406b00c201939137beba14ea9949872cbeaf320/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt#L60-L71

### Testing instructions
I couldn't reproduce the crash no matter how fast I tried to double click the button, if you are able to reproduce it, then please confirm the fix fixes it.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
