### PR TITLE
[REST API] OTP login screen for Jetpack connection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -35,6 +36,21 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
                 WooThemeWithBackground {
                     JetpackActivationWPCom2FAScreen(viewModel = viewModel)
                 }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ShowJetpackActivationScreen -> {
+                    navigateToJetpackActivationScreen(event)
+                }
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -27,7 +27,7 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -39,14 +39,6 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
         }
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setupObservers()
-    }
-
-    private fun setupObservers() {
-        TODO()
-    }
-
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
             JetpackActivationWPCom2FAFragmentDirections

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -31,7 +31,7 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    TODO()
+                    JetpackActivationWPComPasswordScreen(viewModel = viewModel)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -46,6 +48,12 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
     }
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
-        TODO()
+        findNavController().navigateSafely(
+            JetpackActivationWPCom2FAFragmentDirections
+                .actionJetpackActivationWPCom2FAFragmentToJetpackActivationMainFragment(
+                    isJetpackInstalled = event.isJetpackInstalled,
+                    siteUrl = event.siteUrl
+                )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -18,6 +19,8 @@ import javax.inject.Inject
 class JetpackActivationWPCom2FAFragment : BaseFragment() {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
+
+    private val viewModel: JetpackActivationWPCom2FAViewModel by viewModels()
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -31,7 +31,7 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    JetpackActivationWPComPasswordScreen(viewModel = viewModel)
+                    JetpackActivationWPCom2FAScreen(viewModel = viewModel)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -1,0 +1,48 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class JetpackActivationWPCom2FAFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    TODO()
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        TODO()
+    }
+
+    private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
+        TODO()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
@@ -116,5 +117,7 @@ fun JetpackActivationWPCom2FAScreen(
 @Preview
 @Composable
 private fun JetpackActivationWPCom2FAScreenPreview() {
-    JetpackActivationWPCom2FAScreen()
+    WooThemeWithBackground {
+        JetpackActivationWPCom2FAScreen()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun JetpackActivationWPComPasswordScreen(viewModel: JetpackActivationWPCom2FAViewModel) {
+    TODO()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -82,6 +82,7 @@ fun JetpackActivationWPCom2FAScreen(
                         id = R.string.enter_verification_code
                     )
                 )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                 WCPasswordField(
                     value = "",
                     onValueChange = { },
@@ -109,7 +110,6 @@ fun JetpackActivationWPCom2FAScreen(
                     text = stringResource(id = R.string.login_jetpack_connect)
                 )
             }
-
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -15,12 +15,18 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCPasswordField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
@@ -32,12 +38,15 @@ fun JetpackActivationWPCom2FAScreen(viewModel: JetpackActivationWPCom2FAViewMode
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun JetpackActivationWPCom2FAScreen(
     onCloseClick: () -> Unit = {},
     onSMSLinkClick: () -> Unit = {},
     onContinueClick: () -> Unit = {}
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     Scaffold(
         topBar = {
             Toolbar(
@@ -72,8 +81,40 @@ fun JetpackActivationWPCom2FAScreen(
                         id = R.string.enter_verification_code
                     )
                 )
+                WCPasswordField(
+                    value = "",
+                    onValueChange = { },
+                    label = stringResource(id = R.string.verification_code)
+                )
+                WCTextButton(onClick = onSMSLinkClick) {
+                    Text(text = stringResource(id = R.string.login_text_otp))
+                }
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
             }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            WCColoredButton(
+                onClick = {
+                    keyboardController?.hide()
+                    onContinueClick()
+                },
+                enabled = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            ) {
+                Text(
+                    text = stringResource(id = R.string.login_jetpack_connect)
+                )
+            }
+
         }
     }
+}
+
+@Preview
+@Composable
+private fun JetpackActivationWPCom2FAScreenPreview() {
+    JetpackActivationWPCom2FAScreen()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -1,8 +1,79 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
-fun JetpackActivationWPComPasswordScreen(viewModel: JetpackActivationWPCom2FAViewModel) {
-    TODO()
+fun JetpackActivationWPCom2FAScreen(viewModel: JetpackActivationWPCom2FAViewModel) {
+    JetpackActivationWPCom2FAScreen(
+        onCloseClick = viewModel::onCloseClick,
+        onSMSLinkClick = viewModel::onSMSLinkClick,
+        onContinueClick = viewModel::onContinueClick
+    )
+}
+
+@Composable
+fun JetpackActivationWPCom2FAScreen(
+    onCloseClick: () -> Unit = {},
+    onSMSLinkClick: () -> Unit = {},
+    onContinueClick: () -> Unit = {}
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                onNavigationButtonClick = onCloseClick,
+                navigationIcon = Icons.Filled.Clear
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
+                .padding(paddingValues)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(id = R.dimen.major_100)),
+            ) {
+                JetpackToWooHeader()
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+                val title = R.string.login_jetpack_connect
+                Text(
+                    text = stringResource(id = title),
+                    style = MaterialTheme.typography.h4,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Text(
+                    text = stringResource(
+                        id = R.string.enter_verification_code
+                    )
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.wordpress.android.login.R
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,7 +23,7 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
     }
 
     fun onSMSLinkClick() {
-        TODO()
+        triggerEvent(ShowSnackbar(R.string.requesting_otp))
     }
 
     fun onContinueClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.wordpress.android.login.R
 import javax.inject.Inject
 
@@ -16,8 +15,6 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
     selectedSite: SelectedSite,
     jetpackAccountRepository: JetpackActivationRepository,
 ) : JetpackActivationWPComPostLoginViewModel(savedStateHandle, selectedSite, jetpackAccountRepository) {
-    private val isSMSLoadingDialogShown = MutableStateFlow(false)
-
     fun onCloseClick() {
         triggerEvent(Exit)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.login.jetpack.wpcom
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class JetpackActivationWPCom2FAViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    selectedSite: SelectedSite,
+    jetpackAccountRepository: JetpackActivationRepository,
+) : JetpackActivationWPComPostLoginViewModel(savedStateHandle, selectedSite, jetpackAccountRepository) {
+    private val isSMSLoadingDialogShown = MutableStateFlow(false)
+
+    fun onCloseClick() {
+        triggerEvent(Exit)
+    }
+
+    fun onSMSLinkClick() {
+        TODO()
+    }
+
+    fun onContinueClick() {
+        TODO()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
@@ -57,7 +57,7 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is Show2FAScreen -> {
-                    // TODO
+                    navigateTo2FAScreen(event)
                     Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
                 }
 
@@ -76,6 +76,10 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
                 Exit -> findNavController().navigateUp()
             }
         }
+    }
+
+    private fun navigateTo2FAScreen(event: Show2FAScreen) {
+        TODO()
     }
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordFragment.kt
@@ -58,7 +58,6 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
             when (event) {
                 is Show2FAScreen -> {
                     navigateTo2FAScreen(event)
-                    Toast.makeText(requireContext(), "$event", Toast.LENGTH_SHORT).show()
                 }
 
                 is ShowMagicLinkScreen -> {
@@ -79,7 +78,14 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
     }
 
     private fun navigateTo2FAScreen(event: Show2FAScreen) {
-        TODO()
+        findNavController().navigateSafely(
+            JetpackActivationWPComPasswordFragmentDirections
+                .actionJetpackActivationWPComPasswordFragmentToJetpackActivationWPCom2FAFragment(
+                    jetpackStatus = event.jetpackStatus,
+                    emailOrUsername = event.emailOrUsername,
+                    password = event.password
+                )
+        )
     }
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -145,7 +145,8 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
     data class Show2FAScreen(
         val emailOrUsername: String,
         val password: String,
-        val jetpackStatus: JetpackStatus) : MultiLiveEvent.Event()
+        val jetpackStatus: JetpackStatus
+    ) : MultiLiveEvent.Event()
 
     data class ShowMagicLinkScreen(
         val emailOrUsername: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -98,7 +98,7 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
 
                 when (failure?.type) {
                     AuthenticationErrorType.NEEDS_2FA -> {
-                        triggerEvent(Show2FAScreen(navArgs.emailOrUsername, navArgs.jetpackStatus))
+                        triggerEvent(Show2FAScreen(navArgs.emailOrUsername, password.value, navArgs.jetpackStatus))
                     }
 
                     AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD,
@@ -142,7 +142,11 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
         val enableSubmit = password.isNotBlank()
     }
 
-    data class Show2FAScreen(val emailOrUsername: String, val jetpackStatus: JetpackStatus) : MultiLiveEvent.Event()
+    data class Show2FAScreen(
+        val emailOrUsername: String,
+        val password: String,
+        val jetpackStatus: JetpackStatus) : MultiLiveEvent.Event()
+
     data class ShowMagicLinkScreen(
         val emailOrUsername: String,
         val jetpackStatus: JetpackStatus

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -115,5 +115,8 @@
         <argument
             android:name="password"
             app:argType="string" />
+        <action
+            android:id="@+id/action_jetpackActivationWPCom2FAFragment_to_jetpackActivationMainFragment"
+            app:destination="@id/jetpackActivationMainFragment" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -98,5 +98,22 @@
         <action
             android:id="@+id/action_jetpackActivationWPComPasswordFragment_to_jetpackActivationMainFragment"
             app:destination="@id/jetpackActivationMainFragment" />
+        <action
+            android:id="@+id/action_jetpackActivationWPComPasswordFragment_to_jetpackActivationWPCom2FAFragment"
+            app:destination="@id/jetpackActivationWPCom2FAFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/jetpackActivationWPCom2FAFragment"
+        android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPCom2FAFragment"
+        android:label="JetpackActivationWPCom2FAFragment">
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
+        <argument
+            android:name="emailOrUsername"
+            app:argType="string" />
+        <argument
+            android:name="password"
+            app:argType="string" />
     </fragment>
 </navigation>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

First part of: #8397
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the UI part for the OTP screen that's meant to show up after the password screen during Jetpack connection process.

The functionalities will be added in a separate PR.

Some caveats:

1. Entering verification code will do nothing for now.
2. Tapping "Text me a code instead" will only display a Snackbar at the bottom. This differs from the Jetpack app design that shows a popup in the middle with loading indicator. I opt for a Snackbar for consistency and speed of development.
3. Currently it does not differentiate whether to show "Connect Jetpack" or "Install Jetpack" on the header and the bottom button. This will be added in the functionality PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Login by entering a self-hosted Woo site with no Jetpack, then using site credentials,
2. On the My Store screen, tap the Jetpack banner at the bottom,
3. tap "Log In to Continue",
4. Enter a wpcom account email address that has a 2FA already enabled, tap Install Jetpack,
5. on the next screen, enter the password, then tap Install Jetpack,
6. the OTP screen will be shown. Compare the design with the examples below.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Here is the original design:

<img width="42%" alt="Screenshot 2023-03-01 at 12 22 40" src="https://user-images.githubusercontent.com/266376/222052389-866c022e-65a9-46c8-aa51-a29e27f330af.png">

and here are the resulting design:

| OTP screen | Snackbar for SMS |
|-|-|
| ![Screenshot_20230302_204057](https://user-images.githubusercontent.com/266376/222444901-d8994072-1bb9-4749-bfef-6c2020bf67db.png) | ![Screenshot_20230302_204104](https://user-images.githubusercontent.com/266376/222444887-0e447902-15e1-423c-a352-69c09b2dab6f.png) |




- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
