### PR TITLE
[Support Requests] Remap ticket tags and fields

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -491,7 +491,7 @@ private fun buildZendeskCustomFields(
         CustomField(TicketFieldIds.currentSite, currentSiteInformation),
         CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform),
         CustomField(TicketFieldIds.appLanguage, Locale.getDefault().language),
-        CustomField(TicketFieldIds.categoryId, ZendeskConstants.categoryValue),
+        CustomField(TicketFieldIds.categoryId, ticketType.categoryName),
         CustomField(TicketFieldIds.subcategoryId, ticketType.subcategoryName),
         CustomField(TicketFieldIds.blogList, getCombinedLogInformationOfSites(allSites))
     )
@@ -583,16 +583,19 @@ private fun getNetworkInformation(context: Context): String {
 
 sealed class TicketType(
     val form: Long,
+    val categoryName: String,
     val subcategoryName: String,
     val tags: List<String> = emptyList(),
 ) : Parcelable {
     @Parcelize object MobileApp : TicketType(
         form = TicketFieldIds.wooMobileFormID,
+        categoryName = ZendeskConstants.mobileAppCategory,
         subcategoryName = ZendeskConstants.mobileSubcategoryValue,
         tags = listOf(ZendeskTags.mobileApp)
     )
     @Parcelize object InPersonPayments : TicketType(
         form = TicketFieldIds.wooMobileFormID,
+        categoryName = ZendeskConstants.mobileAppCategory,
         subcategoryName = ZendeskConstants.mobileSubcategoryValue,
         tags = listOf(
             ZendeskTags.woocommerceMobileApps,
@@ -601,31 +604,34 @@ sealed class TicketType(
     )
     @Parcelize object Payments : TicketType(
         form = TicketFieldIds.wooFormID,
+        categoryName = ZendeskConstants.supportCategory,
         subcategoryName = ZendeskConstants.paymentsSubcategoryValue,
         tags = listOf(
             ZendeskTags.paymentsProduct,
             ZendeskTags.paymentsProductArea,
             ZendeskTags.mobileAppWooTransfer,
-            ZendeskConstants.categoryValue,
+            ZendeskConstants.supportCategory,
             ZendeskConstants.paymentsSubcategoryValue
         )
     )
     @Parcelize object WooPlugin : TicketType(
         form = TicketFieldIds.wooFormID,
+        categoryName = ZendeskConstants.supportCategory,
         subcategoryName = "",
         tags = listOf(
             ZendeskTags.woocommerceCore,
             ZendeskTags.mobileAppWooTransfer,
-            ZendeskConstants.categoryValue
+            ZendeskConstants.supportCategory
         )
     )
     @Parcelize object OtherPlugins : TicketType(
         form = TicketFieldIds.wooFormID,
+        categoryName = ZendeskConstants.supportCategory,
         subcategoryName = ZendeskConstants.storeSubcategoryValue,
         tags = listOf(
             ZendeskTags.productAreaWooExtensions,
             ZendeskTags.mobileAppWooTransfer,
-            ZendeskConstants.categoryValue,
+            ZendeskConstants.supportCategory,
             ZendeskConstants.storeSubcategoryValue
         )
     )
@@ -636,7 +642,8 @@ private object ZendeskConstants {
     const val blogSeparator = "\n----------\n"
     const val jetpackTag = "jetpack"
     const val mobileHelpCategoryId = 360000041586
-    const val categoryValue = "Support"
+    const val supportCategory = "Support"
+    const val mobileAppCategory = "Mobile App"
     const val mobileSubcategoryValue = "WooCommerce Mobile Apps"
     const val paymentsSubcategoryValue = "Payment"
     const val storeSubcategoryValue = "Store"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -225,7 +225,7 @@ class ZendeskHelper(
         }
 
         val siteConnectionTag = if (selectedSite?.connectionType == SiteConnectionType.ApplicationPasswords) {
-            ZendeskExtraTags.applicationPasswordAuthenticated
+            ZendeskTags.applicationPasswordAuthenticated
         } else null
 
         val tags = (extraTags.orEmpty() + siteConnectionTag).filterNotNull()
@@ -589,20 +589,23 @@ sealed class TicketType(
     @Parcelize object MobileApp : TicketType(
         form = TicketFieldIds.wooMobileFormID,
         subcategoryName = ZendeskConstants.mobileSubcategoryValue,
-        tags = listOf("mobile_app")
+        tags = listOf(ZendeskTags.mobileApp)
     )
     @Parcelize object InPersonPayments : TicketType(
         form = TicketFieldIds.wooMobileFormID,
         subcategoryName = ZendeskConstants.mobileSubcategoryValue,
-        tags = listOf("woocommerce_mobile_apps", "product_area_apps_in_person_payments")
+        tags = listOf(
+            ZendeskTags.woocommerceMobileApps,
+            ZendeskTags.productAreaAppsInPersonPayments
+        )
     )
     @Parcelize object Payments : TicketType(
         form = TicketFieldIds.wooFormID,
         subcategoryName = ZendeskConstants.paymentsSubcategoryValue,
         tags = listOf(
-            ZendeskExtraTags.paymentsProduct,
-            ZendeskExtraTags.paymentsProductArea,
-            "mobile_app_woo_transfer",
+            ZendeskTags.paymentsProduct,
+            ZendeskTags.paymentsProductArea,
+            ZendeskTags.mobileAppWooTransfer,
             ZendeskConstants.categoryValue,
             ZendeskConstants.paymentsSubcategoryValue
         )
@@ -610,14 +613,21 @@ sealed class TicketType(
     @Parcelize object WooPlugin : TicketType(
         form = TicketFieldIds.wooFormID,
         subcategoryName = "",
-        tags = listOf("woocommerce_core", "mobile_app_woo_transfer",
-            ZendeskConstants.categoryValue)
+        tags = listOf(
+            ZendeskTags.woocommerceCore,
+            ZendeskTags.mobileAppWooTransfer,
+            ZendeskConstants.categoryValue
+        )
     )
     @Parcelize object OtherPlugins : TicketType(
         form = TicketFieldIds.wooFormID,
         subcategoryName = ZendeskConstants.storeSubcategoryValue,
-        tags = listOf("product_area_woo_extensions", "mobile_app_woo_transfer",
-            ZendeskConstants.categoryValue, ZendeskConstants.storeSubcategoryValue)
+        tags = listOf(
+            ZendeskTags.productAreaWooExtensions,
+            ZendeskTags.mobileAppWooTransfer,
+            ZendeskConstants.categoryValue,
+            ZendeskConstants.storeSubcategoryValue
+        )
     )
 }
 
@@ -662,11 +672,17 @@ private object TicketFieldIds {
     const val sourcePlatform = 360009311651L
 }
 
-object ZendeskExtraTags {
+object ZendeskTags {
     const val applicationPasswordAuthenticated = "application_password_authenticated"
 
+    const val mobileApp = "mobile_app"
+    const val woocommerceCore = "woocommerce_core"
     const val paymentsProduct = "woocommerce_payments"
     const val paymentsProductArea = "product_area_woo_payment_gateway"
+    const val mobileAppWooTransfer = "mobile_app_woo_transfer"
+    const val woocommerceMobileApps = "woocommerce_mobile_apps"
+    const val productAreaWooExtensions = "product_area_woo_extensions"
+    const val productAreaAppsInPersonPayments = "product_area_apps_in_person_payments"
 }
 
 private object RequestConstants {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -130,7 +130,7 @@ class ZendeskHelper(
         origin: HelpOrigin?,
         selectedSite: SiteModel?,
         extraTags: List<String>? = null,
-        ticketType: TicketType = TicketType.General,
+        ticketType: TicketType = TicketType.Mobile,
     ) {
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
@@ -189,7 +189,7 @@ class ZendeskHelper(
         }
 
         CreateRequest().apply {
-            this.ticketFormId = option.ticketType.form
+            this.ticketFormId = 189946L
             this.subject = subject
             this.description = description
             this.tags = buildZendeskTags(siteStore.sites, origin, option.allTags + extraTags)
@@ -217,7 +217,7 @@ class ZendeskHelper(
         origin: HelpOrigin?,
         selectedSite: SiteModel?,
         extraTags: List<String>? = null,
-        ticketType: TicketType = TicketType.General,
+        ticketType: TicketType = TicketType.Mobile,
         ssr: String? = null
     ) {
         require(isZendeskEnabled) {
@@ -254,7 +254,7 @@ class ZendeskHelper(
         origin: HelpOrigin?,
         selectedSite: SiteModel? = null,
         extraTags: List<String>? = null,
-        ticketType: TicketType = TicketType.General,
+        ticketType: TicketType = TicketType.Mobile,
     ) {
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
@@ -587,8 +587,8 @@ private object ZendeskConstants {
     const val jetpackTag = "jetpack"
     const val mobileHelpCategoryId = 360000041586
     const val categoryValue = "Support"
-    const val subcategoryGeneralValue = "WooCommerce Mobile Apps"
-    const val subcategoryPaymentsValue = "payment"
+    const val mobileSubcategoryValue = "WooCommerce Mobile Apps"
+    const val paymentsSubcategoryValue = "payment"
     const val networkWifi = "WiFi"
     const val networkWWAN = "Mobile"
     const val networkTypeLabel = "Network Type:"
@@ -608,8 +608,8 @@ private object TicketFieldIds {
     const val appVersion = 360000086866L
     const val blogList = 360000087183L
     const val deviceFreeSpace = 360000089123L
-    const val formGeneral = 360000010286L
-    const val formPayments = 189946L
+    const val wooMobileFormID = 360000010286L
+    const val wooFormID = 189946L
     const val categoryId = 25176003L
     const val subcategoryId = 25176023L
     const val logs = 10901699622036L
@@ -625,11 +625,11 @@ data class HelpData(val origin: HelpOrigin, val option: HelpOption)
 
 sealed class HelpOption(val ticketType: TicketType, val extraTags: List<String>) : Parcelable {
     @Parcelize object MobileApp : HelpOption(
-        ticketType = TicketType.General,
+        ticketType = TicketType.Mobile,
         extraTags = listOf("mobile-app")
     )
     @Parcelize object InPersonPayments : HelpOption(
-        ticketType = TicketType.General,
+        ticketType = TicketType.Mobile,
         extraTags = listOf("woocommerce_mobile_apps", "product_area_apps_in_person_payments")
     )
     @Parcelize object Payments : HelpOption(
@@ -637,11 +637,11 @@ sealed class HelpOption(val ticketType: TicketType, val extraTags: List<String>)
         extraTags = emptyList()
     )
     @Parcelize object WooPlugin : HelpOption(
-        ticketType = TicketType.General,
+        ticketType = TicketType.Mobile,
         extraTags = listOf("woocommerce_core")
     )
     @Parcelize object OtherPlugins : HelpOption(
-        ticketType = TicketType.General,
+        ticketType = TicketType.Mobile,
         extraTags = listOf("product_area_woo_extensions")
     )
 
@@ -654,15 +654,15 @@ sealed class TicketType(
     val tags: List<String> = emptyList(),
 ) : Parcelable {
     @Parcelize
-    object General : TicketType(
-        form = TicketFieldIds.formGeneral,
-        subcategoryName = ZendeskConstants.subcategoryGeneralValue,
+    object Mobile : TicketType(
+        form = TicketFieldIds.wooMobileFormID,
+        subcategoryName = ZendeskConstants.mobileSubcategoryValue,
     )
 
     @Parcelize
     object Payments : TicketType(
-        form = TicketFieldIds.formPayments,
-        subcategoryName = ZendeskConstants.subcategoryPaymentsValue,
+        form = TicketFieldIds.wooFormID,
+        subcategoryName = ZendeskConstants.paymentsSubcategoryValue,
         tags = arrayListOf(
             ZendeskExtraTags.paymentsProduct,
             ZendeskExtraTags.paymentsCategory,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -601,18 +601,23 @@ sealed class TicketType(
         subcategoryName = ZendeskConstants.paymentsSubcategoryValue,
         tags = listOf(
             ZendeskExtraTags.paymentsProduct,
-            ZendeskExtraTags.paymentsProductArea
+            ZendeskExtraTags.paymentsProductArea,
+            "mobile_app_woo_transfer",
+            ZendeskConstants.categoryValue,
+            ZendeskConstants.paymentsSubcategoryValue
         )
     )
     @Parcelize object WooPlugin : TicketType(
         form = TicketFieldIds.wooFormID,
         subcategoryName = "",
-        tags = listOf("woocommerce_core")
+        tags = listOf("woocommerce_core", "mobile_app_woo_transfer",
+            ZendeskConstants.categoryValue)
     )
     @Parcelize object OtherPlugins : TicketType(
         form = TicketFieldIds.wooFormID,
         subcategoryName = ZendeskConstants.storeSubcategoryValue,
-        tags = listOf("product_area_woo_extensions")
+        tags = listOf("product_area_woo_extensions", "mobile_app_woo_transfer",
+            ZendeskConstants.categoryValue, ZendeskConstants.storeSubcategoryValue)
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -193,6 +193,7 @@ class ZendeskHelper(
             this.subject = subject
             this.description = description
             this.tags = buildZendeskTags(siteStore.sites, origin, ticketType.tags + extraTags)
+                .filter { ticketType.excludedTags.contains(it).not() }
             this.customFields = buildZendeskCustomFields(context, ticketType, siteStore.sites, selectedSite)
         }.let { request -> requestProvider?.createRequest(request, requestCallback) }
 
@@ -586,6 +587,7 @@ sealed class TicketType(
     val categoryName: String,
     val subcategoryName: String,
     val tags: List<String> = emptyList(),
+    val excludedTags: List<String> = emptyList()
 ) : Parcelable {
     @Parcelize object MobileApp : TicketType(
         form = TicketFieldIds.wooMobileFormID,
@@ -612,7 +614,8 @@ sealed class TicketType(
             ZendeskTags.mobileAppWooTransfer,
             ZendeskTags.supportCategoryTag,
             ZendeskTags.paymentSubcategoryTag
-        )
+        ),
+        excludedTags = listOf(ZendeskTags.jetpackTag)
     )
     @Parcelize object WooPlugin : TicketType(
         form = TicketFieldIds.wooFormID,
@@ -622,7 +625,8 @@ sealed class TicketType(
             ZendeskTags.woocommerceCore,
             ZendeskTags.mobileAppWooTransfer,
             ZendeskTags.supportCategoryTag
-        )
+        ),
+        excludedTags = listOf(ZendeskTags.jetpackTag)
     )
     @Parcelize object OtherPlugins : TicketType(
         form = TicketFieldIds.wooFormID,
@@ -633,7 +637,8 @@ sealed class TicketType(
             ZendeskTags.mobileAppWooTransfer,
             ZendeskTags.supportCategoryTag,
             ZendeskTags.storeSubcategoryTag
-        )
+        ),
+        excludedTags = listOf(ZendeskTags.jetpackTag)
     )
 }
 
@@ -693,6 +698,7 @@ object ZendeskTags {
     const val storeSubcategoryTag = "store"
     const val supportCategoryTag = "support"
     const val paymentSubcategoryTag = "payment"
+    const val jetpackTag = "jetpack"
 }
 
 private object RequestConstants {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -189,7 +189,7 @@ class ZendeskHelper(
         }
 
         CreateRequest().apply {
-            this.ticketFormId = 189946L
+            this.ticketFormId = ticketType.form
             this.subject = subject
             this.description = description
             this.tags = buildZendeskTags(siteStore.sites, origin, ticketType.tags + extraTags)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -610,8 +610,8 @@ sealed class TicketType(
             ZendeskTags.paymentsProduct,
             ZendeskTags.paymentsProductArea,
             ZendeskTags.mobileAppWooTransfer,
-            ZendeskConstants.supportCategory,
-            ZendeskConstants.paymentsSubcategoryValue
+            ZendeskTags.supportCategoryTag,
+            ZendeskTags.paymentSubcategoryTag
         )
     )
     @Parcelize object WooPlugin : TicketType(
@@ -621,7 +621,7 @@ sealed class TicketType(
         tags = listOf(
             ZendeskTags.woocommerceCore,
             ZendeskTags.mobileAppWooTransfer,
-            ZendeskConstants.supportCategory
+            ZendeskTags.supportCategoryTag
         )
     )
     @Parcelize object OtherPlugins : TicketType(
@@ -631,8 +631,8 @@ sealed class TicketType(
         tags = listOf(
             ZendeskTags.productAreaWooExtensions,
             ZendeskTags.mobileAppWooTransfer,
-            ZendeskConstants.supportCategory,
-            ZendeskConstants.storeSubcategoryValue
+            ZendeskTags.supportCategoryTag,
+            ZendeskTags.storeSubcategoryTag
         )
     )
 }
@@ -690,6 +690,9 @@ object ZendeskTags {
     const val woocommerceMobileApps = "woocommerce_mobile_apps"
     const val productAreaWooExtensions = "product_area_woo_extensions"
     const val productAreaAppsInPersonPayments = "product_area_apps_in_person_payments"
+    const val storeSubcategoryTag = "store"
+    const val supportCategoryTag = "support"
+    const val paymentSubcategoryTag = "payment"
 }
 
 private object RequestConstants {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -71,8 +71,8 @@ class HelpActivity : AppCompatActivity() {
         supportActionBar?.setHomeButtonEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.General) }
-        binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.General) }
+        binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.Mobile) }
+        binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.Mobile) }
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener {
             val loginFlow = intent.extras?.getString(LOGIN_FLOW_KEY)
@@ -113,7 +113,7 @@ class HelpActivity : AppCompatActivity() {
         }
 
         if (originFromExtras == HelpOrigin.SITE_PICKER_JETPACK_TIMEOUT) {
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
         }
 
         initObservers(binding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -71,8 +71,8 @@ class HelpActivity : AppCompatActivity() {
         supportActionBar?.setHomeButtonEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.Mobile) }
-        binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.Mobile) }
+        binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.MobileApp) }
+        binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.MobileApp) }
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener {
             val loginFlow = intent.extras?.getString(LOGIN_FLOW_KEY)
@@ -113,7 +113,7 @@ class HelpActivity : AppCompatActivity() {
         }
 
         if (originFromExtras == HelpOrigin.SITE_PICKER_JETPACK_TIMEOUT) {
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
         }
 
         initObservers(binding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -11,7 +11,7 @@ import androidx.core.widget.doOnTextChanged
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
 import com.woocommerce.android.extensions.serializable
-import com.woocommerce.android.support.HelpOption
+import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.RequestCreationFailed
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.RequestCreationSucceeded
@@ -54,11 +54,11 @@ class SupportRequestFormActivity : AppCompatActivity() {
         binding.requestMessage.doOnTextChanged { text, _, _, _ -> viewModel.onMessageChanged(text.toString()) }
         binding.helpOptionsGroup.setOnCheckedChangeListener { _, selectionID ->
             when (selectionID) {
-                binding.mobileAppOption.id -> viewModel.onHelpOptionSelected(HelpOption.MobileApp)
-                binding.ippOption.id -> viewModel.onHelpOptionSelected(HelpOption.InPersonPayments)
-                binding.paymentsOption.id -> viewModel.onHelpOptionSelected(HelpOption.Payments)
-                binding.wooPluginOption.id -> viewModel.onHelpOptionSelected(HelpOption.WooPlugin)
-                binding.otherOption.id -> viewModel.onHelpOptionSelected(HelpOption.OtherPlugins)
+                binding.mobileAppOption.id -> viewModel.onHelpOptionSelected(TicketType.MobileApp)
+                binding.ippOption.id -> viewModel.onHelpOptionSelected(TicketType.InPersonPayments)
+                binding.paymentsOption.id -> viewModel.onHelpOptionSelected(TicketType.Payments)
+                binding.wooPluginOption.id -> viewModel.onHelpOptionSelected(TicketType.WooPlugin)
+                binding.otherOption.id -> viewModel.onHelpOptionSelected(TicketType.OtherPlugins)
             }
         }
         binding.submitRequestButton.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -62,7 +62,7 @@ class SupportRequestFormViewModel @Inject constructor(
                 context,
                 helpOrigin,
                 ticketType,
-                selectedSite.get(),
+                selectedSite.getIfExists(),
                 viewState.value.subject,
                 viewState.value.message,
                 extraTags

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -5,8 +5,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.support.HelpData
-import com.woocommerce.android.support.HelpOption
+import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
@@ -43,8 +42,8 @@ class SupportRequestFormViewModel @Inject constructor(
         .distinctUntilChanged()
         .asLiveData()
 
-    fun onHelpOptionSelected(helpOption: HelpOption) {
-        viewState.update { it.copy(helpOption = helpOption) }
+    fun onHelpOptionSelected(ticketType: TicketType) {
+        viewState.update { it.copy(ticketType = ticketType) }
     }
 
     fun onSubjectChanged(subject: String) {
@@ -56,12 +55,13 @@ class SupportRequestFormViewModel @Inject constructor(
     }
 
     fun onSubmitRequestButtonClicked(context: Context, helpOrigin: HelpOrigin, extraTags: List<String>) {
-        val helpOption = viewState.value.helpOption ?: return
+        val ticketType = viewState.value.ticketType ?: return
         viewState.update { it.copy(isLoading = true) }
         launch {
             zendeskHelper.createRequest(
                 context,
-                HelpData(helpOrigin, helpOption),
+                helpOrigin,
+                ticketType,
                 selectedSite.get(),
                 viewState.value.subject,
                 viewState.value.message,
@@ -83,13 +83,13 @@ class SupportRequestFormViewModel @Inject constructor(
 
     @Parcelize
     data class ViewState(
-        val helpOption: HelpOption?,
+        val ticketType: TicketType?,
         val subject: String,
         val message: String,
         val isLoading: Boolean
     ) : Parcelable {
         val dataIsValid
-            get() = helpOption != null && subject.isNotBlank() && message.isNotBlank()
+            get() = ticketType != null && subject.isNotBlank() && message.isNotBlank()
 
         companion object {
             val EMPTY = ViewState(null, "", "", false)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3076,7 +3076,7 @@
     <string name="support_request">Support Request</string>
     <string name="support_request_help_title">I need help with</string>
     <string name="support_request_title">Let\'s get this sorted</string>
-    <string name="support_request_description">Tell us much as you can about the problem, and we will be in touch soon.</string>
+    <string name="support_request_description">Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon.</string>
     <string name="support_request_subject">Subject</string>
     <string name="support_request_submit">Submit Support Request</string>
     <string name="support_request_message">Message</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpViewModelTest.kt
@@ -51,12 +51,12 @@ class HelpViewModelTest : BaseUnitTest() {
         whenever(selectedSite.exists()).thenReturn(false)
 
         // WHEN
-        viewModel.contactSupport(TicketType.Mobile)
+        viewModel.contactSupport(TicketType.MobileApp)
 
         // THEN
         assertThat(viewModel.event.value).isEqualTo(
             HelpViewModel.ContactSupportEvent.CreateTicket(
-                TicketType.Mobile,
+                TicketType.MobileApp,
                 emptyList(),
             )
         )
@@ -68,7 +68,7 @@ class HelpViewModelTest : BaseUnitTest() {
         whenever(selectedSite.exists()).thenReturn(true)
 
         // WHEN
-        viewModel.contactSupport(TicketType.Mobile)
+        viewModel.contactSupport(TicketType.MobileApp)
 
         // THEN
         assertThat(viewModel.event.value).isEqualTo(HelpViewModel.ContactSupportEvent.ShowLoading)
@@ -88,12 +88,12 @@ class HelpViewModelTest : BaseUnitTest() {
             )
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf("woo_mobile_site_plugins_fetching_error")
                 )
             )
@@ -132,12 +132,12 @@ class HelpViewModelTest : BaseUnitTest() {
             whenever(wooStore.getSitePlugin(any(), any())).thenReturn(null)
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
                         "woo_mobile_stripe_not_installed",
@@ -155,12 +155,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(mock())
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
                         "woo_mobile_stripe_not_installed",
@@ -181,12 +181,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(wcpayPluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",
                         "woo_mobile_stripe_not_installed",
@@ -204,12 +204,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(mock())
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
                         "woo_mobile_stripe_installed_and_not_activated",
@@ -230,12 +230,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
                         "woo_mobile_stripe_installed_and_activated",
@@ -257,12 +257,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
                         "woo_mobile_stripe_installed_and_not_activated",
@@ -286,12 +286,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",
                         "woo_mobile_stripe_installed_and_not_activated",
@@ -315,12 +315,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
                         "woo_mobile_stripe_installed_and_activated",
@@ -346,12 +346,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.Mobile)
+            viewModel.contactSupport(TicketType.MobileApp)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.Mobile,
+                    TicketType.MobileApp,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",
                         "woo_mobile_stripe_installed_and_activated",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpViewModelTest.kt
@@ -51,12 +51,12 @@ class HelpViewModelTest : BaseUnitTest() {
         whenever(selectedSite.exists()).thenReturn(false)
 
         // WHEN
-        viewModel.contactSupport(TicketType.General)
+        viewModel.contactSupport(TicketType.Mobile)
 
         // THEN
         assertThat(viewModel.event.value).isEqualTo(
             HelpViewModel.ContactSupportEvent.CreateTicket(
-                TicketType.General,
+                TicketType.Mobile,
                 emptyList(),
             )
         )
@@ -68,7 +68,7 @@ class HelpViewModelTest : BaseUnitTest() {
         whenever(selectedSite.exists()).thenReturn(true)
 
         // WHEN
-        viewModel.contactSupport(TicketType.General)
+        viewModel.contactSupport(TicketType.Mobile)
 
         // THEN
         assertThat(viewModel.event.value).isEqualTo(HelpViewModel.ContactSupportEvent.ShowLoading)
@@ -88,12 +88,12 @@ class HelpViewModelTest : BaseUnitTest() {
             )
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf("woo_mobile_site_plugins_fetching_error")
                 )
             )
@@ -132,12 +132,12 @@ class HelpViewModelTest : BaseUnitTest() {
             whenever(wooStore.getSitePlugin(any(), any())).thenReturn(null)
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
                         "woo_mobile_stripe_not_installed",
@@ -155,12 +155,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(mock())
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
                         "woo_mobile_stripe_not_installed",
@@ -181,12 +181,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(wcpayPluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",
                         "woo_mobile_stripe_not_installed",
@@ -204,12 +204,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(mock())
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
                         "woo_mobile_stripe_installed_and_not_activated",
@@ -230,12 +230,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_not_installed",
                         "woo_mobile_stripe_installed_and_activated",
@@ -257,12 +257,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
                         "woo_mobile_stripe_installed_and_not_activated",
@@ -286,12 +286,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",
                         "woo_mobile_stripe_installed_and_not_activated",
@@ -315,12 +315,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_installed_and_not_activated",
                         "woo_mobile_stripe_installed_and_activated",
@@ -346,12 +346,12 @@ class HelpViewModelTest : BaseUnitTest() {
                 .thenReturn(stripePluginModel)
 
             // WHEN
-            viewModel.contactSupport(TicketType.General)
+            viewModel.contactSupport(TicketType.Mobile)
 
             // THEN
             assertThat(viewModel.event.value).isEqualTo(
                 HelpViewModel.ContactSupportEvent.CreateTicket(
-                    TicketType.General,
+                    TicketType.Mobile,
                     listOf(
                         "woo_mobile_wcpay_installed_and_activated",
                         "woo_mobile_stripe_installed_and_activated",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.support.requests
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.support.HelpOption
+import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormViewModel.RequestCreationFailed
@@ -47,7 +47,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         // When
         sut.onSubjectChanged("subject")
         sut.onMessageChanged("message")
-        sut.onHelpOptionSelected(HelpOption.MobileApp)
+        sut.onHelpOptionSelected(TicketType.MobileApp)
 
         // Then
         assertThat(isSubmitButtonEnabled).hasSize(2)
@@ -66,7 +66,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         // When
         sut.onSubjectChanged("")
         sut.onMessageChanged("")
-        sut.onHelpOptionSelected(HelpOption.MobileApp)
+        sut.onHelpOptionSelected(TicketType.MobileApp)
 
         // Then
         assertThat(isSubmitButtonEnabled).hasSize(1)
@@ -84,7 +84,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         // When
         sut.onSubjectChanged("subject")
         sut.onMessageChanged("message")
-        sut.onHelpOptionSelected(HelpOption.MobileApp)
+        sut.onHelpOptionSelected(TicketType.MobileApp)
         sut.onSubmitRequestButtonClicked(mock(), HelpOrigin.LOGIN_HELP_NOTIFICATION, emptyList())
 
         // Then
@@ -104,7 +104,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         }
 
         // When
-        sut.onHelpOptionSelected(HelpOption.MobileApp)
+        sut.onHelpOptionSelected(TicketType.MobileApp)
         sut.onSubmitRequestButtonClicked(mock(), HelpOrigin.LOGIN_HELP_NOTIFICATION, emptyList())
 
         // Then
@@ -112,7 +112,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         assertThat(isRequestLoading[0]).isFalse
         assertThat(isRequestLoading[1]).isTrue
         assertThat(isRequestLoading[2]).isFalse
-        verify(zendeskHelper, times(1)).createRequest(any(), any(), any(), any(), any(), any())
+        verify(zendeskHelper, times(1)).createRequest(any(), any(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -129,7 +129,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         // Then
         assertThat(isRequestLoading).hasSize(1)
         assertThat(isRequestLoading[0]).isFalse
-        verify(zendeskHelper, never()).createRequest(any(), any(), any(), any(), any(), any())
+        verify(zendeskHelper, never()).createRequest(any(), any(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -141,7 +141,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         }
 
         // When
-        sut.onHelpOptionSelected(HelpOption.MobileApp)
+        sut.onHelpOptionSelected(TicketType.MobileApp)
         sut.onSubmitRequestButtonClicked(mock(), HelpOrigin.LOGIN_HELP_NOTIFICATION, emptyList())
 
         // Then
@@ -159,7 +159,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         }
 
         // When
-        sut.onHelpOptionSelected(HelpOption.MobileApp)
+        sut.onHelpOptionSelected(TicketType.MobileApp)
         sut.onSubmitRequestButtonClicked(mock(), HelpOrigin.LOGIN_HELP_NOTIFICATION, emptyList())
 
         // Then
@@ -175,6 +175,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         zendeskHelper = mock {
             onBlocking {
                 createRequest(
+                    any(),
                     any(),
                     any(),
                     eq(testSite),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -170,7 +170,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
     private fun configureMocks(requestResult: Result<Request?>) {
         val testSite = SiteModel().apply { id = 123 }
         selectedSite = mock {
-            on { get() }.then { testSite }
+            on { getIfExists() }.then { testSite }
         }
         zendeskHelper = mock {
             onBlocking {


### PR DESCRIPTION
Summary
==========
Fix issue #8423 by updating Zendesk tags and fields configuration per the guidelines described here: pe5pgL-2k3-p2

```
Mobile App
Form: 360000010286
Tags: woocommerce_mobile_apps, jetpack(legacy from old implementation)
Sub-Category: 25176023: WooCommerce Mobile Apps

Card Reader / IPP
Form: 360000010286
Tags: woocommerce_mobile_apps, product_area_apps_in_person_payments, jetpack(legacy from old implementation)
Sub-Category: 25176023: WooCommerce Mobile Apps

WooCommerce Payments
Form: 189946
Tags: woocommerce_payments, support, payment, product_area_woo_payment_gateway, mobile_app_woo_transfer
Category: 25176003: support
Sub-Category: 25176023: payment
Note: Do not send the woo-mobile-sdk tag.

WooCommerce Plugins
Form: 189946
Tags: woocommerce_core, support, mobile_app_woo_transfer
Category: 25176003: support
Note: Do not send the woo-mobile-sdk tag.

Other Plugins
Form: 189946
Tags: support, store, product_area_woo_extensions, mobile_app_woo_transfer
Category: 25176003: support
Sub-Category: 25176023: store
Note: Do not send the woo-mobile-sdk tag.
```

How to Test
==========
1. Testing will be conducted here pe5pgL-2jR#comment-1912. I recommend focusing on the review of the code implementation, but you can also check the tickets created using the same reference described above.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.