### PR TITLE
[Support Requests] Remove dropped ticket sections

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -7,8 +7,6 @@ import android.telephony.TelephonyManager
 import android.text.TextUtils
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
-import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.logInformation
 import com.woocommerce.android.extensions.stateLogInformation
 import com.woocommerce.android.support.help.HelpOrigin
@@ -43,9 +41,7 @@ import zendesk.support.CreateRequest
 import zendesk.support.CustomField
 import zendesk.support.Request
 import zendesk.support.Support
-import zendesk.support.guide.HelpCenterActivity
 import zendesk.support.request.RequestActivity
-import zendesk.support.requestlist.RequestListActivity
 import java.util.Locale
 import java.util.Timer
 import kotlin.concurrent.schedule
@@ -120,48 +116,7 @@ class ZendeskHelper(
     }
 
     /**
-     * This function shows the Zendesk Help Center. It doesn't require a valid identity. If the support identity is
-     * available it'll be used and the "New Ticket" button will be available, if not, it'll work with an anonymous
-     * identity. The configuration will only be passed in if the identity is available, as it's only required if
-     * the user contacts us through it.
-     */
-    fun showZendeskHelpCenter(
-        context: Context,
-        origin: HelpOrigin?,
-        selectedSite: SiteModel?,
-        extraTags: List<String>? = null,
-        ticketType: TicketType = TicketType.MobileApp,
-    ) {
-        require(isZendeskEnabled) {
-            zendeskNeedsToBeEnabledError
-        }
-        val builder = HelpCenterActivity.builder()
-            .withArticlesForCategoryIds(ZendeskConstants.mobileHelpCategoryId)
-            .withContactUsButtonVisible(isIdentitySet)
-            .withLabelNames(ZendeskConstants.articleLabel)
-            .withShowConversationsMenuButton(isIdentitySet)
-        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_HELP_CENTER_VIEWED)
-        if (isIdentitySet) {
-            builder.show(
-                context,
-                buildZendeskConfig(
-                    context,
-                    ticketType,
-                    siteStore.sites,
-                    origin,
-                    selectedSite,
-                    extraTags
-                )
-            )
-        } else {
-            builder.show(context)
-        }
-    }
-
-    /**
      * This function creates a new customer Support Request through the Zendesk API Providers.
-     *
-     * As it is, no identity is required so far. This should be revised in the near future.
      */
     @Suppress("LongParameterList")
     suspend fun createRequest(
@@ -241,30 +196,6 @@ class ZendeskHelper(
                 ssr = ssr,
             )
             RequestActivity.builder().show(context, config)
-        }
-    }
-
-    /**
-     * This function shows the user's ticket list. It'll force a valid identity, so if the user doesn't have one set,
-     * a dialog will be shown where the user will need to enter an email and a name. If they cancel the dialog,
-     * ticket list will not be shown. A Zendesk configuration is passed in as it's required for ticket creation.
-     */
-    fun showAllTickets(
-        context: Context,
-        origin: HelpOrigin?,
-        selectedSite: SiteModel? = null,
-        extraTags: List<String>? = null,
-        ticketType: TicketType = TicketType.MobileApp,
-    ) {
-        require(isZendeskEnabled) {
-            zendeskNeedsToBeEnabledError
-        }
-        requireIdentity(context, selectedSite) {
-            RequestListActivity.builder()
-                .show(
-                    context,
-                    buildZendeskConfig(context, ticketType, siteStore.sites, origin, selectedSite, extraTags)
-                )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -73,7 +73,6 @@ class HelpActivity : AppCompatActivity() {
 
         binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.MobileApp) }
         binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.MobileApp) }
-        binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener {
             val loginFlow = intent.extras?.getString(LOGIN_FLOW_KEY)
             val loginStep = intent.extras?.getString(LOGIN_STEP_KEY)
@@ -90,23 +89,7 @@ class HelpActivity : AppCompatActivity() {
             binding.ssrContainer.setOnClickListener { showSSR() }
         }
 
-        with(binding.contactPaymentsContainer) {
-            setOnClickListener {
-                viewModel.contactSupport(TicketType.Payments)
-            }
-        }
-
         binding.textVersion.text = getString(R.string.version_with_name_param, PackageUtils.getVersionName(this))
-
-        /**
-         * If the user taps on a Zendesk notification, we want to show them the `My Tickets` page. However, this
-         * should only be triggered when the activity is first created, otherwise if the user comes back from
-         * `My Tickets` and rotates the screen (or triggers the activity re-creation in any other way) it'll navigate
-         * them to `My Tickets` again since the `originFromExtras` will still be [Origin.ZENDESK_NOTIFICATION].
-         */
-        if (savedInstanceState == null && originFromExtras == HelpOrigin.ZENDESK_NOTIFICATION) {
-            showZendeskTickets()
-        }
 
         if (originFromExtras == HelpOrigin.LOGIN_HELP_NOTIFICATION) {
             loginNotificationScheduler.onNotificationTapped(extraTagsFromExtras?.first())
@@ -221,11 +204,6 @@ class HelpActivity : AppCompatActivity() {
         } else {
             null
         }
-    }
-
-    private fun showZendeskTickets() {
-        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_TICKETS_VIEWED)
-        zendeskHelper.showAllTickets(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)
     }
 
     private fun showLoginHelpCenter(origin: HelpOrigin, loginFlow: String, loginStep: String) {

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -60,20 +60,6 @@
                 app:optionValue="@string/support_contact_detail"/>
 
             <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/contactPaymentsContainer"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/support_contact_payments"
-                app:optionValue="@string/support_contact_payments_detail"/>
-
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/myTicketsContainer"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/support_my_tickets"
-                app:optionValue="@string/support_my_tickets_detail"/>
-
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
                 android:id="@+id/identityContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1913,10 +1913,6 @@
     <string name="support_faq_detail">Get answers to questions you have</string>
     <string name="support_contact">Contact support</string>
     <string name="support_contact_detail">Reach our happiness engineers who can help answer tough questions</string>
-    <string name="support_my_tickets">My tickets</string>
-    <string name="support_my_tickets_detail">View previously submitted support tickets</string>
-    <string name="support_contact_payments">Contact Payments Support</string>
-    <string name="support_contact_payments_detail">Reach our happiness engineers who can help answer payments related questions</string>
     <string name="support_application_log">Application log</string>
     <string name="support_application_log_detail">Advanced tool to review the app status</string>
     <string name="support_system_status_report">System status report</string>


### PR DESCRIPTION
Summary
==========
Fix issue #8334 by removing the `My Tickets` and `Contact Payment Support` sections from the app Help & Support  view. They won't be needed anymore following the new Ticket creation structure we introduced.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20230301_201200](https://user-images.githubusercontent.com/5920403/222288064-89ba2769-9cb0-44d9-b1cd-90a7b4160498.png) | ![Screenshot_20230301_200927](https://user-images.githubusercontent.com/5920403/222288051-1105bc39-5d23-436d-bfa4-37fb9074972c.png) |

How to Test
==========
1. Access the `Help & Support` area of the app and verify that both `My Tickets` and `Contact Payment Support` sections are no longer available.
2. Verify that accessing the `Contact Support`section still works as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.