### PR TITLE
Issue/8514 restore rest api tag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -184,7 +184,7 @@ class ZendeskHelper(
      * This function will enable push notifications for Zendesk. Both a Zendesk identity and a valid push
      * notification device token is required. If either doesn't exist, the request will simply be ignored.
      */
-    fun enablePushNotifications() {
+    private fun enablePushNotifications() {
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -10,6 +10,8 @@ import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.extensions.logInformation
 import com.woocommerce.android.extensions.stateLogInformation
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooLog
@@ -125,6 +127,12 @@ class ZendeskHelper(
             zendeskNeedsToBeEnabledError
         }
 
+        val siteConnectionTag = if (selectedSite?.connectionType == SiteConnectionType.ApplicationPasswords) {
+            ZendeskTags.applicationPasswordAuthenticated
+        } else null
+
+        val tags = (ticketType.tags + extraTags + siteConnectionTag).filterNotNull()
+
         val requestCallback = object : ZendeskCallback<Request>() {
             override fun onSuccess(result: Request?) {
                 trySend(Result.success(result))
@@ -140,7 +148,7 @@ class ZendeskHelper(
             this.ticketFormId = ticketType.form
             this.subject = subject
             this.description = description
-            this.tags = buildZendeskTags(siteStore.sites, origin, ticketType.tags + extraTags)
+            this.tags = buildZendeskTags(siteStore.sites, origin, tags)
                 .filter { ticketType.excludedTags.contains(it).not() }
             this.customFields = buildZendeskCustomFields(context, ticketType, siteStore.sites, selectedSite)
         }.let { request -> requestProvider?.createRequest(request, requestCallback) }
@@ -511,6 +519,7 @@ private object TicketFieldIds {
 }
 
 object ZendeskTags {
+    const val applicationPasswordAuthenticated = "application_password_authenticated"
     const val mobileApp = "mobile_app"
     const val woocommerceCore = "woocommerce_core"
     const val paymentsProduct = "woocommerce_payments"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8514 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
In the commit b2aaebcc30c7986406a3e3f1c1d1a9e3aaf6bd56, the logic of adding the tag `application_password_authenticated` when the current site uses Application Passwords was accidentally removed, this PR restores it.
We need this tag to be present in all kinds of tickets, so I added it directly in ZendeskHelper (same as before).

### Testing instructions
1. Open the app then sign in using site credentials (use a non-Jetpack site to trigger the flow).
2. Open support screen.
3. Create a test ticket.
4. Check the ticket in Zendesk and confirm it has the tag `application_password_authenticated`.

<img width="381" alt="Screen Shot 2023-03-09 at 08 40 02" src="https://user-images.githubusercontent.com/1657201/223953289-be131bb5-ad65-4f66-8501-68597067f256.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
