### PR TITLE
[TTP] Save if TTP payment method was selected at least once

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -611,4 +611,16 @@ class AppPrefsTest {
             )
         ).isFalse
     }
+
+    @Test
+    fun givenTTPWasUseAtLeastOnceNeverInvokeThenIsTTPWasUsedAtLeastOnceReturnsFalse() {
+        assertThat(AppPrefs.isTTPWasUsedAtLeastOnce()).isFalse
+    }
+
+    @Test
+    fun givenTTPWasUseAtLeastOnceInvokedThenIsTTPWasUsedAtLeastOnceReturnsTrue() {
+        AppPrefs.setTTPWasUsedAtLeastOnce()
+
+        assertThat(AppPrefs.isTTPWasUsedAtLeastOnce()).isTrue
+    }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -618,7 +618,7 @@ class AppPrefsTest {
     }
 
     @Test
-    fun givenTTPWasUseAtLeastOnceInvokedThenIsTTPWasUsedAtLeastOnceReturnsTrue() {
+    fun givenTTPWasUsedAtLeastOnceInvokedThenIsTTPWasUsedAtLeastOnceReturnsTrue() {
         AppPrefs.setTTPWasUsedAtLeastOnce()
 
         assertThat(AppPrefs.isTTPWasUsedAtLeastOnce()).isTrue

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -613,7 +613,7 @@ class AppPrefsTest {
     }
 
     @Test
-    fun givenTTPWasUseAtLeastOnceNeverInvokeThenIsTTPWasUsedAtLeastOnceReturnsFalse() {
+    fun givenTTPWasUsedAtLeastOnceNeverInvokedThenIsTTPWasUsedAtLeastOnceReturnsFalse() {
         assertThat(AppPrefs.isTTPWasUsedAtLeastOnce()).isFalse
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -174,6 +174,9 @@ object AppPrefs {
 
         // Was the IPP feedback survey banner dismissed forever
         IPP_FEEDBACK_SURVEY_BANNER_DISMISSED_FOREVER,
+
+        // Was the Tap To Pay used at least once
+        TTP_WAS_USED_AT_LEAST_ONCE,
     }
 
     fun init(context: Context) {
@@ -926,6 +929,13 @@ object AppPrefs {
 
     fun setIPPFeedbackBannerDismissedForever(dismissedForever: Boolean) {
         setBoolean(UndeletablePrefKey.IPP_FEEDBACK_SURVEY_BANNER_DISMISSED_FOREVER, dismissedForever)
+    }
+
+    fun isTTPWasUsedAtLeastOnce() =
+        getBoolean(UndeletablePrefKey.TTP_WAS_USED_AT_LEAST_ONCE, false)
+
+    fun setTTPWasUsedAtLeastOnce() {
+        setBoolean(UndeletablePrefKey.TTP_WAS_USED_AT_LEAST_ONCE, true)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModel.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -75,6 +76,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private val cardReaderTracker: CardReaderTracker,
     private val wooStore: WooCommerceStore,
     private val isTapToPayAvailable: IsTapToPayAvailable,
+    private val appPrefs: AppPrefs = AppPrefs,
     @Named("select-payment") private val selectPaymentUtmProvider: UtmProvider,
 ) : ScopedViewModel(savedState) {
     private val navArgs: SelectPaymentMethodFragmentArgs by savedState.navArgs()
@@ -271,6 +273,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
     }
 
     fun onTapToPayClicked() {
+        appPrefs.setTTPWasUsedAtLeastOnce()
         triggerEvent(NavigateToCardReaderPaymentFlow(cardReaderPaymentFlowParam, BUILT_IN))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailable.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailable.kt
@@ -19,7 +19,7 @@ class IsTapToPayAvailable @Inject constructor(
             !isTapToPayEnabled() -> Result.NotAvailable.TapToPayDisabled
             !systemVersionUtilsWrapper.isAtLeastP() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
-//            !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
+            !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
             !isTppSupportedInCountry(countryCode) -> Result.NotAvailable.CountryNotSupported
             else -> Result.Available
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailable.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailable.kt
@@ -19,7 +19,7 @@ class IsTapToPayAvailable @Inject constructor(
             !isTapToPayEnabled() -> Result.NotAvailable.TapToPayDisabled
             !systemVersionUtilsWrapper.isAtLeastP() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
-            !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
+//            !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
             !isTppSupportedInCountry(countryCode) -> Result.NotAvailable.CountryNotSupported
             else -> Result.Available
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -107,6 +108,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         on { getStoreCountryCode(site) }.thenReturn(COUNTRY_CODE)
     }
     private val isTapToPayAvailable: IsTapToPayAvailable = mock()
+    private val appPrefs: AppPrefs = mock()
 
     @Test
     fun `given hub flow, when view model init, then navigate to hub flow emitted`() = testBlocking {
@@ -406,6 +408,19 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                     CardReaderType.BUILT_IN
                 )
             )
+        }
+
+    @Test
+    fun `when on tap too pay clicked, then app prefs stores ttp was used`() =
+        testBlocking {
+            // GIVEN
+            val viewModel = initViewModel(Payment(1L, SIMPLE))
+
+            // WHEN
+            viewModel.onTapToPayClicked()
+
+            // THEN
+            verify(appPrefs).setTTPWasUsedAtLeastOnce()
         }
 
     @Test
@@ -1205,6 +1220,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             cardReaderTracker,
             wooStore,
             isTapToPayAvailable,
+            appPrefs,
             selectPaymentUtmProvider,
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8457 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to ask for feedback only if a user used TTP at least once. The PR adds saving of this fact

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Nothing can be tested here - better to look into tests and verify them

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
