### PR TITLE
Refactor of ProductSelectorViewModel's selection result data model

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
@@ -78,7 +79,7 @@ class CouponRestrictionsFragment : BaseFragment(), BackPressListener {
         handleResult<String>(EmailRestrictionFragment.ALLOWED_EMAILS) {
             viewModel.onAllowedEmailsUpdated(it)
         }
-        handleResult<Set<Long>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
+        handleResult<Set<ProductSelectorViewModel.SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
             viewModel.onExcludedProductChanged(it)
         }
         handleResult<Set<Long>>(ProductCategorySelectorFragment.PRODUCT_CATEGORY_SELECTOR_RESULT) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.model.Coupon.CouponRestrictions
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProductCategories
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProducts
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
-import com.woocommerce.android.ui.products.selector.productAndVariationIds
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -122,7 +121,7 @@ class CouponRestrictionsViewModel @Inject constructor(
 
     fun onExcludedProductChanged(excludedProductItems: Set<ProductSelectorViewModel.SelectedItem>) {
         restrictionsDraft.update {
-            it.copy(excludedProductIds = excludedProductItems.productAndVariationIds)
+            it.copy(excludedProductIds = excludedProductItems.map { it.id })
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Coupon.CouponRestrictions
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProductCategories
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProducts
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.ui.products.selector.productAndVariationIds
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -107,16 +109,20 @@ class CouponRestrictionsViewModel @Inject constructor(
     }
 
     fun onExcludeProductsButtonClick() {
-        triggerEvent(EditExcludedProducts(restrictionsDraft.value.excludedProductIds))
+        restrictionsDraft.value.excludedProductIds.map { productOrVariationId ->
+            ProductSelectorViewModel.SelectedItem.ProductOrVariation(productOrVariationId)
+        }.let {
+            triggerEvent(EditExcludedProducts(it))
+        }
     }
 
     fun onExcludeCategoriesButtonClick() {
         triggerEvent(EditExcludedProductCategories(restrictionsDraft.value.excludedCategoryIds))
     }
 
-    fun onExcludedProductChanged(excludedProductIds: Set<Long>) {
+    fun onExcludedProductChanged(excludedProductItems: Set<ProductSelectorViewModel.SelectedItem>) {
         restrictionsDraft.update {
-            it.copy(excludedProductIds = excludedProductIds.toList())
+            it.copy(excludedProductIds = excludedProductItems.productAndVariationIds)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -82,7 +83,7 @@ class EditCouponFragment : BaseFragment() {
             viewModel.onRestrictionsUpdated(it)
         }
 
-        handleResult<Set<Long>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
+        handleResult<Set<ProductSelectorViewModel.SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
             viewModel.onSelectedProductsUpdated(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigationTarget.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.coupons.edit
 
 import com.woocommerce.android.model.Coupon.CouponRestrictions
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
 sealed class EditCouponNavigationTarget : Event() {
@@ -10,8 +11,16 @@ sealed class EditCouponNavigationTarget : Event() {
         val currencyCode: String,
         val showLimitUsageToXItems: Boolean
     ) : EditCouponNavigationTarget()
-    data class EditIncludedProducts(val selectedProductIds: List<Long>) : EditCouponNavigationTarget()
-    data class EditIncludedProductCategories(val categoryIds: List<Long>) : EditCouponNavigationTarget()
-    data class EditExcludedProducts(val excludedProductIds: List<Long>) : EditCouponNavigationTarget()
-    data class EditExcludedProductCategories(val excludedCategoryIds: List<Long>) : EditCouponNavigationTarget()
+
+    data class EditIncludedProducts(val selectedItems: List<ProductSelectorViewModel.SelectedItem>) :
+        EditCouponNavigationTarget()
+
+    data class EditIncludedProductCategories(val categoryIds: List<Long>) :
+        EditCouponNavigationTarget()
+
+    data class EditExcludedProducts(val excludedItems: List<ProductSelectorViewModel.SelectedItem>) :
+        EditCouponNavigationTarget()
+
+    data class EditExcludedProductCategories(val excludedCategoryIds: List<Long>) :
+        EditCouponNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
@@ -30,7 +30,7 @@ object EditCouponNavigator {
             is EditIncludedProducts -> {
                 navController.navigateSafely(
                     EditCouponFragmentDirections.actionEditCouponFragmentToProductSelectorFragment(
-                        target.selectedProductIds.toLongArray()
+                        target.selectedItems.toTypedArray()
                     )
                 )
             }
@@ -53,7 +53,7 @@ object EditCouponNavigator {
             is EditExcludedProducts -> {
                 navController.navigateSafely(
                     CouponRestrictionsFragmentDirections.actionCouponRestrictionsFragmentToProductSelectorFragment(
-                        productIds = target.excludedProductIds.toLongArray()
+                        selectedItems = target.excludedItems.toTypedArray()
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenCo
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
-import com.woocommerce.android.ui.products.selector.productAndVariationIds
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -165,7 +164,7 @@ class EditCouponViewModel @Inject constructor(
 
     fun onSelectedProductsUpdated(productItems: Set<ProductSelectorViewModel.SelectedItem>) {
         couponDraft.update {
-            it?.copy(productIds = productItems.productAndVariationIds)
+            it?.copy(productIds = productItems.map { it.id })
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -19,6 +19,8 @@ import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditIn
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenCouponRestrictions
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
 import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.ui.products.selector.productAndVariationIds
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -153,13 +155,17 @@ class EditCouponViewModel @Inject constructor(
 
     fun onSelectProductsButtonClick() {
         couponDraft.value?.let {
-            triggerEvent(EditIncludedProducts(it.productIds))
+            it.productIds.map { productOrVariationId ->
+                ProductSelectorViewModel.SelectedItem.ProductOrVariation(productOrVariationId)
+            }.let { selectedItems ->
+                triggerEvent(EditIncludedProducts(selectedItems))
+            }
         }
     }
 
-    fun onSelectedProductsUpdated(productIds: Set<Long>) {
+    fun onSelectedProductsUpdated(productItems: Set<ProductSelectorViewModel.SelectedItem>) {
         couponDraft.update {
-            it?.copy(productIds = productIds.toList())
+            it?.copy(productIds = productItems.productAndVariationIds)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -63,7 +63,10 @@ class ProductSelectorFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ExitWithResult<*> -> {
-                    navigateBackWithResult(PRODUCT_SELECTOR_RESULT, event.data as Set<Long>)
+                    navigateBackWithResult(
+                        PRODUCT_SELECTOR_RESULT,
+                        event.data as Set<ProductSelectorViewModel.SelectedItem>
+                    )
                 }
                 is ProductNavigationTarget -> navigator.navigate(this, event)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -178,7 +178,7 @@ class ProductSelectorViewModel @Inject constructor(
     fun onProductClick(item: ProductListItem) {
         if (item.type == VARIABLE && item.numVariations > 0) {
             triggerEvent(NavigateToVariationSelector(item.id, item.selectedVariationIds))
-        } else {
+        } else if (item.type != VARIABLE) {
             selectedItems.update { items ->
                 val selectedProductItems = items.filter {
                     it is SelectedItem.ProductOrVariation || it is SelectedItem.Product

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -340,8 +340,11 @@ class ProductSelectorViewModel @Inject constructor(
 
     @Parcelize
     sealed class SelectedItem(open val productId: Long) : Parcelable {
+        @Parcelize
         data class ProductOrVariation(override val productId: Long) : SelectedItem(productId)
+        @Parcelize
         data class Product(override val productId: Long) : SelectedItem(productId)
+        @Parcelize
         data class ProductVariation(override val productId: Long, val variationId: Long) : SelectedItem(productId)
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -64,7 +64,7 @@
             app:destination="@id/productCategorySelectorFragment" />
         <action
             android:id="@+id/action_couponRestrictionsFragment_to_productSelectorFragment"
-            app:destination="@id/productSelectorFragment" >
+            app:destination="@id/nav_graph_product_selector" >
             <argument
                 android:name="selectedItems"
                 app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -33,8 +33,8 @@
             android:id="@+id/action_editCouponFragment_to_productSelectorFragment"
             app:destination="@id/nav_graph_product_selector" >
             <argument
-                android:name="productIds"
-                app:argType="long[]" />
+                android:name="selectedItems"
+                app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
         </action>
         <action
             android:id="@+id/action_editCouponFragment_to_couponRestrictionsFragment"
@@ -66,8 +66,8 @@
             android:id="@+id/action_couponRestrictionsFragment_to_productSelectorFragment"
             app:destination="@id/productSelectorFragment" >
             <argument
-                android:name="productIds"
-                app:argType="long[]" />
+                android:name="selectedItems"
+                app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
         </action>
     </fragment>
     <fragment

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -31,7 +31,11 @@
             app:argType="long" />
         <action
             android:id="@+id/action_editCouponFragment_to_productSelectorFragment"
-            app:destination="@id/productSelectorFragment" />
+            app:destination="@id/nav_graph_product_selector" >
+            <argument
+                android:name="productIds"
+                app:argType="long[]" />
+        </action>
         <action
             android:id="@+id/action_editCouponFragment_to_couponRestrictionsFragment"
             app:destination="@id/couponRestrictionsFragment" />
@@ -60,53 +64,11 @@
             app:destination="@id/productCategorySelectorFragment" />
         <action
             android:id="@+id/action_couponRestrictionsFragment_to_productSelectorFragment"
-            app:destination="@id/productSelectorFragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/productSelectorFragment"
-        android:name="com.woocommerce.android.ui.products.selector.ProductSelectorFragment"
-        android:label="ProductSelectorFragment" >
-        <argument
-            android:name="productIds"
-            app:argType="long[]" />
-        <action
-            android:id="@+id/action_productSelectorFragment_to_variationSelectorFragment"
-            app:destination="@id/variationSelectorFragment" />
-        <action
-            android:id="@+id/action_productSelectorFragment_to_nav_graph_product_filters"
-            app:destination="@id/nav_graph_product_filters">
+            app:destination="@id/productSelectorFragment" >
             <argument
-                android:name="selectedStockStatus"
-                app:argType="string"
-                app:nullable="true" />
-            <argument
-                android:name="selectedProductType"
-                app:argType="string"
-                app:nullable="true" />
-            <argument
-                android:name="selectedProductStatus"
-                app:argType="string"
-                app:nullable="true" />
-            <argument
-                android:name="selectedProductCategoryId"
-                app:argType="string"
-                app:nullable="true" />
-            <argument
-                android:name="selectedProductCategoryName"
-                app:argType="string"
-                app:nullable="true" />
+                android:name="productIds"
+                app:argType="long[]" />
         </action>
-    </fragment>
-    <fragment
-        android:id="@+id/variationSelectorFragment"
-        android:name="com.woocommerce.android.ui.products.variations.selector.VariationSelectorFragment"
-        android:label="VariationSelectorFragment" >
-        <argument
-            android:name="productId"
-            app:argType="long" />
-        <argument
-            android:name="variationIds"
-            app:argType="long[]" />
     </fragment>
     <fragment
         android:id="@+id/productCategorySelectorFragment"
@@ -124,5 +86,5 @@
             android:name="allowedEmails"
             app:argType="string" />
     </fragment>
-    <include app:graph="@navigation/nav_graph_product_filters" />
+    <include app:graph="@navigation/nav_graph_product_selector" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
@@ -20,8 +20,8 @@
         android:name="com.woocommerce.android.ui.products.selector.ProductSelectorFragment"
         android:label="ProductSelectorFragment">
         <argument
-            android:name="productIds"
-            app:argType="long[]" />
+            android:name="selectedItems"
+            app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
         <action
             android:id="@+id/action_productSelectorFragment_to_variationSelectorFragment"
             app:destination="@id/variationSelectorFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_product_selector"
+    app:startDestination="@id/productSelectorFragment">
+    <fragment
+        android:id="@+id/variationSelectorFragment"
+        android:name="com.woocommerce.android.ui.products.variations.selector.VariationSelectorFragment"
+        android:label="VariationSelectorFragment">
+        <argument
+            android:name="productId"
+            app:argType="long" />
+        <argument
+            android:name="variationIds"
+            app:argType="long[]" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/productSelectorFragment"
+        android:name="com.woocommerce.android.ui.products.selector.ProductSelectorFragment"
+        android:label="ProductSelectorFragment">
+        <argument
+            android:name="productIds"
+            app:argType="long[]" />
+        <action
+            android:id="@+id/action_productSelectorFragment_to_variationSelectorFragment"
+            app:destination="@id/variationSelectorFragment" />
+        <action
+            android:id="@+id/action_productSelectorFragment_to_nav_graph_product_filters"
+            app:destination="@id/nav_graph_product_filters">
+            <argument
+                android:name="selectedStockStatus"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="selectedProductType"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="selectedProductStatus"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="selectedProductCategoryId"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="selectedProductCategoryName"
+                app:argType="string"
+                app:nullable="true" />
+        </action>
+    </fragment>
+    <include app:graph="@navigation/nav_graph_product_filters" />
+</navigation>


### PR DESCRIPTION
#### Refactoring of `ProductSelectorViewModel` to return an all-purpose, reusable data type for the selected product and variation items.

Closes: #8442 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The intention of this PR is to allow reusing `ProductSelectorFragment` for the sake of implementing products and variations multi-selection in the Order creation flow.

This PR introduces a new data type for the item selection result returned by `ProductSelectorViewModel` - `ProductSelectorViewModel.SelectedItem` (context: p1677670455921779/1677660790.501799-slack-CGPNUU63E).

Previously the ids of selected regular products and product variations were merged together into a single `Flow<Set<Long>>` and we couldn't parse them back to something like `Set<Pair<ProductId, VariationId?>>` which is needed to integrate `ProductSelectorFragment` into Order creation flow.

The new data model makes `ProductSelectorFragment` compatible both with the Coupon edition and Order creation APIs.

Other improvements:
- Extracted navigation graph `nav_graph_product_selector` to prepare `ProductSelectorFragment` for reusability
- Disabled tapping on a variable product in case it doesn't have any variations defined

### Testing instructions
We need to ensure that the Coupon edition works without any changes:

1. Coupon edition screen > Edit Products - make sure products and variations are being correctly selected and the selection is preserved when opening the products picker again.
2. Coupon edition screen > Usage Restrictions > Exclude Products - the same as above.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @AnirudhBhat to stay in sync 🦚