### PR TITLE
Update the theme used to create new stores

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
@@ -60,7 +60,7 @@ class PlansViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle, iapManager) {
     companion object {
         const val NEW_SITE_LANGUAGE_ID = "en"
-        const val NEW_SITE_THEME = "pub/zoologist"
+        const val NEW_SITE_THEME = "Tsubaki"
         const val CART_URL = "https://wordpress.com/checkout"
         const val WEBVIEW_SUCCESS_TRIGGER_KEYWORD = "https://wordpress.com/checkout/thank-you/"
         const val WEBVIEW_EXIT_TRIGGER_KEYWORD = "https://woocommerce.com/"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
@@ -60,7 +60,7 @@ class PlansViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle, iapManager) {
     companion object {
         const val NEW_SITE_LANGUAGE_ID = "en"
-        const val NEW_SITE_THEME = "Tsubaki"
+        const val NEW_SITE_THEME = "premium/tsubaki"
         const val CART_URL = "https://wordpress.com/checkout"
         const val WEBVIEW_SUCCESS_TRIGGER_KEYWORD = "https://wordpress.com/checkout/thank-you/"
         const val WEBVIEW_EXIT_TRIGGER_KEYWORD = "https://woocommerce.com/"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Quickfix

### Description
Update the default theme used to create stores from the app to `Tsubaki`. This way we are aligned with the web when creating `eCommerce` sites. 

### Testing instructions
### Testing instructions
1. Create a new site using store creation (if you face issues setting a Google account store to use IAP then use the web checkout. The quickest way to use the web checkout is to set to return `false` in `IsIAPEnabled` class. 
2. Check the new site has the `Tsubaki` theme

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="300"  src="https://user-images.githubusercontent.com/2663464/222512303-c3f3c543-7899-4440-b2c7-233bdf7dc73e.png"> 

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
