### PR TITLE
[Support Requests] Fully enable support request form and remove Feature Flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/SupportModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/SupportModule.kt
@@ -7,7 +7,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Singleton
 
@@ -17,11 +16,9 @@ class SupportModule {
     @Singleton
     @Provides
     fun provideZendeskHelper(
-        accountStore: AccountStore,
         siteStore: SiteStore,
-        supportHelper: SupportHelper,
         dispatchers: CoroutineDispatchers
-    ): ZendeskHelper = ZendeskHelper(accountStore, siteStore, supportHelper, dispatchers)
+    ): ZendeskHelper = ZendeskHelper(siteStore, dispatchers)
 
     @Singleton
     @Provides

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.model.SiteModel
@@ -153,19 +152,8 @@ class HelpActivity : AppCompatActivity() {
             return
         }
 
-        if (FeatureFlag.NEW_SUPPORT_REQUESTS.isEnabled()) {
-            val tags = extraTags + (extraTagsFromExtras ?: emptyList())
-            openSupportRequestForm(tags)
-        } else {
-            zendeskHelper.createNewTicket(
-                context = this,
-                origin = originFromExtras,
-                selectedSite = selectedSiteOrNull(),
-                extraTags = extraTags + extraTagsFromExtras.orEmpty(),
-                ticketType = ticketType,
-                ssr = viewModel.ssr
-            )
-        }
+        val tags = extraTags + (extraTagsFromExtras ?: emptyList())
+        openSupportRequestForm(tags)
     }
 
     private fun showIdentityDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -71,7 +71,12 @@ class SupportRequestFormActivity : AppCompatActivity() {
             }
         }
         binding.submitRequestButton.setOnClickListener {
-            viewModel.onSubmitRequestButtonClicked(this, helpOrigin, extraTags)
+            viewModel.onSubmitRequestButtonClicked(
+                context = this,
+                helpOrigin = helpOrigin,
+                extraTags = extraTags,
+                verifyIdentity = true
+            )
         }
     }
 
