### PR TITLE
Update Woo Purple Color Palette

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
@@ -169,7 +169,7 @@ private fun CountryItem(
             .background(
                 color = colorResource(
                     id = if (country.isSelected)
-                        if (isSystemInDarkTheme()) R.color.color_surface else R.color.woo_purple_10
+                        if (isSystemInDarkTheme()) R.color.color_surface else R.color.woo_purple_0
                     else R.color.color_surface
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansScreen.kt
@@ -305,7 +305,7 @@ fun PlanFeatureRow(@DrawableRes iconId: Int, @StringRes textId: Int) {
                 .height(26.dp)
                 .padding(end = dimensionResource(id = R.dimen.minor_100)),
             contentScale = ContentScale.FillHeight,
-            colorFilter = ColorFilter.tint(color = colorResource(id = R.color.woo_purple_15))
+            colorFilter = ColorFilter.tint(color = colorResource(id = R.color.woo_purple_5))
         )
         Text(
             text = stringResource(id = textId),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerScreen.kt
@@ -242,7 +242,7 @@ private fun ProfilerOptionItem(
             .background(
                 color = colorResource(
                     id = if (category.isSelected)
-                        if (isSystemInDarkTheme()) R.color.color_surface else R.color.woo_purple_10
+                        if (isSystemInDarkTheme()) R.color.color_surface else R.color.woo_purple_0
                     else R.color.color_surface
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -87,7 +87,7 @@ fun Banner(bannerState: BannerState) {
                             .clip(
                                 RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
                             )
-                            .background(colorResource(id = R.color.woo_purple_10)),
+                            .background(colorResource(id = R.color.woo_purple_0)),
                         contentAlignment = Alignment.Center
                     ) {
                         Text(

--- a/WooCommerce/src/main/res/drawable/survey_button_selector.xml
+++ b/WooCommerce/src/main/res/drawable/survey_button_selector.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:state_selected="true"
-        android:color="@color/woo_purple_10"/>
+        android:color="@color/woo_purple_0"/>
     <item
         android:state_selected="false"
         android:color="@android:color/transparent"/>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -114,7 +114,7 @@
     <color name="tag_bg_on_hold">@color/woo_orange_5</color>
     <color name="tag_bg_completed">@color/woo_blue_5</color>
     <color name="tag_bg_other">@color/woo_gray_5</color>
-    <color name="tag_bg_main">@color/woo_purple_15</color>
+    <color name="tag_bg_main">@color/woo_purple_5</color>
     <color name="tag_text_main">@color/color_primary</color>
 
     <!--

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="woo_purple_0">#F7EDF7</color>
-    <color name="woo_purple_5">#E5CFE8</color>
-    <color name="woo_purple_10">#D6B4E0</color>
-    <color name="woo_purple_20">#C792E0</color>
-    <color name="woo_purple_30">#AF7DD1</color>
-    <color name="woo_purple_40">#9A69C7</color>
+    <color name="woo_purple_0">#F2EDFF</color>
+    <color name="woo_purple_5">#DFD1FB</color>
+    <color name="woo_purple_10">#CFB9F6</color>
+    <color name="woo_purple_20">#BEA0F2</color>
+    <color name="woo_purple_30">#AD86E9</color>
+    <color name="woo_purple_40">#966CCF</color>
     <color name="woo_purple_50">#7F54B3</color>
     <color name="woo_purple_60">#674399</color>
     <color name="woo_purple_60_alpha_33">#33674399</color>

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="woo_purple_10">#F7EDF7</color>
-    <color name="woo_purple_15">#E5CFE8</color>
+    <color name="woo_purple_0">#F7EDF7</color>
+    <color name="woo_purple_5">#E5CFE8</color>
+    <color name="woo_purple_10">#D6B4E0</color>
     <color name="woo_purple_20">#C792E0</color>
-    <color name="woo_purple_30">#B17FD4</color>
-    <color name="woo_purple_40">#AF7DD1</color>
+    <color name="woo_purple_30">#AF7DD1</color>
+    <color name="woo_purple_40">#9A69C7</color>
     <color name="woo_purple_50">#7F54B3</color>
     <color name="woo_purple_60">#674399</color>
     <color name="woo_purple_60_alpha_33">#33674399</color>
+    <color name="woo_purple_70">#533582</color>
     <color name="woo_purple_80">#3C2861</color>
     <color name="woo_purple_90">#271B3D</color>
+    <color name="woo_purple_1o0">#140E1F</color>
     <color name="woo_purple_dark_secondary">#99EBEBF5</color>
 
     <color name="woo_pink_10">#ED9BB8</color>


### PR DESCRIPTION
This PR is meant to incorporate the latest light color changes as outlined on p6riRB-8ox-p2

![image](https://user-images.githubusercontent.com/266376/223385427-cb56a816-26ef-49cc-9b9b-30311e8b28a5.png)

As I went to update things, though, I found that the existing color numbering used in Woo Android do not match the numbering scheme in the table above, as well as missing some values (like for 70, or 100):

<img width="575" alt="Screenshot 2023-03-07 at 13 45 48" src="https://user-images.githubusercontent.com/266376/223386011-6f8da98d-625e-4850-a5b9-9b1da96afbee.png">

To sync everything, I applied the update through two commits:

  1. The **first commit** is done to sync the numbering system, without adding the latest color changes yet. 
    - Colors that are already used (`10` and `15` in the code) are renamed to match the table value. 
    - Colors for `30` and `40` are synced with the table,
    - Colors for `70` and `100` are added.
2. Now that the numbering scheme is correct, the **second commit** simply adds the latest updates for the first six colors.


**To test:**
This feels like it needs smoke test only as this shouldn't affect any functionality. Also probably worth going through the two commits individually to see what changes are added.
