### PR TITLE
Update the url for onboarding survey

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -36,6 +36,9 @@ object AppUrls {
 
     const val ADDONS_SURVEY = "https://automattic.survey.fm/woo-app-addons-production"
 
+    const val CROWDSIGNAL_STORE_SETUP_SURVEY =
+        "https://automattic.survey.fm/woo-mobile-%E2%80%93-store-setup-survey-2022"
+
     // Will be used later when the feature is fully launched.
     const val COUPONS_SURVEY = "https://automattic.survey.fm/woo-app-coupon-management-production"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -269,6 +269,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_FEEDBACK_CONTEXT = "context"
         const val VALUE_FEEDBACK_GENERAL_CONTEXT = "general"
         const val VALUE_FEEDBACK_PRODUCT_M3_CONTEXT = "products_m3"
+        const val VALUE_FEEDBACK_STORE_SETUP_CONTEXT = "store_setup"
         const val VALUE_FEEDBACK_SHOWN = "shown"
         const val VALUE_FEEDBACK_LIKED = "liked"
         const val VALUE_FEEDBACK_NOT_LIKED = "didnt_like"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -15,11 +15,15 @@ import com.woocommerce.android.analytics.AnalyticsEvent.SURVEY_SCREEN
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_ACTION
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_COUPONS_FEEDBACK
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_CANCELED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_GENERAL_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_OPENED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_STORE_SETUP_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCT_ADDONS_FEEDBACK
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SHIPPING_LABELS_M4_FEEDBACK
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_FEEDBACK
 import com.woocommerce.android.databinding.FragmentFeedbackSurveyBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.widgets.CustomProgressDialog
@@ -40,10 +44,10 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment(R.layout.fragment_
             SurveyType.MAIN -> VALUE_FEEDBACK_GENERAL_CONTEXT
             SurveyType.PRODUCT -> VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
             SurveyType.STORE_ONBOARDING -> VALUE_FEEDBACK_STORE_SETUP_CONTEXT
-            SurveyType.ORDER_CREATION -> VALUE_FEEDBACK_GENERAL_CONTEXT
-            SurveyType.SHIPPING_LABELS -> VALUE_FEEDBACK_GENERAL_CONTEXT
-            SurveyType.COUPONS -> VALUE_FEEDBACK_GENERAL_CONTEXT
-            SurveyType.ADDONS -> VALUE_FEEDBACK_GENERAL_CONTEXT
+            SurveyType.ORDER_CREATION -> VALUE_SIMPLE_PAYMENTS_FEEDBACK
+            SurveyType.SHIPPING_LABELS -> VALUE_SHIPPING_LABELS_M4_FEEDBACK
+            SurveyType.COUPONS -> VALUE_COUPONS_FEEDBACK
+            SurveyType.ADDONS -> VALUE_PRODUCT_ADDONS_FEEDBACK
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -19,9 +19,9 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBA
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_GENERAL_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_OPENED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_STORE_SETUP_CONTEXT
 import com.woocommerce.android.databinding.FragmentFeedbackSurveyBinding
 import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.ui.feedback.SurveyType.MAIN
 import com.woocommerce.android.widgets.CustomProgressDialog
 
 class FeedbackSurveyFragment : androidx.fragment.app.Fragment(R.layout.fragment_feedback_survey) {
@@ -36,8 +36,15 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment(R.layout.fragment_
     private val surveyWebViewClient = SurveyWebViewClient()
     private val arguments: FeedbackSurveyFragmentArgs by navArgs()
     private val feedbackContext by lazy {
-        if (arguments.surveyType == MAIN) VALUE_FEEDBACK_GENERAL_CONTEXT
-        else VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
+        when (arguments.surveyType) {
+            SurveyType.MAIN -> VALUE_FEEDBACK_GENERAL_CONTEXT
+            SurveyType.PRODUCT -> VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
+            SurveyType.STORE_ONBOARDING -> VALUE_FEEDBACK_STORE_SETUP_CONTEXT
+            SurveyType.ORDER_CREATION -> VALUE_FEEDBACK_GENERAL_CONTEXT
+            SurveyType.SHIPPING_LABELS -> VALUE_FEEDBACK_GENERAL_CONTEXT
+            SurveyType.COUPONS -> VALUE_FEEDBACK_GENERAL_CONTEXT
+            SurveyType.ADDONS -> VALUE_FEEDBACK_GENERAL_CONTEXT
+        }
     }
 
     private var _binding: FragmentFeedbackSurveyBinding? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -10,7 +10,8 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     ORDER_CREATION(AppUrls.ORDER_CREATION_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
     COUPONS(AppUrls.COUPONS_SURVEY),
-    ADDONS(AppUrls.ADDONS_SURVEY);
+    ADDONS(AppUrls.ADDONS_SURVEY),
+    STORE_ONBOARDING(AppUrls.CROWDSIGNAL_STORE_SETUP_SURVEY);
 
     val url
         get() = "$untaggedUrl?$platformTag$appVersionTag$milestoneTag"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -39,6 +39,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingCollapsed
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -224,7 +225,10 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         storeOnboardingViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is StoreOnboardingViewModel.NavigateToOnboardingFullScreen -> openOnboardingInFullScreen()
-                is StoreOnboardingViewModel.NavigateToSurvey -> mainNavigationRouter?.showFeedbackSurvey()
+                is StoreOnboardingViewModel.NavigateToSurvey ->
+                    NavGraphMainDirections.actionGlobalFeedbackSurveyFragment(SurveyType.STORE_ONBOARDING).apply {
+                        findNavController().navigateSafely(this)
+                    }
             }
         }
     }


### PR DESCRIPTION
Quick fix

### Description
Quick one to fix the url I was using for the onboarding list survey. 

### Testing instructions
- Log into a site that has the onboarding list 
- Click on the overflow button of the list and check the url `https://automattic.survey.fm/woo-mobile-%E2%80%93-store-setup-survey-2022` is opened. The survey looks like this: 


https://user-images.githubusercontent.com/2663464/221886956-f903e933-f0ab-4d31-ab87-a99c2592bd1d.mp4

