### PR TITLE
Merge release/12.4-rc-1 into trunk (`beta`)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+12.5
+-----
+
+
 12.4
 -----
 - [***] Add support for signing to self-hosted sites without Jetpack using site credentials [https://github.com/woocommerce/woocommerce-android/pull/8323]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,9 +74,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "12.3"
+            versionName "12.4-rc-1"
         }
-        versionCode 385
+        versionCode 386
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_124"
+msgid ""
+"12.4:\n"
+"You’ve asked for it, and now it’s here! It's now possible to use the app without Jetpack the plugin. This is based upon your direct feedback over the years, and we know you’ll like the change!\n"
+msgstr ""
+
 msgctxt "release_note_123"
 msgid ""
 "12.3:\n"
 "For this release, we focused on taking care of minor bugs that our team found. Don’t be fooled – we are working on some pretty cool stuff for you all! Keep your feedback rolling in; it helps us figure out what to work on next.\n"
-msgstr ""
-
-msgctxt "release_note_122"
-msgid ""
-"12.2:\n"
-"This release includes a few bug fixes and improvements to our in person payments feature. Please try it out and share your feedback!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,5 +1,1 @@
-- [***] Add support for signing to self-hosted sites without Jetpack using site credentials [https://github.com/woocommerce/woocommerce-android/pull/8323]
-- [***] [Internal] Remove XMRPC discovery steps from the REST API login [https://github.com/woocommerce/woocommerce-android/pull/8289]
-- [*][Internal] We added a cancel button to the error states of the IPP flow [https://github.com/woocommerce/woocommerce-android/pull/8317]
-- [*] [Internal] Add a Zendesk tag to allow differentiating sites accessed using Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/8320]
-- [*] Clear button is visible on the products filter screen [https://github.com/woocommerce/woocommerce-android/pull/8341]
+You’ve asked for it, and now it’s here! It's now possible to use the app without Jetpack the plugin. This is based upon your direct feedback over the years, and we know you’ll like the change!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,5 @@
-For this release, we focused on taking care of minor bugs that our team found. Don’t be fooled – we are working on some pretty cool stuff for you all! Keep your feedback rolling in; it helps us figure out what to work on next.
+- [***] Add support for signing to self-hosted sites without Jetpack using site credentials [https://github.com/woocommerce/woocommerce-android/pull/8323]
+- [***] [Internal] Remove XMRPC discovery steps from the REST API login [https://github.com/woocommerce/woocommerce-android/pull/8289]
+- [*][Internal] We added a cancel button to the error states of the IPP flow [https://github.com/woocommerce/woocommerce-android/pull/8317]
+- [*] [Internal] Add a Zendesk tag to allow differentiating sites accessed using Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/8320]
+- [*] Clear button is visible on the products filter screen [https://github.com/woocommerce/woocommerce-android/pull/8341]

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
     mediapickerVersion = '0.1.1'
-    wordPressLoginVersion = 'trunk-7b2706ac5a3dd656705cad8eef825b2fe8a4f6aa'
+    wordPressLoginVersion = '1.1.0'
     aboutAutomatticVersion = '0.0.6'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -544,6 +544,7 @@
     <string name="domains_add_domain_button_title">Add a domain</string>
     <string name="domains_select_domain">Select domain</string>
     <string name="domains_redirect_notice">The domain purchased will redirect users to</string>
+    <string name="domains_error_title">Unable to load site domains</string>
     <!--
         Order Editing
     -->
@@ -1820,6 +1821,7 @@
     <string name="settings_signout">Log out</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
+    <string name="settings_confirm_logout_site_credentials">Are you sure you want to log out of your account?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_beta_feature_failed_snackbar_text">Sorry, we couldn\'t change this feature setting right now</string>


### PR DESCRIPTION
- [x] `build.gradle` file on `WooCommerce` module updated  with version bump. (1e92a6d19a98d415cbb0a1aa1f205a4ceb41db95)
- [x] `release notes` related files updated. (2d1afc65d08b971dc90cba2e4873352da8cebf77 + 1e3ae9fe289c9b091d275ebd1018a0b7f1594541 + 0fb2eba4a1a62ca5d92d69f321b66c24eaf00ab9 + 342e613d17de803c584f63a534f2d51ab6a651d0)
- [x] `new strings` frozen/copied into `fastlane/resources/values/strings.xml`. (2f558234f449f9e42e2d394ce88c53a77f843cd9)
- [x] `12.4-rc-1` WCAndroid beta submitted to Google for review (`Full rollout`).

EXTRAS:
- [x] `login` version bump. (08a61808dc2994f55374ae412103cbdca13184a4)