### PR TITLE
REST API: add a zendesk tag to help HEs identify the connection type

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 12.4
 -----
-
+- [*] [Internal] Add a Zendesk tag to allow differentiating sites accessed using Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/8320]
 
 12.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -582,7 +582,6 @@ sealed class TicketType(
 
 object ZendeskExtraTags {
     const val applicationPasswordAuthenticated = "application_password_authenticated"
-    const val connectingJetpack = "connecting_jetpack"
 
     const val paymentsCategory = "support"
     const val paymentsSubcategory = "payment"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -11,6 +11,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.logInformation
 import com.woocommerce.android.extensions.stateLogInformation
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -158,15 +160,22 @@ class ZendeskHelper(
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
         }
+
+        val siteConnectionTag = if (selectedSite?.connectionType == SiteConnectionType.ApplicationPasswords) {
+            ZendeskExtraTags.applicationPasswordAuthenticated
+        } else null
+
+        val tags = (extraTags.orEmpty() + siteConnectionTag).filterNotNull()
+
         requireIdentity(context, selectedSite) {
             val config = buildZendeskConfig(
-                context,
-                ticketType,
-                siteStore.sites,
-                origin,
-                selectedSite,
-                extraTags,
-                ssr,
+                context = context,
+                ticketType = ticketType,
+                allSites = siteStore.sites,
+                origin = origin,
+                selectedSite = selectedSite,
+                extraTags = tags,
+                ssr = ssr,
             )
             RequestActivity.builder().show(context, config)
         }
@@ -572,6 +581,7 @@ sealed class TicketType(
 }
 
 object ZendeskExtraTags {
+    const val applicationPasswordAuthenticated = "application_password_authenticated"
     const val connectingJetpack = "connecting_jetpack"
 
     const val paymentsCategory = "support"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -117,13 +117,13 @@ class HelpActivity : AppCompatActivity() {
     private fun initObservers(binding: ActivityHelpBinding) {
         viewModel.event.observe(this) { event ->
             when (event) {
-                is HelpViewModel.ContactPaymentsSupportClickEvent -> {
+                is HelpViewModel.ContactSupportEvent -> {
                     when (event) {
-                        is HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket -> {
+                        is HelpViewModel.ContactSupportEvent.CreateTicket -> {
                             binding.helpLoading.visibility = View.GONE
                             createNewZendeskTicket(event.ticketType, extraTags = event.supportTags)
                         }
-                        HelpViewModel.ContactPaymentsSupportClickEvent.ShowLoading -> {
+                        HelpViewModel.ContactSupportEvent.ShowLoading -> {
                             binding.helpLoading.visibility = View.VISIBLE
                         }
                     }.exhaustive

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpViewModel.kt
@@ -46,11 +46,11 @@ class HelpViewModel @Inject constructor(
 
     fun contactSupport(ticketType: TicketType) {
         if (!selectedSite.exists()) {
-            triggerEvent(ContactPaymentsSupportClickEvent.CreateTicket(ticketType, emptyList()))
+            triggerEvent(ContactSupportEvent.CreateTicket(ticketType, emptyList()))
             return
         }
 
-        triggerEvent(ContactPaymentsSupportClickEvent.ShowLoading)
+        triggerEvent(ContactSupportEvent.ShowLoading)
         launch {
             wooStore.fetchSitePlugins(selectedSite.get())
             val fetchSitePluginsResult = wooStore.fetchSitePlugins(selectedSite.get())
@@ -62,7 +62,7 @@ class HelpViewModel @Inject constructor(
 
                 listOf(determineWcPayTag(wcPayPluginInfo), determineStripeTag(stripePluginInfo))
             }
-            triggerEvent(ContactPaymentsSupportClickEvent.CreateTicket(ticketType, tags))
+            triggerEvent(ContactSupportEvent.CreateTicket(ticketType, tags))
         }
     }
 
@@ -84,12 +84,12 @@ class HelpViewModel @Inject constructor(
             STRIPE_INSTALLED
         }
 
-    sealed class ContactPaymentsSupportClickEvent : MultiLiveEvent.Event() {
-        object ShowLoading : ContactPaymentsSupportClickEvent()
+    sealed class ContactSupportEvent : MultiLiveEvent.Event() {
+        object ShowLoading : ContactSupportEvent()
         data class CreateTicket(
             val ticketType: TicketType,
             val supportTags: List<String>,
-        ) : ContactPaymentsSupportClickEvent()
+        ) : ContactSupportEvent()
     }
 
     private companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.databinding.ActivityLoginBinding
 import com.woocommerce.android.experiment.RESTAPILoginExperiment
 import com.woocommerce.android.experiment.RESTAPILoginExperiment.RESTAPILoginVariant
 import com.woocommerce.android.extensions.parcelable
-import com.woocommerce.android.support.ZendeskExtraTags
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
@@ -609,11 +608,10 @@ class LoginActivity :
     }
 
     private fun viewHelpAndSupport(origin: HelpOrigin) {
-        val extraSupportTags = arrayListOf(ZendeskExtraTags.connectingJetpack)
         val flow = unifiedLoginTracker.getFlow()
         val step = unifiedLoginTracker.previousStepBeforeHelpStep
 
-        startActivity(HelpActivity.createIntent(this, origin, extraSupportTags, flow?.value, step?.value))
+        startActivity(HelpActivity.createIntent(this, origin, null, flow?.value, step?.value))
     }
 
     override fun helpSiteAddress(url: String?) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpViewModelTest.kt
@@ -55,7 +55,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(viewModel.event.value).isEqualTo(
-            HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+            HelpViewModel.ContactSupportEvent.CreateTicket(
                 TicketType.General,
                 emptyList(),
             )
@@ -71,7 +71,7 @@ class HelpViewModelTest : BaseUnitTest() {
         viewModel.contactSupport(TicketType.General)
 
         // THEN
-        assertThat(viewModel.event.value).isEqualTo(HelpViewModel.ContactPaymentsSupportClickEvent.ShowLoading)
+        assertThat(viewModel.event.value).isEqualTo(HelpViewModel.ContactSupportEvent.ShowLoading)
     }
 
     @Test
@@ -92,7 +92,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf("woo_mobile_site_plugins_fetching_error")
                 )
@@ -117,7 +117,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.Payments,
                     listOf("woo_mobile_site_plugins_fetching_error")
                 )
@@ -136,7 +136,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
@@ -159,7 +159,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
@@ -185,7 +185,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",
@@ -208,7 +208,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
@@ -234,7 +234,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
@@ -261,7 +261,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
@@ -290,7 +290,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",
@@ -319,7 +319,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
@@ -350,7 +350,7 @@ class HelpViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
-                HelpViewModel.ContactPaymentsSupportClickEvent.CreateTicket(
+                HelpViewModel.ContactSupportEvent.CreateTicket(
                     TicketType.General,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8318 

### Description
This PR's main change is to add a Zendesk tag when the selected site is using Application Passwords.

I added two additional changes:
1. f7d4487c738186f4214b9266f22a464a0c10481c: this commit just renames a class from `ContactPaymentsSupportClickEvent` to `ContactSupportEvent`, and this is because this event is used for both general tickets and payment tickets, and it was confusing for me to understand why with this name.
2. 5120cbe160f954296c348154178c75e16e2b9091: this commit removes the tag `connecting_jetpack` from the login tickets, by taking a look at the history, I found out that this was copied from the WPAndroid, but since our usages are different, it's useless for us, as we send it with every request, while in WPAndroid it's being sent only when using the Jetpack remote installation.

### Testing instructions
1. Make sure the REST API experiment is enabled by setting the treatment value [here](https://github.com/woocommerce/woocommerce-android/blob/c3bd5d6cb2ccc54f51201745ca28932cdfa4e016/WooCommerce/src/main/kotlin/com/woocommerce/android/experiment/RESTAPILoginExperiment.kt#L47).
2. Open the app.
3. Enter the address of a self-hosted site.
4. Enter site credentials.
5. Go to settings.
6. Click on "Help & Support"
7. Click on "Contact support"
8. Enter your email address if needed.
9. Create a test ticket.
10. Check the ticket in Zendesk, and confirm the tag `application_password_authenticated` was added.

### Images/gif
<img width="330" alt="Screen Shot 2023-02-13 at 15 27 30" src="https://user-images.githubusercontent.com/1657201/218489204-d6660489-a7e4-4bc0-b5b3-c0402d980365.png">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
