### PR TITLE
[REST API] Update wording of the logout dialog when using site credentials

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivityAppSettingsBinding
 import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.appwidgets.WidgetUpdater
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -28,7 +29,6 @@ import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
 import dagger.android.DispatchingAndroidInjector
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.Locale
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -153,11 +153,11 @@ class AppSettingsActivity :
     }
 
     override fun confirmLogout() {
-        val message = String.format(
-            Locale.getDefault(),
-            getString(R.string.settings_confirm_logout),
-            presenter.getAccountDisplayName()
-        )
+        val message = when (selectedSite.connectionType) {
+            SiteConnectionType.ApplicationPasswords -> getString(R.string.settings_confirm_logout_site_credentials)
+            else -> getString(R.string.settings_confirm_logout, presenter.getAccountDisplayName())
+        }
+
         MaterialAlertDialogBuilder(this)
             .setMessage(message)
             .setPositiveButton(R.string.signout) { _, _ ->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1820,6 +1820,7 @@
     <string name="settings_signout">Log out</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
+    <string name="settings_confirm_logout_site_credentials">Are you sure you want to log out of your account?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_beta_feature_failed_snackbar_text">Sorry, we couldn\'t change this feature setting right now</string>


### PR DESCRIPTION
Closes: #8283 

### Description
This PR simply updates the wording of the logout dialog when using site credentials.

### Testing instructions
1. Make sure you are using the treatment variant of the REST API experiment by changing the value [here](https://github.com/woocommerce/woocommerce-android/blob/c3bd5d6cb2ccc54f51201745ca28932cdfa4e016/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt#L47)
2. Open the app
3. Sign in using a self-hosted site.
4. Attempt logout.
5. Confirm the logout dialog has the text: "Are you sure you want to log out of your account?".
6. Sign in using a WPCom site.
7. Attempt logout.
8. Confirm the logout dialog has the text: "Are you sure you want to logout from the account {account}?"

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
