### PR TITLE
[Bug] [IPP Feedback Survey] Error handling in `GetIPPFeedbackBannerData`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 12.3
 -----
-
+- [**] [Internal] Improved error handling in `GetIPPFeedbackBannerData` [https://github.com/woocommerce/woocommerce-android/pull/8312]
 
 12.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -183,8 +183,12 @@ class OrderListViewModel @Inject constructor(
                 FeatureFlag.IPP_FEEDBACK_BANNER.isEnabled() && shouldShowFeedbackBanner()
             if (shouldShowFeedbackBanner) {
                 val bannerData = getIPPFeedbackBannerData()
-                viewState = viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(bannerData))
-                trackIPPBannerEvent(AnalyticsEvent.IPP_FEEDBACK_BANNER_SHOWN)
+                if (bannerData != null) {
+                    viewState = viewState.copy(
+                        ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(bannerData)
+                    )
+                    trackIPPBannerEvent(AnalyticsEvent.IPP_FEEDBACK_BANNER_SHOWN)
+                }
             }
             refreshOrdersBannerVisibility()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerData.kt
@@ -28,7 +28,10 @@ class GetIPPFeedbackBannerData @Inject constructor(
 ) {
     @Suppress("ReturnCount", "MaxLineLength")
     suspend operator fun invoke(): IPPFeedbackBanner? {
-        if (!shouldShowFeedbackBanner()) return null
+        if (!shouldShowFeedbackBanner()) {
+            logger.e(AppLog.T.API, "GetIPPFeedbackBannerData should not be shown.")
+            return null
+        }
 
         val activePaymentsPlugin = getActivePaymentsPlugin()
 
@@ -50,7 +53,7 @@ class GetIPPFeedbackBannerData @Inject constructor(
 
         val numberOfTransactionsInLast30Days = response.result?.transactionsCount
         if (numberOfTransactionsInLast30Days == null || numberOfTransactionsInLast30Days < 0) {
-            logger.e(AppLog.T.API, "Transactions count data is not")
+            logger.e(AppLog.T.API, "Transactions count data is malformed.")
             return null
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -785,7 +785,7 @@ class OrderListViewModelTest : BaseUnitTest() {
         testBlocking {
             // given
             whenever(shouldShowFeedbackBanner()).thenReturn(false)
-            whenever(getIPPFeedbackBannerData()).thenReturn(null)
+            assertNull(getIPPFeedbackBannerData())
 
             // when
             viewModel = createViewModel()
@@ -805,7 +805,7 @@ class OrderListViewModelTest : BaseUnitTest() {
         testBlocking {
             // given
             whenever(shouldShowFeedbackBanner()).thenReturn(false)
-            whenever(getIPPFeedbackBannerData()).thenReturn(null)
+            assertNull(getIPPFeedbackBannerData())
 
             // when
             viewModel = createViewModel()
@@ -819,7 +819,7 @@ class OrderListViewModelTest : BaseUnitTest() {
         testBlocking {
             // given
             whenever(shouldShowFeedbackBanner()).thenReturn(false)
-            whenever(getIPPFeedbackBannerData()).thenReturn(null)
+            assertNull(getIPPFeedbackBannerData())
 
             // when
             viewModel = createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -780,6 +780,54 @@ class OrderListViewModelTest : BaseUnitTest() {
             )
         }
 
+    @Test
+    fun `given IPP banner should be shown, when banner data is null, then event is not tracked`() =
+        testBlocking {
+            // given
+            whenever(shouldShowFeedbackBanner()).thenReturn(false)
+            whenever(getIPPFeedbackBannerData()).thenReturn(null)
+
+            // when
+            viewModel = createViewModel()
+
+            // then
+            verify(analyticsTracker, never()).track(
+                AnalyticsEvent.IPP_FEEDBACK_BANNER_SHOWN,
+                mapOf(
+                    KEY_IPP_BANNER_SOURCE to VALUE_IPP_BANNER_SOURCE_ORDER_LIST,
+                    KEY_IPP_BANNER_CAMPAIGN_NAME to FAKE_IPP_FEEDBACK_BANNER_DATA.campaignName
+                )
+            )
+        }
+
+    @Test
+    fun `given IPP banner should be shown, when banner data is null, then Orders banner is shown`() =
+        testBlocking {
+            // given
+            whenever(shouldShowFeedbackBanner()).thenReturn(false)
+            whenever(getIPPFeedbackBannerData()).thenReturn(null)
+
+            // when
+            viewModel = createViewModel()
+
+            // then
+            assertTrue(viewModel.viewState.isSimplePaymentsWIPNoticeCardVisible)
+        }
+
+    @Test
+    fun `given IPP banner should be shown, when banner data is null, then IPP banner is hidden`() =
+        testBlocking {
+            // given
+            whenever(shouldShowFeedbackBanner()).thenReturn(false)
+            whenever(getIPPFeedbackBannerData()).thenReturn(null)
+
+            // when
+            viewModel = createViewModel()
+
+            // then
+            assertEquals(IPPSurveyFeedbackBannerState.Hidden, viewModel.viewState.ippFeedbackBannerState)
+        }
+
     private companion object {
         const val ANY_SEARCH_QUERY = "search query"
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
@@ -28,7 +27,6 @@ import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import java.util.Date
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -56,16 +54,15 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given banner should not be displayed, then should throw exception`() = testBlocking {
+    fun `given banner should not be displayed, then should return null`() = testBlocking {
         // given
         whenever(shouldShowFeedbackBanner()).thenReturn(false)
 
-        // then
-        assertFailsWith(IllegalStateException::class) {
-            testBlocking { sut() }
-        }
+        // when
+        val result = sut()
 
-        Unit
+        // then
+        assertNull(result)
     }
 
     @Test
@@ -79,10 +76,10 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
             val result = sut()
 
             // then
-            assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result.url)
-            assertEquals(R.string.feedback_banner_ipp_title_newbie, result.title)
-            assertEquals(R.string.feedback_banner_ipp_message_newbie, result.message)
-            assertEquals("ipp_not_user", result.campaignName)
+            assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result?.url)
+            assertEquals(R.string.feedback_banner_ipp_title_newbie, result?.title)
+            assertEquals(R.string.feedback_banner_ipp_message_newbie, result?.message)
+            assertEquals("ipp_not_user", result?.campaignName)
         }
 
     @Test
@@ -101,10 +98,10 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result.url)
-        assertEquals(R.string.feedback_banner_ipp_title_newbie, result.title)
-        assertEquals(R.string.feedback_banner_ipp_message_newbie, result.message)
-        assertEquals("ipp_not_user", result.campaignName)
+        assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result?.url)
+        assertEquals(R.string.feedback_banner_ipp_title_newbie, result?.title)
+        assertEquals(R.string.feedback_banner_ipp_message_newbie, result?.message)
+        assertEquals("ipp_not_user", result?.campaignName)
     }
 
     @Test
@@ -123,10 +120,10 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
             val result = sut()
 
             // then
-            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result.url)
-            assertEquals(R.string.feedback_banner_ipp_message_beginner, result.message)
-            assertEquals(R.string.feedback_banner_ipp_title_beginner, result.title)
-            assertEquals("ipp_new_user", result.campaignName)
+            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result?.url)
+            assertEquals(R.string.feedback_banner_ipp_message_beginner, result?.message)
+            assertEquals(R.string.feedback_banner_ipp_title_beginner, result?.title)
+            assertEquals("ipp_new_user", result?.campaignName)
         }
 
     @Test
@@ -150,11 +147,11 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
             val result = sut()
 
             // then
-            assertEquals(R.string.feedback_banner_ipp_message_beginner, result.message)
-            assertEquals(R.string.feedback_banner_ipp_title_beginner, result.title)
-            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result.url)
-            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result.url)
-            assertEquals("ipp_new_user", result.campaignName)
+            assertEquals(R.string.feedback_banner_ipp_message_beginner, result?.message)
+            assertEquals(R.string.feedback_banner_ipp_title_beginner, result?.title)
+            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result?.url)
+            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey", result?.url)
+            assertEquals("ipp_new_user", result?.campaignName)
             assertNull(expectedTimeWindowCaptor.allValues.last())
             assertEquals(Date().daysAgo(30).formatToYYYYmmDD(), expectedTimeWindowCaptor.firstValue)
         }
@@ -175,10 +172,10 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
             val result = sut()
 
             // then
-            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users", result.url)
-            assertEquals(R.string.feedback_banner_ipp_message_ninja, result.message)
-            assertEquals(R.string.feedback_banner_ipp_title_ninja, result.title)
-            assertEquals("ipp_power_user", result.campaignName)
+            assertEquals("https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users", result?.url)
+            assertEquals(R.string.feedback_banner_ipp_message_ninja, result?.message)
+            assertEquals(R.string.feedback_banner_ipp_title_ninja, result?.title)
+            assertEquals("ipp_power_user", result?.campaignName)
         }
 
     @Test
@@ -191,9 +188,9 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(R.string.feedback_banner_ipp_message_newbie, result.message)
-        assertEquals(R.string.feedback_banner_ipp_title_newbie, result.title)
-        assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result.url)
+        assertEquals(R.string.feedback_banner_ipp_message_newbie, result?.message)
+        assertEquals(R.string.feedback_banner_ipp_title_newbie, result?.title)
+        assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result?.url)
     }
 
     @Test
@@ -233,9 +230,9 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(R.string.feedback_banner_ipp_message_newbie, result.message)
-        assertEquals(R.string.feedback_banner_ipp_title_newbie, result.title)
-        assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result.url)
+        assertEquals(R.string.feedback_banner_ipp_message_newbie, result?.message)
+        assertEquals(R.string.feedback_banner_ipp_title_newbie, result?.title)
+        assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result?.url)
     }
 
     @Test
@@ -269,13 +266,13 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
         val result = sut()
 
         // then
-        assertEquals(R.string.feedback_banner_ipp_message_newbie, result.message)
-        assertEquals(R.string.feedback_banner_ipp_title_newbie, result.title)
-        assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result.url)
+        assertEquals(R.string.feedback_banner_ipp_message_newbie, result?.message)
+        assertEquals(R.string.feedback_banner_ipp_title_newbie, result?.title)
+        assertEquals("https://automattic.survey.fm/woo-app-–-cod-survey", result?.url)
     }
 
     @Test
-    fun `given successful endpoint response, when transactions count is negative, then should throw exception `() =
+    fun `given successful endpoint response, when transactions count is negative, then should return null`() =
         testBlocking {
             // given
             whenever(shouldShowFeedbackBanner()).thenReturn(true)
@@ -291,11 +288,10 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
                 )
             ).thenReturn(WooPayload(fakeTransactionsSummary))
 
-            // then
-            assertFailsWith(IllegalStateException::class) {
-                runBlocking { sut() }
-            }
+            // when
+            val result = sut()
 
-            Unit
+            // then
+            assertNull(result)
         }
 }


### PR DESCRIPTION
This PR fixes error handling in `GetIPPFeedbackBannerData` use case. 

<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-android/issues/8311
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There were a few crashes reported (https://github.com/woocommerce/woocommerce-android/issues/8311), potentially happening in case `ShouldShowFeedbackBanner` conditions change during the execution of the target user group detection use case (`GetIPPFeedbackBannerData`). 

While I couldn't reproduce the crash, this PR fixes unsafe error handling design and replaces exception throwing by returning a null value and logging the error, so no crashes are supposed to happen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The IPP survey banner should work as expected, and should not cause a crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
