### PR TITLE
Unit test analytic hub track events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -151,7 +151,7 @@ class AnalyticsHubViewModel @Inject constructor(
 
     fun onDateRangeSelectorClick() {
         onTrackableUIInteraction()
-        AnalyticsTracker.track(AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_BUTTON_TAPPED)
+        tracker.track(AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_BUTTON_TAPPED)
         triggerEvent(AnalyticsViewEvent.OpenDateRangeSelector)
     }
 
@@ -346,7 +346,7 @@ class AnalyticsHubViewModel @Inject constructor(
 
     private fun trackSelectedDateRange() {
         onTrackableUIInteraction()
-        AnalyticsTracker.track(
+        tracker.track(
             AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_SELECTED,
             mapOf(AnalyticsTracker.KEY_OPTION to ranges.selectionType.tracksIdentifier)
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.ui.analytics.hub.sync.ProductsState
 import com.woocommerce.android.ui.analytics.hub.sync.RevenueState
 import com.woocommerce.android.ui.analytics.hub.sync.SessionState
 import com.woocommerce.android.ui.analytics.hub.sync.UpdateAnalyticsHubStats
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.CUSTOM
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.LAST_YEAR
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.TODAY
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.WEEK_TO_DATE
@@ -55,6 +56,7 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Calendar
+import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 import kotlin.test.assertEquals
@@ -602,6 +604,44 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
             )
         )
+    }
+
+    @Test
+    fun `when a new range selection is selected, then the new selection is tracked`() = testBlocking {
+        configureSuccessfulStatsResponse()
+        sut = givenAViewModel()
+
+        sut.onNewRangeSelection(WEEK_TO_DATE)
+
+        verify(tracker).track(
+            AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_SELECTED,
+            mapOf(AnalyticsTracker.KEY_OPTION to WEEK_TO_DATE.tracksIdentifier)
+        )
+    }
+
+    @Test
+    fun `when a custom range selection is selected, then the custom range selection is tracked`() = testBlocking {
+        configureSuccessfulStatsResponse()
+        sut = givenAViewModel()
+        val startDate = Date()
+        val endDate = Date()
+
+        sut.onCustomRangeSelected(startDate, endDate)
+
+        verify(tracker).track(
+            AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_SELECTED,
+            mapOf(AnalyticsTracker.KEY_OPTION to CUSTOM.tracksIdentifier)
+        )
+    }
+
+    @Test
+    fun `when the range selection control is pressed, then register a track event`() = testBlocking {
+        configureSuccessfulStatsResponse()
+        sut = givenAViewModel()
+
+        sut.onDateRangeSelectorClick()
+
+        verify(tracker).track(AnalyticsEvent.ANALYTICS_HUB_DATE_RANGE_BUTTON_TAPPED)
     }
 
     private fun givenAResourceProvider(): ResourceProvider = mock {


### PR DESCRIPTION
### Why
Because most of our decisions are based on measurements about analytics events (the success of a project, if we want to spend more time working on a feature, etc.), it makes sense to carefully check that track events are sent successfully.

### Description
This small PR takes advantage of the changes implemented for the analytics hub feedback banner to add unit tests to the events we were already tracking on the Analytics Hub Screen. With that goal,  it favors the use of the `AnalyticsTrackerWrapper` over the `AnalyticsTracker`

### Testing instructions
Checking that unit tests pass should be enough 🤔