### PR TITLE
Domains: Domain search UI tweaks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/domain/DomainSuggestionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/domain/DomainSuggestionsViewModel.kt
@@ -38,7 +38,8 @@ abstract class DomainSuggestionsViewModel constructor(
     private val currencyFormatter: CurrencyFormatter,
     initialQuery: String,
     private val searchOnlyFreeDomains: Boolean,
-    private val isFreeCreditAvailable: Boolean
+    private val isFreeCreditAvailable: Boolean,
+    private val freeUrl: String? = null
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         const val KEY_IS_FREE_CREDIT_AVAILABLE = "isFreeCreditAvailable"
@@ -70,7 +71,8 @@ abstract class DomainSuggestionsViewModel constructor(
                 selectedDomain,
                 products
             ),
-            selectedDomain = selectedDomain?.name.orEmpty()
+            selectedDomain = selectedDomain?.name.orEmpty(),
+            freeUrl = freeUrl
         )
     }.asLiveData()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/domainpicker/DomainPickerScreen.kt
@@ -94,7 +94,7 @@ private fun DomainSearchForm(
     onDomainQueryChanged: (String) -> Unit,
     onDomainSuggestionSelected: (String) -> Unit,
     onContinueClicked: () -> Unit,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val textHighlightedColor = colorResource(id = R.color.color_on_surface_high)
@@ -107,11 +107,11 @@ private fun DomainSearchForm(
             .padding(dimensionResource(id = R.dimen.major_125)),
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
     ) {
-        Text(
-            text = stringResource(id = string.store_creation_domain_picker_title),
-            style = MaterialTheme.typography.h5,
-        )
         if (state.freeUrl != null) {
+            Text(
+                text = stringResource(id = string.domains_search_domains),
+                style = MaterialTheme.typography.h5,
+            )
             val redirectNotice = stringResource(id = string.domains_redirect_notice)
             Text(
                 text = buildAnnotatedString {
@@ -129,6 +129,10 @@ private fun DomainSearchForm(
                 color = colorResource(id = R.color.color_on_surface_medium)
             )
         } else {
+            Text(
+                text = stringResource(id = string.store_creation_domain_picker_title),
+                style = MaterialTheme.typography.h5,
+            )
             Text(
                 text = stringResource(id = R.string.store_creation_domain_picker_subtitle),
                 style = MaterialTheme.typography.subtitle1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainDashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainDashboardFragment.kt
@@ -49,7 +49,8 @@ class DomainDashboardFragment : BaseFragment() {
                 is ShowMoreAboutDomains -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is NavigateToDomainSearch -> findNavController().navigate(
                     DomainDashboardFragmentDirections.actionDomainDashboardFragmentToDomainSearchFragment(
-                        isFreeCreditAvailable = event.hasFreeCredits
+                        isFreeCreditAvailable = event.hasFreeCredits,
+                        freeDomainUrl = event.freeUrl
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainDashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainDashboardViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
 import javax.inject.Inject
 
 @HiltViewModel
@@ -37,6 +38,7 @@ class DomainDashboardViewModel @Inject constructor(
     }
 
     private var hasFreeCredits = false
+    private lateinit var freeDomain: Domain
 
     private val _viewState = MutableStateFlow<ViewState>(LoadingState)
     val viewState = _viewState.asLiveData()
@@ -77,7 +79,7 @@ class DomainDashboardViewModel @Inject constructor(
         if (domainsResult.isFailure) {
             _viewState.update { ErrorState() }
         } else {
-            val freeDomain = domainsResult.getOrThrow().first { it.wpcomDomain }
+            freeDomain = domainsResult.getOrThrow().first { it.wpcomDomain }
             val paidDomains = domainsResult.getOrNull()
                 ?.filter { !it.wpcomDomain && it.domain != null } ?: emptyList()
             _viewState.update {
@@ -108,7 +110,7 @@ class DomainDashboardViewModel @Inject constructor(
     }
 
     fun onFindDomainButtonTapped() {
-        triggerEvent(NavigateToDomainSearch(hasFreeCredits))
+        triggerEvent(NavigateToDomainSearch(hasFreeCredits, freeDomain.domain))
     }
 
     fun onLearnMoreButtonTapped() {
@@ -138,6 +140,6 @@ class DomainDashboardViewModel @Inject constructor(
         }
     }
 
-    data class NavigateToDomainSearch(val hasFreeCredits: Boolean) : MultiLiveEvent.Event()
+    data class NavigateToDomainSearch(val hasFreeCredits: Boolean, val freeUrl: String?) : MultiLiveEvent.Event()
     data class ShowMoreAboutDomains(val url: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainSearchViewModel.kt
@@ -38,8 +38,12 @@ class DomainSearchViewModel @Inject constructor(
     currencyFormatter = currencyFormatter,
     initialQuery = selectedSite.get().getTitle(""),
     searchOnlyFreeDomains = false,
-    isFreeCreditAvailable = savedStateHandle[KEY_IS_FREE_CREDIT_AVAILABLE]!!
+    isFreeCreditAvailable = savedStateHandle[KEY_IS_FREE_CREDIT_AVAILABLE]!!,
+    freeUrl = savedStateHandle[KEY_FREE_DOMAIN_URL]
 ) {
+    companion object {
+        const val KEY_FREE_DOMAIN_URL = "freeDomainUrl"
+    }
     override val helpOrigin = HelpOrigin.DOMAIN_CHANGE
 
     private val navArgs: DomainSearchFragmentArgs by savedStateHandle.navArgs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainSearchViewModel.kt
@@ -5,8 +5,10 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.getTitle
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.domain.DomainSuggestionsRepository
 import com.woocommerce.android.ui.common.domain.DomainSuggestionsRepository.DomainSuggestion
 import com.woocommerce.android.ui.common.domain.DomainSuggestionsRepository.DomainSuggestion.Paid
@@ -26,6 +28,7 @@ class DomainSearchViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     domainSuggestionsRepository: DomainSuggestionsRepository,
     currencyFormatter: CurrencyFormatter,
+    selectedSite: SelectedSite,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val domainChangeRepository: DomainChangeRepository
@@ -33,7 +36,7 @@ class DomainSearchViewModel @Inject constructor(
     savedStateHandle = savedStateHandle,
     domainSuggestionsRepository = domainSuggestionsRepository,
     currencyFormatter = currencyFormatter,
-    initialQuery = "",
+    initialQuery = selectedSite.get().getTitle(""),
     searchOnlyFreeDomains = false,
     isFreeCreditAvailable = savedStateHandle[KEY_IS_FREE_CREDIT_AVAILABLE]!!
 ) {

--- a/WooCommerce/src/main/res/navigation/nav_graph_domain_change.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_domain_change.xml
@@ -25,6 +25,10 @@
         <action
             android:id="@+id/action_domainSearchFragment_to_domainRegistrationCheckoutFragment"
             app:destination="@id/domainRegistrationCheckoutFragment" />
+        <argument
+            android:name="freeDomainUrl"
+            app:argType="string"
+            app:nullable="true" />
     </fragment>
     <fragment
         android:id="@+id/purchaseSuccessfulFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -554,6 +554,7 @@
     <string name="domains_your_domains">Your site domains</string>
     <string name="domains_add_domain_button_title">Add a domain</string>
     <string name="domains_select_domain">Select domain</string>
+    <string name="domains_search_domains">Search domains</string>
     <string name="domains_redirect_notice">The domain purchased will redirect users to</string>
     <string name="domains_generic_error_title">Unable to load site domains</string>
     <string name="domains_access_error_title">Only store administrators can access domain settings</string>


### PR DESCRIPTION
This PR fixes some minor issues in the domain search screen that were found during the beta testing:

- The domain search field was not prefilled with the domain title
- There was a different title and description above the search bar (domain registration shows a redirection to the free URL notice)

| Store creation | Domain registration |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1522856/224843074-39775c18-e8ba-499e-a3e4-935adce6bc70.png) | ![image](https://user-images.githubusercontent.com/1522856/224843123-30570453-5788-4bd0-bc4f-c6e569693fd9.png) | 

**To test:**
1. Start the store creation flow
2. Go through the steps until you get to the domain search screen
3. Notice the title says "Choose a domain" and has a description saying the domain can be changed later
4. Leave the flow and go to Settings -> Domains (make sure you're logged in as a site administrator)
5. Tap on add domain button
6. Notice the domain search bar is prefilled with the site title
7. Notice the screen title says "Search domains" and there is a redirection notice to the correct free URL