### PR TITLE
Order onboarding tasks according to mobile designs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -21,6 +21,7 @@ class StoreOnboardingRepository @Inject constructor(
             }
             else -> result.model?.map { it.toOnboardingTask() }
                 ?.filter { it.type != MOBILE_UNSUPPORTED }
+                ?.sortedBy { it.type.order }
                 ?: emptyList()
         }
     }
@@ -40,12 +41,12 @@ class StoreOnboardingRepository @Inject constructor(
         val isVisited: Boolean,
     )
 
-    enum class OnboardingTaskType(val id: String) {
-        ABOUT_YOUR_STORE("store_details"),
-        ADD_FIRST_PRODUCT("products"),
-        LAUNCH_YOUR_STORE("launch_site"),
-        CUSTOMIZE_DOMAIN("add_domain"),
-        WC_PAYMENTS("woocommerce-payments"),
-        MOBILE_UNSUPPORTED("mobile-unsupported")
+    enum class OnboardingTaskType(val id: String, val order: Int) {
+        ABOUT_YOUR_STORE(id = "store_details", order = 1),
+        ADD_FIRST_PRODUCT(id = "products", order = 2),
+        LAUNCH_YOUR_STORE(id = "launch_site", order = 3),
+        CUSTOMIZE_DOMAIN(id = "add_domain", order = 4),
+        WC_PAYMENTS(id = "woocommerce-payments", order = 5),
+        MOBILE_UNSUPPORTED(id = "mobile-unsupported", order = -1)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description

Small task to display the onboarding tasks fetched from the API in the order defined by the mobile designs and not the order fetched from the API: 


<img width="300"  src="https://user-images.githubusercontent.com/2663464/224322247-8c13552a-5fe0-4f63-b1ab-e736a21a07b5.png"> 


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Just open the app and check the onboarding tasks are displayed in the right order. Use the screenshot from Figma for reference.


