### PR TITLE
refactor learn more TV to reuse card_reader_learn_more_section.xml

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodFragment.kt
@@ -153,10 +153,9 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_take_payment)
         }
 
         with(binding.learnMoreIppPaymentMethodsTv) {
-            val learMoreIpp = state.learMoreIpp
-            setOnClickListener { learMoreIpp.onClick.invoke() }
-            UiHelpers.setTextOrHide(this, learMoreIpp.label)
+            learnMore.setOnClickListener { state.learMoreIpp.onClick.invoke() }
         }
+        UiHelpers.setTextOrHide(binding.learnMoreIppPaymentMethodsTv.learnMore, state.learMoreIpp.label)
         applyBannerComposeUI(state.bannerState)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodFragment.kt
@@ -154,8 +154,9 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_take_payment)
 
         with(binding.learnMoreIppPaymentMethodsTv) {
             learnMore.setOnClickListener { state.learMoreIpp.onClick.invoke() }
+            UiHelpers.setTextOrHide(binding.learnMoreIppPaymentMethodsTv.learnMore, state.learMoreIpp.label)
         }
-        UiHelpers.setTextOrHide(binding.learnMoreIppPaymentMethodsTv.learnMore, state.learMoreIpp.label)
+
         applyBannerComposeUI(state.bannerState)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
@@ -119,8 +119,8 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
             }
             with(binding.learnMoreIppTv) {
                 learnMore.setOnClickListener { state.learnMoreIppState?.onClick?.invoke() }
+                UiHelpers.setTextOrHide(binding.learnMoreIppTv.learnMore, state.learnMoreIppState?.label)
             }
-            UiHelpers.setTextOrHide(binding.learnMoreIppTv.learnMore, state.learnMoreIppState?.label)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
@@ -118,10 +118,9 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                 UiHelpers.setTextOrHide(this, onboardingErrorAction?.text)
             }
             with(binding.learnMoreIppTv) {
-                val learnMoreIpp = state.learnMoreIppState
-                setOnClickListener { learnMoreIpp?.onClick?.invoke() }
-                UiHelpers.setTextOrHide(this, learnMoreIpp?.label)
+                learnMore.setOnClickListener { state.learnMoreIppState?.onClick?.invoke() }
             }
+            UiHelpers.setTextOrHide(binding.learnMoreIppTv.learnMore, state.learnMoreIppState?.label)
         }
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_hub.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_hub.xml
@@ -34,19 +34,11 @@
         tools:listitem="@layout/card_reader_hub_list_item" />
 
     <!-- android:textColorHighlight="#00FFFFFF": Workaround for a bug https://stackoverflow.com/a/70394538/632516 -->
-    <com.google.android.material.textview.MaterialTextView
+    <include
         android:id="@+id/learn_more_ipp_tv"
-        style="@style/Woo.TextView.Caption"
+        layout="@layout/card_reader_learn_more_section"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        android:drawableStart="@drawable/ic_info_outline_20dp"
-        android:maxLines="2"
-        android:paddingVertical="@dimen/minor_50"
-        android:drawablePadding="@dimen/major_100"
-        android:text="@string/card_reader_connect_learn_more"
-        android:textColor="@color/color_on_surface_high"
-        android:textColorHighlight="#00FFFFFF"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/cardReaderHubRv" />

--- a/WooCommerce/src/main/res/layout/fragment_take_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_take_payment.xml
@@ -93,19 +93,11 @@
         </LinearLayout>
 
         <!-- android:textColorHighlight="#00FFFFFF": Workaround for a bug https://stackoverflow.com/a/70394538/632516 -->
-        <com.google.android.material.textview.MaterialTextView
+        <include
             android:id="@+id/learn_more_ipp_payment_methods_tv"
-            style="@style/Woo.TextView.Caption"
+            layout="@layout/card_reader_learn_more_section"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?attr/selectableItemBackground"
-            android:drawableStart="@drawable/ic_info_outline_20dp"
-            android:drawablePadding="@dimen/major_100"
-            android:paddingVertical="@dimen/minor_50"
-            android:maxLines="2"
-            android:text="@string/card_reader_connect_learn_more"
-            android:textColor="@color/color_on_surface_high"
-            android:textColorHighlight="#00FFFFFF"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/container" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: # N.A
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Refactoring the Material Text view used [here](https://github.com/woocommerce/woocommerce-android/pull/8307) to use card_reader_learn_more_section.xml and fix the animation and alignment issues.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Menus
2. Go to Payments
3. Check if the learn more view shows underneath the rows
4. test on landscape mode, make sure it does not disappear
5. enable and disable Pay in Person option, make sure the Learn More view is displayed in both states
6. Click on the Learn More option
7. make sure it takes you to the right webview
9. Back to the payments menu create a simple payment
10. select collect payment
11. Make sure the learn more link also shows there

### Images/gif

<img width="340" alt="Screen Shot 2023-02-23 at 4 55 20 PM" src="https://user-images.githubusercontent.com/30724184/220962134-719617d0-d305-47ec-a922-ec0e0b05c6fe.png">

<img width="333" alt="Screen Shot 2023-02-23 at 4 55 47 PM" src="https://user-images.githubusercontent.com/30724184/220962172-6ec83c2c-949b-4cb4-82d8-64c3675c134d.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
