### PR TITLE
[REST API] Email screen for the Jetpack connection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/JetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/JetpackStatus.kt
@@ -6,5 +6,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class JetpackStatus(
     val isJetpackInstalled: Boolean,
-    val isJetpackConnected: Boolean
+    val isJetpackConnected: Boolean,
+    val wpComEmail: String?
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.jetpack.benefits
 
 import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.store.JetpackStore
@@ -19,7 +20,8 @@ class FetchJetpackStatus @Inject constructor(
                     Result.success(
                         JetpackStatus(
                             isJetpackInstalled = false,
-                            isJetpackConnected = false
+                            isJetpackConnected = false,
+                            wpComEmail = null
                         )
                     )
                 }
@@ -32,7 +34,8 @@ class FetchJetpackStatus @Inject constructor(
                     Result.success(
                         JetpackStatus(
                             isJetpackInstalled = true,
-                            isJetpackConnected = result.user!!.isConnected
+                            isJetpackConnected = result.user!!.isConnected,
+                            wpComEmail = result.user!!.wpcomEmail.orNullIfEmpty()
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsDialog.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
@@ -67,14 +66,12 @@ class JetpackBenefitsDialog : DialogFragment() {
                 }
 
                 is JetpackBenefitsViewModel.StartApplicationPasswordsInstallation -> {
-                    // TODO
-                    Toast.makeText(
-                        requireContext(),
-                        "Jetpack Status: \n" +
-                            "Installed: ${event.jetpackStatus.isJetpackInstalled}\n" +
-                            "Connected: ${event.jetpackStatus.isJetpackConnected}",
-                        Toast.LENGTH_SHORT
-                    ).show()
+                    findNavController().navigateSafely(
+                        JetpackBenefitsDialogDirections.actionJetpackBenefitsDialogToJetpackActivation(
+                            siteUrl = event.siteUrl,
+                            jetpackStatus = event.jetpackStatus
+                        )
+                    )
                 }
 
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsDialog.kt
@@ -59,13 +59,13 @@ class JetpackBenefitsDialog : DialogFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is JetpackBenefitsViewModel.StartJetpackCPInstallation -> {
+                is JetpackBenefitsViewModel.StartJetpackActivationForJetpackCP -> {
                     findNavController().navigateSafely(
                         JetpackBenefitsDialogDirections.actionJetpackBenefitsDialogToJetpackInstallStartDialog()
                     )
                 }
 
-                is JetpackBenefitsViewModel.StartApplicationPasswordsInstallation -> {
+                is JetpackBenefitsViewModel.StartJetpackActivationForApplicationPasswords -> {
                     findNavController().navigateSafely(
                         JetpackBenefitsDialogDirections.actionJetpackBenefitsDialogToJetpackActivation(
                             siteUrl = event.siteUrl,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
@@ -39,14 +39,14 @@ class JetpackBenefitsViewModel @Inject constructor(
         )
 
         when (selectedSite.connectionType) {
-            SiteConnectionType.JetpackConnectionPackage -> triggerEvent(StartJetpackCPInstallation)
+            SiteConnectionType.JetpackConnectionPackage -> triggerEvent(StartJetpackActivationForJetpackCP)
             SiteConnectionType.ApplicationPasswords -> {
                 _viewState.update { it.copy(isLoadingDialogShown = true) }
                 val jetpackStatusResult = fetchJetpackStatus()
                 jetpackStatusResult.fold(
                     onSuccess = {
                         triggerEvent(
-                            StartApplicationPasswordsInstallation(
+                            StartJetpackActivationForApplicationPasswords(
                                 siteUrl = selectedSite.get().url,
                                 jetpackStatus = it
                             )
@@ -68,8 +68,8 @@ class JetpackBenefitsViewModel @Inject constructor(
         val isLoadingDialogShown: Boolean
     )
 
-    object StartJetpackCPInstallation : Event()
-    data class StartApplicationPasswordsInstallation(
+    object StartJetpackActivationForJetpackCP : Event()
+    data class StartJetpackActivationForApplicationPasswords(
         val siteUrl: String,
         val jetpackStatus: JetpackStatus
     ) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
@@ -44,7 +44,14 @@ class JetpackBenefitsViewModel @Inject constructor(
                 _viewState.update { it.copy(isLoadingDialogShown = true) }
                 val jetpackStatusResult = fetchJetpackStatus()
                 jetpackStatusResult.fold(
-                    onSuccess = { triggerEvent(StartApplicationPasswordsInstallation(it)) },
+                    onSuccess = {
+                        triggerEvent(
+                            StartApplicationPasswordsInstallation(
+                                siteUrl = selectedSite.get().url,
+                                jetpackStatus = it
+                            )
+                        )
+                    },
                     onFailure = { triggerEvent(ShowSnackbar(string.error_generic)) }
                 )
                 _viewState.update { it.copy(isLoadingDialogShown = false) }
@@ -63,6 +70,7 @@ class JetpackBenefitsViewModel @Inject constructor(
 
     object StartJetpackCPInstallation : Event()
     data class StartApplicationPasswordsInstallation(
+        val siteUrl: String,
         val jetpackStatus: JetpackStatus
     ) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
@@ -1,0 +1,31 @@
+package com.woocommerce.android.ui.login
+
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.util.dispatchAndAwait
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.store.AccountStore.FetchAuthOptionsPayload
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthOptionsFetched
+import org.wordpress.android.login.AuthOptions
+import javax.inject.Inject
+
+class WPComLoginRepository @Inject constructor(
+    private val dispatcher: Dispatcher
+) {
+    suspend fun fetchAuthOptions(emailOrUsername: String): Result<AuthOptions> {
+        val action = AccountActionBuilder.newFetchAuthOptionsAction(
+            FetchAuthOptionsPayload(emailOrUsername)
+        )
+        val event: OnAuthOptionsFetched = dispatcher.dispatchAndAwait(action)
+
+        return when {
+            event.isError -> Result.failure(OnChangedException(event.error))
+            else -> Result.success(
+                AuthOptions(
+                    isPasswordless = event.isPasswordless,
+                    isEmailVerified = event.isEmailVerified
+                )
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/components/JetpackConsent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/components/JetpackConsent.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.ui.login.jetpack.components
+
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.util.ChromeCustomTabUtils
+
+@Composable
+fun JetpackConsent(modifier: Modifier = Modifier) {
+    val consent = annotatedStringRes(stringResId = R.string.login_jetpack_connection_consent)
+    val context = LocalContext.current
+    ClickableText(
+        text = consent,
+        style = MaterialTheme.typography.caption.copy(
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colors.onSurface
+        ),
+        modifier = modifier
+    ) {
+        consent.getStringAnnotations(tag = URL_ANNOTATION_TAG, start = it, end = it)
+            .firstOrNull()
+            ?.let { annotation ->
+                when (annotation.item) {
+                    "terms" -> ChromeCustomTabUtils.launchUrl(context, AppUrls.WORPRESS_COM_TERMS)
+                    "sync" -> ChromeCustomTabUtils.launchUrl(context, AppUrls.JETPACK_SYNC_POLICY)
+                }
+            }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartJetpackActivationForNewSite
+import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComLoginForJetpackActivation
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -25,6 +26,7 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
         viewModel.event.observe(this) { event ->
             when (event) {
                 is StartJetpackActivationForNewSite -> navigateToJetpackActivationStartScreen(event)
+                is StartWPComLoginForJetpackActivation -> navigateToWPComEmailScreen(event)
             }
         }
     }
@@ -35,6 +37,15 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
                 .actionJetpackActivationDispatcherFragmentToJetpackActivationStartFragment(
                     siteUrl = event.siteUrl,
                     isJetpackInstalled = event.isJetpackInstalled
+                )
+        )
+    }
+
+    private fun navigateToWPComEmailScreen(event: StartWPComLoginForJetpackActivation) {
+        findNavController().navigate(
+            JetpackActivationDispatcherFragmentDirections
+                .actionJetpackActivationDispatcherFragmentToJetpackActivationWPComEmailFragment(
+                    jetpackStatus = event.jetpackStatus
                 )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.ui.login.jetpack.dispatcher
+
+import android.os.Bundle
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartJetpackActivationForNewSite
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+/**
+ * An empty screen that allows dispatching between the different flows of
+ * the Jetpack Activation (Installation and connection)
+ */
+@AndroidEntryPoint
+class JetpackActivationDispatcherFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: JetpackActivationDispatcherViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // Use the fragment as the lifecycle owner since we don't have any view here
+        viewModel.event.observe(this) { event ->
+            when (event) {
+                is StartJetpackActivationForNewSite -> navigateToJetpackActivationStartScreen(event)
+            }
+        }
+    }
+
+    private fun navigateToJetpackActivationStartScreen(event: StartJetpackActivationForNewSite) {
+        findNavController().navigate(
+            JetpackActivationDispatcherFragmentDirections
+                .actionJetpackActivationDispatcherFragmentToJetpackActivationStartFragment(
+                    siteUrl = event.siteUrl,
+                    isJetpackInstalled = event.isJetpackInstalled
+                )
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherViewModel.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.login.jetpack.dispatcher
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class JetpackActivationDispatcherViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    selectedSite: SelectedSite
+) : ScopedViewModel(savedStateHandle) {
+    private val args: JetpackActivationDispatcherFragmentArgs by savedState.navArgs()
+
+    init {
+        when (selectedSite.connectionType) {
+            SiteConnectionType.ApplicationPasswords -> {
+                // Handle Jetpack activation for "Application Passwords" users
+                TODO()
+            }
+
+            else -> {
+                // Handle connecting a new site
+                triggerEvent(
+                    StartJetpackActivationForNewSite(
+                        args.siteUrl,
+                        args.jetpackStatus.isJetpackInstalled
+                    )
+                )
+            }
+        }
+    }
+
+    data class StartJetpackActivationForNewSite(
+        val siteUrl: String,
+        val isJetpackInstalled: Boolean
+    ) : MultiLiveEvent.Event()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.jetpack.dispatcher
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -19,8 +20,13 @@ class JetpackActivationDispatcherViewModel @Inject constructor(
     init {
         when (selectedSite.connectionType) {
             SiteConnectionType.ApplicationPasswords -> {
-                // Handle Jetpack activation for "Application Passwords" users
-                TODO()
+                if (args.jetpackStatus.isJetpackConnected) {
+                    // Start authentication using the retrieved email
+                    TODO()
+                } else {
+                    // Start regular WordPress.com authentication
+                    triggerEvent(StartWPComLoginForJetpackActivation(args.jetpackStatus))
+                }
             }
 
             else -> {
@@ -38,5 +44,9 @@ class JetpackActivationDispatcherViewModel @Inject constructor(
     data class StartJetpackActivationForNewSite(
         val siteUrl: String,
         val isJetpackInstalled: Boolean
+    ) : MultiLiveEvent.Event()
+
+    data class StartWPComLoginForJetpackActivation(
+        val jetpackStatus: JetpackStatus
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/start/JetpackActivationStartScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -37,19 +36,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
-import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.components.JetpackConsent
 import com.woocommerce.android.ui.login.jetpack.start.JetpackActivationStartViewModel.JetpackActivationState
-import com.woocommerce.android.util.ChromeCustomTabUtils
 
 @Composable
 fun JetpackActivationStartScreen(viewModel: JetpackActivationStartViewModel) {
@@ -142,7 +138,9 @@ fun JetpackActivationStartScreen(
                 }
             } else {
                 JetpackConsent(
-                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = dimensionResource(id = R.dimen.major_100))
                 )
             }
         }
@@ -248,29 +246,6 @@ private fun SiteUrlAndIcon(
             style = MaterialTheme.typography.subtitle1,
             fontWeight = FontWeight.SemiBold
         )
-    }
-}
-
-@Composable
-private fun JetpackConsent(modifier: Modifier = Modifier) {
-    val consent = annotatedStringRes(stringResId = R.string.login_jetpack_connection_consent)
-    val context = LocalContext.current
-    ClickableText(
-        text = consent,
-        style = MaterialTheme.typography.caption.copy(
-            textAlign = TextAlign.Center,
-            color = MaterialTheme.colors.onSurface
-        ),
-        modifier = modifier
-    ) {
-        consent.getStringAnnotations(tag = URL_ANNOTATION_TAG, start = it, end = it)
-            .firstOrNull()
-            ?.let { annotation ->
-                when (annotation.item) {
-                    "terms" -> ChromeCustomTabUtils.launchUrl(context, AppUrls.WORPRESS_COM_TERMS)
-                    "sync" -> ChromeCustomTabUtils.launchUrl(context, AppUrls.JETPACK_SYNC_POLICY)
-                }
-            }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailFragment.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class JetpackActivationWPComEmailFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: JetpackActivationWPComEmailViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    JetpackActivationWPComScreen(viewModel = viewModel)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailFragment.kt
@@ -4,13 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailViewModel.ShowMagicLinkScreen
+import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailViewModel.ShowPasswordScreen
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class JetpackActivationWPComEmailFragment : BaseFragment() {
@@ -18,6 +26,9 @@ class JetpackActivationWPComEmailFragment : BaseFragment() {
         get() = AppBarStatus.Hidden
 
     private val viewModel: JetpackActivationWPComEmailViewModel by viewModels()
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return ComposeView(requireContext()).apply {
@@ -27,6 +38,27 @@ class JetpackActivationWPComEmailFragment : BaseFragment() {
                 WooThemeWithBackground {
                     JetpackActivationWPComScreen(viewModel = viewModel)
                 }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ShowPasswordScreen -> {
+                    // TODO
+                    Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
+                }
+                is ShowMagicLinkScreen -> {
+                    // TODO
+                    Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
+                }
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailFragment.kt
@@ -36,7 +36,7 @@ class JetpackActivationWPComEmailFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    JetpackActivationWPComScreen(viewModel = viewModel)
+                    JetpackActivationWPComEmailScreen(viewModel = viewModel)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailScreen.kt
@@ -146,7 +146,7 @@ fun JetpackActivationWPComEmailScreen(
     }
 
     if (viewState.isLoadingDialogShown) {
-        ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
+        ProgressDialog(title = "", subtitle = stringResource(id = R.string.checking_email))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailScreen.kt
@@ -37,9 +37,9 @@ import com.woocommerce.android.ui.login.jetpack.components.JetpackConsent
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
-fun JetpackActivationWPComScreen(viewModel: JetpackActivationWPComEmailViewModel) {
+fun JetpackActivationWPComEmailScreen(viewModel: JetpackActivationWPComEmailViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        JetpackActivationWPComScreen(
+        JetpackActivationWPComEmailScreen(
             viewState = it,
             onEmailChanged = viewModel::onEmailChanged,
             onCloseClick = viewModel::onCloseClick,
@@ -50,7 +50,7 @@ fun JetpackActivationWPComScreen(viewModel: JetpackActivationWPComEmailViewModel
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun JetpackActivationWPComScreen(
+fun JetpackActivationWPComEmailScreen(
     viewState: JetpackActivationWPComEmailViewModel.ViewState,
     onEmailChanged: (String) -> Unit = {},
     onCloseClick: () -> Unit = {},
@@ -154,7 +154,7 @@ fun JetpackActivationWPComScreen(
 @Composable
 private fun JetpackActivationWPComScreenPreview() {
     WooThemeWithBackground {
-        JetpackActivationWPComScreen(
+        JetpackActivationWPComEmailScreen(
             viewState = JetpackActivationWPComEmailViewModel.ViewState(
                 email = "",
                 isJetpackInstalled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
-import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -70,13 +69,12 @@ fun JetpackActivationWPComEmailScreen(
             modifier = Modifier
                 .background(MaterialTheme.colors.surface)
                 .padding(paddingValues)
-                .fillMaxSize(),
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
         ) {
             Column(
                 modifier = Modifier
-                    .weight(1f)
                     .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
                     .padding(dimensionResource(id = R.dimen.major_100)),
             ) {
                 JetpackToWooHeader()
@@ -119,6 +117,8 @@ fun JetpackActivationWPComEmailScreen(
                 )
             }
 
+            Spacer(modifier = Modifier.weight(1f))
+
             WCColoredButton(
                 onClick = {
                     keyboardController?.hide()
@@ -139,7 +139,7 @@ fun JetpackActivationWPComEmailScreen(
             JetpackConsent(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = dimensionResource(id = dimen.major_100))
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
             )
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
@@ -150,7 +150,7 @@ fun JetpackActivationWPComEmailScreen(
     }
 }
 
-@Preview
+@Preview(heightDp = 130)
 @Composable
 private fun JetpackActivationWPComScreenPreview() {
     WooThemeWithBackground {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
@@ -1,25 +1,36 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
+import androidx.core.util.PatternsCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.ui.login.WPComLoginRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.AccountStore.AuthOptionsError
+import org.wordpress.android.fluxc.store.AccountStore.AuthOptionsErrorType
+import org.wordpress.android.login.R
 import javax.inject.Inject
 
 @HiltViewModel
 class JetpackActivationWPComEmailViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val wpComLoginRepository: WPComLoginRepository
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: JetpackActivationWPComEmailFragmentArgs by savedStateHandle.navArgs()
 
     private val email = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "email")
-    private val errorMessage = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = 0, key = "error-message")
+    private val errorMessage =
+        savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = 0, key = "error-message")
     private val isLoadingDialogShown = MutableStateFlow(false)
 
     val viewState = combine(email, isLoadingDialogShown, errorMessage) { email, isLoadingDialogShown, errorMessage ->
@@ -32,6 +43,7 @@ class JetpackActivationWPComEmailViewModel @Inject constructor(
     }.asLiveData()
 
     fun onEmailChanged(email: String) {
+        errorMessage.value = 0
         this.email.value = email
     }
 
@@ -39,8 +51,41 @@ class JetpackActivationWPComEmailViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
-    fun onContinueClick() {
-        TODO()
+    fun onContinueClick() = launch {
+        val email = email.value
+        if (!PatternsCompat.EMAIL_ADDRESS.matcher(email).matches()) {
+            errorMessage.value = R.string.email_invalid
+            return@launch
+        }
+
+        isLoadingDialogShown.value = true
+        wpComLoginRepository.fetchAuthOptions(email).fold(
+            onSuccess = {
+                if (it.isPasswordless) {
+                    triggerEvent(ShowMagicLinkScreen(email))
+                } else {
+                    triggerEvent(ShowPasswordScreen(email))
+                }
+            },
+            onFailure = {
+                val failure = (it as? OnChangedException)?.error as? AuthOptionsError
+
+                when (failure?.type) {
+                    AuthOptionsErrorType.UNKNOWN_USER -> {
+                        errorMessage.value = R.string.email_not_registered_wpcom
+                    }
+
+                    AuthOptionsErrorType.EMAIL_LOGIN_NOT_ALLOWED -> {
+                        TODO()
+                    }
+
+                    else -> {
+                        triggerEvent(ShowSnackbar(R.string.error_generic))
+                    }
+                }
+            }
+        )
+        isLoadingDialogShown.value = false
     }
 
     data class ViewState(
@@ -51,4 +96,7 @@ class JetpackActivationWPComEmailViewModel @Inject constructor(
     ) {
         val enableSubmit = email.isNotBlank()
     }
+
+    data class ShowPasswordScreen(val emailOrUsername: String) : MultiLiveEvent.Event()
+    data class ShowMagicLinkScreen(val emailOrUsername: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
@@ -1,12 +1,54 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 
 @HiltViewModel
 class JetpackActivationWPComEmailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: JetpackActivationWPComEmailFragmentArgs by savedStateHandle.navArgs()
+
+    private val email = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "email")
+    private val errorMessage = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = 0, key = "error-message")
+    private val isLoadingDialogShown = MutableStateFlow(false)
+
+    val viewState = combine(email, isLoadingDialogShown, errorMessage) { email, isLoadingDialogShown, errorMessage ->
+        ViewState(
+            email = email,
+            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+            isLoadingDialogShown = isLoadingDialogShown,
+            errorMessage = errorMessage.takeIf { it != 0 }
+        )
+    }.asLiveData()
+
+    fun onEmailChanged(email: String) {
+        this.email.value = email
+    }
+
+    fun onCloseClick() {
+        triggerEvent(Exit)
+    }
+
+    fun onContinueClick() {
+        TODO()
+    }
+
+    data class ViewState(
+        val email: String,
+        val isJetpackInstalled: Boolean,
+        val isLoadingDialogShown: Boolean = false,
+        val errorMessage: Int? = null
+    ) {
+        val enableSubmit = email.isNotBlank()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class JetpackActivationWPComEmailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
@@ -52,7 +52,7 @@ class JetpackActivationWPComEmailViewModel @Inject constructor(
     }
 
     fun onContinueClick() = launch {
-        val email = email.value
+        val email = email.value.trim()
         if (!PatternsCompat.EMAIL_ADDRESS.matcher(email).matches()) {
             errorMessage.value = R.string.email_invalid
             return@launch

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComScreen.kt
@@ -18,7 +18,9 @@ import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -46,6 +48,7 @@ fun JetpackActivationWPComScreen(viewModel: JetpackActivationWPComEmailViewModel
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun JetpackActivationWPComScreen(
     viewState: JetpackActivationWPComEmailViewModel.ViewState,
@@ -53,6 +56,8 @@ fun JetpackActivationWPComScreen(
     onCloseClick: () -> Unit = {},
     onContinueClick: () -> Unit = {}
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     Scaffold(
         topBar = {
             Toolbar(
@@ -102,16 +107,23 @@ fun JetpackActivationWPComScreen(
                     onValueChange = onEmailChanged,
                     label = stringResource(id = R.string.email_address),
                     isError = viewState.errorMessage != null,
+                    helperText = viewState.errorMessage?.let { stringResource(id = it) },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
-                        onDone = { TODO() }
+                        onDone = {
+                            keyboardController?.hide()
+                            // TODO
+                        }
                     )
                 )
             }
 
             WCColoredButton(
-                onClick = onContinueClick,
+                onClick = {
+                    keyboardController?.hide()
+                    onContinueClick()
+                },
                 enabled = viewState.enableSubmit,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComScreen.kt
@@ -1,7 +1,152 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons.Filled
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.ui.compose.component.ProgressDialog
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.components.JetpackConsent
+import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
 fun JetpackActivationWPComScreen(viewModel: JetpackActivationWPComEmailViewModel) {
+    viewModel.viewState.observeAsState().value?.let {
+        JetpackActivationWPComScreen(
+            viewState = it,
+            onEmailChanged = viewModel::onEmailChanged,
+            onCloseClick = viewModel::onCloseClick,
+            onContinueClick = viewModel::onContinueClick
+        )
+    }
+}
+
+@Composable
+fun JetpackActivationWPComScreen(
+    viewState: JetpackActivationWPComEmailViewModel.ViewState,
+    onEmailChanged: (String) -> Unit = {},
+    onCloseClick: () -> Unit = {},
+    onContinueClick: () -> Unit = {}
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                onNavigationButtonClick = onCloseClick,
+                navigationIcon = Filled.Clear
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
+                .padding(paddingValues)
+                .fillMaxSize(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(dimensionResource(id = R.dimen.major_100)),
+            ) {
+                JetpackToWooHeader()
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+                val title = if (viewState.isJetpackInstalled) {
+                    R.string.login_jetpack_connect
+                } else {
+                    R.string.login_jetpack_install
+                }
+                Text(
+                    text = stringResource(id = title),
+                    style = MaterialTheme.typography.h4,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                Text(
+                    text = stringResource(
+                        id = if (viewState.isJetpackInstalled) {
+                            R.string.login_jetpack_connection_enter_wpcom_email
+                        } else {
+                            R.string.login_jetpack_installation_enter_wpcom_email
+                        }
+                    )
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                WCOutlinedTextField(
+                    value = viewState.email,
+                    onValueChange = onEmailChanged,
+                    label = stringResource(id = R.string.email_address),
+                    isError = viewState.errorMessage != null,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = { TODO() }
+                    )
+                )
+            }
+
+            WCColoredButton(
+                onClick = onContinueClick,
+                enabled = viewState.enableSubmit,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            ) {
+                Text(
+                    text = stringResource(
+                        id = if (viewState.isJetpackInstalled) R.string.login_jetpack_connect
+                        else R.string.login_jetpack_install
+                    )
+                )
+            }
+            JetpackConsent(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = dimen.major_100))
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        }
+    }
+
+    if (viewState.isLoadingDialogShown) {
+        ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
+    }
+}
+
+@Preview
+@Composable
+private fun JetpackActivationWPComScreenPreview() {
+    WooThemeWithBackground {
+        JetpackActivationWPComScreen(
+            viewState = JetpackActivationWPComEmailViewModel.ViewState(
+                email = "",
+                isJetpackInstalled = false
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComScreen.kt
@@ -113,7 +113,7 @@ fun JetpackActivationWPComScreen(
                     keyboardActions = KeyboardActions(
                         onDone = {
                             keyboardController?.hide()
-                            // TODO
+                            onContinueClick()
                         }
                     )
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComScreen.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun JetpackActivationWPComScreen(viewModel: JetpackActivationWPComEmailViewModel) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateToHelpScreen
+import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.base.BaseFragment
@@ -115,7 +116,11 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
             SitePickerSiteDiscoveryFragmentDirections
                 .actionSitePickerSiteDiscoveryFragmentToJetpackActivation(
                     siteUrl = event.siteAddress,
-                    isJetpackInstalled = event.isJetpackInstalled
+                    jetpackStatus = JetpackStatus(
+                        isJetpackInstalled = event.isJetpackInstalled,
+                        isJetpackConnected = false,
+                        wpComEmail = null
+                    )
                 )
         )
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -2,8 +2,24 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/nav_graph_jetpack_activation"
-    app:startDestination="@id/jetpackActivationStartFragment">
+    app:startDestination="@id/jetpackActivationDispatcherFragment">
 
+    <fragment
+        android:id="@+id/jetpackActivationDispatcherFragment"
+        android:name="com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherFragment"
+        android:label="JetpackActivationDispatcherFragment">
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
+        <argument
+            android:name="siteUrl"
+            app:argType="string" />
+        <action
+            android:id="@+id/action_jetpackActivationDispatcherFragment_to_jetpackActivationStartFragment"
+            app:destination="@id/jetpackActivationStartFragment"
+            app:popUpTo="@id/jetpackActivationDispatcherFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
     <fragment
         android:id="@+id/jetpackActivationStartFragment"
         android:name="com.woocommerce.android.ui.login.jetpack.start.JetpackActivationStartFragment"
@@ -17,8 +33,9 @@
         <action
             android:id="@+id/action_jetpackActivationStartFragment_to_jetpackActivationSiteCredentialsFragment"
             app:destination="@id/jetpackActivationSiteCredentialsFragment" />
-        <action android:id="@+id/action_jetpackActivationStartFragment_to_jetpackActivationMainFragment"
-                app:destination="@id/jetpackActivationMainFragment"/>
+        <action
+            android:id="@+id/action_jetpackActivationStartFragment_to_jetpackActivationMainFragment"
+            app:destination="@id/jetpackActivationMainFragment" />
     </fragment>
     <fragment
         android:id="@+id/jetpackActivationSiteCredentialsFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -19,6 +19,11 @@
             app:destination="@id/jetpackActivationStartFragment"
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_jetpackActivationDispatcherFragment_to_jetpackActivationWPComEmailFragment"
+            app:destination="@id/jetpackActivationWPComEmailFragment"
+            app:popUpTo="@id/jetpackActivationDispatcherFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/jetpackActivationStartFragment"
@@ -63,5 +68,13 @@
         <argument
             android:name="isJetpackInstalled"
             app:argType="boolean" />
+    </fragment>
+    <fragment
+        android:id="@+id/jetpackActivationWPComEmailFragment"
+        android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailFragment"
+        android:label="JetpackActivationWPComEmailFragment" >
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_install.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_install.xml
@@ -26,5 +26,16 @@
         <action
             android:id="@+id/action_jetpackBenefitsDialog_to_jetpackInstallStartDialog"
             app:destination="@id/jetpackInstallStartDialog" />
+        <action
+            android:id="@+id/action_jetpackBenefitsDialog_to_jetpack_activation"
+            app:destination="@id/nav_graph_jetpack_activation" >
+            <argument
+                android:name="siteUrl"
+                app:argType="string" />
+            <argument
+                android:name="jetpackStatus"
+                app:argType="com.woocommerce.android.model.JetpackStatus" />
+        </action>
     </dialog>
+    <include app:graph="@navigation/nav_graph_jetpack_activation" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_site_picker.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_site_picker.xml
@@ -48,8 +48,8 @@
                 android:name="siteUrl"
                 app:argType="string" />
             <argument
-                android:name="isJetpackInstalled"
-                app:argType="boolean" />
+                android:name="jetpackStatus"
+                app:argType="com.woocommerce.android.model.JetpackStatus" />
         </action>
     </fragment>
     <fragment

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -339,6 +339,8 @@
     <string name="login_jetpack_installation_continue_connection">Continue connection</string>
     <string name="login_jetpack_installation_exit_without_connection">Exit Without Connecting</string>
     <string name="login_application_passwords_unavailable">It looks like Application Passwords feature is disabled in your site %1$s.\n Please enable it to use the WooCommerce app.</string>
+    <string name="login_jetpack_connection_enter_wpcom_email">Log in with your WordPress.com account to connect Jetpack</string>
+    <string name="login_jetpack_installation_enter_wpcom_email">Log in with your WordPress.com account to install Jetpack</string>
 
     <!--
         My Store View


### PR DESCRIPTION
Closes: #8395 

### Description
Internal docs: pe5sF9-19y-p2

This PR is the first in a series for PR to add a WordPress.com login flow for the Jetpack installation/connection, this PR has the following changes:
1. Introduce an intermediary screen to the "Jetpack Activation" flow (here I mean specifically the nav_graph of the Jetpack activation), this screen will allow choosing the start point of the flow depending on the status of site.
2. Add WordPress.com email screen.

### Testing instructions
##### WordPress.com email screen
1. Open the app, then sign in using a non-Jetpack site.
2. Click on the Jetpack benefits banner.
3. Click on "Log in to continue"
4. Confirm a WordPress.com email screen is shown.
5. Enter a non valid email, then click on Install Jetpack, confirm an error is shown.
6. Enter a non-registered email then click on Install Jetpack, confirm an error is shown.
7. Enter a valid WordPress.com email, then confirm a toast is shown with the correct event.

##### Non-regression
1. Open the app, then sign in using a Jetpack site.
2. Open the site picker.
3. Click on Add a store, then choose Connect an existing store.
4. Enter the address of a non-Jetpack site.
5. Confirm the Jetpack activation start screen is shown correctly.

### Images/gif
<img width=360 src="https://user-images.githubusercontent.com/1657201/221211919-4fb28bd0-7c17-4334-bca9-2a606dba749b.png"/>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->