### PR TITLE
[REST API] handle WordPress.com connection for sites already connected to Jetpack

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/GoToStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/GoToStore.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android.ui.login.jetpack
+
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+
+object GoToStore : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -94,7 +94,15 @@ class JetpackActivationRepository @Inject constructor(
             return@runWithRetry if (site == null) {
                 WooLog.d(WooLog.T.LOGIN, "Jetpack Activation: Site $siteUrl is missing from account sites")
                 Result.failure(IllegalStateException("Site missing"))
-            } else Result.success(site)
+            } else {
+                if (!site.hasWooCommerce) {
+                    // If the site doesn't have WooCommerce, let's do one additional fetch using `fetchSite`,
+                    // this function will make sure to fetch data from the remote site, which might result in more
+                    // accurate result
+                    siteStore.fetchSite(site)
+                }
+                Result.success(site)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartJetpackActivationForNewSite
+import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComAuthenticationForEmail
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComLoginForJetpackActivation
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,6 +28,7 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
             when (event) {
                 is StartJetpackActivationForNewSite -> navigateToJetpackActivationStartScreen(event)
                 is StartWPComLoginForJetpackActivation -> navigateToWPComEmailScreen(event)
+                is StartWPComAuthenticationForEmail -> navigateToWPComPasswordScreen(event)
             }
         }
     }
