### PR TITLE
[Support Requests] Add tracks to support request form

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 12.6
 -----
+- [**] Support: Merchants can now contact support with a new and refined experience. [https://github.com/woocommerce/woocommerce-android/issues/8336]
 - [*] Search in local database when searching for products in the edit coupons flow. [https://github.com/woocommerce/woocommerce-android/pull/8391]
 
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -646,7 +646,6 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SUPPORT_NEW_REQUEST_CREATED,
     SUPPORT_NEW_REQUEST_FAILED,
 
-
     // -- Push notifications
     PUSH_NOTIFICATION_RECEIVED,
     PUSH_NOTIFICATION_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -641,6 +641,12 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SUPPORT_SSR_OPENED,
     SUPPORT_SSR_COPY_BUTTON_TAPPED,
 
+    // -- Support Request Form
+    SUPPORT_NEW_REQUEST_VIEWED,
+    SUPPORT_NEW_REQUEST_CREATED,
+    SUPPORT_NEW_REQUEST_FAILED,
+
+
     // -- Push notifications
     PUSH_NOTIFICATION_RECEIVED,
     PUSH_NOTIFICATION_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -50,6 +50,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
             observeViewEvents(this)
             observeViewModelEvents(this)
         }
+        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_VIEWED)
     }
 
     private fun ActivitySupportRequestFormBinding.setupActionBar() {
@@ -105,6 +106,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
     }
 
     private fun showRequestCreationSuccessDialog() {
+        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_CREATED)
         WooDialog.showDialog(
             activity = this,
             titleId = R.string.support_request_success_title,
@@ -115,6 +117,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
     }
 
     private fun showRequestCreationFailureDialog() {
+        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_FAILED)
         WooDialog.showDialog(
             activity = this,
             titleId = R.string.support_request_error_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -50,7 +50,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
             observeViewEvents(this)
             observeViewModelEvents(this)
         }
-        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_VIEWED)
+        viewModel.onViewCreated()
     }
 
     private fun ActivitySupportRequestFormBinding.setupActionBar() {
@@ -106,7 +106,6 @@ class SupportRequestFormActivity : AppCompatActivity() {
     }
 
     private fun showRequestCreationSuccessDialog() {
-        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_CREATED)
         WooDialog.showDialog(
             activity = this,
             titleId = R.string.support_request_success_title,
@@ -117,7 +116,6 @@ class SupportRequestFormActivity : AppCompatActivity() {
     }
 
     private fun showRequestCreationFailureDialog() {
-        AnalyticsTracker.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_FAILED)
         WooDialog.showDialog(
             activity = this,
             titleId = R.string.support_request_error_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.SupportHelper
 import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.ZendeskHelper
@@ -32,6 +33,7 @@ class SupportRequestFormViewModel @Inject constructor(
     private val zendeskHelper: ZendeskHelper,
     private val supportHelper: SupportHelper,
     private val selectedSite: SelectedSite,
+    private val tracks: AnalyticsTrackerWrapper,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val viewState = savedState.getStateFlow(
@@ -48,6 +50,10 @@ class SupportRequestFormViewModel @Inject constructor(
         .map { it.isLoading }
         .distinctUntilChanged()
         .asLiveData()
+
+    fun onViewCreated() {
+        tracks.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_VIEWED)
+    }
 
     fun onHelpOptionSelected(ticketType: TicketType) {
         viewState.update { it.copy(ticketType = ticketType) }
@@ -116,8 +122,14 @@ class SupportRequestFormViewModel @Inject constructor(
     private fun Result<Request?>.handleCreateRequestResult() {
         viewState.update { it.copy(isLoading = false) }
         fold(
-            onSuccess = { triggerEvent(RequestCreationSucceeded) },
-            onFailure = { triggerEvent(RequestCreationFailed) }
+            onSuccess = {
+                triggerEvent(RequestCreationSucceeded)
+                tracks.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_CREATED)
+            },
+            onFailure = {
+                triggerEvent(RequestCreationFailed)
+                tracks.track(AnalyticsEvent.SUPPORT_NEW_REQUEST_FAILED)
+            }
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.support.requests
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.TicketType
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.support.help.HelpOrigin
@@ -29,6 +31,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
     private lateinit var sut: SupportRequestFormViewModel
     private lateinit var zendeskHelper: ZendeskHelper
     private lateinit var selectedSite: SelectedSite
+    private lateinit var tracks: AnalyticsTrackerWrapper
     private val savedState = SavedStateHandle()
 
     @Before
@@ -147,6 +150,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         // Then
         assertThat(event).hasSize(1)
         assertThat(event[0]).isEqualTo(RequestCreationSucceeded)
+        verify(tracks, times(1)).track(AnalyticsEvent.SUPPORT_NEW_REQUEST_CREATED)
     }
 
     @Test
@@ -165,9 +169,20 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         // Then
         assertThat(event).hasSize(1)
         assertThat(event[0]).isEqualTo(RequestCreationFailed)
+        verify(tracks, times(1)).track(AnalyticsEvent.SUPPORT_NEW_REQUEST_FAILED)
+    }
+
+    @Test
+    fun `when onViewCreated is called, then trigger the expected track event`() {
+        // When
+        sut.onViewCreated()
+
+        // Then
+        verify(tracks, times(1)).track(AnalyticsEvent.SUPPORT_NEW_REQUEST_VIEWED)
     }
 
     private fun configureMocks(requestResult: Result<Request?>) {
+        tracks = mock()
         val testSite = SiteModel().apply { id = 123 }
         selectedSite = mock {
             on { getIfExists() }.then { testSite }
@@ -191,6 +206,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
             zendeskHelper = zendeskHelper,
             supportHelper = mock(),
             selectedSite = selectedSite,
+            tracks = tracks,
             savedState = savedState
         )
     }


### PR DESCRIPTION
Summary
==========
Fix issue #8479 by adding the missing tracks event to match the ones added on the WCiOS form.

How to Test
==========
I recommend adjusting the ZendeskHelper `createRequest` function to hard code the callback call to test the success and failure scenarios without creating Zendesk tickets there. If not, you can create a ticket for the success scenario, and use a debug build to trigger the failure scenario, since the debug build doesn't carry the Zendesk credentials.

1. Open the Support Request Form and verify if the `SUPPORT_NEW_REQUEST_VIEWED` event is triggered
2. Submit a request and verify that for the success scenario, the `SUPPORT_NEW_REQUEST_CREATED` event is triggered, and the `SUPPORT_NEW_REQUEST_FAILED` is triggered for the failure scenario.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.