### PR TITLE
[REST API] Validate credentials username before attempting password delete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.14.0'
+    fluxCVersion = 'trunk-641682777fff4f491a4961fb3ceda064ab3dc352'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #8298 
⚠️ Depends on the WCAndroid [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2651)

### Description
This PR is a continuation of the previous PR #8302, it implements the same validation when getting the credentials UUID before the deletion.

### Testing instructions
The following test would fail in `trunk`, and should work correctly using this branch.

1. Make sure you are using the treatment variant of the REST API experiment by changing the value [here](https://github.com/woocommerce/woocommerce-android/blob/c3bd5d6cb2ccc54f51201745ca28932cdfa4e016/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt#L47)
2. Prepare two accounts in your site, let's call them: account 1 and account 2.
3. Open the app, the sign in using account 1.
4. After the sign in, disable network, then logout from the app.
5. Restore network, then sign in using account 2.
6. After the sign in, disable network, then logout from the app.
7. Attempt sign in using account 1.
8. Confirm the sign in works correctly.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
