### PR TITLE
Fix crash when `adminUrl` is missing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.extensions
 
 import android.text.TextUtils
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.utils.extensions.slashJoin
 
 val SiteModel.logInformation: String
     get() {
@@ -35,3 +36,6 @@ fun SiteModel?.getTitle(default: String): String {
 // The isWPCom property is set as true only for pure WPCom sites that don't have Jetpack connection
 val SiteModel.isSimpleWPComSite
     get() = isWPCom
+
+val SiteModel.safeAdminUrl
+    get() = adminUrl ?: url.slashJoin("wp-admin")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -37,5 +37,5 @@ fun SiteModel?.getTitle(default: String): String {
 val SiteModel.isSimpleWPComSite
     get() = isWPCom
 
-val SiteModel.safeAdminUrl
+val SiteModel.adminUrlOrDefault
     get() = adminUrl ?: url.slashJoin("wp-admin")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.analytics.hub.sync
 
+import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
-import com.woocommerce.android.extensions.safeAdminUrl
 import com.woocommerce.android.model.DeltaPercentage
 import com.woocommerce.android.model.OrdersStat
 import com.woocommerce.android.model.ProductItem
@@ -312,7 +312,7 @@ class AnalyticsRepository @Inject constructor(
         ).flowOn(dispatchers.io).single().mapCatching { it }
 
     private fun getCurrencyCode() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode
-    private fun getAdminPanelUrl() = selectedSite.getIfExists()?.safeAdminUrl
+    private fun getAdminPanelUrl() = selectedSite.getIfExists()?.adminUrlOrDefault
 
     companion object {
         const val ANALYTICS_REVENUE_PATH = "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.analytics.hub.sync
 
 import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
+import com.woocommerce.android.extensions.safeAdminUrl
 import com.woocommerce.android.model.DeltaPercentage
 import com.woocommerce.android.model.OrdersStat
 import com.woocommerce.android.model.ProductItem
@@ -311,7 +312,7 @@ class AnalyticsRepository @Inject constructor(
         ).flowOn(dispatchers.io).single().mapCatching { it }
 
     private fun getCurrencyCode() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode
-    private fun getAdminPanelUrl() = selectedSite.getIfExists()?.adminUrl
+    private fun getAdminPanelUrl() = selectedSite.getIfExists()?.safeAdminUrl
 
     companion object {
         const val ANALYTICS_REVENUE_PATH = "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -240,7 +240,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 button.setOnClickListener {
                     isReturningFromWpAdmin = true
 
-                    val installJetpackInWpAdminUrl = selectedSite.get().adminUrl + JETPACK_INSTALL_URL
+                    val installJetpackInWpAdminUrl = selectedSite.get().safeAdminUrl + JETPACK_INSTALL_URL
                     ChromeCustomTabUtils.launchUrl(requireContext(), installJetpackInWpAdminUrl)
 
                     AnalyticsTracker.track(
@@ -253,7 +253,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 button.setOnClickListener {
                     isReturningFromWpAdmin = true
 
-                    val activateJetpackInWpAdminUrl = selectedSite.get().adminUrl + JETPACK_ACTIVATE_URL
+                    val activateJetpackInWpAdminUrl = selectedSite.get().safeAdminUrl + JETPACK_ACTIVATE_URL
                     ChromeCustomTabUtils.launchUrl(requireContext(), activateJetpackInWpAdminUrl)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackInstallProgressDialog.kt
@@ -240,7 +240,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 button.setOnClickListener {
                     isReturningFromWpAdmin = true
 
-                    val installJetpackInWpAdminUrl = selectedSite.get().safeAdminUrl + JETPACK_INSTALL_URL
+                    val installJetpackInWpAdminUrl = selectedSite.get().adminUrlOrDefault + JETPACK_INSTALL_URL
                     ChromeCustomTabUtils.launchUrl(requireContext(), installJetpackInWpAdminUrl)
 
                     AnalyticsTracker.track(
@@ -253,7 +253,7 @@ class JetpackInstallProgressDialog : DialogFragment(R.layout.dialog_jetpack_inst
                 button.setOnClickListener {
                     isReturningFromWpAdmin = true
 
-                    val activateJetpackInWpAdminUrl = selectedSite.get().safeAdminUrl + JETPACK_ACTIVATE_URL
+                    val activateJetpackInWpAdminUrl = selectedSite.get().adminUrlOrDefault + JETPACK_ACTIVATE_URL
                     ChromeCustomTabUtils.launchUrl(requireContext(), activateJetpackInWpAdminUrl)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/notwoo/LoginNotWooViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/notwoo/LoginNotWooViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.safeAdminUrl
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -44,7 +45,7 @@ class LoginNotWooViewModel @Inject constructor(
     fun openWooInstallationScreen() = launch {
         val site = wpApiSiteRepository.getSiteByUrl(siteUrl)
 
-        val installationUrl = (site?.adminUrl ?: siteUrl.slashJoin("wp-admin")).slashJoin(INSTALL_PATH)
+        val installationUrl = (site?.safeAdminUrl ?: siteUrl.slashJoin("wp-admin")).slashJoin(INSTALL_PATH)
 
         triggerEvent(LaunchWooInstallation(installationUrl))
         hasOpenedInstallationPage = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/notwoo/LoginNotWooViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/notwoo/LoginNotWooViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.safeAdminUrl
+import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -45,7 +45,7 @@ class LoginNotWooViewModel @Inject constructor(
     fun openWooInstallationScreen() = launch {
         val site = wpApiSiteRepository.getSiteByUrl(siteUrl)
 
-        val installationUrl = (site?.safeAdminUrl ?: siteUrl.slashJoin("wp-admin")).slashJoin(INSTALL_PATH)
+        val installationUrl = (site?.adminUrlOrDefault ?: siteUrl.slashJoin("wp-admin")).slashJoin(INSTALL_PATH)
 
         triggerEvent(LaunchWooInstallation(installationUrl))
         hasOpenedInstallationPage = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_M
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_PAYMENTS_BADGE_VISIBLE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_REVIEWS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_VIEW_STORE
+import com.woocommerce.android.extensions.safeAdminUrl
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
@@ -137,7 +138,7 @@ class MoreMenuViewModel @Inject constructor(
 
     private fun onViewAdminButtonClick() {
         trackMoreMenuOptionSelected(VALUE_MORE_MENU_ADMIN_MENU)
-        triggerEvent(MoreMenuEvent.ViewAdminEvent(selectedSite.get().adminUrl))
+        triggerEvent(MoreMenuEvent.ViewAdminEvent(selectedSite.get().safeAdminUrl))
     }
 
     private fun onViewStoreButtonClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -14,7 +14,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_M
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_PAYMENTS_BADGE_VISIBLE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_REVIEWS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_VIEW_STORE
-import com.woocommerce.android.extensions.safeAdminUrl
+import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
@@ -138,7 +138,7 @@ class MoreMenuViewModel @Inject constructor(
 
     private fun onViewAdminButtonClick() {
         trackMoreMenuOptionSelected(VALUE_MORE_MENU_ADMIN_MENU)
-        triggerEvent(MoreMenuEvent.ViewAdminEvent(selectedSite.get().safeAdminUrl))
+        triggerEvent(MoreMenuEvent.ViewAdminEvent(selectedSite.get().adminUrlOrDefault))
     }
 
     private fun onViewStoreButtonClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.isCashPayment
 import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.joinToString
+import com.woocommerce.android.extensions.safeAdminUrl
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.model.OrderNote
@@ -335,7 +336,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     fun onOpenStoreAdminLinkClicked() {
-        triggerEvent(OpenUrl(selectedSite.get().adminUrl))
+        triggerEvent(OpenUrl(selectedSite.get().safeAdminUrl))
     }
 
     private fun showRefundSummary() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -19,12 +19,12 @@ import com.woocommerce.android.analytics.AnalyticsEvent.REFUND_CREATE_FAILED
 import com.woocommerce.android.analytics.AnalyticsEvent.REFUND_CREATE_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.extensions.calculateTotals
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.isCashPayment
 import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.joinToString
-import com.woocommerce.android.extensions.safeAdminUrl
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.model.OrderNote
@@ -336,7 +336,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     fun onOpenStoreAdminLinkClicked() {
-        triggerEvent(OpenUrl(selectedSite.get().safeAdminUrl))
+        triggerEvent(OpenUrl(selectedSite.get().adminUrlOrDefault))
     }
 
     private fun showRefundSummary() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8428 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When accessing a site using site credentials, the property `adminUrl` will be missing (until we find a way to fetch it in the future), this causes a crash when trying to access the property in different places in the app (the main one is in the More screen).

### Testing instructions
1. Open the app then sign in using non-Jetpack site.
2. Open the More screen.
3. Click on "WC Admin"
4. Confirm a browser is opened and the app doesn't crash

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
