### PR TITLE
[REST API] OTP login functionality for Jetpack connection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -51,6 +52,7 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
                     navigateToJetpackActivationScreen(event)
                 }
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -98,7 +98,7 @@ fun JetpackActivationWPCom2FAScreen(
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                 WCPasswordField(
-                    value = "",
+                    value = viewState.otp,
                     onValueChange = onOTPChanged,
                     label = stringResource(id = R.string.verification_code),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
@@ -146,6 +146,7 @@ private fun JetpackActivationWPCom2FAScreenPreview() {
             viewState = JetpackActivationWPCom2FAViewModel.ViewState(
                 emailOrUsername = "test@email.com",
                 password = "",
+                otp = "123456",
                 isJetpackInstalled = false
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -145,16 +145,8 @@ fun JetpackActivationWPCom2FAScreen(
         }
     }
 
-    if (viewState.isLoadingDialogShown || viewState.isSMSRequestDialogShown) {
-        ProgressDialog(
-            title = "",
-            subtitle = stringResource(
-                id = if (viewState.isLoadingDialogShown)
-                    R.string.logging_in
-                else
-                    R.string.requesting_otp
-            )
-        )
+    viewState.loadingMessage?.let {
+        ProgressDialog(title = "", subtitle = stringResource(id = it))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -123,7 +123,7 @@ fun JetpackActivationWPCom2FAScreen(
                     keyboardController?.hide()
                     onContinueClick()
                 },
-                enabled = true,
+                enabled = viewState.enableSubmit,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -75,7 +75,11 @@ fun JetpackActivationWPCom2FAScreen(
             ) {
                 JetpackToWooHeader()
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
-                val title = R.string.login_jetpack_connect
+                val title = if (viewState.isJetpackInstalled) {
+                    R.string.login_jetpack_connect
+                } else {
+                    R.string.login_jetpack_install
+                }
                 Text(
                     text = stringResource(id = title),
                     style = MaterialTheme.typography.h4,
@@ -112,7 +116,10 @@ fun JetpackActivationWPCom2FAScreen(
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))
             ) {
                 Text(
-                    text = stringResource(id = R.string.login_jetpack_connect)
+                    text = stringResource(
+                        id = if (viewState.isJetpackInstalled) R.string.login_jetpack_connect
+                        else R.string.login_jetpack_install
+                    )
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -32,16 +33,20 @@ import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
 fun JetpackActivationWPCom2FAScreen(viewModel: JetpackActivationWPCom2FAViewModel) {
-    JetpackActivationWPCom2FAScreen(
-        onCloseClick = viewModel::onCloseClick,
-        onSMSLinkClick = viewModel::onSMSLinkClick,
-        onContinueClick = viewModel::onContinueClick
-    )
+    viewModel.viewState.observeAsState().value?.let {
+        JetpackActivationWPCom2FAScreen(
+            viewState = it,
+            onCloseClick = viewModel::onCloseClick,
+            onSMSLinkClick = viewModel::onSMSLinkClick,
+            onContinueClick = viewModel::onContinueClick
+        )
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun JetpackActivationWPCom2FAScreen(
+    viewState: JetpackActivationWPCom2FAViewModel.ViewState,
     onCloseClick: () -> Unit = {},
     onSMSLinkClick: () -> Unit = {},
     onContinueClick: () -> Unit = {}
@@ -118,6 +123,12 @@ fun JetpackActivationWPCom2FAScreen(
 @Composable
 private fun JetpackActivationWPCom2FAScreenPreview() {
     WooThemeWithBackground {
-        JetpackActivationWPCom2FAScreen()
+        JetpackActivationWPCom2FAScreen(
+            viewState = JetpackActivationWPCom2FAViewModel.ViewState(
+                emailOrUsername = "test@email.com",
+                password = "",
+                isJetpackInstalled = false
+            )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
@@ -22,6 +24,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -38,7 +41,8 @@ fun JetpackActivationWPCom2FAScreen(viewModel: JetpackActivationWPCom2FAViewMode
             viewState = it,
             onCloseClick = viewModel::onCloseClick,
             onSMSLinkClick = viewModel::onSMSLinkClick,
-            onContinueClick = viewModel::onContinueClick
+            onContinueClick = viewModel::onContinueClick,
+            onOTPChanged = viewModel::onOTPChanged
         )
     }
 }
@@ -49,7 +53,8 @@ fun JetpackActivationWPCom2FAScreen(
     viewState: JetpackActivationWPCom2FAViewModel.ViewState,
     onCloseClick: () -> Unit = {},
     onSMSLinkClick: () -> Unit = {},
-    onContinueClick: () -> Unit = {}
+    onContinueClick: () -> Unit = {},
+    onOTPChanged: (String) -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -94,8 +99,15 @@ fun JetpackActivationWPCom2FAScreen(
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                 WCPasswordField(
                     value = "",
-                    onValueChange = { },
-                    label = stringResource(id = R.string.verification_code)
+                    onValueChange = onOTPChanged,
+                    label = stringResource(id = R.string.verification_code),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            keyboardController?.hide()
+                            onContinueClick()
+                        }
+                    )
                 )
                 WCTextButton(onClick = onSMSLinkClick) {
                     Text(text = stringResource(id = R.string.login_text_otp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -140,12 +140,16 @@ fun JetpackActivationWPCom2FAScreen(
         }
     }
 
-    if (viewState.isLoadingDialogShown) {
-        ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
-    }
-
-    if (viewState.isSMSRequestDialogShown) {
-        ProgressDialog(title = "", subtitle = stringResource(id = R.string.requesting_otp))
+    if (viewState.isLoadingDialogShown || viewState.isSMSRequestDialogShown) {
+        ProgressDialog(
+            title = "",
+            subtitle = stringResource(
+                id = if (viewState.isLoadingDialogShown)
+                    R.string.logging_in
+                else
+                    R.string.requesting_otp
+            )
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -102,6 +102,8 @@ fun JetpackActivationWPCom2FAScreen(
                     value = viewState.otp,
                     onValueChange = onOTPChanged,
                     label = stringResource(id = R.string.verification_code),
+                    isError = viewState.errorMessage != null,
+                    helperText = viewState.errorMessage?.let { stringResource(id = it) },
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
                         onDone = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -25,12 +25,13 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCPasswordField
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
@@ -98,19 +99,23 @@ fun JetpackActivationWPCom2FAScreen(
                     )
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
-                WCPasswordField(
+                WCOutlinedTextField(
                     value = viewState.otp,
                     onValueChange = onOTPChanged,
                     label = stringResource(id = R.string.verification_code),
                     isError = viewState.errorMessage != null,
                     helperText = viewState.errorMessage?.let { stringResource(id = it) },
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Done
+                    ),
                     keyboardActions = KeyboardActions(
                         onDone = {
                             keyboardController?.hide()
                             onContinueClick()
                         }
-                    )
+                    ),
+                    singleLine = true
                 )
                 WCTextButton(onClick = onSMSLinkClick) {
                     Text(text = stringResource(id = R.string.login_text_otp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCPasswordField
@@ -135,6 +136,10 @@ fun JetpackActivationWPCom2FAScreen(
                 )
             }
         }
+    }
+
+    if (viewState.isLoadingDialogShown) {
+        ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAScreen.kt
@@ -141,6 +141,10 @@ fun JetpackActivationWPCom2FAScreen(
     if (viewState.isLoadingDialogShown) {
         ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
     }
+
+    if (viewState.isSMSRequestDialogShown) {
+        ProgressDialog(title = "", subtitle = stringResource(id = R.string.requesting_otp))
+    }
 }
 
 @Preview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -17,8 +17,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType.INVALID_OTP
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType.NOT_AUTHENTICATED
 import javax.inject.Inject
 
 @HiltViewModel
@@ -87,9 +89,10 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
                 val failure = (it as? OnChangedException)?.error as? AuthenticationError
 
                 when (failure?.type) {
-                    AccountStore.AuthenticationErrorType.INVALID_OTP ->
+                    INVALID_OTP ->
                         errorMessage.value = R.string.otp_incorrect
-
+                    INCORRECT_USERNAME_OR_PASSWORD, NOT_AUTHENTICATED ->
+                        triggerEvent(Exit)
                     else -> {
                         triggerEvent(ShowSnackbar(R.string.error_generic))
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -39,7 +39,6 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
     private val errorMessage =
         savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = 0, key = "error-message")
 
-
     val viewState = combine(
         flowOf(Pair(navArgs.emailOrUsername, navArgs.password)),
         flowOf(Pair(isLoadingDialogShown, isSMSRequestDialogShown)),
@@ -88,7 +87,7 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
             onFailure = {
                 val failure = (it as? OnChangedException)?.error as? AuthenticationError
 
-                when(failure?.type) {
+                when (failure?.type) {
                     AccountStore.AuthenticationErrorType.INVALID_OTP ->
                         errorMessage.value = R.string.otp_incorrect
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -2,10 +2,12 @@ package com.woocommerce.android.ui.login.jetpack.wpcom
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
@@ -22,6 +24,7 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
 
     private val navArgs: JetpackActivationWPCom2FAFragmentArgs by savedStateHandle.navArgs()
 
+    private val otp = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "otp")
     val viewState = combine(
         flowOf(navArgs.emailOrUsername),
         flowOf(navArgs.password)
@@ -43,6 +46,10 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
 
     fun onContinueClick() {
         TODO()
+    }
+
+    fun onOTPChanged(enteredOTP: String) {
+        this.otp.value = enteredOTP
     }
 
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -27,11 +27,13 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
     private val otp = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "otp")
     val viewState = combine(
         flowOf(navArgs.emailOrUsername),
-        flowOf(navArgs.password)
-    ) { emailOrUsername, password ->
+        flowOf(navArgs.password),
+        otp,
+    ) { emailOrUsername, password, otp ->
         ViewState(
             emailOrUsername = emailOrUsername,
             password = password,
+            otp = otp,
             isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled
         )
     }.asLiveData()
@@ -55,6 +57,7 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
     data class ViewState(
         val emailOrUsername: String,
         val password: String,
+        val otp: String,
         val isJetpackInstalled: Boolean
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -96,8 +96,6 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
                         triggerEvent(ShowSnackbar(R.string.error_generic))
                     }
                 }
-
-                triggerEvent(ShowSnackbar(R.string.error_generic))
             }
         )
         isLoadingDialogShown.value = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -3,7 +3,10 @@ package com.woocommerce.android.ui.login.jetpack.wpcom
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.ui.login.WPComLoginRepository
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -12,7 +15,7 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
-import org.wordpress.android.login.R
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,6 +23,8 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     selectedSite: SelectedSite,
     jetpackAccountRepository: JetpackActivationRepository,
+    private val wpComLoginRepository: WPComLoginRepository,
+    private val accountRepository: AccountRepository
 ) : JetpackActivationWPComPostLoginViewModel(savedStateHandle, selectedSite, jetpackAccountRepository) {
 
     private val navArgs: JetpackActivationWPCom2FAFragmentArgs by savedStateHandle.navArgs()
@@ -46,8 +51,26 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
         triggerEvent(ShowSnackbar(R.string.requesting_otp))
     }
 
-    fun onContinueClick() {
-        TODO()
+    fun onContinueClick() = launch {
+        wpComLoginRepository.submitTwoStepCode(
+            emailOrUsername = navArgs.emailOrUsername,
+            password = navArgs.password,
+            twoStepCode = otp.value
+        ).fold(
+            onSuccess = { fetchAccount() },
+            onFailure = { triggerEvent(ShowSnackbar(R.string.error_generic)) }
+        )
+    }
+
+    private suspend fun fetchAccount() {
+        accountRepository.fetchUserAccount().fold(
+            onSuccess = {
+                onLoginSuccess(navArgs.jetpackStatus)
+            },
+            onFailure = {
+                triggerEvent(ShowSnackbar(R.string.error_fetch_my_profile))
+            }
+        )
     }
 
     fun onOTPChanged(enteredOTP: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -41,17 +41,18 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
 
     val viewState = combine(
         flowOf(Pair(navArgs.emailOrUsername, navArgs.password)),
-        flowOf(Pair(isLoadingDialogShown, isSMSRequestDialogShown)),
         otp,
         errorMessage,
-    ) { (emailOrUsername, password), (isLoadingDialogShown, isSMSRequestDialogShown), otp, errorMessage ->
+        isLoadingDialogShown,
+        isSMSRequestDialogShown
+    ) { (emailOrUsername, password), otp, errorMessage, isLoadingDialogShown, isSMSRequestDialogShown ->
         ViewState(
             emailOrUsername = emailOrUsername,
             password = password,
             otp = otp,
             isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
-            isLoadingDialogShown = isLoadingDialogShown.value,
-            isSMSRequestDialogShown = isSMSRequestDialogShown.value,
+            isLoadingDialogShown = isLoadingDialogShown,
+            isSMSRequestDialogShown = isSMSRequestDialogShown,
             errorMessage = errorMessage.takeIf { it != 0 }
         )
     }.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -55,8 +55,20 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
-    fun onSMSLinkClick() {
-        triggerEvent(ShowSnackbar(R.string.requesting_otp))
+    fun onSMSLinkClick() = launch {
+        isSMSRequestDialogShown.value = true
+        wpComLoginRepository.requestTwoStepSMS(
+            emailOrUsername = navArgs.emailOrUsername,
+            password = navArgs.password
+        ).fold(
+            onSuccess = {
+                triggerEvent(ShowSnackbar(R.string.requesting_sms_otp_success))
+            },
+            onFailure = {
+                triggerEvent(ShowSnackbar(R.string.requesting_sms_otp_failure))
+            }
+        )
+        isSMSRequestDialogShown.value = false
     }
 
     fun onContinueClick() = launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -32,19 +32,22 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
 
     private val otp = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "otp")
     private val isLoadingDialogShown = MutableStateFlow(false)
+    private val isSMSRequestDialogShown = MutableStateFlow(false)
 
     val viewState = combine(
         flowOf(navArgs.emailOrUsername),
         flowOf(navArgs.password),
         otp,
-        isLoadingDialogShown
-    ) { emailOrUsername, password, otp, isLoadingDialogShown ->
+        isLoadingDialogShown,
+        isSMSRequestDialogShown
+    ) { emailOrUsername, password, otp, isLoadingDialogShown, isSMSRequestDialogShown ->
         ViewState(
             emailOrUsername = emailOrUsername,
             password = password,
             otp = otp,
             isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
-            isLoadingDialogShown = isLoadingDialogShown
+            isLoadingDialogShown = isLoadingDialogShown,
+            isSMSRequestDialogShown = isSMSRequestDialogShown
         )
     }.asLiveData()
 
@@ -89,6 +92,7 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
         val password: String,
         val otp: String,
         val isJetpackInstalled: Boolean,
-        val isLoadingDialogShown: Boolean = false
+        val isLoadingDialogShown: Boolean = false,
+        val isSMSRequestDialogShown: Boolean = false
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -1,11 +1,15 @@
 package com.woocommerce.android.ui.login.jetpack.wpcom
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import org.wordpress.android.login.R
 import javax.inject.Inject
 
@@ -15,6 +19,20 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
     selectedSite: SelectedSite,
     jetpackAccountRepository: JetpackActivationRepository,
 ) : JetpackActivationWPComPostLoginViewModel(savedStateHandle, selectedSite, jetpackAccountRepository) {
+
+    private val navArgs: JetpackActivationWPCom2FAFragmentArgs by savedStateHandle.navArgs()
+
+    val viewState = combine(
+        flowOf(navArgs.emailOrUsername),
+        flowOf(navArgs.password)
+    ) { emailOrUsername, password ->
+        ViewState(
+            emailOrUsername = emailOrUsername,
+            password = password,
+            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled
+        )
+    }.asLiveData()
+
     fun onCloseClick() {
         triggerEvent(Exit)
     }
@@ -26,4 +44,10 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
     fun onContinueClick() {
         TODO()
     }
+
+    data class ViewState(
+        val emailOrUsername: String,
+        val password: String,
+        val isJetpackInstalled: Boolean
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPCom2FAViewModel.kt
@@ -106,5 +106,7 @@ class JetpackActivationWPCom2FAViewModel @Inject constructor(
         val isJetpackInstalled: Boolean,
         val isLoadingDialogShown: Boolean = false,
         val isSMSRequestDialogShown: Boolean = false
-    )
+    ) {
+        val enableSubmit = otp.isNotBlank()
+    }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2012,6 +2012,9 @@
 
 
     <string name="requesting_otp">Requesting a verification code via SMS.</string>
+    <string name="requesting_sms_otp_success">SMS requested, please check your messages for the code.</string>
+    <string name="requesting_sms_otp_failure">SMS request failed. Please try again.</string>
+
 
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2017,6 +2017,7 @@
 
 
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
+    <string name="otp_incorrect">The OTP code is incorrect. Please double check your information and try again.</string>
 
 
     <string name="login_magic_link_email_requesting">Requesting log-in email</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8397
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the actual functionality in the OTP screen:
1. Installation process is continued if entered OTP is correct,
2. OTP via SMS request button is working,
3. Error handling and basic validation is added.


### Testing instructions
1. Login by entering a self-hosted Woo site with no Jetpack, then using site credentials,
4. On the My Store screen, tap the Jetpack banner at the bottom,
5. tap "Log In to Continue",

At this point, prepare an account that has 2FA via code, and has 2FA via SMS.

*code case*
1. Enter a wpcom account email address that has a 2FA via app enabled, tap Install Jetpack,
2. On the next screen, enter the password, then tap Install Jetpack,
3. the OTP screen will be shown. Enter OTP code from authenticator app, then tap Install Jetpack,
6. Verify that the Installation process is then continued.

*SMS case*
1. Enter a wpcom account email address that has a 2FA via SMS enabled, tap Install Jetpack,
2. On the next screen, enter the password, then tap Install Jetpack,
3. the OTP screen will be shown. Enter OTP code from SMS, then tap Install Jetpack,
4. Verify that the Installation process is then continued.

*Error case*
1. Try entering the wrong OTP code,
2. Try tapping the SMS request button for the account that has 2FA via app,
3. Turn on Airplane mode on the OTP screen, and try the buttons


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
The screenshots are from a site that already has Jetpack installed but not connected, hence why it says "Connect Jetpack". If there's no Jetpack plugin installed, it will say "Install Jetpack".

| main | entering code | sms request dialog | login dialog |
|-|-|-|-|
| ![Screenshot_20230303_202648](https://user-images.githubusercontent.com/266376/222731911-6b8b01c6-4e2a-4c30-8033-4530005ab626.png) | ![Screenshot_20230303_202743](https://user-images.githubusercontent.com/266376/222732057-c804f743-bf25-4d32-99d8-fc408e4995ef.png) | ![Screenshot_20230303_204110](https://user-images.githubusercontent.com/266376/222734882-a0d1f597-3c46-4c3b-b517-28e5ac5c06f9.png) |  ![Screenshot_20230303_204227](https://user-images.githubusercontent.com/266376/222735258-5de37e74-10ad-42ea-8a02-d6b4aba5e7ca.png) |


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
