### PR TITLE
Merge release/12.5-rc-1 into trunk (`beta`)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+12.6
+-----
+
+
 12.5
 -----
 

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,9 +74,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "12.4"
+            versionName "12.5-rc-1"
         }
-        versionCode 387
+        versionCode 388
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_125"
+msgid ""
+"12.5:\n"
+"This release includes several bug fixes and improvements to make your experience smoother and more enjoyable. We're committed to continuously improving the WooCommerce app, and we have some exciting updates coming in the next few weeks. Stay tuned for more information!\n"
+msgstr ""
+
 msgctxt "release_note_124"
 msgid ""
 "12.4:\n"
 "You’ve asked for it, and now it’s here! It's now possible to use the app without Jetpack the plugin. This is based upon your direct feedback over the years, and we know you’ll like the change!\n"
-msgstr ""
-
-msgctxt "release_note_123"
-msgid ""
-"12.3:\n"
-"For this release, we focused on taking care of minor bugs that our team found. Don’t be fooled – we are working on some pretty cool stuff for you all! Keep your feedback rolling in; it helps us figure out what to work on next.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,2 @@
-You’ve asked for it, and now it’s here! It's now possible to use the app without Jetpack the plugin. This is based upon your direct feedback over the years, and we know you’ll like the change!
+
+

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,2 +1,1 @@
-
-
+This release includes several bug fixes and improvements to make your experience smoother and more enjoyable. We're committed to continuously improving the WooCommerce app, and we have some exciting updates coming in the next few weeks. Stay tuned for more information!

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-1f7ac469a04ae792fbc67fa29b64056cc9aaefd0'
+    fluxCVersion = '2.15.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -545,6 +545,11 @@
     <string name="domains_select_domain">Select domain</string>
     <string name="domains_redirect_notice">The domain purchased will redirect users to</string>
     <string name="domains_error_title">Unable to load site domains</string>
+    <string name="domains_free_with_credits">Free for the first year</string>
+    <string name="domains_purchase_successful_heading">Congratulations on your purchase</string>
+    <string name="domains_purchase_successful_delay_notice">Your site address is being set up. It may take up 30 minutes for your domain to start working.</string>
+    <string name="domains_purchase_successful_settings_notice">You can find the domain settings in Settings -&gt; Domains</string>Y
+
     <!--
         Order Editing
     -->


### PR DESCRIPTION
- [x] `build.gradle` file on `WooCommerce` module updated  with version bump. (e929994c2444cc195bed04c1cf1ce1ced71c4904)
- [x] `release notes` related files updated. (29b2fefd654c56fc15e742e90eaefad7cb10e9a9 + 0d1f52e8172f729df8a29c1db31e9f81820ce053 + a27a0b9cb676e3f1564d9ccec768a714c3c2cbac + 4a5fb84531add661859acaaf01ffa50f9f59aa03)
- [x] `new strings` frozen/copied into `fastlane/resources/values/strings.xml`. (926589ea3125f9e4527a69b12ea64a15553aa7a2)
- [x] `12.5-rc-1` WCAndroid beta submitted to Google for review (`Full rollout`).

EXTRAS:
- [x] `fluxc` version bump. (0b99638ceea17923e96c50280ec61e88d2922661)