### PR TITLE
[REST API] Validate credentials' username before using

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.13'
+    fluxCVersion = '2.14.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #8298 

⚠️ Please don't merge until the FluxC [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2650) is merged, and a new FluxC version is published.

### Description
Check the linked issue for a description about the bug, this PR updates FluxC to bring the changes that implement the fix.

### Testing instructions
1. Prepare two accounts on your site: one eligible and the other not eligible.
2. Make sure you are using the treatment variant of the REST API experiment (you can do so by hardcoding the value [here](https://github.com/woocommerce/woocommerce-android/blob/c3bd5d6cb2ccc54f51201745ca28932cdfa4e016/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt#L47))
3. Open the app, then sign in using the ineligible account.
4. Notice the error screen.
5. Click on "Log in with another account"
6. Complete the sign in using the eligible account.
7. Confirm the app works correctly now.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
