### PR TITLE
[Build] Remove Gradle Enterprise from Project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,3 +208,4 @@ tasks.register("configureApply") {
 }
 
 apply from: './config/gradle/jacoco.gradle'
+apply from: './config/gradle/gradle_build_scan.gradle'

--- a/config/gradle/gradle_build_cache.gradle
+++ b/config/gradle/gradle_build_cache.gradle
@@ -1,0 +1,12 @@
+
+// Only run build cache on CI builds.
+if (System.getenv('CI')) {
+    buildCache {
+        remote(HttpBuildCache) {
+            url = "http://10.0.2.215:5071/cache/"
+            allowUntrustedServer = true
+            allowInsecureProtocol = true
+            push = true
+        }
+    }
+}

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,0 +1,11 @@
+
+// Only run build scan on CI builds.
+if (System.getenv('CI')) {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+        tag 'CI'
+        publishAlways()
+        uploadInBackground = false
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,30 +42,6 @@ plugins {
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.5'
 }
 
-gradleEnterprise {
-    server = "https://gradle.a8c.com"
-    allowUntrustedServer = false
-    buildScan {
-        def disableGE = System.getenv("GRADLE_ENTERPRISE_ANALYTICS_DISABLE")
-        if (!(disableGE == "1" || disableGE == "true")) {
-            publishAlways()
-        }
-        capture {
-            taskInputFiles = true
-        }
-        uploadInBackground = System.getenv("CI") == null
-
-        if (!System.getenv().containsKey("CI")) {
-            // Obfuscate personal data unless it's a CI build
-            obfuscation {
-                username { username -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_USERNAME") ?: username }
-                hostname { hostname -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME") ?: hostname }
-                ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
-            }
-        }
-    }
-}
-
 rootProject.name = 'WCAndroid'
 
 include ':quicklogin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,7 +39,6 @@ pluginManagement {
 
 plugins {
     id 'com.gradle.enterprise' version '3.9'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.5'
 }
 
 rootProject.name = 'WCAndroid'

--- a/settings.gradle
+++ b/settings.gradle
@@ -64,3 +64,4 @@ gradle.ext {
 }
 
 apply from: './config/gradle/include_builds.gradle'
+apply from: './config/gradle/gradle_build_cache.gradle'


### PR DESCRIPTION
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since `Gradle Enterprise (GE)` is shut down, at least temporarily (see `paaHJt-4Ap-p2`), this PR removes the existing `Gradle Enterprise` configuration as well (703d26e0f2e7f420d6f5fcdc1adf863c293980e1 + fe321fd511430bd6602b1a3ac38f6b4aac8ecb18).

Also, this PR adds back the previously removed custom Gradle related `buildScan` and `buildCache` configuration on `CI` builds only (1c37ce542a4889a2a54d3534bc6bf94cbb744e41 + 130e047175d003aff5f2a5f425e698b9832aaf91).

PS: I also chose not to bring back the `GRADLE_ENTERPRISE_ANALYTICS_DISABLE`, `GRADLE_ENTERPRISE_ANALYTICS_USERNAME`, and `GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME` configuration that was added to `buildScan` afterwards (#6461). And this was done due to the fact that automatic build scan publishing is disabled for `LOCAL` builds anyway. As such, I don't think this kind of obfuscation is still necessary for when working without `Gradle Enterprise`. 🤔

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- (`GE`): Verify `LOCAL` and `CI` builds no longer output the `A network error occurred.` error at the end of the build, related to it failing to connect to `Gradle Enterprise` since it has been shut down for day now.
- (`buildScan`): Verify `CI` builds are publishing the build scan at the end of the build, and create the corresponding build scan link.
- (`buildCache`): Verify `CI` builds are able to use the remote build cache. FYI: You can do that by looking at the build scan that is published on `CI` (looks for `Avoidance savings`, up to date and local/remote build cache savings).

[Buildkite](https://buildkite.com/automattic/woocommerce-android/builds/10022#0186b7bc-55fe-4795-b5b2-9077771d5751) -> [Build Scan](https://gradle.com/s/imdarhbnq2scw) -> `Performance` -> `Task execusion`

![image](https://user-images.githubusercontent.com/9729923/223176799-0bf4dc0c-6d58-472f-9747-75941a219dd6.png)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
