### PR TITLE
[REST API] Fixes to the home widget

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -30,12 +30,12 @@ import com.woocommerce.android.support.help.HelpViewModel.ContactSupportEvent.Cr
 import com.woocommerce.android.support.help.HelpViewModel.ContactSupportEvent.ShowLoading
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
@@ -43,7 +43,7 @@ import javax.inject.Inject
 class HelpActivity : AppCompatActivity() {
     private val viewModel: HelpViewModel by viewModels()
 
-    @Inject lateinit var accountStore: AccountStore
+    @Inject lateinit var accountRepository: AccountRepository
     @Inject lateinit var siteStore: SiteStore
     @Inject lateinit var supportHelper: SupportHelper
     @Inject lateinit var zendeskHelper: ZendeskHelper
@@ -144,7 +144,7 @@ class HelpActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    private fun userIsLoggedIn() = accountStore.hasAccessToken()
+    private fun userIsLoggedIn() = accountRepository.isUserLoggedIn()
 
     private fun createNewZendeskTicket(ticketType: TicketType, extraTags: List<String> = emptyList()) {
         if (!AppPrefs.hasSupportEmail()) {
@@ -165,7 +165,7 @@ class HelpActivity : AppCompatActivity() {
             AppPrefs.getSupportEmail()
         } else {
             supportHelper
-                .getSupportEmailAndNameSuggestion(accountStore.account, selectedSiteOrNull()).first
+                .getSupportEmailAndNameSuggestion(accountRepository.getUserAccount(), selectedSiteOrNull()).first
         }
 
         supportHelper.showSupportIdentityInputDialog(this, emailSuggestion) { email, _ ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStats.kt
@@ -2,17 +2,17 @@ package com.woocommerce.android.ui.appwidgets.stats
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.mystore.data.StatsRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WCStatsStore
 import javax.inject.Inject
 
 class GetWidgetStats @Inject constructor(
-    private val accountStore: AccountStore,
+    private val accountRepository: AccountRepository,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val statsRepository: StatsRepository,
     private val coroutineDispatchers: CoroutineDispatchers,
@@ -25,7 +25,7 @@ class GetWidgetStats @Inject constructor(
         return withContext(coroutineDispatchers.io) {
             when {
                 // If user is not logged in, exit the function with WidgetStatsAuthFailure
-                accountStore.hasAccessToken().not() -> WidgetStatsResult.WidgetStatsAuthFailure
+                accountRepository.isUserLoggedIn().not() -> WidgetStatsResult.WidgetStatsAuthFailure
                 // If V4 stats is not supported, exit the function with WidgetStatsAPINotSupportedFailure
                 appPrefsWrapper.isV4StatsSupported().not() -> WidgetStatsResult.WidgetStatsAPINotSupportedFailure
                 // If network is not available, exit the function with WidgetStatsNetworkFailure

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayStatsWidgetUIHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/TodayStatsWidgetUIHelper.kt
@@ -78,6 +78,15 @@ class TodayStatsWidgetUIHelper @Inject constructor(
         remoteViews.setViewVisibility(R.id.widget_visitors_value, View.VISIBLE)
         remoteViews.setViewVisibility(R.id.widget_visitors_skeleton, View.INVISIBLE)
 
+        remoteViews.setViewVisibility(
+            R.id.widget_visitors_title,
+            if (stats.areVisitorStatsSupported) View.VISIBLE else View.GONE
+        )
+        remoteViews.setViewVisibility(
+            R.id.widget_visitors_value,
+            if (stats.areVisitorStatsSupported) View.VISIBLE else View.GONE
+        )
+
         remoteViews.setTextViewText(
             R.id.widget_update_time,
             String.format(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.DASHBOARD
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -268,15 +269,21 @@ class StatsRepository @Inject constructor(
     suspend fun fetchStats(
         granularity: StatsGranularity,
         forced: Boolean,
+        includeVisitorStats: Boolean,
         site: SiteModel = selectedSite.get()
     ): WooResult<SiteStats> = coroutineScope {
-        val fetchVisitorStats = async {
-            fetchVisitorStats(
-                granularity = granularity,
-                forced = forced,
-                site = site
-            )
+        val fetchVisitorStats = if (includeVisitorStats) {
+            async {
+                fetchVisitorStats(
+                    granularity = granularity,
+                    forced = forced,
+                    site = site
+                )
+            }
+        } else {
+            CompletableDeferred(WooResult(emptyMap()))
         }
+
         val fetchRevenueStats = async {
             fetchRevenueStats(
                 granularity = granularity,


### PR DESCRIPTION
Closes: #8491 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR has the following changes:
1. Updates the home widget logic to properly detect when the user is signed in.
2. Hides the visitor stats from the home widget when connecting to a site using site credentials or Jetpack CP.
3. Updates the HelpActivity to properly detect when the user is signed in and show the "System Status Report" button.

### Testing instructions
1. Open the app then sign in to a non-Jetpack site using site credentials.
2. Go to your device's home screen, then add the app's widget.
3. Confirm that the widget works correctly, and that the Visitor stats row is hidden.
4. Go back to the app then open the help screen.
5. Confirm that the button "System Status Report" is shown, and works correctly.

### Images/gif
<img width=320 src="https://user-images.githubusercontent.com/1657201/223370542-aca38576-7cd7-4570-aef5-ed7299962b51.png"/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