@@ -134,12 +139,11 @@ class SupportRequestFormActivity : AppCompatActivity() {
 
     private fun showSupportIdentityInputDialog(emailSuggestion: String) {
         supportHelper.showSupportIdentityInputDialog(this, emailSuggestion) { email, _ ->
-            zendeskHelper.setSupportEmail(email)
-            AnalyticsTracker.track(AnalyticsEvent.SUPPORT_IDENTITY_SET)
-            viewModel.onSubmitRequestButtonClicked(
+            viewModel.onUserIdentitySet(
                 context = this,
                 helpOrigin = helpOrigin,
-                extraTags = extraTags
+                extraTags = extraTags,
+                selectedEmail = email
             )
         }
         AnalyticsTracker.track(AnalyticsEvent.SUPPORT_IDENTITY_FORM_VIEWED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -22,9 +22,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.store.AccountStore
 import zendesk.support.Request
 import javax.inject.Inject
-import org.wordpress.android.fluxc.store.AccountStore
 
 @HiltViewModel
 class SupportRequestFormViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.support.SupportHelper
 import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.ZendeskHelper
@@ -59,9 +61,29 @@ class SupportRequestFormViewModel @Inject constructor(
         viewState.update { it.copy(message = message) }
     }
 
-    fun onSubmitRequestButtonClicked(context: Context, helpOrigin: HelpOrigin, extraTags: List<String>) {
+    fun onUserIdentitySet(
+        context: Context,
+        helpOrigin: HelpOrigin,
+        extraTags: List<String>,
+        selectedEmail: String
+    ) {
+        zendeskHelper.setSupportEmail(selectedEmail)
+        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_IDENTITY_SET)
+        onSubmitRequestButtonClicked(
+            context = context,
+            helpOrigin = helpOrigin,
+            extraTags = extraTags
+        )
+    }
+
+    fun onSubmitRequestButtonClicked(
+        context: Context,
+        helpOrigin: HelpOrigin,
+        extraTags: List<String>,
+        verifyIdentity: Boolean = false
+    ) {
         val ticketType = viewState.value.ticketType ?: return
-        if (AppPrefs.hasSupportEmail().not()) {
+        if (verifyIdentity && AppPrefs.hasSupportEmail().not()) {
             handleEmptyCredentials()
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.login.LoginPrologueCarouselFragment.PrologueCarouselListener
 import com.woocommerce.android.ui.login.LoginPrologueFragment.PrologueFinishedListener
@@ -607,7 +608,13 @@ class LoginActivity :
 
     override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {
         unifiedLoginTracker.trackClick(Click.HELP_FINDING_SITE_ADDRESS)
-        zendeskHelper.createNewTicket(this, HelpOrigin.LOGIN_SITE_ADDRESS, null)
+        startActivity(
+            SupportRequestFormActivity.createIntent(
+                context = this,
+                origin = HelpOrigin.LOGIN_SITE_ADDRESS,
+                extraTags = ArrayList()
+            )
+        )
     }
 
     // TODO This can be modified to also receive the URL the user entered, so we can make that the primary store

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -28,7 +28,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_LOGIN_
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.ActivityLoginBinding
 import com.woocommerce.android.extensions.parcelable
-import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
@@ -150,7 +149,6 @@ class LoginActivity :
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
     @Inject internal lateinit var loginAnalyticsListener: LoginAnalyticsListener
     @Inject internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
-    @Inject internal lateinit var zendeskHelper: ZendeskHelper
     @Inject internal lateinit var urlUtils: UrlUtils
     @Inject internal lateinit var experimentTracker: ExperimentTracker
     @Inject internal lateinit var appPrefsWrapper: AppPrefsWrapper

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel
@@ -73,9 +74,7 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                CreateZendeskTicket -> {
-                    zendeskHelper.createNewTicket(requireActivity(), HelpOrigin.LOGIN_SITE_ADDRESS, null)
-                }
+                is CreateZendeskTicket -> startSupportRequestForm()
                 is NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
                 is StartWebBasedJetpackInstallation -> startWebBasedJetpackInstallation(event.siteAddress)
                 is StartNativeJetpackActivation -> startNativeJetpackActivation(event)
@@ -122,6 +121,16 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
                         wpComEmail = null
                     )
                 )
+        )
+    }
+
+    private fun startSupportRequestForm() {
+        startActivity(
+            SupportRequestFormActivity.createIntent(
+                context = requireActivity(),
+                origin = HelpOrigin.LOGIN_SITE_ADDRESS,
+                extraTags = ArrayList()
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.model.JetpackStatus
-import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.BaseFragment
@@ -35,7 +34,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.login.LoginMode
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class SitePickerSiteDiscoveryFragment : BaseFragment() {
@@ -46,9 +44,6 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
     }
 
     private val viewModel: SitePickerSiteDiscoveryViewModel by viewModels()
-
-    @Inject
-    lateinit var zendeskHelper: ZendeskHelper
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -19,7 +19,6 @@ enum class FeatureFlag {
     DOMAIN_CHANGE,
     IPP_FEEDBACK_BANNER,
     STORE_CREATION_ONBOARDING,
-    NEW_SUPPORT_REQUESTS,
     FREE_TRIAL,
     REST_API_I2;
 
@@ -42,7 +41,6 @@ enum class FeatureFlag {
             IPP_TAP_TO_PAY,
             DOMAIN_CHANGE,
             STORE_CREATION_ONBOARDING,
-            NEW_SUPPORT_REQUESTS,
             FREE_TRIAL,
             REST_API_I2 -> PackageUtils.isDebugBuild()
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -187,7 +187,9 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         }
 
         sut = SupportRequestFormViewModel(
+            accountStore = mock(),
             zendeskHelper = zendeskHelper,
+            supportHelper = mock(),
             selectedSite = selectedSite,
             savedState = savedState
         )


### PR DESCRIPTION
Summary
==========
Fix issue #8336 by removing the Support Request feature flag and activating the form in all possible entry points for Zendesk tickets of the app.

How to Test
==========
### Scenario 1

1. From the My Store view, select the App Menu at the bottom bar
2. Select Help & Settings
3. Select Contact Support
4. Verify if the Support Request form opens

### Scenario 2

1. Log out
2. Once in the Log in screen select `Enter your store address`
3. Then select `Find your site address`
5. Select `Need more help?` in the dialog
6. Verify if the Support Request form opens

### Scenario 3

1. Log out from the app
2. Once inside the Log in screen select `Get started`
3. Select the `Log in` option at the view top
4. Enter your WordPress.com credentials
5. Once inside the Store selection screen, scroll all the way down to the bottom of the list
6. Select `Add a Store`
7. Select `Connect an existing store`
8. Then select `Find your site address`
9. Select `Need more help?` 
10. Verify if the Support Request form opens 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.