### PR TITLE
Analytics hub feedback banner tracks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.DeltaPercentage
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.OrdersStat
@@ -62,6 +63,7 @@ class AnalyticsHubViewModel @Inject constructor(
     private val updateStats: UpdateAnalyticsHubStats,
     private val localeProvider: LocaleProvider,
     private val feedbackRepository: FeedbackRepository,
+    private val tracker: AnalyticsTrackerWrapper,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
 
@@ -361,6 +363,13 @@ class AnalyticsHubViewModel @Inject constructor(
     )
 
     fun onSendFeedbackClicked() {
+        tracker.track(
+            AnalyticsEvent.FEATURE_FEEDBACK_BANNER,
+            mapOf(
+                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_ANALYTICS_HUB_FEEDBACK,
+                AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
+            )
+        )
         feedbackRepository.saveFeatureFeedback(
             FeatureFeedbackSettings.Feature.ANALYTICS_HUB,
             FeatureFeedbackSettings.FeedbackState.GIVEN
@@ -370,6 +379,13 @@ class AnalyticsHubViewModel @Inject constructor(
     }
 
     fun onDismissBannerClicked() {
+        tracker.track(
+            AnalyticsEvent.FEATURE_FEEDBACK_BANNER,
+            mapOf(
+                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_ANALYTICS_HUB_FEEDBACK,
+                AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
+            )
+        )
         feedbackRepository.saveFeatureFeedback(
             FeatureFeedbackSettings.Feature.ANALYTICS_HUB,
             FeatureFeedbackSettings.FeedbackState.DISMISSED


### PR DESCRIPTION

### Description
This PR adds track events to the analytics hub feedback banner. One event will be triggered when pressing the send survey button and another one when pressing the dismiss button. 
Events:
```
Send Feedback event:
🔵 Tracked: feature_feedback_banner, Properties: {"context":"analytics_hub","action":"gave_feedback","blog_id":214253715,"is_wpcom_store":true,"is_debug":true}

Dismiss Feedback event:
🔵 Tracked: feature_feedback_banner, Properties: {"context":"analytics_hub","action":"dismissed","blog_id":214253715,"is_wpcom_store":true,"is_debug":true}
```

### Testing instructions
TC1
1. On MyStore Screen, press the See more button in the stats view
2. Check that the feedback request banner is shown
3. Tap on the dismiss button (the X button on the top right)
4. Check that the Dismiss Feedback event is sent

Using Flipper or another tool, remove the analytics hub status from the preferences

<img width="1225" alt="Screenshot 2023-03-08 at 00 38 10" src="https://user-images.githubusercontent.com/18119390/223637864-4ed091ea-4859-47e0-be77-70dd842a0783.png">

TC2
1. On MyStore Screen, press the See more button in the stats view
2. Check that the feedback request banner is shown
3. Tap on the share feedback button
4. Check that the Send Feedback event is sent