### PR TITLE
Domain change: Admin access check

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.ui.prefs
 
-import com.woocommerce.android.model.UserRole
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
-import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.FeatureFlag
@@ -22,12 +20,10 @@ class MainSettingsPresenter @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val featureAnnouncementRepository: FeatureAnnouncementRepository,
     private val buildConfigWrapper: BuildConfigWrapper,
-    userEligibilityFetcher: UserEligibilityFetcher
 ) : MainSettingsContract.Presenter {
     private var appSettingsFragmentView: MainSettingsContract.View? = null
 
     private var jetpackMonitoringJob: Job? = null
-    private val isUserAdmin = userEligibilityFetcher.getUser()?.roles?.contains(UserRole.Administrator) ?: false
 
     override fun takeView(view: MainSettingsContract.View) {
         appSettingsFragmentView = view
@@ -82,5 +78,5 @@ class MainSettingsPresenter @Inject constructor(
     }
 
     override val isDomainOptionVisible: Boolean
-        get() = selectedSite.get().isWPComAtomic && isUserAdmin && FeatureFlag.DOMAIN_CHANGE.isEnabled()
+        get() = selectedSite.get().isWPComAtomic && FeatureFlag.DOMAIN_CHANGE.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainDashboardScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainDashboardScreen.kt
@@ -58,6 +58,9 @@ import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.prefs.domain.DomainDashboardViewModel.ViewState.DashboardState
 import com.woocommerce.android.ui.prefs.domain.DomainDashboardViewModel.ViewState.ErrorState
+import com.woocommerce.android.ui.prefs.domain.DomainDashboardViewModel.ViewState.ErrorState.ErrorType
+import com.woocommerce.android.ui.prefs.domain.DomainDashboardViewModel.ViewState.ErrorState.ErrorType.ACCESS_ERROR
+import com.woocommerce.android.ui.prefs.domain.DomainDashboardViewModel.ViewState.ErrorState.ErrorType.GENERIC_ERROR
 import com.woocommerce.android.ui.prefs.domain.DomainDashboardViewModel.ViewState.LoadingState
 
 @Composable
@@ -83,8 +86,8 @@ fun DomainDashboardScreen(viewModel: DomainDashboardViewModel) {
                                 .padding(padding)
                         )
                     }
+                    is ErrorState -> ErrorScreen(viewState.errorType)
                     LoadingState -> ProgressIndicator()
-                    ErrorState -> ErrorScreen()
                 }
             }
         }
@@ -328,7 +331,7 @@ private fun PrimaryDomainTag() {
 }
 
 @Composable
