### PR TITLE
[Support Requests] Adapt zendesk code to support Request Creation from API Providers

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -326,7 +326,7 @@ dependencies {
     }
     androidTestImplementation "org.apache.httpcomponents:httpclient-android:$httpClientAndroidVersion"
 
-    implementation("com.zendesk:support:5.0.8") {
+    implementation("com.zendesk:support:5.1.1") {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -326,7 +326,7 @@ dependencies {
     }
     androidTestImplementation "org.apache.httpcomponents:httpclient-android:$httpClientAndroidVersion"
 
-    implementation("com.zendesk:support:5.1.1") {
+    implementation("com.zendesk:support:5.0.8") {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/SupportModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/SupportModule.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.di
 
 import com.woocommerce.android.support.SupportHelper
 import com.woocommerce.android.support.ZendeskHelper
+import com.woocommerce.android.util.CoroutineDispatchers
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,8 +19,9 @@ class SupportModule {
     fun provideZendeskHelper(
         accountStore: AccountStore,
         siteStore: SiteStore,
-        supportHelper: SupportHelper
-    ): ZendeskHelper = ZendeskHelper(accountStore, siteStore, supportHelper)
+        supportHelper: SupportHelper,
+        dispatchers: CoroutineDispatchers
+    ): ZendeskHelper = ZendeskHelper(accountStore, siteStore, supportHelper, dispatchers)
 
     @Singleton
     @Provides

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -151,6 +151,12 @@ class ZendeskHelper(
         }
     }
 
+
+    /**
+     * This function creates a new customer Support Request through the Zendesk API Providers.
+     *
+     * As it is, no identity is required so far. This should be revised in the near future.
+     */
     suspend fun createRequest(
         context: Context,
         selectedSite: SiteModel?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -31,7 +31,9 @@ import zendesk.core.AnonymousIdentity
 import zendesk.core.Identity
 import zendesk.core.PushRegistrationProvider
 import zendesk.core.Zendesk
+import zendesk.support.CreateRequest
 import zendesk.support.CustomField
+import zendesk.support.Request
 import zendesk.support.Support
 import zendesk.support.guide.HelpCenterActivity
 import zendesk.support.request.RequestActivity
@@ -41,8 +43,6 @@ import java.util.Timer
 import kotlin.concurrent.schedule
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
-import zendesk.support.CreateRequest
-import zendesk.support.Request
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
 private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500
@@ -150,7 +150,6 @@ class ZendeskHelper(
             builder.show(context)
         }
     }
-
 
     /**
      * This function creates a new customer Support Request through the Zendesk API Providers.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -157,8 +157,6 @@ class ZendeskHelper(
     /**
      * This function creates a new customer Support Request through the Zendesk API Providers.
      *
-     * This function should called outside the main coroutine scope as it'll suspend until the request is created.
-     *
      * As it is, no identity is required so far. This should be revised in the near future.
      */
     suspend fun createRequest(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -58,6 +58,9 @@ class ZendeskHelper(
     private val zendeskPushRegistrationProvider: PushRegistrationProvider?
         get() = zendeskInstance.provider()?.pushRegistrationProvider()
 
+    private val requestProvider
+        get() = Support.INSTANCE.provider()?.requestProvider()
+
     private val timer: Timer by lazy {
         Timer()
     }
@@ -101,6 +104,7 @@ class ZendeskHelper(
         zendeskInstance.init(context, zendeskUrl, applicationId, oauthClientId)
         Logger.setLoggable(enableLogs)
         Support.INSTANCE.init(zendeskInstance)
+
         refreshIdentity()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -155,7 +155,6 @@ class ZendeskHelper(
         ticketType: TicketType,
         subject: String,
         description: String,
-        tags: List<String> = emptyList(),
         ssr: String? = null,
         onSuccess: (Request?) -> Unit,
         onError: (ErrorResponse) -> Unit
@@ -169,7 +168,7 @@ class ZendeskHelper(
             this.ticketFormId = ticketType.form
             this.subject = subject
             this.description = description
-            this.tags = tags + ticketType.tags
+            this.tags = ticketType.tags
             this.customFields = buildZendeskCustomFields(context, ticketType, siteStore.sites, selectedSite, ssr)
         }.let { requestProvider?.createRequest(it, requestCallback) }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -453,17 +453,17 @@ private fun buildZendeskCustomFields(
         "not_selected"
     }
     return listOf(
+        CustomField(TicketFieldIds.appVersion, PackageUtils.getVersionName(context)),
+        CustomField(TicketFieldIds.deviceFreeSpace, DeviceUtils.getTotalAvailableMemorySize()),
+        CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context)),
+        CustomField(TicketFieldIds.logs, WooLog.toString().takeLast(maxLogfileLength)),
+        CustomField(TicketFieldIds.currentSite, currentSiteInformation),
+        CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform),
+        CustomField(TicketFieldIds.appLanguage, Locale.getDefault().language),
         CustomField(TicketFieldIds.categoryId, ZendeskConstants.categoryValue),
         CustomField(TicketFieldIds.subcategoryId, ticketType.subcategoryName),
-        CustomField(TicketFieldIds.appVersion, PackageUtils.getVersionName(context)),
         CustomField(TicketFieldIds.blogList, getCombinedLogInformationOfSites(allSites)),
-        CustomField(TicketFieldIds.currentSite, currentSiteInformation),
-        CustomField(TicketFieldIds.deviceFreeSpace, DeviceUtils.getTotalAvailableMemorySize()),
-        CustomField(TicketFieldIds.logs, WooLog.toString().takeLast(maxLogfileLength)),
-        CustomField(TicketFieldIds.ssr, ssr),
-        CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context)),
-        CustomField(TicketFieldIds.appLanguage, Locale.getDefault().language),
-        CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform)
+        CustomField(TicketFieldIds.ssr, ssr)
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.util.WooLog.T
 import com.zendesk.logger.Logger
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -44,7 +45,6 @@ import java.util.Timer
 import kotlin.concurrent.schedule
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
-import kotlinx.coroutines.withContext
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
 private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -154,6 +154,8 @@ class ZendeskHelper(
     /**
      * This function creates a new customer Support Request through the Zendesk API Providers.
      *
+     * This function should called outside the main coroutine scope as it'll suspend until the request is created.
+     *
      * As it is, no identity is required so far. This should be revised in the near future.
      */
     suspend fun createRequest(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -39,6 +39,7 @@ import zendesk.support.requestlist.RequestListActivity
 import java.util.Locale
 import java.util.Timer
 import kotlin.concurrent.schedule
+import zendesk.support.CreateRequest
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
 private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500
@@ -63,6 +64,22 @@ class ZendeskHelper(
 
     private val timer: Timer by lazy {
         Timer()
+    }
+
+    private fun createRequest(
+        formID: Long,
+        subject: String,
+        description: String,
+        tags: List<String>,
+        customFields: Map<Long, String>
+    ) {
+        val request = CreateRequest().apply {
+            this.ticketFormId = formID
+            this.subject = subject
+            this.description = description
+            this.tags = tags
+            this.customFields = customFields.map { CustomField(it.key, it.value) }
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -40,6 +40,7 @@ import java.util.Locale
 import java.util.Timer
 import kotlin.concurrent.schedule
 import zendesk.support.CreateRequest
+import zendesk.support.Request
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
 private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500
@@ -71,7 +72,9 @@ class ZendeskHelper(
         subject: String,
         description: String,
         tags: List<String>,
-        customFields: Map<Long, String>
+        customFields: Map<Long, String>,
+        onSuccess: (Request?) -> Unit,
+        onError: (ErrorResponse) -> Unit
     ) {
         val request = CreateRequest().apply {
             this.ticketFormId = formID
@@ -80,6 +83,16 @@ class ZendeskHelper(
             this.tags = tags
             this.customFields = customFields.map { CustomField(it.key, it.value) }
         }
+
+        requestProvider?.createRequest(request, object : ZendeskCallback<Request>() {
+            override fun onSuccess(result: Request?) {
+                onSuccess(result)
+            }
+
+            override fun onError(error: ErrorResponse) {
+                onError(error)
+            }
+        })
     }
 
     /**


### PR DESCRIPTION
Summary
==========
Fix issue #8332 by introducing a simple function that explores, validates, and uses the API Providers from the Zendesk SDK. This one uses specifically the Request Providers, allowing us to create a Support Request through our own custom UI experience instead of calling the SDK Activities and views.

The primary purpose of this PR is to adapt the ZendeskHelper class to support the API Providers, so this code is still to be validated in upcoming PRs.

How to Test
==========
1. So far, there's no way to test this implementation since no part of the app is consuming it, and the ZendeskHelper class needs some reworking to allow unit tests. Upcoming PRs will fix this.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.