### PR TITLE
[Support Requests] Replace jetpack tag with WCPay tag from ipp ticket

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -429,7 +429,8 @@ sealed class TicketType(
         tags = listOf(
             ZendeskTags.woocommerceMobileApps,
             ZendeskTags.productAreaAppsInPersonPayments
-        )
+        ),
+        excludedTags = listOf(ZendeskTags.jetpackTag)
     )
     @Parcelize object Payments : TicketType(
         form = TicketFieldIds.wooFormID,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -427,6 +427,7 @@ sealed class TicketType(
         categoryName = ZendeskConstants.mobileAppCategory,
         subcategoryName = ZendeskConstants.mobileSubcategoryValue,
         tags = listOf(
+            ZendeskTags.paymentsProduct,
             ZendeskTags.woocommerceMobileApps,
             ZendeskTags.productAreaAppsInPersonPayments
         ),


### PR DESCRIPTION
Summary
==========
There was a warning that iPP tickets were not correctly being prioritized. After digging a bit, the problem is that we were not setting the correct product tag for Card Reader / IPP tickets.

To fix this problem we need to send the woocommerce_payments tag instead of the jetpack tag.

How to Test
==========
1. Create the ticket using the iPP option in the Support Requests form and verify if the ticket contains the correct set of tags.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.