### PR TITLE
TPP: Refactor TPP availability checker to use card reader country configuration

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/manuals/CardReaderManualsSupportedReadersMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/manuals/CardReaderManualsSupportedReadersMapper.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.connection.ReaderType.BuildInReader.CotsDevice
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.Chipper2X
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeM2
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.WisePade3
@@ -16,7 +17,7 @@ class CardReaderManualsSupportedReadersMapper @Inject constructor() {
         cardReaderConfigForSupportedCountry: CardReaderConfigForSupportedCountry,
         clickListeners: Map<ReaderType, () -> Unit>
     ) = cardReaderConfigForSupportedCountry
-        .supportedReaders.map {
+        .supportedReaders.mapNotNull {
             when (it) {
                 Chipper2X -> ManualItem(
                     icon = drawable.ic_chipper_reader,
@@ -33,6 +34,7 @@ class CardReaderManualsSupportedReadersMapper @Inject constructor() {
                     label = string.card_reader_wisepad_3_manual_card_reader,
                     onManualClicked = clickListeners[it]!!
                 )
+                CotsDevice -> null // This is built-in reader, we don't need to show it in the list
                 else -> error("$it doesn't have a manual")
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/manuals/CardReaderManualsSupportedReadersMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/manuals/CardReaderManualsSupportedReadersMapperTest.kt
@@ -13,7 +13,7 @@ import org.junit.Before
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class CardReaderManualsSupportedReaderMapperTest : BaseUnitTest() {
+class CardReaderManualsSupportedReadersMapperTest : BaseUnitTest() {
     private lateinit var manualsMapper: CardReaderManualsSupportedReadersMapper
 
     @Before
@@ -23,7 +23,6 @@ class CardReaderManualsSupportedReaderMapperTest : BaseUnitTest() {
 
     @Test
     fun `given US store, when screen shown, US readers are displayed`() {
-
         val supportedCountry = CardReaderConfigForUSA
         val expectedManualItems = listOf(
             ManualItem(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailableTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailableTest.kt
@@ -1,5 +1,9 @@
 package com.woocommerce.android.ui.payments.taptopay
 
+import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
+import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
+import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
+import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.SystemVersionUtilsWrapper
 import org.assertj.core.api.Assertions.assertThat
@@ -8,11 +12,15 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class IsTapToPayAvailableTest {
-
     private val systemVersionUtilsWrapper = mock<SystemVersionUtilsWrapper> {
         on { isAtLeastP() }.thenReturn(true)
     }
     private val isTapToPayEnabled: IsTapToPayEnabled = mock()
+    private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider = mock {
+        on { provideCountryConfigFor("US") }.thenReturn(CardReaderConfigForUSA)
+        on { provideCountryConfigFor("CA") }.thenReturn(CardReaderConfigForCanada)
+        on { provideCountryConfigFor("RU") }.thenReturn(CardReaderConfigForUnsupportedCountry)
+    }
 
     @Test
     fun `given device has no NFC, when invoking, then nfc disabled returned`() {
@@ -23,7 +31,12 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(isTapToPayEnabled.invoke()).thenReturn(true)
 
-        val result = IsTapToPayAvailable(isTapToPayEnabled, deviceFeatures, systemVersionUtilsWrapper).invoke("US")
+        val result = IsTapToPayAvailable(
+            isTapToPayEnabled,
+            deviceFeatures,
+            systemVersionUtilsWrapper,
+            cardReaderCountryConfigProvider
+        ).invoke("US")
 
         assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.NfcNotAvailable)
     }
@@ -37,7 +50,12 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(isTapToPayEnabled.invoke()).thenReturn(true)
 
-        val result = IsTapToPayAvailable(isTapToPayEnabled, deviceFeatures, systemVersionUtilsWrapper).invoke("US")
+        val result = IsTapToPayAvailable(
+            isTapToPayEnabled,
+            deviceFeatures,
+            systemVersionUtilsWrapper,
+            cardReaderCountryConfigProvider
+        ).invoke("US")
 
         assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.GooglePlayServicesNotAvailable)
     }
@@ -51,7 +69,12 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(false)
         whenever(isTapToPayEnabled.invoke()).thenReturn(true)
 
-        val result = IsTapToPayAvailable(isTapToPayEnabled, context, systemVersionUtilsWrapper).invoke("US")
+        val result = IsTapToPayAvailable(
+            isTapToPayEnabled,
+            context,
+            systemVersionUtilsWrapper,
+            cardReaderCountryConfigProvider
+        ).invoke("US")
 
         assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.SystemVersionNotSupported)
     }
@@ -65,7 +88,12 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(isTapToPayEnabled.invoke()).thenReturn(true)
 
-        val result = IsTapToPayAvailable(isTapToPayEnabled, context, systemVersionUtilsWrapper).invoke("CA")
+        val result = IsTapToPayAvailable(
+            isTapToPayEnabled,
+            context,
+            systemVersionUtilsWrapper,
+            cardReaderCountryConfigProvider
+        ).invoke("CA")
 
         assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.CountryNotSupported)
     }
@@ -79,7 +107,12 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(isTapToPayEnabled.invoke()).thenReturn(false)
 
-        val result = IsTapToPayAvailable(isTapToPayEnabled, context, systemVersionUtilsWrapper).invoke("US")
+        val result = IsTapToPayAvailable(
+            isTapToPayEnabled,
+            context,
+            systemVersionUtilsWrapper,
+            cardReaderCountryConfigProvider
+        ).invoke("US")
 
         assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.TapToPayDisabled)
     }
@@ -93,7 +126,12 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(isTapToPayEnabled.invoke()).thenReturn(true)
 
-        val result = IsTapToPayAvailable(isTapToPayEnabled, context, systemVersionUtilsWrapper).invoke("US")
+        val result = IsTapToPayAvailable(
+            isTapToPayEnabled,
+            context,
+            systemVersionUtilsWrapper,
+            cardReaderCountryConfigProvider
+        ).invoke("US")
 
         assertThat(result).isEqualTo(IsTapToPayAvailable.Result.Available)
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForUSA.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForUSA.kt
@@ -8,7 +8,11 @@ import kotlinx.parcelize.Parcelize
 object CardReaderConfigForUSA : CardReaderConfigForSupportedCountry(
     currency = "USD",
     countryCode = "US",
-    supportedReaders = listOf(ReaderType.ExternalReader.Chipper2X, ReaderType.ExternalReader.StripeM2),
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.Chipper2X,
+        ReaderType.ExternalReader.StripeM2,
+        ReaderType.BuildInReader.CotsDevice,
+    ),
     paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
     supportedExtensions = listOf(
         SupportedExtension(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8316
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds the usage of the list of supported readers in the country configuration to determine if TPP is available.

The PR should not bring any changes in the app behavior

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Run IPP on a store in the US -> Notice that TPP is available
* Run IPP on a store other than the US -> Notice that TPP is not available
* Check readers manuals screen both for the US and CA


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
