### PR TITLE
[Analysis] Resolve All Adapter Position Deprecation Warnings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -205,10 +205,9 @@ class OrderDetailShippingLabelsAdapter(
 
             // Shipping label header
             with(viewBinding.shippingLabelListLblPackage) {
-                @Suppress("DEPRECATION")
                 text = context.getString(
                     R.string.orderdetail_shipping_label_item_header,
-                    adapterPosition + 1
+                    bindingAdapterPosition + 1
                 )
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -65,7 +65,7 @@ class ShippingCustomsAdapter(
         return customsPackages[position].data.id.hashCode().toLong()
     }
 
-    @Suppress("MagicNumber", "DEPRECATION")
+    @Suppress("MagicNumber")
     inner class PackageCustomsViewHolder(val binding: ShippingCustomsListItemBinding) : ViewHolder(binding.root) {
         private val linesAdapter: ShippingCustomsLineAdapter by lazy {
             ShippingCustomsLineAdapter(
@@ -105,36 +105,36 @@ class ShippingCustomsAdapter(
 
             // Setup listeners
             binding.returnCheckbox.setOnCheckedChangeListener { _, isChecked ->
-                listener.onReturnToSenderChanged(adapterPosition, isChecked)
+                listener.onReturnToSenderChanged(bindingAdapterPosition, isChecked)
             }
             binding.contentsTypeSpinner.setup(
                 values = ContentsType.values(),
-                onSelected = { listener.onContentsTypeChanged(adapterPosition, it) },
+                onSelected = { listener.onContentsTypeChanged(bindingAdapterPosition, it) },
                 mapper = { context.getString(it.title) }
             )
             binding.contentsTypeDescription.setOnTextChangedListener {
-                it?.let { listener.onContentsDescriptionChanged(adapterPosition, it.toString()) }
+                it?.let { listener.onContentsDescriptionChanged(bindingAdapterPosition, it.toString()) }
             }
             binding.restrictionTypeSpinner.setup(
                 values = RestrictionType.values(),
-                onSelected = { listener.onRestrictionTypeChanged(adapterPosition, it) },
+                onSelected = { listener.onRestrictionTypeChanged(bindingAdapterPosition, it) },
                 mapper = { context.getString(it.title) }
             )
             binding.restrictionTypeDescription.setOnTextChangedListener {
-                it?.let { listener.onRestrictionDescriptionChanged(adapterPosition, it.toString()) }
+                it?.let { listener.onRestrictionDescriptionChanged(bindingAdapterPosition, it.toString()) }
             }
             binding.itnEditText.setOnTextChangedListener {
-                it?.let { listener.onItnChanged(adapterPosition, it.toString()) }
+                it?.let { listener.onItnChanged(bindingAdapterPosition, it.toString()) }
             }
             binding.titleLayout.setOnClickListener {
                 if (isExpanded) {
                     binding.expandIcon.animate().rotation(0f).start()
                     binding.detailsLayout.collapse()
-                    listener.onPackageExpandedChanged(adapterPosition, false)
+                    listener.onPackageExpandedChanged(bindingAdapterPosition, false)
                 } else {
                     binding.expandIcon.animate().rotation(180f).start()
                     binding.detailsLayout.expand()
-                    listener.onPackageExpandedChanged(adapterPosition, true)
+                    listener.onPackageExpandedChanged(bindingAdapterPosition, true)
                 }
             }
         }
@@ -166,7 +166,7 @@ class ShippingCustomsAdapter(
             binding.itnEditText.setTextIfDifferent(customsPackage.itn)
             binding.itnEditText.error = validationState.itnErrorMessage
 
-            linesAdapter.parentItemPosition = adapterPosition
+            linesAdapter.parentItemPosition = bindingAdapterPosition
             linesAdapter.customsLines = uiState.customsLinesUiState
 
             if (uiState.isExpanded) {
@@ -231,7 +231,7 @@ class ShippingCustomsLineAdapter(
         holder.bind(customsLines[position])
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("MagicNumber")
     inner class CustomsLineViewHolder(val binding: ShippingCustomsLineListItemBinding) : ViewHolder(binding.root) {
         private val context
             get() = binding.root.context
@@ -264,20 +264,20 @@ class ShippingCustomsLineAdapter(
             )
 
             binding.itemDescriptionEditText.setOnTextChangedListener {
-                it?.let { listener.onItemDescriptionChanged(parentItemPosition, adapterPosition, it.toString()) }
+                it?.let { listener.onItemDescriptionChanged(parentItemPosition, bindingAdapterPosition, it.toString()) }
             }
             binding.hsTariffNumberEditText.setOnTextChangedListener {
-                it?.let { listener.onHsTariffNumberChanged(parentItemPosition, adapterPosition, it.toString()) }
+                it?.let { listener.onHsTariffNumberChanged(parentItemPosition, bindingAdapterPosition, it.toString()) }
             }
             binding.weightEditText.setOnTextChangedListener {
-                it?.let { listener.onWeightChanged(parentItemPosition, adapterPosition, it.toString()) }
+                it?.let { listener.onWeightChanged(parentItemPosition, bindingAdapterPosition, it.toString()) }
             }
             binding.valueEditText.setOnTextChangedListener {
-                it?.let { listener.onItemValueChanged(parentItemPosition, adapterPosition, it.toString()) }
+                it?.let { listener.onItemValueChanged(parentItemPosition, bindingAdapterPosition, it.toString()) }
             }
             binding.countrySpinner.setup(
                 values = countries,
-                onSelected = { listener.onOriginCountryChanged(parentItemPosition, adapterPosition, it) },
+                onSelected = { listener.onOriginCountryChanged(parentItemPosition, bindingAdapterPosition, it) },
                 mapper = { it.name }
             )
         }
@@ -294,7 +294,10 @@ class ShippingCustomsLineAdapter(
 
         fun bind(uiState: CustomsLineUiState) {
             val (customsLine, validationState) = uiState
-            binding.lineTitle.text = context.getString(R.string.shipping_label_customs_line_item, adapterPosition + 1)
+            binding.lineTitle.text = context.getString(
+                R.string.shipping_label_customs_line_item,
+                bindingAdapterPosition + 1
+            )
 
             binding.itemDescriptionEditText.setTextIfDifferent(customsLine.itemDescription)
             binding.itemDescriptionEditText.error = validationState.itemDescriptionErrorMessage

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -71,7 +71,7 @@ class ShippingLabelPackagesAdapter(
         super.onBindViewHolder(holder, position, payloads)
     }
 
-    @Suppress("MagicNumber", "DEPRECATION")
+    @Suppress("MagicNumber")
     inner class ShippingLabelPackageViewHolder(
         val binding: ShippingLabelPackageDetailsListItemBinding
     ) : ViewHolder(binding.root) {
@@ -91,9 +91,9 @@ class ShippingLabelPackagesAdapter(
             binding.weightEditText.setOnTextChangedListener {
                 val weight = it?.toString()?.trim('.')?.ifEmpty { null }?.toFloat() ?: Float.NaN
                 // Return early if the weight wasn't changed
-                if (weight == uiModels[adapterPosition].data.weight) return@setOnTextChangedListener
+                if (weight == uiModels[bindingAdapterPosition].data.weight) return@setOnTextChangedListener
 
-                onWeightEdited(adapterPosition, weight)
+                onWeightEdited(bindingAdapterPosition, weight)
 
                 if (weight <= 0.0) {
                     val context = binding.root.context
@@ -105,18 +105,18 @@ class ShippingLabelPackagesAdapter(
             }
 
             binding.selectedPackageSpinner.setClickListener {
-                onPackageSpinnerClicked(adapterPosition)
+                onPackageSpinnerClicked(bindingAdapterPosition)
             }
 
             binding.titleLayout.setOnClickListener {
                 if (isExpanded) {
                     binding.expandIcon.animate().rotation(0f).start()
                     binding.detailsLayout.collapse()
-                    onExpandedChanged(adapterPosition, false)
+                    onExpandedChanged(bindingAdapterPosition, false)
                 } else {
                     binding.expandIcon.animate().rotation(180f).start()
                     binding.detailsLayout.expand()
-                    onExpandedChanged(adapterPosition, true)
+                    onExpandedChanged(bindingAdapterPosition, true)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassAdapter.kt
@@ -51,7 +51,7 @@ class ProductShippingClassAdapter(
         RecyclerView.ViewHolder(viewBinding.root) {
         init {
             itemView.setOnClickListener {
-                @Suppress("DEPRECATION") val position = adapterPosition
+                val position = bindingAdapterPosition
                 if (position > -1) {
                     onItemClicked(items[position])
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListAdapter.kt
@@ -45,7 +45,7 @@ class ParentCategoryListAdapter(
         RecyclerView.ViewHolder(viewBinder.root) {
         init {
             viewBinder.root.setOnClickListener {
-                @Suppress("DEPRECATION") val position = adapterPosition
+                val position = bindingAdapterPosition
                 if (position > -1) {
                     getItem(position).let {
                         selectedCategoryId = it.category.remoteCategoryId

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
@@ -52,8 +52,7 @@ class VariationListAdapter(
         )
 
         holder.itemView.setOnClickListener {
-            @Suppress("DEPRECATION")
-            onItemClick(getItem(holder.adapterPosition))
+            onItemClick(getItem(holder.bindingAdapterPosition))
         }
         return holder
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -143,13 +143,12 @@ class AttributeTermsListAdapter(
             areItemsTheSame(oldItemPosition, newItemPosition)
     }
 
-    @Suppress("DEPRECATION")
     @SuppressLint("ClickableViewAccessibility")
     inner class TermViewHolder(val viewBinding: AttributeTermListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
         init {
             viewBinding.root.setOnClickListener {
-                termNames.getOrNull(adapterPosition)?.let {
+                termNames.getOrNull(bindingAdapterPosition)?.let {
                     onTermListener.onTermClick(it)
                 }
             }
@@ -157,7 +156,7 @@ class AttributeTermsListAdapter(
             if (enableDeleting) {
                 viewBinding.termContainer.setBackgroundResource(defaultItemBackground.resourceId)
                 viewBinding.termDelete.setOnClickListener {
-                    termNames.getOrNull(adapterPosition)?.let {
+                    termNames.getOrNull(bindingAdapterPosition)?.let {
                         removeTerm(it)
                         onTermListener.onTermDelete(it)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DraggableItemTouchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DraggableItemTouchHelper.kt
@@ -10,14 +10,13 @@ class DraggableItemTouchHelper(
     private val onMove: (from: Int, to: Int) -> Unit
 ) : ItemTouchHelper(
     object : ItemTouchHelper.SimpleCallback(dragDirs, 0) {
-        @Suppress("DEPRECATION")
         override fun onMove(
             recyclerView: RecyclerView,
             viewHolder: ViewHolder,
             target: ViewHolder
         ): Boolean {
-            val from = viewHolder.adapterPosition
-            val to = target.adapterPosition
+            val from = viewHolder.bindingAdapterPosition
+            val to = target.bindingAdapterPosition
             onMove(from, to)
 
             return true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -387,10 +387,9 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             return@OnTouchListener false
         }
 
-        @Suppress("DEPRECATION")
         private val onClickListener = OnClickListener {
-            if (adapterPosition > NO_POSITION) {
-                onImageClicked(adapterPosition)
+            if (bindingAdapterPosition > NO_POSITION) {
+                onImageClicked(bindingAdapterPosition)
             }
         }
 

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -109,8 +109,6 @@
     <ID>MagicNumber:SectionedRecyclerViewAdapter.kt$SectionedRecyclerViewAdapter$3</ID>
     <ID>MagicNumber:SectionedRecyclerViewAdapter.kt$SectionedRecyclerViewAdapter$4</ID>
     <ID>MagicNumber:SectionedRecyclerViewAdapter.kt$SectionedRecyclerViewAdapter$5</ID>
-    <ID>MagicNumber:ShippingCustomsAdapter.kt$ShippingCustomsLineAdapter.CustomsLineViewHolder$180f</ID>
-    <ID>MagicNumber:ShippingCustomsAdapter.kt$ShippingCustomsLineAdapter.CustomsLineViewHolder$300</ID>
     <ID>MagicNumber:ShippingCustomsViewModel.kt$ShippingCustomsViewModel$2500.0</ID>
     <ID>MagicNumber:ShippingLabel.kt$ShippingLabel$30</ID>
     <ID>MagicNumber:SkeletonView.kt$SkeletonView$250</ID>


### PR DESCRIPTION
This PR resolves all `adapterPosition` related deprecation warnings by simply replacing `adapterPosition` with `bindingAdapterPosition`, which is anyway what the `RecyclerView.java` class does underneath anyway, that is, when `getAdapterPosition()` is called.

As such, this change is perfectly safe and can be actually considered zero change, that is, at least functionality-wise.

-----

Warning Messages: `'getAdapterPosition()' is deprecated`

Explanation: `This method is confusing when adapters nest other adapters. If you are calling this in the context of an Adapter, you probably want to call 'getBindingAdapterPosition' or if you want the position as 'RecyclerView' sees it, you should call 'getAbsoluteAdapterPosition'.`

For more info see: [RecyclerView.ViewHolder#getAdapterPosition()](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView.ViewHolder#getAdapterPosition())

-----

PS: @AnirudhBhat I added you as the main reviewer, that is, in addition to the @woocommerce/apps-infrastructure  team itself, but randomly, since I just wanted someone from the Woo team to sign-off on that change for WCAndroid.

-----

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. If you really want to be thorough, just do a quick smoke test on any of the screens affected by this change and see if it works as expected.

-----

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
