### PR TITLE
Track Order Creation IPP Flows - Fix review comments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -327,15 +327,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 viewState = viewState.copy(isProgressDialogShown = true)
                 orderCreateEditRepository.placeOrder(order).fold(
                     onSuccess = {
-                        AnalyticsTracker.track(
-                            ORDER_CREATION_SUCCESS,
-                            mutableMapOf<String, String>().also { mutableMap ->
-                                OrderDurationRecorder.millisecondsSinceOrderAddNew().getOrNull()?.let { timeElapsed ->
-                                    mutableMap[AnalyticsTracker.KEY_TIME_ELAPSED_SINCE_ADD_NEW_ORDER_IN_MILLIS] =
-                                        timeElapsed.toString()
-                                }
-                            }
-                        )
+                        trackOrderCreationSuccess()
                         triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
                         triggerEvent(ShowCreatedOrder(it.id))
                     },
@@ -350,6 +342,18 @@ class OrderCreateEditViewModel @Inject constructor(
                 triggerEvent(Exit)
             }
         }
+    }
+
+    private fun trackOrderCreationSuccess() {
+        tracker.track(
+            ORDER_CREATION_SUCCESS,
+            mutableMapOf<String, String>().also { mutableMap ->
+                OrderDurationRecorder.millisecondsSinceOrderAddNew().getOrNull()?.let { timeElapsed ->
+                    mutableMap[AnalyticsTracker.KEY_TIME_ELAPSED_SINCE_ADD_NEW_ORDER_IN_MILLIS] =
+                        timeElapsed.toString()
+                }
+            }
+        )
     }
 
     fun onBackButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsSharedViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.payments.simplepayments
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tracker.OrderDurationRecorder
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -18,6 +19,11 @@ class SimplePaymentsSharedViewModel @Inject constructor(
 
     val decimals: Int
         get() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber ?: DEFAULT_DECIMAL_PRECISION
+
+    init {
+        // Reset order duration recorder to ensure we don't track Simple Payments flow
+        OrderDurationRecorder.reset()
+    }
 
     companion object {
         private const val DEFAULT_DECIMAL_PRECISION = 2


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR implements a few improvements based on review comments from https://github.com/woocommerce/woocommerce-android/pull/8347.


> 🔍 We could use the tracker: AnalyticsTrackerWrapper property instead of the static method to make it easier to write unit tests in the future.

Fixed in https://github.com/woocommerce/woocommerce-android/commit/81966620fdeb356df673d6da4bcedfa862c3483d

> 🔍 I'd suggest extracting event tracking part to a separate function, e.g. ::trackOrderCreationSuccess.

Fixed in https://github.com/woocommerce/woocommerce-android/commit/81966620fdeb356df673d6da4bcedfa862c3483d

> 🔍 ::getAndResetFlowsDuration function is primarily responsible for returning elapsed time data. OrderDurationRecorder.reset() is a side effect - I'd suggest moving it out of this function.

While I agree it's a side-effect, I still believe the pros out-weight the cons. This approach of manual reset isn't optimal in general and isn't reliable, however, the closer we keep it to the tracking code, the higher the chance the next developer or future me won't forget about adding it when tracking success from a different part of the codebase.

Hopefully, we'll remove this code before it needs to be used for a different flow :P.

> ❓ My concern is that in the case of simple payment flow, we might track false KEY_TIME_ELAPSED_SINCE_ADD_NEW_ORDER_IN_MILLIS values. Maybe we could reset the timestamps at the start of the simple payment flow too?

Fixed in https://github.com/woocommerce/woocommerce-android/commit/b173a2134c05dca6837c6f5729294bfbfb61f5b1


### Testing instructions
Smoke test order creation.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
