### PR TITLE
Fix crash in store creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationRepository.kt
@@ -74,6 +74,7 @@ class StoreCreationRepository @Inject constructor(
         val result = withContext(Dispatchers.Default) {
             val site = SiteModel().apply {
                 this.siteId = siteId
+                this.origin = SiteModel.ORIGIN_WPCOM_REST
                 this.setIsWPCom(true)
             }
             siteStore.fetchSite(site)


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8327

### Description
The FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2643 added a new type of sites (sites that use the Core REST API directly without XMLRPC), and thus I updated the logic of the `fetchSite` to depend on the `origin` to be clearer, but I didn't think it would cause any impact, until the WPAndroid team faced an issue in the beta release p1676285366236739-slack-C011BKNU1V5.

The same thing happens in our app, when fetching the site after store creation, we set it to be a simple WPCom site `setIsWpCom(true)`, but we don't set the `origin`, and this causes this crash when trying to fetch the site after the creation:

```
java.lang.NullPointerException: site.xmlRpcUrl must not be null

at org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient.fetchSite(SiteXMLRPCClient.kt:105)
...
```

### Testing instructions
Test store creation, and confirm it doesn't crash for you.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->