### PR TITLE
Feature/8425 launch store error handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.LogLevel.e
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ToastUtils
 
@@ -55,6 +56,7 @@ class LaunchStoreFragment : BaseFragment() {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is UpgradeToEcommercePlan -> openInWebView(event.url)
                 is ShareStoreUrl -> shareStoreUrl(event.url)
+                is ShowDialog -> event.showDialog()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
@@ -73,7 +73,7 @@ class LaunchStoreViewModel @Inject constructor(
                 }
             }
         }
-        _viewState.value = _viewState.value.copy(isLoading = true)
+        _viewState.value = _viewState.value.copy(isLoading = false)
     }
 
     fun onUpgradePlanBannerClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
@@ -2,11 +2,17 @@ package com.woocommerce.android.ui.login.storecreation.onboarding.launchstore
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isCurrentPlanEcommerceTrial
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.Error
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.LaunchStoreError.ALREADY_LAUNCHED
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.LaunchStoreError.GENERIC_ERROR
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.Success
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,9 +49,28 @@ class LaunchStoreViewModel @Inject constructor(
         _viewState.value = _viewState.value.copy(isLoading = true)
         launch {
             val result = launchStoreOnboardingRepository.launchStore()
-            when {
-                result.isFailure -> TODO()
-                result.isSuccess -> _viewState.value = _viewState.value.copy(isStoreLaunched = true)
+            when (result) {
+                Success -> _viewState.value = _viewState.value.copy(isStoreLaunched = true)
+                is Error -> {
+                    when (result.type) {
+                        ALREADY_LAUNCHED -> triggerEvent(
+                            ShowDialog(
+                                titleId = R.string.store_onboarding_store_already_launched_error_title,
+                                messageId = R.string.store_onboarding_store_already_launched_error_description,
+                                positiveButtonId = R.string.link_dialog_button_ok
+                            )
+                        )
+                        GENERIC_ERROR -> triggerEvent(
+                            ShowDialog(
+                                titleId = R.string.store_onboarding_launch_store_generic_error_title,
+                                messageId = R.string.store_onboarding_launch_store_generic_error_description,
+                                positiveButtonId = R.string.try_again,
+                                positiveBtnAction = { _, _ -> launchStore() },
+                                negativeButtonId = R.string.cancel
+                            )
+                        )
+                    }
+                }
             }
         }
         _viewState.value = _viewState.value.copy(isLoading = true)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3143,6 +3143,10 @@
     <string name="store_onboarding_launched_title">Your store is live!</string>
     <string name="store_onboarding_launch_store_task_private_tag">Private</string>
     <string name="store_onboarding_share_url_error">Unable to share store url</string>
+    <string name="store_onboarding_store_already_launched_error_title">Could not launch your store</string>
+    <string name="store_onboarding_store_already_launched_error_description">We found that the store has already launched.</string>
+    <string name="store_onboarding_launch_store_generic_error_title">Unexpected error</string>
+    <string name="store_onboarding_launch_store_generic_error_description">Oops, some unexpected errors happened.</string>
 
     <!--
     Support Request


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Do not merge until `trunk` is the base branch. Merge this PR first #8507

Part of: #8425 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Adds error handling for launch store request. The agreed design was to consider these 2 errors: 
![Screenshot 2023-03-10 at 15 23 27](https://user-images.githubusercontent.com/2663464/224340503-32fc762e-5a69-4cc5-96bc-3363a339fba1.png)

Additional context can be found in Figma: VyLr7LvKodHE4kINfBE7Lw-fi-2617%3A92748

### Testing instructions
- The easiest way to test this is to go `StoreOnboardingRepository` -> `launchStore()` and force the return error types. Although it is very likely you can reproduce "Already launched error" without changing the code. Any site created through store creation flow prior to[ this fix ](https://github.com/woocommerce/woocommerce-android/pull/8448) merged last week, will appear as pending to be launched when in reality is already launched. So this scenario is probably easy to reproduce. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

Generic error:

<img width="300"  src="https://user-images.githubusercontent.com/2663464/224346283-3e1dee83-1636-4942-bd12-3f46a57327a2.png"> 

Already launched error: 

<img width="300"  src="https://user-images.githubusercontent.com/2663464/224345865-de00f3e1-7a58-4c62-a803-48de144607e5.png">