### PR TITLE
Ignore length of the lines that contains back ticks

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/iap/IapEligibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/iap/IapEligibilityViewModelTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MaxLineLength")
-
 package com.woocommerce.android.ui.login.storecreation.iap
 
 import androidx.lifecycle.SavedStateHandle

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -1,4 +1,3 @@
-@file:Suppress("MaxLineLength")
 package com.woocommerce.android.ui.orders
 
 import androidx.lifecycle.SavedStateHandle
@@ -86,7 +85,8 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val pagedListWrapper: PagedListWrapper<OrderListItemUIType> = mock()
     private val orderFetcher: WCOrderFetcher = mock()
     private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters = mock()
-    private val getWCOrderListDescriptorWithFiltersAndSearchQuery: GetWCOrderListDescriptorWithFiltersAndSearchQuery = mock()
+    private val getWCOrderListDescriptorWithFiltersAndSearchQuery: GetWCOrderListDescriptorWithFiltersAndSearchQuery =
+        mock()
     private val getSelectedOrderFiltersCount: GetSelectedOrderFiltersCount = mock()
     private val shouldShowFeedbackBanner: ShouldShowFeedbackBanner = mock()
     private val getIPPFeedbackBannerData: GetIPPFeedbackBannerData = mock()
@@ -95,7 +95,11 @@ class OrderListViewModelTest : BaseUnitTest() {
     @Before
     fun setup() = testBlocking {
         whenever(getWCOrderListDescriptorWithFilters.invoke()).thenReturn(WCOrderListDescriptor(site = mock()))
-        whenever(getWCOrderListDescriptorWithFiltersAndSearchQuery.invoke(anyString())).thenReturn(WCOrderListDescriptor(site = mock()))
+        whenever(getWCOrderListDescriptorWithFiltersAndSearchQuery.invoke(anyString())).thenReturn(
+            WCOrderListDescriptor(
+                site = mock()
+            )
+        )
         whenever(pagedListWrapper.listError).doReturn(mock())
         whenever(pagedListWrapper.isEmpty).doReturn(mock())
         whenever(pagedListWrapper.isFetchingFirstPage).doReturn(mock())
@@ -576,7 +580,9 @@ class OrderListViewModelTest : BaseUnitTest() {
         testBlocking {
             // given
             viewModel.viewState =
-                viewModel.viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA))
+                viewModel.viewState.copy(
+                    ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA)
+                )
 
             // when
             viewModel.onDismissIPPFeedbackBannerClicked()
@@ -589,20 +595,31 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `given IPP banner is shown, when CTA is clicked, then survey is opened`() {
         // given
         viewModel.viewState =
-            viewModel.viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA))
+            viewModel.viewState.copy(
+                ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(
+                    FAKE_IPP_FEEDBACK_BANNER_DATA
+                )
+            )
 
         // when
         viewModel.onIPPFeedbackBannerCTAClicked()
 
         // then
-        assertEquals(OrderListViewModel.OrderListEvent.OpenIPPFeedbackSurveyLink(FAKE_IPP_FEEDBACK_BANNER_DATA.url), viewModel.event.value)
+        assertEquals(
+            OrderListViewModel.OrderListEvent.OpenIPPFeedbackSurveyLink(FAKE_IPP_FEEDBACK_BANNER_DATA.url),
+            viewModel.event.value
+        )
     }
 
     @Test
     fun `given IPP banner is shown, when CTA is clicked, then IPP banner is hidden`() {
         // given
         viewModel.viewState =
-            viewModel.viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA))
+            viewModel.viewState.copy(
+                ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(
+                    FAKE_IPP_FEEDBACK_BANNER_DATA
+                )
+            )
 
         // when
         viewModel.onIPPFeedbackBannerCTAClicked()
@@ -615,7 +632,11 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `given IPP banner is shown, when CTA is clicked, then Orders banner is shown`() {
         // given
         viewModel.viewState =
-            viewModel.viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA))
+            viewModel.viewState.copy(
+                ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(
+                    FAKE_IPP_FEEDBACK_BANNER_DATA
+                )
+            )
 
         // when
         viewModel.onIPPFeedbackBannerCTAClicked()
@@ -628,7 +649,11 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `given IPP banner is shown, when dismiss forever is clicked, then IPP banner is hidden`() {
         // given
         viewModel.viewState =
-            viewModel.viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA))
+            viewModel.viewState.copy(
+                ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(
+                    FAKE_IPP_FEEDBACK_BANNER_DATA
+                )
+            )
 
         // when
         viewModel.onIPPFeedbackBannerDismissedForever()
