### PR TITLE
[REST API] Password screen for the Jetpack connection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
@@ -53,7 +53,11 @@ class WPComLoginRepository @Inject constructor(
         WooLog.i(WooLog.T.LOGIN, "Sumbitting 2FA verification code")
 
         return submitAuthRequest(emailOrUsername, password, null, true)
-            .map { SMSRequestResult.UserSignedIn }
+            .map {
+                // If we get a successful response, then this means the user was successfully signed in
+                // This can happen only if 2FA was disabled in the account before sending the request
+                SMSRequestResult.UserSignedIn
+            }
             .recoverCatching {
                 if (((it as? OnChangedException)?.error as? AuthenticationError)?.type == NEEDS_2FA) {
                     SMSRequestResult.SMSRequested

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
@@ -76,15 +76,15 @@ class WPComLoginRepository @Inject constructor(
         val event: OnAuthenticationChanged =
             dispatcher.dispatchAndAwait(AuthenticationActionBuilder.newAuthenticateAction(payload))
 
-        if (event.isError) {
+        return if (event.isError) {
             WooLog.w(
                 WooLog.T.LOGIN,
                 "Authentication request failed: " + event.error.type + " - " + event.error.message
             )
-            return Result.failure(OnChangedException(event.error))
+            Result.failure(OnChangedException(event.error))
         } else {
             WooLog.i(WooLog.T.LOGIN, "Authentication Succeeded for user ${event.userName}")
-            return Result.success(Unit)
+            Result.success(Unit)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
@@ -1,11 +1,17 @@
 package com.woocommerce.android.ui.login
 
 import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.dispatchAndAwait
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType.NEEDS_2FA
 import org.wordpress.android.fluxc.store.AccountStore.FetchAuthOptionsPayload
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthOptionsFetched
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.login.AuthOptions
 import javax.inject.Inject
 
@@ -27,5 +33,62 @@ class WPComLoginRepository @Inject constructor(
                 )
             )
         }
+    }
+
+    suspend fun login(emailOrUsername: String, password: String): Result<Unit> {
+        WooLog.i(
+            WooLog.T.LOGIN,
+            "Signing in using WPCom email or username: $emailOrUsername"
+        )
+        return submitAuthRequest(emailOrUsername, password, null, false)
+    }
+
+    suspend fun submitTwoStepCode(emailOrUsername: String, password: String, twoStepCode: String): Result<Unit> {
+        WooLog.i(WooLog.T.LOGIN, "Sumbitting 2FA verification code")
+
+        return submitAuthRequest(emailOrUsername, password, twoStepCode, false)
+    }
+
+    suspend fun requestTwoStepSMS(emailOrUsername: String, password: String): Result<SMSRequestResult> {
+        WooLog.i(WooLog.T.LOGIN, "Sumbitting 2FA verification code")
+
+        return submitAuthRequest(emailOrUsername, password, null, true)
+            .map { SMSRequestResult.UserSignedIn }
+            .recoverCatching {
+                if (((it as? OnChangedException)?.error as? AuthenticationError)?.type == NEEDS_2FA) {
+                    SMSRequestResult.SMSRequested
+                } else {
+                    throw it
+                }
+            }
+    }
+
+    private suspend fun submitAuthRequest(
+        emailOrUsername: String,
+        password: String,
+        twoStepCode: String?,
+        shouldRequestTwoStepCode: Boolean
+    ): Result<Unit> {
+        val payload = AuthenticatePayload(emailOrUsername, password).apply {
+            this.twoStepCode = twoStepCode
+            this.shouldSendTwoStepSms = shouldRequestTwoStepCode
+        }
+        val event: OnAuthenticationChanged =
+            dispatcher.dispatchAndAwait(AuthenticationActionBuilder.newAuthenticateAction(payload))
+
+        if (event.isError) {
+            WooLog.w(
+                WooLog.T.LOGIN,
+                "Authentication request failed: " + event.error.type + " - " + event.error.message
+            )
+            return Result.failure(OnChangedException(event.error))
+        } else {
+            WooLog.i(WooLog.T.LOGIN, "Authentication Succeeded for user ${event.userName}")
+            return Result.success(Unit)
+        }
+    }
+
+    enum class SMSRequestResult {
+        UserSignedIn, SMSRequested
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPComLoginRepository.kt
@@ -50,7 +50,7 @@ class WPComLoginRepository @Inject constructor(
     }
 
     suspend fun requestTwoStepSMS(emailOrUsername: String, password: String): Result<SMSRequestResult> {
-        WooLog.i(WooLog.T.LOGIN, "Sumbitting 2FA verification code")
+        WooLog.i(WooLog.T.LOGIN, "Submitting 2FA verification code")
 
         return submitAuthRequest(emailOrUsername, password, null, true)
             .map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailFragment.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -50,16 +51,27 @@ class JetpackActivationWPComEmailFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowPasswordScreen -> {
-                    // TODO
-                    Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
+                    navigateToPasswordScreen(event)
                 }
+
                 is ShowMagicLinkScreen -> {
                     // TODO
                     Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
                 }
+
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 Exit -> findNavController().navigateUp()
             }
         }
+    }
+
+    private fun navigateToPasswordScreen(event: ShowPasswordScreen) {
+        findNavController().navigateSafely(
+            JetpackActivationWPComEmailFragmentDirections
+                .actionJetpackActivationWPComEmailFragmentToJetpackActivationWPComPasswordFragment(
+                    jetpackStatus = event.jetpackStatus,
+                    emailOrUsername = event.emailOrUsername
+                )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.ui.login.WPComLoginRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -64,7 +65,7 @@ class JetpackActivationWPComEmailViewModel @Inject constructor(
                 if (it.isPasswordless) {
                     triggerEvent(ShowMagicLinkScreen(email))
                 } else {
-                    triggerEvent(ShowPasswordScreen(email))
+                    triggerEvent(ShowPasswordScreen(email, navArgs.jetpackStatus))
                 }
             },
             onFailure = {
@@ -97,6 +98,10 @@ class JetpackActivationWPComEmailViewModel @Inject constructor(
         val enableSubmit = email.isNotBlank()
     }
 
-    data class ShowPasswordScreen(val emailOrUsername: String) : MultiLiveEvent.Event()
+    data class ShowPasswordScreen(
+        val emailOrUsername: String,
+        val jetpackStatus: JetpackStatus
+    ) : MultiLiveEvent.Event()
+
     data class ShowMagicLinkScreen(val emailOrUsername: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
@@ -1,0 +1,54 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class JetpackActivationWPComPasswordFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: JetpackActivationWPComPasswordViewModel by viewModels()
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    JetpackActivationWPComPasswordScreen(viewModel = viewModel)
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                Exit -> findNavController().navigateUp()
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
@@ -17,7 +17,9 @@ import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPass
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordViewModel.ShowMagicLinkScreen
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -65,6 +67,7 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
                     navigateToJetpackActivationScreen(event)
                 }
 
+                is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 Exit -> findNavController().navigateUp()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
@@ -4,13 +4,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordViewModel.Show2FAScreen
+import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -46,9 +50,28 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is Show2FAScreen -> {
+                    // TODO
+                    Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
+                }
+
+                is ShowJetpackActivationScreen -> {
+                    navigateToJetpackActivationScreen(event)
+                }
+
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 Exit -> findNavController().navigateUp()
             }
         }
+    }
+
+    private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
+        findNavController().navigateSafely(
+            JetpackActivationWPComPasswordFragmentDirections
+                .actionJetpackActivationWPComPasswordFragmentToJetpackActivationMainFragment(
+                    isJetpackInstalled = event.isJetpackInstalled,
+                    siteUrl = event.siteUrl
+                )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordViewModel.Show2FAScreen
+import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordViewModel.ShowMagicLinkScreen
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -51,6 +52,11 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is Show2FAScreen -> {
+                    // TODO
+                    Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
+                }
+
+                is ShowMagicLinkScreen -> {
                     // TODO
                     Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -103,13 +103,13 @@ fun JetpackActivationWPComPasswordScreen(
                     style = MaterialTheme.typography.h4,
                     fontWeight = FontWeight.Bold
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 UserInfo(
                     emailOrUsername = viewState.emailOrUsername,
                     avatarUrl = viewState.avatarUrl,
                     modifier = Modifier.fillMaxWidth()
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 Text(
                     text = stringResource(id = R.string.enter_wpcom_password)
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -87,13 +87,12 @@ fun JetpackActivationWPComPasswordScreen(
             modifier = Modifier
                 .background(MaterialTheme.colors.surface)
                 .padding(paddingValues)
-                .fillMaxSize(),
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
         ) {
             Column(
                 modifier = Modifier
-                    .weight(1f)
                     .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
                     .padding(dimensionResource(id = R.dimen.major_100)),
             ) {
                 JetpackToWooHeader()
@@ -142,6 +141,8 @@ fun JetpackActivationWPComPasswordScreen(
                     Text(text = stringResource(id = R.string.reset_your_password))
                 }
             }
+
+            Spacer(modifier = Modifier.weight(1f))
 
             WCColoredButton(
                 onClick = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCPasswordField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
@@ -56,7 +57,8 @@ fun JetpackActivationWPComPasswordScreen(viewModel: JetpackActivationWPComPasswo
             onPasswordChanged = viewModel::onPasswordChanged,
             onCloseClick = viewModel::onCloseClick,
             onContinueClick = viewModel::onContinueClick,
-            onMagicLinkClick = viewModel::onMagicLinkClick
+            onMagicLinkClick = viewModel::onMagicLinkClick,
+            onResetPasswordClick = viewModel::onResetPasswordClick
         )
     }
 }
@@ -68,7 +70,8 @@ fun JetpackActivationWPComPasswordScreen(
     onPasswordChanged: (String) -> Unit = {},
     onCloseClick: () -> Unit = {},
     onContinueClick: () -> Unit = {},
-    onMagicLinkClick: () -> Unit = {}
+    onMagicLinkClick: () -> Unit = {},
+    onResetPasswordClick: () -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -132,6 +135,9 @@ fun JetpackActivationWPComPasswordScreen(
                         }
                     )
                 )
+                WCTextButton(onClick = onResetPasswordClick) {
+                    Text(text = stringResource(id = R.string.reset_your_password))
+                }
             }
 
             WCColoredButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -55,7 +55,8 @@ fun JetpackActivationWPComPasswordScreen(viewModel: JetpackActivationWPComPasswo
             viewState = it,
             onPasswordChanged = viewModel::onPasswordChanged,
             onCloseClick = viewModel::onCloseClick,
-            onContinueClick = viewModel::onContinueClick
+            onContinueClick = viewModel::onContinueClick,
+            onMagicLinkClick = viewModel::onMagicLinkClick
         )
     }
 }
@@ -66,7 +67,8 @@ fun JetpackActivationWPComPasswordScreen(
     viewState: JetpackActivationWPComPasswordViewModel.ViewState,
     onPasswordChanged: (String) -> Unit = {},
     onCloseClick: () -> Unit = {},
-    onContinueClick: () -> Unit = {}
+    onContinueClick: () -> Unit = {},
+    onMagicLinkClick: () -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -150,7 +152,7 @@ fun JetpackActivationWPComPasswordScreen(
                 )
             }
             WCOutlinedButton(
-                onClick = { /*TODO*/ },
+                onClick = onMagicLinkClick,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -182,14 +182,14 @@ private fun UserInfo(
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(
-            dimensionResource(id =  R.dimen.major_100),
+            dimensionResource(id = R.dimen.major_100),
             Alignment.Start
         ),
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .border(1.dp, color = colorResource(id = R.color.divider_color), shape = MaterialTheme.shapes.medium)
             .semantics(mergeDescendants = true) {}
-            .padding(dimensionResource(id =  R.dimen.major_100))
+            .padding(dimensionResource(id = R.dimen.major_100))
     ) {
         AsyncImage(
             model = Builder(LocalContext.current)
@@ -199,7 +199,9 @@ private fun UserInfo(
                 .error(R.drawable.img_gravatar_placeholder)
                 .build(),
             contentDescription = null,
-            modifier = Modifier.size(dimensionResource(id =  R.dimen.image_minor_100)).clip(CircleShape)
+            modifier = Modifier
+                .size(dimensionResource(id = R.dimen.image_minor_100))
+                .clip(CircleShape)
         )
         Text(
             text = emailOrUsername,
@@ -207,7 +209,6 @@ private fun UserInfo(
         )
     }
 }
-
 
 @Preview
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -116,7 +116,10 @@ fun JetpackActivationWPComPasswordScreen(
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 Text(
-                    text = stringResource(id = R.string.enter_wpcom_password)
+                    text = stringResource(
+                        id = if (viewState.isJetpackInstalled) R.string.login_jetpack_connection_enter_wpcom_password
+                        else R.string.login_jetpack_installation_enter_wpcom_password
+                    )
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 WCPasswordField(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -1,13 +1,18 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -18,22 +23,29 @@ import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest.Builder
 import com.woocommerce.android.R
-import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.component.WCPasswordField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.jetpack.components.JetpackConsent
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
@@ -92,6 +104,12 @@ fun JetpackActivationWPComPasswordScreen(
                     fontWeight = FontWeight.Bold
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                UserInfo(
+                    emailOrUsername = viewState.emailOrUsername,
+                    avatarUrl = viewState.avatarUrl,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                 Text(
                     text = stringResource(
                         id = if (viewState.isJetpackInstalled) {
@@ -102,18 +120,19 @@ fun JetpackActivationWPComPasswordScreen(
                     )
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-                WCOutlinedTextField(
-                    value = viewState.email,
+                WCPasswordField(
+                    value = viewState.password,
                     onValueChange = onPasswordChanged,
-                    label = stringResource(id = R.string.email_address),
+                    label = stringResource(id = R.string.password),
                     isError = viewState.errorMessage != null,
                     helperText = viewState.errorMessage?.let { stringResource(id = it) },
-                    singleLine = true,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
                         onDone = {
-                            keyboardController?.hide()
-                            onContinueClick()
+                            if (viewState.enableSubmit) {
+                                keyboardController?.hide()
+                                onContinueClick()
+                            }
                         }
                     )
                 )
@@ -136,11 +155,16 @@ fun JetpackActivationWPComPasswordScreen(
                     )
                 )
             }
-            JetpackConsent(
+            WCOutlinedButton(
+                onClick = { /*TODO*/ },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = dimensionResource(id = dimen.major_100))
-            )
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            ) {
+                Text(
+                    text = stringResource(id = R.string.login_jetpack_installation_continue_magic_link)
+                )
+            }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
     }
@@ -150,14 +174,50 @@ fun JetpackActivationWPComPasswordScreen(
     }
 }
 
+@Composable
+private fun UserInfo(
+    emailOrUsername: String,
+    avatarUrl: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(
+            dimensionResource(id =  R.dimen.major_100),
+            Alignment.Start
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .border(1.dp, color = colorResource(id = R.color.divider_color), shape = MaterialTheme.shapes.medium)
+            .semantics(mergeDescendants = true) {}
+            .padding(dimensionResource(id =  R.dimen.major_100))
+    ) {
+        AsyncImage(
+            model = Builder(LocalContext.current)
+                .data(avatarUrl)
+                .crossfade(true)
+                .placeholder(R.drawable.img_gravatar_placeholder)
+                .error(R.drawable.img_gravatar_placeholder)
+                .build(),
+            contentDescription = null,
+            modifier = Modifier.size(dimensionResource(id =  R.dimen.image_minor_100)).clip(CircleShape)
+        )
+        Text(
+            text = emailOrUsername,
+            style = MaterialTheme.typography.subtitle1
+        )
+    }
+}
+
+
 @Preview
 @Composable
 private fun JetpackActivationWPComScreenPreview() {
     WooThemeWithBackground {
         JetpackActivationWPComPasswordScreen(
             viewState = JetpackActivationWPComPasswordViewModel.ViewState(
-                email = "",
+                emailOrUsername = "test@email.com",
                 password = "",
+                avatarUrl = "",
                 isJetpackInstalled = false
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -111,13 +111,7 @@ fun JetpackActivationWPComPasswordScreen(
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                 Text(
-                    text = stringResource(
-                        id = if (viewState.isJetpackInstalled) {
-                            R.string.login_jetpack_connection_enter_wpcom_email
-                        } else {
-                            R.string.login_jetpack_installation_enter_wpcom_email
-                        }
-                    )
+                    text = stringResource(id = R.string.enter_wpcom_password)
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 WCPasswordField(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordScreen.kt
@@ -1,0 +1,165 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons.Filled
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.ui.compose.component.ProgressDialog
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.components.JetpackConsent
+import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
+
+@Composable
+fun JetpackActivationWPComPasswordScreen(viewModel: JetpackActivationWPComPasswordViewModel) {
+    viewModel.viewState.observeAsState().value?.let {
+        JetpackActivationWPComPasswordScreen(
+            viewState = it,
+            onPasswordChanged = viewModel::onPasswordChanged,
+            onCloseClick = viewModel::onCloseClick,
+            onContinueClick = viewModel::onContinueClick
+        )
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun JetpackActivationWPComPasswordScreen(
+    viewState: JetpackActivationWPComPasswordViewModel.ViewState,
+    onPasswordChanged: (String) -> Unit = {},
+    onCloseClick: () -> Unit = {},
+    onContinueClick: () -> Unit = {}
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    Scaffold(
+        topBar = {
+            Toolbar(
+                onNavigationButtonClick = onCloseClick,
+                navigationIcon = Filled.Clear
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
+                .padding(paddingValues)
+                .fillMaxSize(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(dimensionResource(id = R.dimen.major_100)),
+            ) {
+                JetpackToWooHeader()
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+                val title = if (viewState.isJetpackInstalled) {
+                    R.string.login_jetpack_connect
+                } else {
+                    R.string.login_jetpack_install
+                }
+                Text(
+                    text = stringResource(id = title),
+                    style = MaterialTheme.typography.h4,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                Text(
+                    text = stringResource(
+                        id = if (viewState.isJetpackInstalled) {
+                            R.string.login_jetpack_connection_enter_wpcom_email
+                        } else {
+                            R.string.login_jetpack_installation_enter_wpcom_email
+                        }
+                    )
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                WCOutlinedTextField(
+                    value = viewState.email,
+                    onValueChange = onPasswordChanged,
+                    label = stringResource(id = R.string.email_address),
+                    isError = viewState.errorMessage != null,
+                    helperText = viewState.errorMessage?.let { stringResource(id = it) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            keyboardController?.hide()
+                            onContinueClick()
+                        }
+                    )
+                )
+            }
+
+            WCColoredButton(
+                onClick = {
+                    keyboardController?.hide()
+                    onContinueClick()
+                },
+                enabled = viewState.enableSubmit,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            ) {
+                Text(
+                    text = stringResource(
+                        id = if (viewState.isJetpackInstalled) R.string.login_jetpack_connect
+                        else R.string.login_jetpack_install
+                    )
+                )
+            }
+            JetpackConsent(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = dimen.major_100))
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        }
+    }
+
+    if (viewState.isLoadingDialogShown) {
+        ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
+    }
+}
+
+@Preview
+@Composable
+private fun JetpackActivationWPComScreenPreview() {
+    WooThemeWithBackground {
+        JetpackActivationWPComPasswordScreen(
+            viewState = JetpackActivationWPComPasswordViewModel.ViewState(
+                email = "",
+                password = "",
+                isJetpackInstalled = false
+            )
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -1,36 +1,73 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.login.WPComLoginRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+import org.wordpress.android.util.GravatarUtils
 import javax.inject.Inject
 
 @HiltViewModel
 class JetpackActivationWPComPasswordViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val wpComLoginRepository: WPComLoginRepository
+    private val wpComLoginRepository: WPComLoginRepository,
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: JetpackActivationWPComPasswordFragmentArgs by savedStateHandle.navArgs()
 
-    val viewState: LiveData<ViewState>
-        get() = TODO()
+    private val password = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "password")
+    private val errorMessage =
+        savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = 0, key = "error-message")
+    private val isLoadingDialogShown = MutableStateFlow(false)
+
+    val viewState = combine(
+        password,
+        isLoadingDialogShown,
+        errorMessage,
+        flowOf(Pair(navArgs.emailOrUsername, avatarUrlFromEmail(navArgs.emailOrUsername)))
+    ) { password, isLoadingDialogShown, errorMessage, (emailOrUsername, avatarUrl) ->
+        ViewState(
+            emailOrUsername = emailOrUsername,
+            password = password,
+            avatarUrl = avatarUrl,
+            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+            isLoadingDialogShown = isLoadingDialogShown,
+            errorMessage = errorMessage.takeIf { it != 0 }
+        )
+    }.asLiveData()
 
     fun onPasswordChanged(password: String) {
-        TODO()
+        errorMessage.value = 0
+        this.password.value = password
     }
 
     fun onCloseClick() {
-        TODO()
+        triggerEvent(Exit)
     }
 
     fun onContinueClick() {
         TODO()
     }
 
+    private fun avatarUrlFromEmail(email: String): String {
+        val avatarSize = resourceProvider.getDimensionPixelSize(R.dimen.image_minor_100)
+        return GravatarUtils.gravatarFromEmail(email, avatarSize, GravatarUtils.DefaultImage.STATUS_404)
+    }
+
     data class ViewState(
-        val email: String,
+        val emailOrUsername: String,
         val password: String,
+        val avatarUrl: String,
         val isJetpackInstalled: Boolean,
         val isLoadingDialogShown: Boolean = false,
         val errorMessage: Int? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -6,13 +6,13 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPComLoginRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
-import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,10 +28,11 @@ import javax.inject.Inject
 @HiltViewModel
 class JetpackActivationWPComPasswordViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    selectedSite: SelectedSite,
     private val wpComLoginRepository: WPComLoginRepository,
     private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider
-) : ScopedViewModel(savedStateHandle) {
+) : JetpackActivationWPComPostLoginViewModel(savedStateHandle, selectedSite) {
     private val navArgs: JetpackActivationWPComPasswordFragmentArgs by savedStateHandle.navArgs()
 
     private val password = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "password")
@@ -78,6 +79,7 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
                         triggerEvent(Show2FAScreen(navArgs.emailOrUsername, navArgs.jetpackStatus))
                     }
 
+                    AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD,
                     AuthenticationErrorType.NOT_AUTHENTICATED -> {
                         errorMessage.value = R.string.password_incorrect
                     }
@@ -94,7 +96,7 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
     private suspend fun fetchAccount() {
         accountRepository.fetchUserAccount().fold(
             onSuccess = {
-                TODO()
+                onLoginSuccess(navArgs.jetpackStatus)
             },
             onFailure = {
                 triggerEvent(ShowSnackbar(R.string.error_fetch_my_profile))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -1,0 +1,40 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.login.WPComLoginRepository
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class JetpackActivationWPComPasswordViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val wpComLoginRepository: WPComLoginRepository
+) : ScopedViewModel(savedStateHandle) {
+
+    val viewState: LiveData<ViewState>
+        get() = TODO()
+
+    fun onPasswordChanged(password: String) {
+        TODO()
+    }
+
+    fun onCloseClick() {
+        TODO()
+    }
+
+    fun onContinueClick() {
+        TODO()
+    }
+
+    data class ViewState(
+        val email: String,
+        val password: String,
+        val isJetpackInstalled: Boolean,
+        val isLoadingDialogShown: Boolean = false,
+        val errorMessage: Int? = null
+    ) {
+        val enableSubmit = password.isNotBlank()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -65,6 +65,21 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
+    fun onMagicLinkClick() {
+        triggerEvent(
+            ShowMagicLinkScreen(
+                emailOrUsername = navArgs.emailOrUsername,
+                jetpackStatus = navArgs.jetpackStatus
+            )
+        )
+    }
+
+    fun onResetPasswordClick() {
+        triggerEvent(
+            ShowPasswordReset()
+        )
+    }
+
     fun onContinueClick() = launch {
         isLoadingDialogShown.value = true
         wpComLoginRepository.login(navArgs.emailOrUsername, password.value).fold(
@@ -121,4 +136,8 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
     }
 
     data class Show2FAScreen(val emailOrUsername: String, val jetpackStatus: JetpackStatus) : MultiLiveEvent.Event()
+    data class ShowMagicLinkScreen(
+        val emailOrUsername: String,
+        val jetpackStatus: JetpackStatus
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPComLoginRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -33,6 +34,10 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
     private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider
 ) : JetpackActivationWPComPostLoginViewModel(savedStateHandle, selectedSite) {
+    companion object {
+        private const val RESET_PASSWORD_URL = "https://wordpress.com/wp-login.php?action=lostpassword"
+    }
+
     private val navArgs: JetpackActivationWPComPasswordFragmentArgs by savedStateHandle.navArgs()
 
     private val password = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "password")
@@ -76,7 +81,7 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
 
     fun onResetPasswordClick() {
         triggerEvent(
-            ShowPasswordReset()
+            LaunchUrlInChromeTab(RESET_PASSWORD_URL)
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
@@ -10,9 +10,9 @@ open class JetpackActivationWPComPostLoginViewModel(
     savedStateHandle: SavedStateHandle,
     private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
-    protected suspend fun onLoginSuccess(jetpackStatus: JetpackStatus) {
+    protected fun onLoginSuccess(jetpackStatus: JetpackStatus) {
         if (jetpackStatus.isJetpackConnected) {
-            // TODO fetch sites then show main activity
+            TODO("fetch sites then show main activity")
         } else {
             triggerEvent(
                 ShowJetpackActivationScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+
+open class JetpackActivationWPComPostLoginViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val selectedSite: SelectedSite
+) : ScopedViewModel(savedStateHandle) {
+    protected suspend fun onLoginSuccess(jetpackStatus: JetpackStatus) {
+        if (jetpackStatus.isJetpackConnected) {
+            // TODO fetch sites then show main activity
+        } else {
+            triggerEvent(
+                ShowJetpackActivationScreen(
+                    isJetpackInstalled = jetpackStatus.isJetpackInstalled,
+                    siteUrl = selectedSite.get().url
+                )
+            )
+        }
+    }
+
+    data class ShowJetpackActivationScreen(
+        val isJetpackInstalled: Boolean,
+        val siteUrl: String
+    ) : MultiLiveEvent.Event()
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -90,5 +90,8 @@
         <argument
             android:name="emailOrUsername"
             app:argType="string" />
+        <action
+            android:id="@+id/action_jetpackActivationWPComPasswordFragment_to_jetpackActivationMainFragment"
+            app:destination="@id/jetpackActivationMainFragment" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -72,9 +72,23 @@
     <fragment
         android:id="@+id/jetpackActivationWPComEmailFragment"
         android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailFragment"
-        android:label="JetpackActivationWPComEmailFragment" >
+        android:label="JetpackActivationWPComEmailFragment">
         <argument
             android:name="jetpackStatus"
             app:argType="com.woocommerce.android.model.JetpackStatus" />
+        <action
+            android:id="@+id/action_jetpackActivationWPComEmailFragment_to_jetpackActivationWPComPasswordFragment"
+            app:destination="@id/jetpackActivationWPComPasswordFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/jetpackActivationWPComPasswordFragment"
+        android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordFragment"
+        android:label="JetpackActivationWPComPasswordFragment">
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
+        <argument
+            android:name="emailOrUsername"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -341,6 +341,8 @@
     <string name="login_application_passwords_unavailable">It looks like Application Passwords feature is disabled in your site %1$s.\n Please enable it to use the WooCommerce app.</string>
     <string name="login_jetpack_connection_enter_wpcom_email">Log in with your WordPress.com account to connect Jetpack</string>
     <string name="login_jetpack_installation_enter_wpcom_email">Log in with your WordPress.com account to install Jetpack</string>
+    <string name="login_jetpack_connection_enter_wpcom_password">Enter the password of your WordPress.com account to connect to Jetpack</string>
+    <string name="login_jetpack_installation_enter_wpcom_password">Enter the password of your WordPress.com account to install Jetpack</string>
     <string name="login_jetpack_installation_continue_magic_link">Or continue using Magic Link</string>
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -341,6 +341,7 @@
     <string name="login_application_passwords_unavailable">It looks like Application Passwords feature is disabled in your site %1$s.\n Please enable it to use the WooCommerce app.</string>
     <string name="login_jetpack_connection_enter_wpcom_email">Log in with your WordPress.com account to connect Jetpack</string>
     <string name="login_jetpack_installation_enter_wpcom_email">Log in with your WordPress.com account to install Jetpack</string>
+    <string name="login_jetpack_installation_continue_magic_link">Or continue using Magic Link</string>
 
     <!--
         My Store View


### PR DESCRIPTION
Closes: #8396 

### Description
This PR adds the password screen for the WordPress.com authentication needed for the Jetpack connection.
For now, this supports only the basic flow of "email + password" login, so no support yet for:
1. 2FA
2. Magic link

### Testing instructions
1. Open the app, then sign in using a non-Jetpack site.
2. Click on the Jetpack benefits banner.
3. Click on "Log in to continue"
4. Enter a valid WordPress.com email, then click on "Install Jetpack"
5. Enter a wrong password then click on continue on "Install Jetpack"
6. Confirm an error is shown.
7. Enter the correct password.
8. Confirm the Jetpack installation/connection starts (the flow will fail after finishing the connection, this will be handled in future PRs).

Note: if your account has 2FA enabled, at step 8, a Toast will be shown instead.

### Images/gif
<img width="360" src="https://user-images.githubusercontent.com/1657201/221632991-e6981d8e-33bc-4dbc-9eb8-a609a246034d.png" />

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
