### PR TITLE
Talkback list content description

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/listcard/AnalyticsHubListCardItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/listcard/AnalyticsHubListCardItemView.kt
@@ -10,6 +10,7 @@ import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsListCardItemViewBinding
 import com.woocommerce.android.di.GlideApp
+import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.util.PhotonUtils
 
 class AnalyticsHubListCardItemView @JvmOverloads constructor(
@@ -28,11 +29,28 @@ class AnalyticsHubListCardItemView @JvmOverloads constructor(
         binding.analyticsCardListItemDescription.text = viewState.description
         binding.divider.isVisible = viewState.showDivider == true
 
+        contentDescription = getViewContentDescription(
+            context = context,
+            title = viewState.title,
+            description = viewState.description,
+            value = viewState.value
+        )
+
         GlideApp
             .with(binding.root.context)
             .load(PhotonUtils.getPhotonImageUrl(viewState.imageUri, imageSize, imageSize))
             .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
             .placeholder(R.drawable.ic_product)
             .into(binding.analyticsCardListItemImage)
+    }
+
+    private fun getViewContentDescription(context: Context, title: String, description: String, value: String): String {
+        val items = StringUtils.getQuantityString(
+            context = context,
+            quantity = value.toIntOrNull() ?: 1,
+            one = R.string.analytics_item,
+            default = R.string.analytics_items
+        )
+        return context.getString(R.string.analytics_list_item_products_sold, title, description, value, items)
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -433,6 +433,9 @@
     <string name="analytics_session_card_title">Sessions</string>
     <string name="analytics_conversion_subtitle">Conversion Rate</string>
     <string name="analytics_visitors_subtitle">Visitors</string>
+    <string name="analytics_item">item</string>
+    <string name="analytics_items">items</string>
+    <string name="analytics_list_item_products_sold">%1$s, %2$s, %3$s, %4$s sold</string>
 
     <!--
         Order List View


### PR DESCRIPTION
Partially closes: #8130

### Description
This PR enhances the content description for the sold items list on the analytics hub screen. 

### Testing instructions
1. Enable Talkback on the device settings
2. Go to the app and open the MyStrore screen
3. Tap on the See more button in the store stats section
4. Tap on different sold items and check that the content description mentions the number of sold items
5. Check that the description is correct for one or multiple items (1 _item_ sold, 3 _items_ sold, for example)

### Images/gif
<img width="300" src="https://user-images.githubusercontent.com/18119390/223847554-a94acd1d-a39e-48a2-87c7-306229ba3e91.png" />


