### PR TITLE
Create new stores private by default

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationRepository.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload
 import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated
 import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
-import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
+import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PRIVATE
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.login.util.SiteUtils
 import org.wordpress.android.util.UrlUtils
@@ -145,7 +145,7 @@ class StoreCreationRepository @Inject constructor(
         siteData: SiteCreationData,
         languageWordPressId: String,
         timeZoneId: String,
-        siteVisibility: SiteVisibility = PUBLIC,
+        siteVisibility: SiteVisibility = PRIVATE,
         dryRun: Boolean = false
     ): StoreCreationResult<Long> {
         fun isWordPressComSubDomain(url: String) = url.endsWith(".wordpress.com")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Quickfix

### Description
We currently where creating all the sites public, but what we want is to create them private by default. So I'm updating that default value. 

### Testing instructions
1. Create a new site using store creation (if you face issues setting a Google account store to use IAP then use the web checkout. The quickest way to use the web checkout is to set to return `false` in `IsIAPEnabled` class. 
2. Check the new site is private. 

Note that this has the consequence that the preview won't be available: 

<img width="300"  src="https://user-images.githubusercontent.com/2663464/222496958-f8a9ab42-1ac1-4ece-8d3f-c16b200f2334.png"> 
