### PR TITLE
Feature/8260 overflow button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -18,16 +19,23 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProgressIndicatorDefaults
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +47,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.Companion.NUMBER_ITEMS_IN_COLLAPSED_MODE
@@ -80,39 +90,76 @@ fun StoreOnboardingCollapsed(
     modifier: Modifier = Modifier,
     numberOfItemsToShowInCollapsedMode: Int = NUMBER_ITEMS_IN_COLLAPSED_MODE,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colors.surface)
-            .padding(dimensionResource(id = R.dimen.major_100))
-    ) {
-        Text(
-            text = stringResource(id = onboardingState.title),
-            style = MaterialTheme.typography.h6,
-        )
-        @Suppress("MagicNumber")
-        OnboardingTaskCollapsedProgressHeader(
-            tasks = onboardingState.tasks,
+    Box(modifier = modifier.fillMaxWidth()) {
+        Column(
             modifier = Modifier
-                .padding(top = dimensionResource(id = R.dimen.major_100))
-                .fillMaxWidth(0.5f)
-        )
-        val taskToDisplay = if (onboardingState.tasks.filter { !it.isCompleted }.size == 1)
-            onboardingState.tasks.filter { !it.isCompleted }
-        else onboardingState.tasks.take(numberOfItemsToShowInCollapsedMode)
-        OnboardingTaskList(
-            tasks = taskToDisplay,
-            modifier = Modifier
-                .padding(top = dimensionResource(id = R.dimen.major_100))
                 .fillMaxWidth()
+                .background(MaterialTheme.colors.surface)
+                .padding(dimensionResource(id = R.dimen.major_100))
+        ) {
+            Text(
+                text = stringResource(id = onboardingState.title),
+                style = MaterialTheme.typography.h6,
+            )
+            @Suppress("MagicNumber")
+            OnboardingTaskCollapsedProgressHeader(
+                tasks = onboardingState.tasks,
+                modifier = Modifier
+                    .padding(top = dimensionResource(id = R.dimen.major_100))
+                    .fillMaxWidth(0.5f)
+            )
+            val taskToDisplay = if (onboardingState.tasks.filter { !it.isCompleted }.size == 1)
+                onboardingState.tasks.filter { !it.isCompleted }
+            else onboardingState.tasks.take(numberOfItemsToShowInCollapsedMode)
+            OnboardingTaskList(
+                tasks = taskToDisplay,
+                modifier = Modifier
+                    .padding(top = dimensionResource(id = R.dimen.major_100))
+                    .fillMaxWidth()
+            )
+            Text(
+                modifier = Modifier.clickable { onViewAllClicked() },
+                text = stringResource(R.string.store_onboarding_task_view_all, onboardingState.tasks.size),
+                style = MaterialTheme.typography.subtitle1,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colors.primary,
+            )
+        }
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = dimensionResource(id = R.dimen.minor_100))
+        ) {
+            OverflowMenu {
+                DropdownMenuItem(
+                    modifier = Modifier
+                        .height(dimensionResource(id = R.dimen.major_175)),
+                    onClick = { /*TODO*/ }) {
+                    Text(stringResource(id = R.string.store_onboarding_menu_share_feedback))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun OverflowMenu(content: @Composable () -> Unit) {
+    var showMenu by remember { mutableStateOf(false) }
+    IconButton(onClick = { showMenu = !showMenu }) {
+        Icon(
+            imageVector = Icons.Outlined.MoreVert,
+            contentDescription = stringResource(R.string.more_menu),
         )
-        Text(
-            modifier = Modifier.clickable { onViewAllClicked() },
-            text = stringResource(R.string.store_onboarding_task_view_all, onboardingState.tasks.size),
-            style = MaterialTheme.typography.subtitle1,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colors.primary,
-        )
+    }
+    DropdownMenu(
+        offset = DpOffset(
+            x = dimensionResource(id = R.dimen.major_100),
+            y = 0.dp
+        ),
+        expanded = showMenu,
+        onDismissRequest = { showMenu = false }
+    ) {
+        content()
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -87,6 +87,7 @@ fun StoreOnboardingScreen(viewModel: StoreOnboardingViewModel) {
 fun StoreOnboardingCollapsed(
     onboardingState: StoreOnboardingViewModel.OnboardingState,
     onViewAllClicked: () -> Unit,
+    onShareFeedbackClicked: () -> Unit,
     modifier: Modifier = Modifier,
     numberOfItemsToShowInCollapsedMode: Int = NUMBER_ITEMS_IN_COLLAPSED_MODE,
 ) {
@@ -134,7 +135,7 @@ fun StoreOnboardingCollapsed(
                 DropdownMenuItem(
                     modifier = Modifier
                         .height(dimensionResource(id = R.dimen.major_175)),
-                    onClick = { /*TODO*/ }) {
+                    onClick = { onShareFeedbackClicked() }) {
                     Text(stringResource(id = R.string.store_onboarding_menu_share_feedback))
                 }
             }
@@ -322,6 +323,7 @@ private fun OnboardingPreview() {
                 )
             )
         ),
-        onViewAllClicked = {}
+        onViewAllClicked = {},
+        onShareFeedbackClicked = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -135,7 +135,8 @@ fun StoreOnboardingCollapsed(
                 DropdownMenuItem(
                     modifier = Modifier
                         .height(dimensionResource(id = R.dimen.major_175)),
-                    onClick = { onShareFeedbackClicked() }) {
+                    onClick = { onShareFeedbackClicked() }
+                ) {
                     Text(stringResource(id = R.string.store_onboarding_menu_share_feedback))
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -60,6 +60,10 @@ class StoreOnboardingViewModel @Inject constructor(
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
+    fun onShareFeedbackClicked() {
+        triggerEvent(NavigateToSurvey)
+    }
+
     private fun OnboardingTask.toOnboardingTaskUi() =
         OnboardingTaskUi(
             icon = getIconResource(),
@@ -117,4 +121,5 @@ class StoreOnboardingViewModel @Inject constructor(
     ) : Parcelable
 
     object NavigateToOnboardingFullScreen : MultiLiveEvent.Event()
+    object NavigateToSurvey : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -211,7 +211,8 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                             WooThemeWithBackground {
                                 StoreOnboardingCollapsed(
                                     onboardingState = state,
-                                    onViewAllClicked = storeOnboardingViewModel::viewAllClicked
+                                    onViewAllClicked = storeOnboardingViewModel::viewAllClicked,
+                                    onShareFeedbackClicked = storeOnboardingViewModel::onShareFeedbackClicked
                                 )
                             }
                         }
@@ -222,22 +223,25 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
         storeOnboardingViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is StoreOnboardingViewModel.NavigateToOnboardingFullScreen -> {
-                    exitTransition = MaterialElevationScale(false).apply {
-                        duration = resources.getInteger(R.integer.default_fragment_transition).toLong()
-                    }
-                    reenterTransition = MaterialElevationScale(true).apply {
-                        duration = resources.getInteger(R.integer.default_fragment_transition).toLong()
-                    }
-                    val transitionName = getString(R.string.store_onboarding_full_screen_transition_name)
-                    val extras = FragmentNavigatorExtras(binding.storeOnboardingView to transitionName)
-                    findNavController().navigateSafely(
-                        directions = MyStoreFragmentDirections.actionMyStoreToOnboardingFragment(),
-                        extras = extras
-                    )
-                }
+                is StoreOnboardingViewModel.NavigateToOnboardingFullScreen -> openOnboardingInFullScreen()
+                is StoreOnboardingViewModel.NavigateToSurvey -> mainNavigationRouter?.showFeedbackSurvey()
             }
         }
+    }
+
+    private fun openOnboardingInFullScreen() {
+        exitTransition = MaterialElevationScale(false).apply {
+            duration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        }
+        reenterTransition = MaterialElevationScale(true).apply {
+            duration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        }
+        val transitionName = getString(R.string.store_onboarding_full_screen_transition_name)
+        val extras = FragmentNavigatorExtras(binding.storeOnboardingView to transitionName)
+        findNavController().navigateSafely(
+            directions = MyStoreFragmentDirections.actionMyStoreToOnboardingFragment(),
+            extras = extras
+        )
     }
 
     @Suppress("ComplexMethod", "MagicNumber", "LongMethod")

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3083,5 +3083,6 @@
     <string name="store_onboarding_task_view_all">View all (%1$d)</string>
     <string name="store_onboarding_full_screen_transition_name">Onboarding full screen</string>
     <string name="store_onboarding_collapsed_transition_name">Onboarding collapsed list</string>
+    <string name="store_onboarding_menu_share_feedback">Share feedback</string>
 
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Do not merge until parent branch is merged here: #8385

Part of: #8260 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Adds an overflow menu to onboarding list that enables user to open the crowdsignal survey

### Testing instructions
1. Log into a new store that has the onboarding list available (any Jurassic ninja or atomic site will suffice) 
2. Click on overflow button and open the survey
3. Check crowdsignal main survey is opened

 
### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2663464/221132855-168ba930-8c6e-482e-9bd2-9a5e8c13d4ea.mp4

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
