### PR TITLE
Fix Jetpack identification during the WPCom site discovery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
     mediapickerVersion = '0.1.1'
-    wordPressLoginVersion = 'trunk-8a6e41fa5db0e82a1d6d8da54cdb1fdb5d21bca2'
+    wordPressLoginVersion = 'trunk-7b2706ac5a3dd656705cad8eef825b2fe8a4f6aa'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'


### PR DESCRIPTION
### Description
When reviewing #8323, @JorgeMucientes identified an issue where the WPCom API `/site-info` fails to identify Jetpack sites if the path has some suffixes like `wp-admin`.
While testing, I found that the same issue causes another bug, when doing the same thing with an atomic site, it's identified as a non-WordPress site.

To fix this, this PR uses the changes from the Login [PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/110).

### Testing instructions
1. Use a Jetpack site (Please test using both an atomic one and a self-hosted one).
2. Open the app.
3. Click on Enter site address.
4. Enter the site address + the `wp-admin` suffix.
5. Confirm the app correctly asks you for the WordPress.com login.
6. Repeat the test with the scheme and without it (try to break it as you can 😄).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
