### PR TITLE
[Mobile Payments] Missing datewords on error message

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+12.8
+-----
+- [*] [Internal] Fix the wording for the cases when we don't have due date on stripe pending requirements state for IPP [https://github.com/woocommerce/woocommerce-android/pull/8516]
+
 12.7
 -----
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -412,7 +412,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
         Locale("", countryCode.orEmpty()).displayName
 
     private fun formatDueDate(state: StripeAccountPendingRequirement) =
-        state.dueDate?.let { Date(it * UNIX_TO_JAVA_TIMESTAMP_OFFSET).formatToMMMMdd() } ?: ""
+        state.dueDate?.let { Date(it * UNIX_TO_JAVA_TIMESTAMP_OFFSET).formatToMMMMdd() }
 
     sealed class OnboardingEvent : Event() {
         object NavigateToSupport : Event()
@@ -619,13 +619,15 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 override val onContactSupportActionClicked: () -> Unit,
                 override val onLearnMoreActionClicked: () -> Unit,
                 override val onButtonActionClicked: () -> Unit,
-                val dueDate: String
+                val dueDate: String?
             ) : StripeAcountError(
                 headerLabel = UiString
                     .UiStringRes(R.string.card_reader_onboarding_account_pending_requirements_header),
-                hintLabel = UiString.UiStringRes(
+                hintLabel = if (dueDate != null) UiString.UiStringRes(
                     R.string.card_reader_onboarding_account_pending_requirements_hint,
                     listOf(UiString.UiStringText(dueDate))
+                ) else UiString.UiStringRes(
+                    R.string.card_reader_onboarding_account_pending_requirements_without_date_hint,
                 ),
                 buttonLabel = UiString.UiStringRes(R.string.skip)
             )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1405,6 +1405,7 @@
 
     <string name="card_reader_onboarding_account_pending_requirements_header">Your account has pending requirements</string>
     <string name="card_reader_onboarding_account_pending_requirements_hint">There are pending requirements in your account. Please complete those requirements by %1$s to keep accepting In-Person Payments.</string>
+    <string name="card_reader_onboarding_account_pending_requirements_without_date_hint">There are pending requirements in your account. Please complete those requirements to keep accepting In-Person Payments.</string>
     <string name="card_reader_onboarding_account_pending_requirements_dismiss_button" translatable="false">@string/dismiss</string>
 
     <string name="card_reader_onboarding_wcpay_in_test_mode_with_live_account_header">In-Person Payments is currently unavailable</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -1908,12 +1908,12 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when account pending requirements, then due date not empty`() =
+    fun `given due date is not given, when account pending requirements, then due date is null`() =
         testBlocking {
             whenever(onboardingChecker.getOnboardingState())
                 .thenReturn(
                     StripeAccountPendingRequirement(
-                        0L,
+                        null,
                         WOOCOMMERCE_PAYMENTS,
                         pluginVersion,
                         countryCode
@@ -1924,7 +1924,54 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             assertThat(
                 (viewModel.viewStateData.value as StripeAcountError.StripeAccountPendingRequirementsState).dueDate
-            ).isNotEmpty()
+            ).isNull()
+        }
+
+    @Test
+    fun `given due date is not given, when account pending requirements, then string used without date`() =
+        testBlocking {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(
+                    StripeAccountPendingRequirement(
+                        null,
+                        WOOCOMMERCE_PAYMENTS,
+                        pluginVersion,
+                        countryCode
+                    )
+                )
+
+            val viewModel = createVM()
+
+            assertThat(
+                (viewModel.viewStateData.value as StripeAcountError.StripeAccountPendingRequirementsState).hintLabel
+            ).isEqualTo(UiString.UiStringRes(
+                R.string.card_reader_onboarding_account_pending_requirements_without_date_hint)
+            )
+        }
+
+    @Test
+    fun `given due date is given, when account pending requirements, then string used with date`() =
+        testBlocking {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(
+                    StripeAccountPendingRequirement(
+                        1L,
+                        WOOCOMMERCE_PAYMENTS,
+                        pluginVersion,
+                        countryCode,
+                    )
+                )
+
+            val viewModel = createVM()
+
+            assertThat(
+                (viewModel.viewStateData.value as StripeAcountError.StripeAccountPendingRequirementsState).hintLabel
+            ).isEqualTo(
+                UiString.UiStringRes(
+                    R.string.card_reader_onboarding_account_pending_requirements_hint,
+                    listOf(UiString.UiStringText("January 01"))
+                )
+            )
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -1944,8 +1944,10 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             assertThat(
                 (viewModel.viewStateData.value as StripeAcountError.StripeAccountPendingRequirementsState).hintLabel
-            ).isEqualTo(UiString.UiStringRes(
-                R.string.card_reader_onboarding_account_pending_requirements_without_date_hint)
+            ).isEqualTo(
+                UiString.UiStringRes(
+                    R.string.card_reader_onboarding_account_pending_requirements_without_date_hint
+                )
             )
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8383
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Use another string when we don't receive "dueDate" on pending requirements response

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Have a site with pending requirements
* Run onboarding
* If backend returns no due date then notice a new string `There are pending requirements in your account. Please complete those requirements to keep accepting In-Person Payments.` (@jostnes please test that, I have no site like that)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
