### PR TITLE
Merge release/12.3-rc-1 into trunk (`beta`)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+12.4
+-----
+
+
 12.3
 -----
 - [*] Add IPP feedback banner icon for dark mode [https://github.com/woocommerce/woocommerce-android/pull/8309]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,9 +74,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "12.2"
+            versionName "12.3-rc-1"
         }
-        versionCode 383
+        versionCode 384
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_123"
+msgid ""
+"12.3:\n"
+"For this release, we focused on taking care of minor bugs that our team found. Don’t be fooled – we are working on some pretty cool stuff for you all! Keep your feedback rolling in; it helps us figure out what to work on next.\n"
+msgstr ""
+
 msgctxt "release_note_122"
 msgid ""
 "12.2:\n"
 "This release includes a few bug fixes and improvements to our in person payments feature. Please try it out and share your feedback!\n"
-msgstr ""
-
-msgctxt "release_note_121"
-msgid ""
-"12.1:\n"
-"This release includes a handful of minor improvements and bug fixes that our team found. We’ve also made some tweaks to improve performance. Please keep sending your feedback! We read every one of them.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,2 @@
-This release includes a few bug fixes and improvements to our in person payments feature. Please try it out and share your feedback!
+- [*] Add IPP feedback banner icon for dark mode [https://github.com/woocommerce/woocommerce-android/pull/8309]
+

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,2 +1,1 @@
-- [*] Add IPP feedback banner icon for dark mode [https://github.com/woocommerce/woocommerce-android/pull/8309]
-
+For this release, we focused on taking care of minor bugs that our team found. Don’t be fooled – we are working on some pretty cool stuff for you all! Keep your feedback rolling in; it helps us figure out what to work on next.

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-641682777fff4f491a4961fb3ceda064ab3dc352'
+    fluxCVersion = '2.14.1'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -489,7 +489,7 @@ platform :android do
       end
     end
 
-    is_repo_clean = ("git status --porcelain").empty?
+    is_repo_clean = (`git status --porcelain`).empty?
     unless is_repo_clean then
       commit_strings(options)
     end


### PR DESCRIPTION
- [x] `build.gradle` file on `WooCommerce` module updated  with version bump. (1857d8e0da3c1a177417ef6b3f5b3e16d53dda8b)
- [x] `release notes` related files updated. (a9c2a4ea5591adb4c22bcce2723c1d3dd6fb903f + a662569e7cebef29b77ef1016be372a3364ecf67 + 24bb3e472e08f47abfe8edec12cddef93ab0ef94 + 2e273de430a93fad5226bfcab3bef25f8d1363c8)
- [x] `12.3-rc-1` WCAndroid beta submitted to Google for review (`Full rollout`).

EXTRAS:
- [x] `fluxc` version bump. (45673f9c79571642ffe5c2ba743de3f26afa7f5a)
- [x] `typo` fix in logic to decide if strings needs committing on the `localize_libs` lane. (cd064e848830237684a56eff867ad00bb6d10805)