### PR TITLE
Fix deliver results navigation in Products Filter

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentProductFilterOptionListBinding
 import com.woocommerce.android.extensions.hide
-import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.navigateToParentWithResult
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
@@ -95,7 +95,11 @@ class ProductFilterOptionListFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ExitWithResult<*> -> {
-                    navigateBackWithResult(ProductListFragment.PRODUCT_FILTER_RESULT_KEY, event.data, R.id.products)
+                    navigateToParentWithResult(
+                        ProductListFragment.PRODUCT_FILTER_RESULT_KEY,
+                        event.data,
+                        R.id.productFilterListFragment
+                    )
                 }
                 else -> event.isHandled = false
             }


### PR DESCRIPTION
Fixes crash that occurs when the user selects a filter in the product selector in the Edit Coupons feature.

<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The app crashes when the user selects a filter in the Edit Coupons - Select Product feature. This PR fixes the issue by making the result navigation more generic - the app navigates to a parent of ProductFilterListFragment no matter which parent it is.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

`#1` Products Filter
1. Open Product List
2. Smoke test filters

`#2` Edit Coupons (You might need to hardcode `isCouponsEnabled=true` in `MoreMenuViewModel` in order to enable the feature)
1. Open More Menu
2. Tap on Coupons
3. Select a coupon
4. Tap on the overflow menu
5. Select Edit coupon
6. Tap on "Edit Products"
7. Smoke test filters (notice the app doesn't crash)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @samiuelson Just pinging you since we discussed this issue.