@@ -641,7 +666,11 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `given IPP banner is shown, when dismiss forever is clicked, then Orders banner is shown`() {
         // given
         viewModel.viewState =
-            viewModel.viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA))
+            viewModel.viewState.copy(
+                ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(
+                    FAKE_IPP_FEEDBACK_BANNER_DATA
+                )
+            )
 
         // when
         viewModel.onIPPFeedbackBannerDismissedForever()
@@ -654,7 +683,11 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `given IPP banner is shown, when dismissed temporarily, then IPP banner is hidden`() {
         // given
         viewModel.viewState =
-            viewModel.viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA))
+            viewModel.viewState.copy(
+                ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(
+                    FAKE_IPP_FEEDBACK_BANNER_DATA
+                )
+            )
 
         // when
         viewModel.onIPPFeedbackBannerDismissedShowLater()
@@ -667,7 +700,11 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `given IPP banner is shown, when dismissed temporarily, then Orders banner is shown`() {
         // given
         viewModel.viewState =
-            viewModel.viewState.copy(ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(FAKE_IPP_FEEDBACK_BANNER_DATA))
+            viewModel.viewState.copy(
+                ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(
+                    FAKE_IPP_FEEDBACK_BANNER_DATA
+                )
+            )
 
         // when
         viewModel.onIPPFeedbackBannerDismissedShowLater()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/feedback/ipp/GetIPPFeedbackBannerDataTest.kt
@@ -1,4 +1,3 @@
-@file:Suppress("MaxLineLength")
 package com.woocommerce.android.ui.payments.feedback.ipp
 
 import com.woocommerce.android.R
@@ -197,27 +196,28 @@ class GetIPPFeedbackBannerDataTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given banner should be displayed, then should analyze IPP stats from the correct time window`() = testBlocking {
-        // given
-        whenever(shouldShowFeedbackBanner()).thenReturn(true)
-        whenever(getActivePaymentsPlugin())
-            .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
+    fun `given banner should be displayed, then should analyze IPP stats from the correct time window`() =
+        testBlocking {
+            // given
+            whenever(shouldShowFeedbackBanner()).thenReturn(true)
+            whenever(getActivePaymentsPlugin())
+                .thenReturn(WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS)
 
-        val expectedTimeWindowCaptor = ArgumentCaptor.forClass(String::class.java)
+            val expectedTimeWindowCaptor = ArgumentCaptor.forClass(String::class.java)
 
-        // when
-        sut()
-        verify(ippStore).fetchTransactionsSummary(
-            any(),
-            any(),
-            expectedTimeWindowCaptor.capture()
-        )
+            // when
+            sut()
+            verify(ippStore).fetchTransactionsSummary(
+                any(),
+                any(),
+                expectedTimeWindowCaptor.capture()
+            )
 
-        // then
-        val timeWindowLengthDays = 30
-        val desiredTimeWindowStart = Date().daysAgo(timeWindowLengthDays).formatToYYYYmmDD()
-        assertEquals(desiredTimeWindowStart, expectedTimeWindowCaptor.value)
-    }
+            // then
+            val timeWindowLengthDays = 30
+            val desiredTimeWindowStart = Date().daysAgo(timeWindowLengthDays).formatToYYYYmmDD()
+            assertEquals(desiredTimeWindowStart, expectedTimeWindowCaptor.value)
+        }
 
     @Test
     fun `given COD enabled and endpoint returns error, then should detect newbie`() = testBlocking {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -18,6 +18,9 @@ formatting:
   Indentation:
     active: true
     autoCorrect: true
+  MaximumLineLength:
+    active: true
+    ignoreBackTickedIdentifier: true
 
 style:
   UnnecessaryAbstractClass:
@@ -27,6 +30,8 @@ style:
     ignoreAnnotated: [ 'Composable' ]
   UnusedPrivateMember:
     ignoreAnnotated: [ 'Preview' ]
+  MaxLineLength:
+    active: false
 
 naming:
   FunctionNaming:


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As discussed here (p1675154103697509-slack-C6H8C3G23) we would like to make it possible to have longer test names.

The approach with `ignoreAnnotated: [ 'Test' ]` has the disadvantage that detekt ignores the whole test function in this case. That's why I take a bit different approach here

The rule that checks the max length of a line is available both in Detekt And Ktlint and before this PR was enabled in both. From the [documentation](https://detekt.dev/docs/rules/formatting#maximumlinelength):

> This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength) from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can auto-correct the issue.

Therefore this PR:
* Disables duplicated Detekt rule
* Makes Ktlint to ignore text in "back ticks" which are tests in our case

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Play with enabling/disabling the max line length rule. Try to introduce long lines inside the tests

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->