### PR TITLE
IPP: Disconnect from a connected reader BT or built in if user leaves an error screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 12.4
 -----
-
+- [*][Internal] We added a cancel button to the error states of the IPP flow
 
 12.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 12.4
 -----
-- [*][Internal] We added a cancel button to the error states of the IPP flow
+- [*][Internal] We added a cancel button to the error states of the IPP flow [https://github.com/woocommerce/woocommerce-android/pull/8317]
 - [*] [Internal] Add a Zendesk tag to allow differentiating sites accessed using Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/8320]
 
 12.3

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus
@@ -622,7 +623,7 @@ class CardReaderPaymentViewModel
 
     fun onBackPressed() {
         onCancelPaymentFlow()
-        disconnectFromReaderIfPaymentState()
+        disconnectFromReaderIfPaymentFailedState()
     }
 
     private fun onCancelPaymentFlow() {
@@ -641,9 +642,14 @@ class CardReaderPaymentViewModel
         }
     }
 
-    private fun disconnectFromReaderIfPaymentState() {
-        if (viewState.value is FailedPaymentState || viewState.value is FailedRefundState) {
-            launch { cardReaderManager.disconnectReader() }
+    private fun disconnectFromReaderIfPaymentFailedState() {
+        val readerStatus = cardReaderManager.readerStatus.value
+        if (readerStatus is CardReaderStatus.Connected) {
+            if (ReaderType.isBuiltInReaderType(readerStatus.cardReader.type) && (
+                    viewState.value is FailedPaymentState || viewState.value is FailedRefundState)
+            ) {
+                launch { cardReaderManager.disconnectReader() }
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -645,8 +645,8 @@ class CardReaderPaymentViewModel
     private fun disconnectFromReaderIfPaymentFailedState() {
         val readerStatus = cardReaderManager.readerStatus.value
         if (readerStatus is CardReaderStatus.Connected) {
-            if (ReaderType.isBuiltInReaderType(readerStatus.cardReader.type) && (
-                    viewState.value is FailedPaymentState || viewState.value is FailedRefundState)
+            if (ReaderType.isBuiltInReaderType(readerStatus.cardReader.type) &&
+                (viewState.value is FailedPaymentState || viewState.value is FailedRefundState)
             ) {
                 launch { cardReaderManager.disconnectReader() }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -475,8 +475,7 @@ class CardReaderPaymentViewModel
 
     private fun showPaymentSuccessfulState() {
         launch {
-            val order = orderRepository.getOrderById(orderId)
-                ?: throw IllegalStateException("Order URL not available.")
+            val order = requireNotNull(orderRepository.getOrderById(orderId)) { "Order URL not available." }
             val amountLabel = order.getAmountLabel()
             val receiptUrl = getReceiptUrl(order.id)
             val onPrintReceiptClicked = {
@@ -681,9 +680,11 @@ class CardReaderPaymentViewModel
 
     private suspend fun getStoreCountryCode(): String {
         return withContext(dispatchers.io) {
-            wooStore.getStoreCountryCode(
-                selectedSite.get()
-            ) ?: throw IllegalStateException("Store's country code not found.")
+            requireNotNull(
+                wooStore.getStoreCountryCode(
+                    selectedSite.get()
+                )
+            ) { "Store's country code not found." }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -441,7 +441,9 @@ class CardReaderPaymentViewModel
                 FailedRefundState(
                     errorType,
                     amountLabel,
-                    onPrimaryActionClicked = onRetryClicked
+                    onPrimaryActionClicked = onRetryClicked,
+                    secondaryLabel = R.string.cancel,
+                    onSecondaryActionClicked = { onBackPressed() }
                 )
             )
         }
@@ -467,7 +469,9 @@ class CardReaderPaymentViewModel
                 FailedPaymentState(
                     errorType,
                     amountLabel,
-                    onPrimaryActionClicked = onRetryClicked
+                    onPrimaryActionClicked = onRetryClicked,
+                    secondaryLabel = R.string.cancel,
+                    onSecondaryActionClicked = { onBackPressed() }
                 )
             )
         }
@@ -618,6 +622,7 @@ class CardReaderPaymentViewModel
 
     fun onBackPressed() {
         onCancelPaymentFlow()
+        disconnectFromReaderIfPaymentState()
     }
 
     private fun onCancelPaymentFlow() {
@@ -633,6 +638,12 @@ class CardReaderPaymentViewModel
                 trackCancelledFlow(state)
             }
             triggerEvent(Exit)
+        }
+    }
+
+    private fun disconnectFromReaderIfPaymentState() {
+        if (viewState.value is FailedPaymentState || viewState.value is FailedRefundState) {
+            launch { cardReaderManager.disconnectReader() }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
@@ -49,13 +49,16 @@ sealed class ViewState(
         private val errorType: PaymentFlowError,
         override val amountWithCurrencyLabel: String?,
         private val primaryLabel: Int? = R.string.try_again,
-        override val onPrimaryActionClicked: (() -> Unit)
+        private val secondaryLabel: Int? = null,
+        override val onPrimaryActionClicked: (() -> Unit),
+        override val onSecondaryActionClicked: (() -> Unit)? = null,
     ) : ViewState(
         headerLabel = R.string.card_reader_payment_payment_failed_header,
         paymentStateLabel = errorType.message,
         paymentStateLabelTopMargin = R.dimen.major_100,
         primaryActionLabel = primaryLabel,
-        illustration = R.drawable.img_products_error
+        illustration = R.drawable.img_products_error,
+        secondaryActionLabel = secondaryLabel
     )
 
     data class ExternalReaderCollectPaymentState(
@@ -204,13 +207,16 @@ sealed class ViewState(
         private val errorType: InteracRefundFlowError,
         override val amountWithCurrencyLabel: String?,
         private val primaryLabel: Int? = R.string.try_again,
+        private val secondaryLabel: Int? = null,
         override val onPrimaryActionClicked: (() -> Unit),
+        override val onSecondaryActionClicked: (() -> Unit)? = null,
     ) : ViewState(
         headerLabel = R.string.card_reader_interac_refund_refund_failed_header,
         paymentStateLabel = errorType.message,
         paymentStateLabelTopMargin = R.dimen.major_100,
         primaryActionLabel = primaryLabel,
-        illustration = R.drawable.img_products_error
+        illustration = R.drawable.img_products_error,
+        secondaryActionLabel = secondaryLabel,
     )
 
     data class CollectRefundState(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderType.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderType.kt
@@ -31,6 +31,8 @@ sealed class ReaderType(val name: String) {
             }
 
         fun isExternalReaderType(name: String?): Boolean = name?.let { fromName(name) is ExternalReader } ?: false
+
+        fun isBuiltInReaderType(name: String?): Boolean = name?.let { fromName(name) is BuildInReader } ?: false
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8290
Closes: #8294
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds 2 changes:
* Cancel buttons on the "retryable" error screens (both BT/Built-in Payment/Refund failed)
* Going back or canceling from the error states will cause the currently connected reader to be disconnected

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The easiest way to reproduce retriable errors for TPP would be disabling NFC on the phone. For IAP you could disable internet connection after a BT reader gets connected and use the card to attempt a payment
* Notice the "cancel" button is shown for retriable errors
* Notice the "ok" button is shown for NON retriable errors
* Notice that it works and a reader (both BT and Build in) gets disconnected after leaving the flow
* Notice that coming back behaves the same way as clicking on the cancel button

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/218427906-b497ddfd-5eac-40cf-90e5-1a5768dc24b3.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
