### PR TITLE
[Support Requests] Integrate Support Request Form UI with Zendesk API rules

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -163,6 +163,7 @@ class ZendeskHelper(
      */
     suspend fun createRequest(
         context: Context,
+        origin: HelpOrigin,
         selectedSite: SiteModel?,
         ticketType: TicketType,
         extraTags: List<String>,
@@ -178,7 +179,7 @@ class ZendeskHelper(
             this.ticketFormId = ticketType.form
             this.subject = subject
             this.description = description
-            this.tags = ticketType.tags + extraTags
+            this.tags =  buildZendeskTags(siteStore.sites, origin, ticketType.tags + extraTags)
             this.customFields = buildZendeskCustomFields(context, ticketType, siteStore.sites, selectedSite)
         }.let { request -> requestProvider?.createRequest(request, requestCallback) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -166,7 +166,8 @@ class ZendeskHelper(
         helpData: HelpData,
         selectedSite: SiteModel?,
         subject: String,
-        description: String
+        description: String,
+        extraTags: List<String>
     ) = callbackFlow {
         val (origin, option) = helpData
         val requestCallback = object : ZendeskCallback<Request>() {
@@ -184,7 +185,7 @@ class ZendeskHelper(
             this.ticketFormId = option.ticketType.form
             this.subject = subject
             this.description = description
-            this.tags = buildZendeskTags(siteStore.sites, origin, option.allTags)
+            this.tags = buildZendeskTags(siteStore.sites, origin, option.allTags + extraTags)
             this.customFields = buildZendeskCustomFields(context, option.ticketType, siteStore.sites, selectedSite)
         }.let { request -> requestProvider?.createRequest(request, requestCallback) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -44,6 +44,7 @@ import zendesk.support.requestlist.RequestListActivity
 import java.util.Locale
 import java.util.Timer
 import kotlin.concurrent.schedule
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 
@@ -180,6 +181,8 @@ class ZendeskHelper(
             this.tags = ticketType.tags
             this.customFields = buildZendeskCustomFields(context, ticketType, siteStore.sites, selectedSite, ssr)
         }.let { request -> requestProvider?.createRequest(request, requestCallback) }
+
+        awaitClose()
     }.flowOn(dispatchers.io)
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -171,6 +171,10 @@ class ZendeskHelper(
         description: String,
         extraTags: List<String>
     ) = callbackFlow {
+        require(isZendeskEnabled) {
+            zendeskNeedsToBeEnabledError
+        }
+
         val (origin, option) = helpData
         val requestCallback = object : ZendeskCallback<Request>() {
             override fun onSuccess(result: Request?) {
@@ -191,6 +195,7 @@ class ZendeskHelper(
             this.customFields = buildZendeskCustomFields(context, option.ticketType, siteStore.sites, selectedSite)
         }.let { request -> requestProvider?.createRequest(request, requestCallback) }
 
+        // Sets a timeout since the callback might not be called from Zendesk API
         launch {
             delay(RequestConstants.requestCreationTimeout)
             trySend(Result.failure(Throwable(RequestConstants.requestCreationTimeoutErrorMessage)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -164,9 +164,8 @@ class ZendeskHelper(
     suspend fun createRequest(
         context: Context,
         origin: HelpOrigin,
+        option: HelpOption,
         selectedSite: SiteModel?,
-        ticketType: TicketType,
-        extraTags: List<String>,
         subject: String,
         description: String
     ) = callbackFlow {
@@ -182,11 +181,11 @@ class ZendeskHelper(
         }
 
         CreateRequest().apply {
-            this.ticketFormId = ticketType.form
+            this.ticketFormId = option.ticketType.form
             this.subject = subject
             this.description = description
-            this.tags =  buildZendeskTags(siteStore.sites, origin, ticketType.tags + extraTags)
-            this.customFields = buildZendeskCustomFields(context, ticketType, siteStore.sites, selectedSite)
+            this.tags =  buildZendeskTags(siteStore.sites, origin, option.allTags)
+            this.customFields = buildZendeskCustomFields(context, option.ticketType, siteStore.sites, selectedSite)
         }.let { request -> requestProvider?.createRequest(request, requestCallback) }
 
         awaitClose()
@@ -627,6 +626,8 @@ sealed class HelpOption(val ticketType: TicketType, val extraTags: List<String>)
         ticketType = TicketType.General,
         extraTags = listOf("product_area_woo_extensions")
     )
+
+    val allTags get() = ticketType.tags + extraTags
 }
 
 sealed class TicketType(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.support
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.os.Parcelable
 import android.telephony.TelephonyManager
 import android.text.TextUtils
 import com.woocommerce.android.AppPrefs
@@ -45,6 +46,7 @@ import java.util.Timer
 import kotlin.concurrent.schedule
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.parcelize.Parcelize
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
 private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500
@@ -602,12 +604,14 @@ sealed class TicketType(
     val form: Long,
     val subcategoryName: String,
     val tags: List<String> = emptyList(),
-) {
+) : Parcelable {
+    @Parcelize
     object General : TicketType(
         form = TicketFieldIds.formGeneral,
         subcategoryName = ZendeskConstants.subcategoryGeneralValue,
     )
 
+    @Parcelize
     object Payments : TicketType(
         form = TicketFieldIds.formPayments,
         subcategoryName = ZendeskConstants.subcategoryPaymentsValue,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -171,8 +171,14 @@ class ZendeskHelper(
         description: String
     ) = callbackFlow {
         val requestCallback = object : ZendeskCallback<Request>() {
-            override fun onSuccess(result: Request?) { trySend(Result.success(result)) }
-            override fun onError(error: ErrorResponse) { trySend(Result.failure(Throwable(error.reason))) }
+            override fun onSuccess(result: Request?) {
+                trySend(Result.success(result))
+                close()
+            }
+            override fun onError(error: ErrorResponse) {
+                trySend(Result.failure(Throwable(error.reason)))
+                close()
+            }
         }
 
         CreateRequest().apply {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -22,8 +22,10 @@ import com.zendesk.logger.Logger
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
@@ -47,8 +49,6 @@ import zendesk.support.requestlist.RequestListActivity
 import java.util.Locale
 import java.util.Timer
 import kotlin.concurrent.schedule
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
 private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500
@@ -163,6 +163,7 @@ class ZendeskHelper(
      *
      * As it is, no identity is required so far. This should be revised in the near future.
      */
+    @Suppress("LongParameterList")
     suspend fun createRequest(
         context: Context,
         helpData: HelpData,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -606,6 +606,28 @@ private object TicketFieldIds {
     const val appLanguage = 360008583691L
     const val sourcePlatform = 360009311651L
 }
+sealed class HelpOption(val ticketType: TicketType, val extraTags: List<String>) : Parcelable {
+    @Parcelize object MobileApp : HelpOption(
+        ticketType = TicketType.General,
+        extraTags = listOf("mobile-app")
+    )
+    @Parcelize object InPersonPayments : HelpOption(
+        ticketType = TicketType.General,
+        extraTags = listOf("woocommerce_mobile_apps", "product_area_apps_in_person_payments")
+    )
+    @Parcelize object Payments : HelpOption(
+        ticketType = TicketType.Payments,
+        extraTags = emptyList()
+    )
+    @Parcelize object WooPlugin : HelpOption(
+        ticketType = TicketType.General,
+        extraTags = listOf("woocommerce_core")
+    )
+    @Parcelize object OtherPlugins : HelpOption(
+        ticketType = TicketType.General,
+        extraTags = listOf("product_area_woo_extensions")
+    )
+}
 
 sealed class TicketType(
     val form: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -163,7 +163,7 @@ class ZendeskHelper(
      */
     suspend fun createRequest(
         context: Context,
-        helpData: Pair<HelpOrigin, HelpOption>,
+        helpData: HelpData,
         selectedSite: SiteModel?,
         subject: String,
         description: String
@@ -605,6 +605,8 @@ private object TicketFieldIds {
     const val appLanguage = 360008583691L
     const val sourcePlatform = 360009311651L
 }
+
+data class HelpData(val origin: HelpOrigin, val option: HelpOption)
 
 sealed class HelpOption(val ticketType: TicketType, val extraTags: List<String>) : Parcelable {
     @Parcelize object MobileApp : HelpOption(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -22,6 +22,7 @@ import com.zendesk.logger.Logger
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
 import kotlinx.coroutines.withContext
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -46,7 +47,6 @@ import java.util.Timer
 import kotlin.concurrent.schedule
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
-import kotlinx.parcelize.Parcelize
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
 private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -165,9 +165,9 @@ class ZendeskHelper(
         context: Context,
         selectedSite: SiteModel?,
         ticketType: TicketType,
+        extraTags: List<String>,
         subject: String,
-        description: String,
-        ssr: String? = null
+        description: String
     ) = callbackFlow {
         val requestCallback = object : ZendeskCallback<Request>() {
             override fun onSuccess(result: Request?) { trySend(Result.success(result)) }
@@ -178,8 +178,8 @@ class ZendeskHelper(
             this.ticketFormId = ticketType.form
             this.subject = subject
             this.description = description
-            this.tags = ticketType.tags
-            this.customFields = buildZendeskCustomFields(context, ticketType, siteStore.sites, selectedSite, ssr)
+            this.tags = ticketType.tags + extraTags
+            this.customFields = buildZendeskCustomFields(context, ticketType, siteStore.sites, selectedSite)
         }.let { request -> requestProvider?.createRequest(request, requestCallback) }
 
         awaitClose()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -259,7 +259,10 @@ class HelpActivity : AppCompatActivity() {
     }
 
     private fun openSupportRequestForm() {
-        startActivity(Intent(this, SupportRequestFormActivity::class.java))
+        Intent(this, SupportRequestFormActivity::class.java).apply {
+            putExtra(SupportRequestFormActivity.ORIGIN_KEY, originFromExtras)
+            startActivity(this)
+        }
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -197,7 +197,7 @@ class HelpActivity : AppCompatActivity() {
                 .getSupportEmailAndNameSuggestion(accountStore.account, selectedSiteOrNull()).first
         }
 
-        supportHelper.showSupportIdentityInputDialog(this, emailSuggestion, isNameInputHidden = true) { email, _ ->
+        supportHelper.showSupportIdentityInputDialog(this, emailSuggestion) { email, _ ->
             zendeskHelper.setSupportEmail(email)
             AnalyticsTracker.track(AnalyticsEvent.SUPPORT_IDENTITY_SET)
             if (createNewTicket) createNewZendeskTicket(ticketType, extraTags)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -25,6 +25,9 @@ import com.woocommerce.android.support.SupportHelper
 import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.WooLogViewerActivity
 import com.woocommerce.android.support.ZendeskHelper
+import com.woocommerce.android.support.help.HelpViewModel.ContactSupportEvent
+import com.woocommerce.android.support.help.HelpViewModel.ContactSupportEvent.CreateTicket
+import com.woocommerce.android.support.help.HelpViewModel.ContactSupportEvent.ShowLoading
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
@@ -68,12 +71,7 @@ class HelpActivity : AppCompatActivity() {
         supportActionBar?.setHomeButtonEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        if (FeatureFlag.NEW_SUPPORT_REQUESTS.isEnabled()) {
-            binding.contactContainer.setOnClickListener { openSupportRequestForm() }
-        } else {
-            binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.General) }
-        }
-
+        binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.General) }
         binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.General) }
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener {
@@ -124,13 +122,13 @@ class HelpActivity : AppCompatActivity() {
     private fun initObservers(binding: ActivityHelpBinding) {
         viewModel.event.observe(this) { event ->
             when (event) {
-                is HelpViewModel.ContactSupportEvent -> {
+                is ContactSupportEvent -> {
                     when (event) {
-                        is HelpViewModel.ContactSupportEvent.CreateTicket -> {
+                        is CreateTicket -> {
                             binding.helpLoading.visibility = View.GONE
                             createNewZendeskTicket(event.ticketType, extraTags = event.supportTags)
                         }
-                        HelpViewModel.ContactSupportEvent.ShowLoading -> {
+                        is ShowLoading -> {
                             binding.helpLoading.visibility = View.VISIBLE
                         }
                     }.exhaustive
@@ -172,14 +170,19 @@ class HelpActivity : AppCompatActivity() {
             return
         }
 
-        zendeskHelper.createNewTicket(
-            context = this,
-            origin = originFromExtras,
-            selectedSite = selectedSiteOrNull(),
-            extraTags = extraTags + extraTagsFromExtras.orEmpty(),
-            ticketType = ticketType,
-            ssr = viewModel.ssr
-        )
+        if (FeatureFlag.NEW_SUPPORT_REQUESTS.isEnabled()) {
+            val tags = extraTags + (extraTagsFromExtras ?: emptyList())
+            openSupportRequestForm(tags)
+        } else {
+            zendeskHelper.createNewTicket(
+                context = this,
+                origin = originFromExtras,
+                selectedSite = selectedSiteOrNull(),
+                extraTags = extraTags + extraTagsFromExtras.orEmpty(),
+                ticketType = ticketType,
+                ssr = viewModel.ssr
+            )
+        }
     }
 
     private fun showIdentityDialog(
@@ -258,12 +261,12 @@ class HelpActivity : AppCompatActivity() {
         startActivity(Intent(this, SSRActivity::class.java))
     }
 
-    private fun openSupportRequestForm() {
+    private fun openSupportRequestForm(extraTags: List<String>) {
         startActivity(
             SupportRequestFormActivity.createIntent(
                 this,
                 originFromExtras,
-                extraTagsFromExtras ?: ArrayList()
+                ArrayList(extraTags)
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -259,10 +259,13 @@ class HelpActivity : AppCompatActivity() {
     }
 
     private fun openSupportRequestForm() {
-        Intent(this, SupportRequestFormActivity::class.java).apply {
-            putExtra(SupportRequestFormActivity.ORIGIN_KEY, originFromExtras)
-            startActivity(this)
-        }
+        startActivity(
+            SupportRequestFormActivity.createIntent(
+                this,
+                originFromExtras,
+                extraTagsFromExtras ?: ArrayList()
+            )
+        )
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -10,6 +10,8 @@ import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
 import com.woocommerce.android.extensions.serializable
 import com.woocommerce.android.support.HelpOption
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.support.requests.SupportRequestFormViewModel.RequestCreationFailed
+import com.woocommerce.android.support.requests.SupportRequestFormViewModel.RequestCreationSucceeded
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -63,6 +65,12 @@ class SupportRequestFormActivity : AppCompatActivity() {
         viewModel.isRequestLoading.observe(this) { isLoading ->
             if (isLoading) showProgressDialog() else hideProgressDialog()
         }
+        viewModel.event.observe(this) {
+            when (it) {
+                is RequestCreationSucceeded -> showRequestCreationSuccessDialog()
+                is RequestCreationFailed -> showRequestCreationFailureDialog()
+            }
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -71,6 +79,13 @@ class SupportRequestFormActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun showRequestCreationSuccessDialog() {
+    }
+
+    private fun showRequestCreationFailureDialog() {
+
     }
 
     private fun showProgressDialog() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -27,6 +27,10 @@ class SupportRequestFormActivity : AppCompatActivity() {
         intent.extras?.serializable(ORIGIN_KEY) ?: HelpOrigin.UNKNOWN
     }
 
+    private val extraTags by lazy {
+        intent.extras?.getStringArrayList(EXTRA_TAGS_KEY) ?: emptyList()
+    }
+
     private var progressDialog: CustomProgressDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -58,7 +62,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
             }
         }
         binding.submitRequestButton.setOnClickListener {
-            viewModel.onSubmitRequestButtonClicked(this, helpOrigin)
+            viewModel.onSubmitRequestButtonClicked(this, helpOrigin, extraTags)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -32,12 +32,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
 
     private fun observeViewEvents(binding: ActivitySupportRequestFormBinding) {
         binding.submitRequestButton.setOnClickListener {
-            viewModel.onSubmitRequestButtonClicked(
-                this,
-                TicketType.General,
-                "This is a Test",
-                "Please Ignore"
-            )
+            viewModel.onSubmitRequestButtonClicked(this)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.support.requests
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.viewModels
@@ -116,6 +118,17 @@ class SupportRequestFormActivity : AppCompatActivity() {
     }
 
     companion object {
-        const val ORIGIN_KEY = "ORIGIN_KEY"
+        private const val ORIGIN_KEY = "ORIGIN_KEY"
+        private const val EXTRA_TAGS_KEY = "EXTRA_TAGS_KEY"
+
+        @JvmStatic
+        fun createIntent(
+            context: Context,
+            origin: HelpOrigin,
+            extraTags: java.util.ArrayList<String>
+        ) = Intent(context, SupportRequestFormActivity::class.java).apply {
+            putExtra(ORIGIN_KEY, origin)
+            putStringArrayListExtra(EXTRA_TAGS_KEY, ArrayList(extraTags))
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -8,12 +8,8 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.widget.doOnTextChanged
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
 import com.woocommerce.android.extensions.serializable
+import com.woocommerce.android.support.HelpOption
 import com.woocommerce.android.support.help.HelpOrigin
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.InPersonPayments
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.MobileApp
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.OtherPlugins
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.Payments
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.WooPlugin
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -45,11 +41,11 @@ class SupportRequestFormActivity : AppCompatActivity() {
         binding.requestMessage.doOnTextChanged { text, _, _, _ -> viewModel.onMessageChanged(text.toString()) }
         binding.helpOptionsGroup.setOnCheckedChangeListener { _, selectionID ->
             when (selectionID) {
-                binding.mobileAppOption.id -> viewModel.onHelpOptionSelected(MobileApp)
-                binding.ippOption.id -> viewModel.onHelpOptionSelected(InPersonPayments)
-                binding.paymentsOption.id -> viewModel.onHelpOptionSelected(Payments)
-                binding.wooPluginOption.id -> viewModel.onHelpOptionSelected(WooPlugin)
-                binding.otherOption.id -> viewModel.onHelpOptionSelected(OtherPlugins)
+                binding.mobileAppOption.id -> viewModel.onHelpOptionSelected(HelpOption.MobileApp)
+                binding.ippOption.id -> viewModel.onHelpOptionSelected(HelpOption.InPersonPayments)
+                binding.paymentsOption.id -> viewModel.onHelpOptionSelected(HelpOption.Payments)
+                binding.wooPluginOption.id -> viewModel.onHelpOptionSelected(HelpOption.WooPlugin)
+                binding.otherOption.id -> viewModel.onHelpOptionSelected(HelpOption.OtherPlugins)
             }
         }
         binding.submitRequestButton.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -6,12 +6,14 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.widget.doOnTextChanged
+import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
 import com.woocommerce.android.extensions.serializable
 import com.woocommerce.android.support.HelpOption
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.RequestCreationFailed
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.RequestCreationSucceeded
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -82,6 +84,12 @@ class SupportRequestFormActivity : AppCompatActivity() {
     }
 
     private fun showRequestCreationSuccessDialog() {
+        WooDialog.showDialog(
+            activity = this,
+            titleId = R.string.support_request_success_title,
+            messageId = R.string.support_request_success_message,
+            positiveButtonId = R.string.support_request_success_action
+        )
     }
 
     private fun showRequestCreationFailureDialog() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -88,12 +88,17 @@ class SupportRequestFormActivity : AppCompatActivity() {
             activity = this,
             titleId = R.string.support_request_success_title,
             messageId = R.string.support_request_success_message,
-            positiveButtonId = R.string.support_request_success_action
+            positiveButtonId = R.string.support_request_dialog_action
         )
     }
 
     private fun showRequestCreationFailureDialog() {
-
+        WooDialog.showDialog(
+            activity = this,
+            titleId = R.string.support_request_error_title,
+            messageId = R.string.support_request_error_message,
+            positiveButtonId = R.string.support_request_dialog_action
+        )
     }
 
     private fun showProgressDialog() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -18,8 +18,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
             setContentView(root)
             setupActionBar()
             observeViewEvents(this)
-            // Disabled to avoid triggering a support request while testing, it will be removed later
-            submitRequestButton.isEnabled = false
+            observeViewModelEvents(this)
         }
     }
 
@@ -32,6 +31,12 @@ class SupportRequestFormActivity : AppCompatActivity() {
     private fun observeViewEvents(binding: ActivitySupportRequestFormBinding) {
         binding.submitRequestButton.setOnClickListener {
             viewModel.onSubmitRequestButtonClicked(this)
+        }
+    }
+
+    private fun observeViewModelEvents(binding: ActivitySupportRequestFormBinding) {
+        viewModel.isSubmitButtonEnabled.observe(this) { isEnabled ->
+            binding.submitRequestButton.isEnabled = isEnabled
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -7,6 +7,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.widget.doOnTextChanged
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
+import com.woocommerce.android.extensions.serializable
+import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.InPersonPayments
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.MobileApp
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.OtherPlugins
@@ -17,6 +19,10 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class SupportRequestFormActivity : AppCompatActivity() {
     private val viewModel: SupportRequestFormViewModel by viewModels()
+
+    private val helpOrigin by lazy {
+        intent.extras?.serializable(ORIGIN_KEY) ?: HelpOrigin.UNKNOWN
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -63,5 +69,9 @@ class SupportRequestFormActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    companion object {
+        private const val ORIGIN_KEY = "ORIGIN_KEY"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -104,8 +104,8 @@ class SupportRequestFormActivity : AppCompatActivity() {
     private fun showProgressDialog() {
         hideProgressDialog()
         progressDialog = CustomProgressDialog.show(
-            "Sending your request",
-            "Please wait..."
+            getString(R.string.support_request_loading_title),
+            getString(R.string.support_request_loading_message)
         ).also { it.show(supportFragmentManager, CustomProgressDialog.TAG) }
         progressDialog?.isCancelable = false
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -116,6 +116,6 @@ class SupportRequestFormActivity : AppCompatActivity() {
     }
 
     companion object {
-        private const val ORIGIN_KEY = "ORIGIN_KEY"
+        const val ORIGIN_KEY = "ORIGIN_KEY"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -5,6 +5,7 @@ import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.widget.doOnTextChanged
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -29,6 +30,8 @@ class SupportRequestFormActivity : AppCompatActivity() {
     }
 
     private fun observeViewEvents(binding: ActivitySupportRequestFormBinding) {
+        binding.requestSubject.setOnTextChangedListener { viewModel.onSubjectChanged(it.toString()) }
+        binding.requestMessage.doOnTextChanged { text, _, _, _ -> viewModel.onMessageChanged(text.toString()) }
         binding.submitRequestButton.setOnClickListener {
             viewModel.onSubmitRequestButtonClicked(this)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -7,6 +7,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.widget.doOnTextChanged
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
+import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.InPersonPayments
+import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.MobileApp
+import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.OtherPlugins
+import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.Payments
+import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.WooPlugin
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -32,6 +37,15 @@ class SupportRequestFormActivity : AppCompatActivity() {
     private fun observeViewEvents(binding: ActivitySupportRequestFormBinding) {
         binding.requestSubject.setOnTextChangedListener { viewModel.onSubjectChanged(it.toString()) }
         binding.requestMessage.doOnTextChanged { text, _, _, _ -> viewModel.onMessageChanged(text.toString()) }
+        binding.helpOptionsGroup.setOnCheckedChangeListener { _, selectionID ->
+            when (selectionID) {
+                binding.mobileAppOption.id -> viewModel.onHelpOptionSelected(MobileApp)
+                binding.ippOption.id -> viewModel.onHelpOptionSelected(InPersonPayments)
+                binding.paymentsOption.id -> viewModel.onHelpOptionSelected(Payments)
+                binding.wooPluginOption.id -> viewModel.onHelpOptionSelected(WooPlugin)
+                binding.otherOption.id -> viewModel.onHelpOptionSelected(OtherPlugins)
+            }
+        }
         binding.submitRequestButton.setOnClickListener {
             viewModel.onSubmitRequestButtonClicked(this)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -94,7 +94,8 @@ class SupportRequestFormActivity : AppCompatActivity() {
             activity = this,
             titleId = R.string.support_request_success_title,
             messageId = R.string.support_request_success_message,
-            positiveButtonId = R.string.support_request_dialog_action
+            positiveButtonId = R.string.support_request_dialog_action,
+            posBtnAction = { _, _ -> finish() }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
-import com.woocommerce.android.support.TicketType
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
 import com.woocommerce.android.extensions.serializable
 import com.woocommerce.android.support.HelpOption
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -19,6 +20,8 @@ class SupportRequestFormActivity : AppCompatActivity() {
     private val helpOrigin by lazy {
         intent.extras?.serializable(ORIGIN_KEY) ?: HelpOrigin.UNKNOWN
     }
+
+    private var progressDialog: CustomProgressDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,6 +60,9 @@ class SupportRequestFormActivity : AppCompatActivity() {
         viewModel.isSubmitButtonEnabled.observe(this) { isEnabled ->
             binding.submitRequestButton.isEnabled = isEnabled
         }
+        viewModel.isRequestLoading.observe(this) { isLoading ->
+            if (isLoading) showProgressDialog() else hideProgressDialog()
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -65,6 +71,20 @@ class SupportRequestFormActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun showProgressDialog() {
+        hideProgressDialog()
+        progressDialog = CustomProgressDialog.show(
+            "Sending your request",
+            "Please wait..."
+        ).also { it.show(supportFragmentManager, CustomProgressDialog.TAG) }
+        progressDialog?.isCancelable = false
+    }
+
+    private fun hideProgressDialog() {
+        progressDialog?.dismiss()
+        progressDialog = null
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -53,7 +53,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
             }
         }
         binding.submitRequestButton.setOnClickListener {
-            viewModel.onSubmitRequestButtonClicked(this)
+            viewModel.onSubmitRequestButtonClicked(this, helpOrigin)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -16,8 +16,8 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
 
 @HiltViewModel
 class SupportRequestFormViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.support.HelpOption
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -71,10 +72,13 @@ class SupportRequestFormViewModel @Inject constructor(
     private fun Result<Request?>.handleCreateRequestResult() {
         viewState.update { it.copy(isLoading = false) }
         fold(
-            onSuccess = { },
-            onFailure = { }
+            onSuccess = { triggerEvent(RequestCreationSucceeded) },
+            onFailure = { triggerEvent(RequestCreationFailed) }
         )
     }
+
+    object RequestCreationSucceeded: Event()
+    object RequestCreationFailed: Event()
 
     @Parcelize
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -4,17 +4,10 @@ import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.R
 import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.TicketType.General
 import com.woocommerce.android.support.ZendeskHelper
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.InPersonPayments
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.MobileApp
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.OtherPlugins
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.Payments
-import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.WooPlugin
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,7 +21,6 @@ import javax.inject.Inject
 class SupportRequestFormViewModel @Inject constructor(
     private val zendeskHelper: ZendeskHelper,
     private val selectedSite: SelectedSite,
-    private val resourceProvider: ResourceProvider,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val viewState = savedState.getStateFlow(
@@ -60,17 +52,6 @@ class SupportRequestFormViewModel @Inject constructor(
         launch { zendeskHelper.createRequest(context, selectedSite.get(), ticketType, subject, message) }
     }
 
-    private fun generateHelpOptionFromDescription(description: String): HelpOption {
-        return when (description) {
-            resourceProvider.getString(MobileApp.descriptionResource) -> MobileApp
-            resourceProvider.getString(InPersonPayments.descriptionResource) -> InPersonPayments
-            resourceProvider.getString(Payments.descriptionResource) -> Payments
-            resourceProvider.getString(WooPlugin.descriptionResource) -> WooPlugin
-            resourceProvider.getString(OtherPlugins.descriptionResource) -> OtherPlugins
-            else -> throw IllegalArgumentException("Unknown help option: $description")
-        }
-    }
-
     data class ViewState(
         val helpOption: HelpOption?,
         val subject: String,
@@ -81,11 +62,11 @@ class SupportRequestFormViewModel @Inject constructor(
         }
     }
 
-    sealed class HelpOption(val ticketType: TicketType, val descriptionResource: Int) {
-        object MobileApp : HelpOption(General, R.string.support_request_help_app)
-        object InPersonPayments : HelpOption(TicketType.Payments, R.string.support_request_help_ipp)
-        object Payments : HelpOption(TicketType.Payments, R.string.support_request_help_payments)
-        object WooPlugin : HelpOption(General, R.string.support_request_help_plugins)
-        object OtherPlugins : HelpOption(General, R.string.support_request_help_other)
+    sealed class HelpOption(val ticketType: TicketType) {
+        object MobileApp : HelpOption(General)
+        object InPersonPayments : HelpOption(TicketType.Payments)
+        object Payments : HelpOption(TicketType.Payments)
+        object WooPlugin : HelpOption(General)
+        object OtherPlugins : HelpOption(General)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -49,12 +49,13 @@ class SupportRequestFormViewModel @Inject constructor(
     }
 
     fun onSubmitRequestButtonClicked(context: Context) {
-        val ticketType = viewState.value.helpOption?.ticketType ?: return
+        val helpOption = viewState.value.helpOption ?: return
         launch {
             zendeskHelper.createRequest(
                 context,
                 selectedSite.get(),
-                ticketType,
+                helpOption.ticketType,
+                helpOption.extraTags,
                 viewState.value.subject,
                 viewState.value.message
             ).collect { it.handleCreateRequestResult() }
@@ -83,26 +84,26 @@ class SupportRequestFormViewModel @Inject constructor(
         }
     }
 
-    sealed class HelpOption(val ticketType: TicketType, tags: List<String>) : Parcelable {
+    sealed class HelpOption(val ticketType: TicketType, val extraTags: List<String>) : Parcelable {
         @Parcelize object MobileApp : HelpOption(
             ticketType = General,
-            tags = listOf("mobile-app")
+            extraTags = listOf("mobile-app")
         )
         @Parcelize object InPersonPayments : HelpOption(
             ticketType = General,
-            tags = listOf("woocommerce_mobile_apps", "product_area_apps_in_person_payments")
+            extraTags = listOf("woocommerce_mobile_apps", "product_area_apps_in_person_payments")
         )
         @Parcelize object Payments : HelpOption(
             ticketType = TicketType.Payments,
-            tags = emptyList()
+            extraTags = emptyList()
         )
         @Parcelize object WooPlugin : HelpOption(
             ticketType = General,
-            tags = listOf("woocommerce_core")
+            extraTags = listOf("woocommerce_core")
         )
         @Parcelize object OtherPlugins : HelpOption(
             ticketType = General,
-            tags = listOf("product_area_woo_extensions")
+            extraTags = listOf("product_area_woo_extensions")
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.TicketType.General
 import com.woocommerce.android.support.ZendeskHelper
+import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -48,11 +49,12 @@ class SupportRequestFormViewModel @Inject constructor(
         viewState.update { it.copy(message = message) }
     }
 
-    fun onSubmitRequestButtonClicked(context: Context) {
+    fun onSubmitRequestButtonClicked(context: Context, helpOrigin: HelpOrigin) {
         val helpOption = viewState.value.helpOption ?: return
         launch {
             zendeskHelper.createRequest(
                 context,
+                helpOrigin,
                 selectedSite.get(),
                 helpOption.ticketType,
                 helpOption.extraTags,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -55,7 +55,7 @@ class SupportRequestFormViewModel @Inject constructor(
         viewState.update { it.copy(message = message) }
     }
 
-    fun onSubmitRequestButtonClicked(context: Context, helpOrigin: HelpOrigin) {
+    fun onSubmitRequestButtonClicked(context: Context, helpOrigin: HelpOrigin, extraTags: List<String>) {
         val helpOption = viewState.value.helpOption ?: return
         viewState.update { it.copy(isLoading = true) }
         launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.support.requests
 
 import android.content.Context
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.parcelize.Parcelize
 
 @HiltViewModel
 class SupportRequestFormViewModel @Inject constructor(
@@ -51,22 +53,22 @@ class SupportRequestFormViewModel @Inject constructor(
         val message = viewState.value.message
         launch { zendeskHelper.createRequest(context, selectedSite.get(), ticketType, subject, message) }
     }
-
+    @Parcelize
     data class ViewState(
         val helpOption: HelpOption?,
         val subject: String,
         val message: String
-    ) {
+    ) : Parcelable {
         companion object {
             val EMPTY = ViewState(null, "", "")
         }
     }
 
-    sealed class HelpOption(val ticketType: TicketType) {
-        object MobileApp : HelpOption(General)
-        object InPersonPayments : HelpOption(TicketType.Payments)
-        object Payments : HelpOption(TicketType.Payments)
-        object WooPlugin : HelpOption(General)
-        object OtherPlugins : HelpOption(General)
+    sealed class HelpOption(val ticketType: TicketType) : Parcelable {
+        @Parcelize object MobileApp : HelpOption(General)
+        @Parcelize object InPersonPayments : HelpOption(TicketType.Payments)
+        @Parcelize object Payments : HelpOption(TicketType.Payments)
+        @Parcelize object WooPlugin : HelpOption(General)
+        @Parcelize object OtherPlugins : HelpOption(General)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -28,7 +28,7 @@ class SupportRequestFormViewModel @Inject constructor(
     )
 
     val isSubmitButtonEnabled = viewState
-        .map { it.helpOption != HelpOption.None && it.subject.isNotBlank() && it.message.isNotBlank() }
+        .map { it.helpOption != null && it.subject.isNotBlank() && it.message.isNotBlank() }
         .distinctUntilChanged()
         .asLiveData()
 
@@ -46,22 +46,21 @@ class SupportRequestFormViewModel @Inject constructor(
     }
 
     data class ViewState(
-        val helpOption: HelpOption,
+        val helpOption: HelpOption?,
         val subject: String,
         val message: String
     ) {
         companion object {
-            val EMPTY = ViewState(HelpOption.None, "", "")
+            val EMPTY = ViewState(null, "", "")
         }
     }
 
-    sealed class HelpOption(val ticketType: TicketType?) {
+    sealed class HelpOption(val ticketType: TicketType) {
         object MobileApp: HelpOption(TicketType.General)
         object InPersonPayments: HelpOption(TicketType.Payments)
         object Payments: HelpOption(TicketType.Payments)
         object WooPlugin: HelpOption(TicketType.General)
         object OtherPlugins: HelpOption(TicketType.General)
-        object None: HelpOption(null)
 
         companion object {
             fun fromDescription(description: String): HelpOption {
@@ -71,7 +70,7 @@ class SupportRequestFormViewModel @Inject constructor(
                     "Payments" -> Payments
                     "WooCommerce Plugin" -> WooPlugin
                     "Other Plugins" -> OtherPlugins
-                    else -> None
+                    else -> throw IllegalArgumentException("Unknown help option: $description")
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import zendesk.support.Request
 
 @HiltViewModel
 class SupportRequestFormViewModel @Inject constructor(
@@ -49,10 +50,28 @@ class SupportRequestFormViewModel @Inject constructor(
 
     fun onSubmitRequestButtonClicked(context: Context) {
         val ticketType = viewState.value.helpOption?.ticketType ?: return
-        val subject = viewState.value.subject
-        val message = viewState.value.message
-        launch { zendeskHelper.createRequest(context, selectedSite.get(), ticketType, subject, message) }
+        launch {
+            zendeskHelper.createRequest(
+                context,
+                selectedSite.get(),
+                ticketType,
+                viewState.value.subject,
+                viewState.value.message
+            ).collect { it.handleCreateRequestResult() }
+        }
     }
+
+    private fun Result<Request?>.handleCreateRequestResult() {
+        fold(
+            onSuccess = { request ->
+
+            },
+            onFailure = {
+
+            }
+        )
+    }
+
     @Parcelize
     data class ViewState(
         val helpOption: HelpOption?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -24,4 +24,12 @@ class SupportRequestFormViewModel @Inject constructor(
     ) {
         launch { zendeskHelper.createRequest(context, selectedSite.get(), ticketType, subject, message) }
     }
+
+    sealed class HelpOption(val ticketType: TicketType) {
+        object MobileApp: HelpOption(TicketType.General)
+        object InPersonPayments: HelpOption(TicketType.Payments)
+        object Payments: HelpOption(TicketType.Payments)
+        object WooPlugin: HelpOption(TicketType.General)
+        object OtherPlugins: HelpOption(TicketType.General)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.support.HelpData
 import com.woocommerce.android.support.HelpOption
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
@@ -53,7 +54,7 @@ class SupportRequestFormViewModel @Inject constructor(
         launch {
             zendeskHelper.createRequest(
                 context,
-                Pair(helpOrigin, helpOption),
+                HelpData(helpOrigin, helpOption),
                 selectedSite.get(),
                 viewState.value.subject,
                 viewState.value.message
@@ -63,7 +64,7 @@ class SupportRequestFormViewModel @Inject constructor(
 
     private fun Result<Request?>.handleCreateRequestResult() {
         fold(
-            onSuccess = { request -> },
+            onSuccess = { },
             onFailure = { }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 
 @HiltViewModel
 class SupportRequestFormViewModel @Inject constructor(
@@ -30,6 +31,10 @@ class SupportRequestFormViewModel @Inject constructor(
         .map { it.helpOption != HelpOption.None && it.subject.isNotBlank() && it.message.isNotBlank() }
         .distinctUntilChanged()
         .asLiveData()
+
+    fun onHelpOptionSelected(helpDescription: String) {
+        viewState.update { it.copy(helpOption = HelpOption.fromDescription(helpDescription)) }
+    }
 
     fun onSubmitRequestButtonClicked(
         context: Context,
@@ -57,5 +62,18 @@ class SupportRequestFormViewModel @Inject constructor(
         object WooPlugin: HelpOption(TicketType.General)
         object OtherPlugins: HelpOption(TicketType.General)
         object None: HelpOption(null)
+
+        companion object {
+            fun fromDescription(description: String): HelpOption {
+                return when (description) {
+                    "Mobile App" -> MobileApp
+                    "In-Person Payments" -> InPersonPayments
+                    "Payments" -> Payments
+                    "WooCommerce Plugin" -> WooPlugin
+                    "Other Plugins" -> OtherPlugins
+                    else -> None
+                }
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -64,7 +64,8 @@ class SupportRequestFormViewModel @Inject constructor(
                 HelpData(helpOrigin, helpOption),
                 selectedSite.get(),
                 viewState.value.subject,
-                viewState.value.message
+                viewState.value.message,
+                extraTags
             ).collect { it.handleCreateRequestResult() }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -2,13 +2,16 @@ package com.woocommerce.android.support.requests
 
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.flow.map
 
 @HiltViewModel
 class SupportRequestFormViewModel @Inject constructor(
@@ -16,6 +19,11 @@ class SupportRequestFormViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
+    val viewState = savedState.getStateFlow(
+        scope = viewModelScope,
+        initialValue = ViewState.EMPTY
+    )
+
     fun onSubmitRequestButtonClicked(
         context: Context,
         ticketType: TicketType,
@@ -29,13 +37,18 @@ class SupportRequestFormViewModel @Inject constructor(
         val helpOption: HelpOption,
         val subject: String,
         val message: String
-    )
+    ) {
+        companion object {
+            val EMPTY = ViewState(HelpOption.None, "", "")
+        }
+    }
 
-    sealed class HelpOption(val ticketType: TicketType) {
+    sealed class HelpOption(val ticketType: TicketType?) {
         object MobileApp: HelpOption(TicketType.General)
         object InPersonPayments: HelpOption(TicketType.Payments)
         object Payments: HelpOption(TicketType.Payments)
         object WooPlugin: HelpOption(TicketType.General)
         object OtherPlugins: HelpOption(TicketType.General)
+        object None: HelpOption(null)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -78,8 +78,8 @@ class SupportRequestFormViewModel @Inject constructor(
         )
     }
 
-    object RequestCreationSucceeded: Event()
-    object RequestCreationFailed: Event()
+    object RequestCreationSucceeded : Event()
+    object RequestCreationFailed : Event()
 
     @Parcelize
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -36,6 +36,14 @@ class SupportRequestFormViewModel @Inject constructor(
         viewState.update { it.copy(helpOption = HelpOption.fromDescription(helpDescription)) }
     }
 
+    fun onSubjectChanged(subject: String) {
+        viewState.update { it.copy(subject = subject) }
+    }
+
+    fun onMessageChanged(message: String) {
+        viewState.update { it.copy(message = message) }
+    }
+
     fun onSubmitRequestButtonClicked(
         context: Context,
         ticketType: TicketType,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -17,8 +17,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import javax.inject.Inject
 import zendesk.support.Request
+import javax.inject.Inject
 
 @HiltViewModel
 class SupportRequestFormViewModel @Inject constructor(
@@ -53,10 +53,8 @@ class SupportRequestFormViewModel @Inject constructor(
         launch {
             zendeskHelper.createRequest(
                 context,
-                helpOrigin,
+                Pair(helpOrigin, helpOption),
                 selectedSite.get(),
-                helpOption.ticketType,
-                helpOption.extraTags,
                 viewState.value.subject,
                 viewState.value.message
             ).collect { it.handleCreateRequestResult() }
@@ -65,12 +63,8 @@ class SupportRequestFormViewModel @Inject constructor(
 
     private fun Result<Request?>.handleCreateRequestResult() {
         fold(
-            onSuccess = { request ->
-
-            },
-            onFailure = {
-
-            }
+            onSuccess = { request -> },
+            onFailure = { }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -5,8 +5,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.support.TicketType
-import com.woocommerce.android.support.TicketType.General
+import com.woocommerce.android.support.HelpOption
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
@@ -84,28 +83,5 @@ class SupportRequestFormViewModel @Inject constructor(
         companion object {
             val EMPTY = ViewState(null, "", "")
         }
-    }
-
-    sealed class HelpOption(val ticketType: TicketType, val extraTags: List<String>) : Parcelable {
-        @Parcelize object MobileApp : HelpOption(
-            ticketType = General,
-            extraTags = listOf("mobile-app")
-        )
-        @Parcelize object InPersonPayments : HelpOption(
-            ticketType = General,
-            extraTags = listOf("woocommerce_mobile_apps", "product_area_apps_in_person_payments")
-        )
-        @Parcelize object Payments : HelpOption(
-            ticketType = TicketType.Payments,
-            extraTags = emptyList()
-        )
-        @Parcelize object WooPlugin : HelpOption(
-            ticketType = General,
-            extraTags = listOf("woocommerce_core")
-        )
-        @Parcelize object OtherPlugins : HelpOption(
-            ticketType = General,
-            extraTags = listOf("product_area_woo_extensions")
-        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.support.TicketType
+import com.woocommerce.android.support.TicketType.General
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.InPersonPayments
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.HelpOption.MobileApp
@@ -52,12 +53,10 @@ class SupportRequestFormViewModel @Inject constructor(
         viewState.update { it.copy(message = message) }
     }
 
-    fun onSubmitRequestButtonClicked(
-        context: Context,
-        ticketType: TicketType,
-        subject: String,
-        message: String
-    ) {
+    fun onSubmitRequestButtonClicked(context: Context) {
+        val ticketType = viewState.value.helpOption?.ticketType ?: return
+        val subject = viewState.value.subject
+        val message = viewState.value.message
         launch { zendeskHelper.createRequest(context, selectedSite.get(), ticketType, subject, message) }
     }
 
@@ -83,10 +82,10 @@ class SupportRequestFormViewModel @Inject constructor(
     }
 
     sealed class HelpOption(val ticketType: TicketType, val descriptionResource: Int) {
-        object MobileApp: HelpOption(TicketType.General, R.string.support_request_help_app)
+        object MobileApp: HelpOption(General, R.string.support_request_help_app)
         object InPersonPayments: HelpOption(TicketType.Payments, R.string.support_request_help_ipp)
         object Payments: HelpOption(TicketType.Payments, R.string.support_request_help_payments)
-        object WooPlugin: HelpOption(TicketType.General, R.string.support_request_help_plugins)
-        object OtherPlugins: HelpOption(TicketType.General, R.string.support_request_help_other)
+        object WooPlugin: HelpOption(General, R.string.support_request_help_plugins)
+        object OtherPlugins: HelpOption(General, R.string.support_request_help_other)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -25,6 +25,12 @@ class SupportRequestFormViewModel @Inject constructor(
         launch { zendeskHelper.createRequest(context, selectedSite.get(), ticketType, subject, message) }
     }
 
+    data class ViewState(
+        val helpOption: HelpOption,
+        val subject: String,
+        val message: String
+    )
+
     sealed class HelpOption(val ticketType: TicketType) {
         object MobileApp: HelpOption(TicketType.General)
         object InPersonPayments: HelpOption(TicketType.Payments)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -83,11 +83,26 @@ class SupportRequestFormViewModel @Inject constructor(
         }
     }
 
-    sealed class HelpOption(val ticketType: TicketType) : Parcelable {
-        @Parcelize object MobileApp : HelpOption(General)
-        @Parcelize object InPersonPayments : HelpOption(TicketType.Payments)
-        @Parcelize object Payments : HelpOption(TicketType.Payments)
-        @Parcelize object WooPlugin : HelpOption(General)
-        @Parcelize object OtherPlugins : HelpOption(General)
+    sealed class HelpOption(val ticketType: TicketType, tags: List<String>) : Parcelable {
+        @Parcelize object MobileApp : HelpOption(
+            ticketType = General,
+            tags = listOf("mobile-app")
+        )
+        @Parcelize object InPersonPayments : HelpOption(
+            ticketType = General,
+            tags = listOf("woocommerce_mobile_apps", "product_area_apps_in_person_payments")
+        )
+        @Parcelize object Payments : HelpOption(
+            ticketType = TicketType.Payments,
+            tags = emptyList()
+        )
+        @Parcelize object WooPlugin : HelpOption(
+            ticketType = General,
+            tags = listOf("woocommerce_core")
+        )
+        @Parcelize object OtherPlugins : HelpOption(
+            ticketType = General,
+            tags = listOf("product_area_woo_extensions")
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -37,6 +37,11 @@ class SupportRequestFormViewModel @Inject constructor(
         .distinctUntilChanged()
         .asLiveData()
 
+    val isRequestLoading = viewState
+        .map { it.isLoading }
+        .distinctUntilChanged()
+        .asLiveData()
+
     fun onHelpOptionSelected(helpOption: HelpOption) {
         viewState.update { it.copy(helpOption = helpOption) }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -41,8 +41,8 @@ class SupportRequestFormViewModel @Inject constructor(
         .distinctUntilChanged()
         .asLiveData()
 
-    fun onHelpOptionSelected(helpDescription: String) {
-        viewState.update { it.copy(helpOption = generateHelpOptionFromDescription(helpDescription)) }
+    fun onHelpOptionSelected(helpOption: HelpOption) {
+        viewState.update { it.copy(helpOption = helpOption) }
     }
 
     fun onSubjectChanged(subject: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.support.requests
 
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.ZendeskHelper
@@ -11,6 +12,7 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 @HiltViewModel
@@ -19,10 +21,15 @@ class SupportRequestFormViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    val viewState = savedState.getStateFlow(
+    private val viewState = savedState.getStateFlow(
         scope = viewModelScope,
         initialValue = ViewState.EMPTY
     )
+
+    val isSubmitButtonEnabled = viewState
+        .map { it.helpOption != HelpOption.None && it.subject.isNotBlank() && it.message.isNotBlank() }
+        .distinctUntilChanged()
+        .asLiveData()
 
     fun onSubmitRequestButtonClicked(
         context: Context,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -18,11 +18,11 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
-import javax.inject.Inject
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class SupportRequestFormViewModel @Inject constructor(
@@ -82,10 +82,10 @@ class SupportRequestFormViewModel @Inject constructor(
     }
 
     sealed class HelpOption(val ticketType: TicketType, val descriptionResource: Int) {
-        object MobileApp: HelpOption(General, R.string.support_request_help_app)
-        object InPersonPayments: HelpOption(TicketType.Payments, R.string.support_request_help_ipp)
-        object Payments: HelpOption(TicketType.Payments, R.string.support_request_help_payments)
-        object WooPlugin: HelpOption(General, R.string.support_request_help_plugins)
-        object OtherPlugins: HelpOption(General, R.string.support_request_help_other)
+        object MobileApp : HelpOption(General, R.string.support_request_help_app)
+        object InPersonPayments : HelpOption(TicketType.Payments, R.string.support_request_help_ipp)
+        object Payments : HelpOption(TicketType.Payments, R.string.support_request_help_payments)
+        object WooPlugin : HelpOption(General, R.string.support_request_help_plugins)
+        object OtherPlugins : HelpOption(General, R.string.support_request_help_other)
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3086,5 +3086,12 @@
     <string name="support_request_help_payments">WooCommerce Payments</string>
     <string name="support_request_help_plugins">WooCommerce Plugin</string>
     <string name="support_request_help_other">Other Extension / Plugin</string>
+    <string name="support_request_loading_title">Sending your request</string>
+    <string name="support_request_loading_message">Please wait…</string>
+    <string name="support_request_success_title">Request sent!</string>
+    <string name="support_request_success_message">Your support request has landed safely in our inbox. We will reply via email as quickly as we can.</string>
+    <string name="support_request_success_action">Got It!</string>
+    <string name="support_request_error_title">Something went wrong</string>
+    <string name="support_request_error_message">Sorry, we cannot create support requests right now, please try again later.</string>
 
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3090,7 +3090,7 @@
     <string name="support_request_loading_message">Please wait…</string>
     <string name="support_request_success_title">Request sent!</string>
     <string name="support_request_success_message">Your support request has landed safely in our inbox. We will reply via email as quickly as we can.</string>
-    <string name="support_request_success_action">Got It!</string>
+    <string name="support_request_dialog_action">Got It!</string>
     <string name="support_request_error_title">Something went wrong</string>
     <string name="support_request_error_message">Sorry, we cannot create support requests right now, please try again later.</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.support.requests
+
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+internal class SupportRequestFormViewModelTest {
+    private lateinit var sut: SupportRequestFormViewModel
+
+    @Before
+    fun setUp() {
+        sut = SupportRequestFormViewModel(
+            zendeskHelper = mock(),
+            selectedSite = mock(),
+            savedState = mock()
+        )
+    }
+
+    @Test
+    fun `when all fields are filled, then submit button is enabled`() {
+        assert(true)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -60,4 +60,44 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         assertThat(isSubmitButtonEnabled[0]).isFalse
         assertThat(isSubmitButtonEnabled[1]).isTrue
     }
+
+    @Test
+    fun `when text fields are empty, then submit button is disabled`() = testBlocking {
+        // Given
+        val isSubmitButtonEnabled = mutableListOf<Boolean>()
+        sut.isSubmitButtonEnabled.observeForever {
+            isSubmitButtonEnabled.add(it)
+        }
+
+        // When
+        sut.onSubjectChanged("")
+        sut.onMessageChanged("")
+        sut.onHelpOptionSelected(HelpOption.MobileApp)
+
+        // Then
+        assertThat(isSubmitButtonEnabled).hasSize(1)
+        assertThat(isSubmitButtonEnabled[0]).isFalse
+    }
+
+    @Test
+    fun `when view is loading, then submit button is disabled`() = testBlocking {
+        // Given
+        val isSubmitButtonEnabled = mutableListOf<Boolean>()
+        sut.isSubmitButtonEnabled.observeForever {
+            isSubmitButtonEnabled.add(it)
+        }
+
+        // When
+        sut.onSubjectChanged("subject")
+        sut.onMessageChanged("message")
+        sut.onHelpOptionSelected(HelpOption.MobileApp)
+        sut.onSubmitRequestButtonClicked(mock(), HelpOrigin.LOGIN_HELP_NOTIFICATION, emptyList())
+
+        // Then
+        assertThat(isSubmitButtonEnabled).hasSize(4)
+        assertThat(isSubmitButtonEnabled[0]).isFalse
+        assertThat(isSubmitButtonEnabled[1]).isTrue
+        assertThat(isSubmitButtonEnabled[2]).isFalse
+        assertThat(isSubmitButtonEnabled[3]).isTrue
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.support.requests
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -24,7 +25,7 @@ internal class SupportRequestFormViewModelTest {
             on { get() }.then { testSite }
         }
         zendeskHelper = mock {
-            onBlocking { createRequest(any(), testSite, any(), any(), any()) } doReturn Result.success(Request())
+            onBlocking { createRequest(any(), any(), testSite, any(), any(), any()) } doReturn flowOf(Result.success(Request()))
         }
 
         sut = SupportRequestFormViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -1,18 +1,36 @@
 package com.woocommerce.android.support.requests
 
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.support.ZendeskHelper
+import com.woocommerce.android.tools.SelectedSite
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
+import zendesk.support.Request
 
 internal class SupportRequestFormViewModelTest {
     private lateinit var sut: SupportRequestFormViewModel
+    private lateinit var zendeskHelper: ZendeskHelper
+    private lateinit var selectedSite: SelectedSite
+    private val savedState = SavedStateHandle()
 
     @Before
     fun setUp() {
+        val testSite = SiteModel().apply { id = 123 }
+        selectedSite = mock {
+            on { get() }.then { testSite }
+        }
+        zendeskHelper = mock {
+            onBlocking { createRequest(any(), testSite, any(), any(), any()) } doReturn Result.success(Request())
+        }
+
         sut = SupportRequestFormViewModel(
-            zendeskHelper = mock(),
-            selectedSite = mock(),
-            savedState = mock()
+            zendeskHelper = zendeskHelper,
+            selectedSite = selectedSite,
+            savedState = savedState
         )
     }
 


### PR DESCRIPTION
Summary
==========
Fix issue #8333 by integrating the zendesk Support Request creation call with the Support Request Form ViewModel and View, following the expected UI behavior around request loading, success, and failure.

There are two things important to be aware of when testing this PR: the UI is connected to the actual zendesk API, but it will only work using a release build (see the test instructions for more information). Also, remember that you will need to provide a non-A8C email to submit the request.

Captures
==========
https://user-images.githubusercontent.com/5920403/221723692-e05220c0-2211-4195-abeb-fac382d8d515.mp4

How to Test
==========
1. You will need a release build to submit Zendesk tickets to the A8C Zendesk queues properly, so before testing, run the `./gradlew configureApply` command to setup the `vanillaRelease` variant. Also, set the Support Request Feature Flag as `true` since it will be disabled in the release build.
2. Open the app and hit the Menu section in the bottom bar
3. Once inside the menu, hit the gear icon to go to the app settings
4. Select the Help & support option of the app settings list. It's the very first option
5. Inside the Help options, select the Contact support option
6. Verify that the new form opens and that all expected UI interactions work as expected through all view elements.

⚠️ Remember, if you're using the release build, the request will be submitted to the real Zendesk instance, so you must go to the Woo Mobile queue and finish that ticket. Please provide a subject and message that makes clear to the HEs that ticket was created for test purposes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