-fun ErrorScreen() {
+fun ErrorScreen(errorType: ErrorType) {
     Column(
         modifier = Modifier
             .background(MaterialTheme.colors.surface)
@@ -341,8 +344,12 @@ fun ErrorScreen() {
         ) {
             Image(painter = painterResource(id = drawable.img_woo_generic_error), contentDescription = null)
 
+            val message = when (errorType) {
+                ErrorType.GENERIC_ERROR -> stringResource(id = string.domains_generic_error_title)
+                ErrorType.ACCESS_ERROR -> stringResource(id = string.domains_access_error_title)
+            }
             Text(
-                text = stringResource(id = string.domains_error_title),
+                text = message,
                 style = MaterialTheme.typography.h6,
                 modifier = Modifier
                     .padding(
@@ -410,5 +417,5 @@ fun NoDomainsPickerPreview() {
 @Preview()
 @Composable
 fun ErrorScreenPreview() {
-    ErrorScreen()
+    ErrorScreen(ACCESS_ERROR)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainDashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainDashboardViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.prefs.domain
 
-import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -17,12 +16,11 @@ import com.woocommerce.android.ui.prefs.domain.DomainDashboardViewModel.ViewStat
 import com.woocommerce.android.ui.prefs.domain.DomainDashboardViewModel.ViewState.LoadingState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
-import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -39,7 +37,7 @@ class DomainDashboardViewModel @Inject constructor(
 
     private var hasFreeCredits = false
 
-    private val _viewState = savedStateHandle.getStateFlow<ViewState>(this, LoadingState)
+    private val _viewState = MutableStateFlow<ViewState>(LoadingState)
     val viewState = _viewState.asLiveData()
 
     init {
@@ -119,11 +117,9 @@ class DomainDashboardViewModel @Inject constructor(
         triggerEvent(ShowMoreAboutDomains(LEARN_MORE_URL))
     }
 
-    sealed interface ViewState : Parcelable {
-        @Parcelize
+    sealed interface ViewState {
         object LoadingState : ViewState
 
-        @Parcelize
         data class ErrorState(val errorType: ErrorType = GENERIC_ERROR) : ViewState {
             enum class ErrorType {
                 GENERIC_ERROR,
@@ -131,18 +127,16 @@ class DomainDashboardViewModel @Inject constructor(
             }
         }
 
-        @Parcelize
         data class DashboardState(
             val wpComDomain: Domain,
             val isDomainClaimBannerVisible: Boolean,
             val paidDomains: List<Domain>
         ) : ViewState {
-            @Parcelize
             data class Domain(
                 val url: String,
                 val renewalDate: String? = null,
                 val isPrimary: Boolean
-            ) : Parcelable
+            )
         }
     }
 

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -7,7 +7,7 @@ Language: ar
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">هل أنت متأكد من رغبتك في تسجيل الخروج من حسابك؟</string>
-    <string name="domains_error_title">يتعذر تحميل نطاقات المواقع</string>
+    <string name="domains_generic_error_title">يتعذر تحميل نطاقات المواقع</string>
     <string name="store_onboarding_completed_tasks_status">تم إكمال ⁦%1$d⁩/%2$d</string>
     <string name="store_onboarding_task_change_domain_description">احصل على عنوان URL مخصص لاستضافة متجرك.</string>
     <string name="store_onboarding_task_change_domain_title">تخصيص نطاقك</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -7,7 +7,7 @@ Language: de
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Möchtest du dich wirklich von deinem Konto abmelden?</string>
-    <string name="domains_error_title">Website-Domains konnten nicht geladen werden</string>
+    <string name="domains_generic_error_title">Website-Domains konnten nicht geladen werden</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d abgeschlossen</string>
     <string name="store_onboarding_task_change_domain_description">Sichere dir eine individuelle URL, um deinen Shop zu hosten.</string>
     <string name="store_onboarding_task_change_domain_title">Deine Domain anpassen</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -7,7 +7,7 @@ Language: es
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">¿Estás seguro de que quieres salir de tu cuenta?</string>
-    <string name="domains_error_title">No se han podido cargar los dominios del sitio</string>
+    <string name="domains_generic_error_title">No se han podido cargar los dominios del sitio</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d completado</string>
     <string name="store_onboarding_task_change_domain_description">Consigue una URL personalizada para alojar tu tienda.</string>
     <string name="store_onboarding_task_change_domain_title">Personaliza tu dominio</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -7,7 +7,7 @@ Language: fr
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Voulez-vous vraiment vous déconnecter de votre compte ?</string>
-    <string name="domains_error_title">Impossible de charger les domaines de site</string>
+    <string name="domains_generic_error_title">Impossible de charger les domaines de site</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d terminé</string>
     <string name="store_onboarding_task_change_domain_description">Choisissez une URL personnalisée pour héberger votre boutique.</string>
     <string name="store_onboarding_task_change_domain_title">Personnalisez votre domaine</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -7,7 +7,7 @@ Language: he_IL
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">ביקשת להתנתק מהחשבון - האם ההחלטה סופית?</string>
-    <string name="domains_error_title">אין אפשרות לטעון את הדומיינים של האתר.</string>
+    <string name="domains_generic_error_title">אין אפשרות לטעון את הדומיינים של האתר.</string>
     <string name="store_onboarding_completed_tasks_status">הושלמו ⁦%1$d⁩/%2$d</string>
     <string name="store_onboarding_task_change_domain_description">כתובת URL מותאמת אישית לאחסון החנות שלך.</string>
     <string name="store_onboarding_task_change_domain_title">להתאים אישית את הדומיין שלך</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -7,7 +7,7 @@ Language: id
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Apakah Anda yakin ingin keluar dari akun Anda?</string>
-    <string name="domains_error_title">Tidak dapat memuat domain situs</string>
+    <string name="domains_generic_error_title">Tidak dapat memuat domain situs</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d selesai</string>
     <string name="store_onboarding_task_change_domain_description">Miliki URL khusus untuk menjadi host toko Anda sendiri.</string>
     <string name="store_onboarding_task_change_domain_title">Sesuaikan domain Anda</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -7,7 +7,7 @@ Language: it
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Vuoi davvero uscire dal tuo account?</string>
-    <string name="domains_error_title">Impossibile caricare i domini del sito</string>
+    <string name="domains_generic_error_title">Impossibile caricare i domini del sito</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d completato</string>
     <string name="store_onboarding_task_change_domain_description">Un URL personalizzato per ospitare il tuo negozio</string>
     <string name="store_onboarding_task_change_domain_title">Personalizza il tuo dominio</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -7,7 +7,7 @@ Language: ja_JP
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">アカウントからログアウトしてもよろしいですか ?</string>
-    <string name="domains_error_title">サイトドメインを読み込めません</string>
+    <string name="domains_generic_error_title">サイトドメインを読み込めません</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d 完了</string>
     <string name="store_onboarding_task_change_domain_description">ストアをホストするカスタム URL を所有する。</string>
     <string name="store_onboarding_task_change_domain_title">ドメインをカスタマイズ</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -7,7 +7,7 @@ Language: ko_KR
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">계정에서 로그아웃하시겠나요?</string>
-    <string name="domains_error_title">사이트 도메인을 로드할 수 없음</string>
+    <string name="domains_generic_error_title">사이트 도메인을 로드할 수 없음</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d개 완료됨</string>
     <string name="store_onboarding_task_change_domain_description">스토어를 호스팅할 사용자 정의 URL을 가지세요.</string>
     <string name="store_onboarding_task_change_domain_title">도메인 사용자 정의</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -7,7 +7,7 @@ Language: nl
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Weet je zeker dat je wilt uitloggen bij je account?</string>
-    <string name="domains_error_title">Kan sitedomeinen niet laden</string>
+    <string name="domains_generic_error_title">Kan sitedomeinen niet laden</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d voltooid</string>
     <string name="store_onboarding_task_change_domain_description">Host je winkel met een aangepaste URL.</string>
     <string name="store_onboarding_task_change_domain_title">Je domein aanpassen</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -7,7 +7,7 @@ Language: pt_BR
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Tem certeza de que deseja fazer logout da sua conta?</string>
-    <string name="domains_error_title">Não foi possível carregar os domínios do site</string>
+    <string name="domains_generic_error_title">Não foi possível carregar os domínios do site</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d tarefas concluídas</string>
     <string name="store_onboarding_task_change_domain_description">Tenha uma URL personalizada para hospedar sua loja.</string>
     <string name="store_onboarding_task_change_domain_title">Personalize seu domínio</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -7,7 +7,7 @@ Language: ru
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Вы уверены, что хотите выйти из учётной записи?</string>
-    <string name="domains_error_title">Не удаётся загрузить домены сайта</string>
+    <string name="domains_generic_error_title">Не удаётся загрузить домены сайта</string>
     <string name="store_onboarding_completed_tasks_status">Готово: %1$d из %2$d</string>
     <string name="store_onboarding_task_change_domain_description">Настройте URL-адрес для своего магазина.</string>
     <string name="store_onboarding_task_change_domain_title">Настроить домен</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -7,7 +7,7 @@ Language: sv_SE
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Är du säker på att du vill logga ut från ditt konto?</string>
-    <string name="domains_error_title">Kan inte ladda webbplatsdomäner</string>
+    <string name="domains_generic_error_title">Kan inte ladda webbplatsdomäner</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d har slutförts</string>
     <string name="store_onboarding_task_change_domain_description">Få en anpassad URL för din butik.</string>
     <string name="store_onboarding_task_change_domain_title">Anpassa din domän</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -7,7 +7,7 @@ Language: tr
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">Hesabınızla açılan oturumu kapatmak istediğinizden emin misiniz?</string>
-    <string name="domains_error_title">Site alan adları yüklenemiyor </string>
+    <string name="domains_generic_error_title">Site alan adları yüklenemiyor </string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d tamamlandı</string>
     <string name="store_onboarding_task_change_domain_description">Mağazanızı depolamak için özel bir URL\'ye sahip olun.</string>
     <string name="store_onboarding_task_change_domain_title">Alan adınızı özelleştirin</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -7,7 +7,7 @@ Language: zh_CN
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">是否确定要注销您的帐户？</string>
-    <string name="domains_error_title">无法加载站点域名</string>
+    <string name="domains_generic_error_title">无法加载站点域名</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d 已完成</string>
     <string name="store_onboarding_task_change_domain_description">有用于托管您的商店的自定义 URL。</string>
     <string name="store_onboarding_task_change_domain_title">自定义您的域名</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -7,7 +7,7 @@ Language: zh_TW
 -->
 <resources>
     <string name="settings_confirm_logout_site_credentials">確定要登出帳號嗎？</string>
-    <string name="domains_error_title">無法載入網站網域</string>
+    <string name="domains_generic_error_title">無法載入網站網域</string>
     <string name="store_onboarding_completed_tasks_status">已完成 %1$d/%2$d</string>
     <string name="store_onboarding_task_change_domain_description">使用自訂 URL 來託管你的商店。</string>
     <string name="store_onboarding_task_change_domain_title">自訂你的網域</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -544,7 +544,8 @@
     <string name="domains_add_domain_button_title">Add a domain</string>
     <string name="domains_select_domain">Select domain</string>
     <string name="domains_redirect_notice">The domain purchased will redirect users to</string>
-    <string name="domains_error_title">Unable to load site domains</string>
+    <string name="domains_generic_error_title">Unable to load site domains</string>
+    <string name="domains_access_error_title">Only store administrators can access domain settings</string>
     <string name="domains_free_with_credits">Free for the first year</string>
     <string name="domains_purchase_successful_heading">Congratulations on your purchase</string>
     <string name="domains_purchase_successful_delay_notice">Your site address is being set up. It may take up 30 minutes for your domain to start working.</string>


### PR DESCRIPTION
This PR moves the user role check from Settings to the Domain dashboard. It also changes the DB value check in favour of fetching a fresh value for 2 reasons:

1. After a logged-in user creates a new store, the user info is not in the database so even if the user were an administrator, they wouldn't see the Domains settings after switching to the new site.
2. If a user isn't an administrator, they might not know why they can't access the Domain settings. Now there is a descriptive message.

<img src="https://user-images.githubusercontent.com/1522856/221869530-10451097-c104-4e1b-8ccd-1f5fd3d66f04.png" width="300" />

**To test:**
1. Log in to a site using an account with the Admin role
2. Go to Settings 
4. Notice the Domain setting is visible
5. Tap on Domains and verify you can see the site domains
6. Go back
7. On the web, change the role of the user to a Shop manager, for example
8. Go to Settings, notice the Domains setting is there
9. Tap on Domains
10. Notice an error message is displayed saying you need to be an admin