@@ -45,6 +47,16 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
         findNavController().navigate(
             JetpackActivationDispatcherFragmentDirections
                 .actionJetpackActivationDispatcherFragmentToJetpackActivationWPComEmailFragment(
+                    jetpackStatus = event.jetpackStatus
+                )
+        )
+    }
+
+    private fun navigateToWPComPasswordScreen(event: StartWPComAuthenticationForEmail) {
+        findNavController().navigate(
+            JetpackActivationDispatcherFragmentDirections
+                .actionJetpackActivationDispatcherFragmentToJetpackActivationWPComPasswordFragment(
+                    emailOrUsername = event.wpComEmail,
                     jetpackStatus = event.jetpackStatus
                 )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherViewModel.kt
@@ -21,8 +21,13 @@ class JetpackActivationDispatcherViewModel @Inject constructor(
         when (selectedSite.connectionType) {
             SiteConnectionType.ApplicationPasswords -> {
                 if (args.jetpackStatus.isJetpackConnected) {
-                    // Start authentication using the retrieved email
-                    TODO()
+                    // Jetpack is already connected and we know the address email, handle the authentication
+                    triggerEvent(
+                        StartWPComAuthenticationForEmail(
+                            wpComEmail = requireNotNull(args.jetpackStatus.wpComEmail),
+                            jetpackStatus = args.jetpackStatus
+                        )
+                    )
                 } else {
                     // Start regular WordPress.com authentication
                     triggerEvent(StartWPComLoginForJetpackActivation(args.jetpackStatus))
@@ -47,6 +52,11 @@ class JetpackActivationDispatcherViewModel @Inject constructor(
     ) : MultiLiveEvent.Event()
 
     data class StartWPComLoginForJetpackActivation(
+        val jetpackStatus: JetpackStatus
+    ) : MultiLiveEvent.Event()
+
+    data class StartWPComAuthenticationForEmail(
+        val wpComEmail: String,
         val jetpackStatus: JetpackStatus
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
@@ -23,8 +23,8 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.DisplayMode
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
+import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.GoToPasswordScreen
-import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.GoToStore
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ShowJetpackConnectionWebView
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ShowWooNotInstalledScreen
 import com.woocommerce.android.ui.main.AppBarStatus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginAct
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginInstallFailed
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginInstalled
 import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -354,7 +355,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     private suspend fun confirmSiteConnection() {
         WooLog.d(WooLog.T.LOGIN, "Jetpack Activation: fetch sites and confirm site connection")
-        jetpackActivationRepository.checkSiteConnection(navArgs.siteUrl).fold(
+        jetpackActivationRepository.fetchJetpackSite(navArgs.siteUrl).fold(
             onSuccess = {
                 connectionStep.value = ConnectionStep.Approved
             },
@@ -427,7 +428,6 @@ class JetpackActivationMainViewModel @Inject constructor(
         val connectionValidationUrls: List<String>
     ) : MultiLiveEvent.Event()
 
-    object GoToStore : MultiLiveEvent.Event()
     data class GoToPasswordScreen(val email: String) : MultiLiveEvent.Event()
     data class ShowWooNotInstalledScreen(val siteUrl: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -13,10 +14,12 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordViewModel.Show2FAScreen
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordViewModel.ShowMagicLinkScreen
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
@@ -67,6 +70,7 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
                     navigateToJetpackActivationScreen(event)
                 }
 
+                is GoToStore -> goToStore()
                 is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 Exit -> findNavController().navigateUp()
@@ -82,5 +86,14 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
                     siteUrl = event.siteUrl
                 )
         )
+    }
+
+    private fun goToStore() {
+        (requireActivity() as? MainActivity)?.handleSitePickerResult() ?: run {
+            val intent = Intent(requireActivity(), MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            }
+            startActivity(intent)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPComLoginRepository
+import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
@@ -30,10 +31,11 @@ import javax.inject.Inject
 class JetpackActivationWPComPasswordViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     selectedSite: SelectedSite,
+    jetpackAccountRepository: JetpackActivationRepository,
     private val wpComLoginRepository: WPComLoginRepository,
     private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider
-) : JetpackActivationWPComPostLoginViewModel(savedStateHandle, selectedSite) {
+) : JetpackActivationWPComPostLoginViewModel(savedStateHandle, selectedSite, jetpackAccountRepository) {
     companion object {
         private const val RESET_PASSWORD_URL = "https://wordpress.com/wp-login.php?action=lostpassword"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
@@ -1,18 +1,32 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.jetpack.GoToStore
+import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 
 open class JetpackActivationWPComPostLoginViewModel(
     savedStateHandle: SavedStateHandle,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val jetpackActivationRepository: JetpackActivationRepository
 ) : ScopedViewModel(savedStateHandle) {
-    protected fun onLoginSuccess(jetpackStatus: JetpackStatus) {
+    protected suspend fun onLoginSuccess(jetpackStatus: JetpackStatus) {
         if (jetpackStatus.isJetpackConnected) {
-            TODO("fetch sites then show main activity")
+            jetpackActivationRepository.fetchJetpackSite(selectedSite.get().url)
+                .fold(
+                    onSuccess = {
+                        selectedSite.set(it)
+                        triggerEvent(GoToStore)
+                    },
+                    onFailure = {
+                        triggerEvent(ShowSnackbar(R.string.error_generic))
+                    }
+                )
         } else {
             triggerEvent(
                 ShowJetpackActivationScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
@@ -20,7 +20,7 @@ open class JetpackActivationWPComPostLoginViewModel(
             jetpackActivationRepository.fetchJetpackSite(selectedSite.get().url)
                 .fold(
                     onSuccess = {
-                        selectedSite.set(it)
+                        jetpackActivationRepository.setSelectedSiteAndCleanOldSites(it)
                         triggerEvent(GoToStore)
                     },
                     onFailure = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.WooException
@@ -49,7 +50,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     private val loginAnalyticsListener: LoginAnalyticsListener,
     private val resourceProvider: ResourceProvider,
     applicationPasswordsNotifier: ApplicationPasswordsNotifier,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val appPrefs: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         const val SITE_ADDRESS_KEY = "site-address"
@@ -172,6 +174,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                     // handle the flow
                     loginAnalyticsListener.trackAnalyticsSignIn(false)
                 }
+                appPrefs.removeLoginSiteAddress()
                 selectedSite.set(site)
                 triggerEvent(LoggedIn(selectedSite.getSelectedSiteId()))
             },

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -24,6 +24,11 @@
             app:destination="@id/jetpackActivationWPComEmailFragment"
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_jetpackActivationDispatcherFragment_to_jetpackActivationWPComPasswordFragment"
+            app:destination="@id/jetpackActivationWPComPasswordFragment"
+            app:popUpTo="@id/jetpackActivationDispatcherFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/jetpackActivationStartFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.sitecredentials
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -61,6 +62,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     private val loginAnalyticsListener: LoginAnalyticsListener = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+    private val appPrefs: AppPrefsWrapper = mock()
 
     private lateinit var viewModel: LoginSiteCredentialsViewModel
 
@@ -79,7 +81,8 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             loginAnalyticsListener = loginAnalyticsListener,
             resourceProvider = resourceProvider,
             applicationPasswordsNotifier = applicationPasswordsNotifier,
-            analyticsTracker = analyticsTracker
+            analyticsTracker = analyticsTracker,
+            appPrefs = appPrefs
         )
     }
 


### PR DESCRIPTION
Closes: #8419 

### Description
This PR handles the connection flow when Jetpack is already connected, this can happen if the user installed and connected Jetpack later after their connection to the app using Application Passwords.

### Testing instructions
1. Open the app then enter the address of a non-Jetpack site.
2. Login using site credentials.
3. Open wp-admin of your site, then install and connect Jetpack.
4. Return to the app, then tap the Jetpack benefits banner.
5. Click on "Log in to continue"
6. Confirm that after the "Jetpack status fetch" dialog, the app shows you the password screen directly with the correct WordPress.com email.
7. Enter your password then tap on "Connect Jetpack" (Magic Link is not supported yet)
8. Confirm the MainActivity is restarted with the correct site, and that all features are unlocked.

### Images/gif
https://user-images.githubusercontent.com/1657201/221641962-2f7f05de-1d06-4077-a18e-c4ad9401ec76.mov

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
