### PR TITLE
Issue/8551 zendesk tag login issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -120,6 +120,7 @@ class LoginActivity :
         private const val FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword"
         private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect"
         private const val JETPACK_CONNECTED_REDIRECT_URL = "woocommerce://jetpack-connected"
+        private const val APPLICATION_PASSWORD_LOGIN_ZENDESK_TAG = "application_password_login_error"
 
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
         private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
@@ -568,11 +569,11 @@ class LoginActivity :
         // TODO: Support self-signed SSL sites and show dialog (only needed when XML-RPC support is added)
     }
 
-    private fun viewHelpAndSupport(origin: HelpOrigin) {
+    private fun viewHelpAndSupport(origin: HelpOrigin, extraTags: ArrayList<String>? = null) {
         val flow = unifiedLoginTracker.getFlow()
         val step = unifiedLoginTracker.previousStepBeforeHelpStep
 
-        startActivity(HelpActivity.createIntent(this, origin, null, flow?.value, step?.value))
+        startActivity(HelpActivity.createIntent(this, origin, extraTags, flow?.value, step?.value))
     }
 
     override fun helpSiteAddress(url: String?) {
@@ -635,7 +636,10 @@ class LoginActivity :
     }
 
     override fun helpUsernamePassword(url: String?, username: String?, isWpcom: Boolean) {
-        viewHelpAndSupport(HelpOrigin.LOGIN_USERNAME_PASSWORD)
+        val extraSupportTags = if (!isWpcom) {
+            arrayListOf(APPLICATION_PASSWORD_LOGIN_ZENDESK_TAG)
+        } else null
+        viewHelpAndSupport(HelpOrigin.LOGIN_USERNAME_PASSWORD, extraTags = extraSupportTags)
     }
 
     override fun helpNoJetpackScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.login.error.ApplicationPasswordsDisabledDialog
 import com.woocommerce.android.ui.login.error.notwoo.LoginNotWooDialogFragment
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.LoggedIn
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowApplicationPasswordsUnavailableScreen
+import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowHelpScreen
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowNonWooErrorScreen
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsViewModel.ShowResetPasswordScreen
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -75,6 +76,7 @@ class LoginSiteCredentialsFragment : Fragment() {
                 is ShowApplicationPasswordsUnavailableScreen ->
                     ApplicationPasswordsDisabledDialogFragment.newInstance(it.siteAddress, it.isJetpackConnected)
                         .show(childFragmentManager, LoginNotWooDialogFragment.TAG)
+                is ShowHelpScreen -> loginListener.helpUsernamePassword(it.siteAddress, it.username, false)
                 is ShowSnackbar -> uiMessageResolver.showSnack(it.message)
                 is ShowUiStringSnackbar -> uiMessageResolver.showSnack(it.message)
                 is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
-import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
@@ -37,7 +37,8 @@ fun LoginSiteCredentialsScreen(viewModel: LoginSiteCredentialsViewModel) {
             onPasswordChanged = viewModel::onPasswordChanged,
             onContinueClick = viewModel::onContinueClick,
             onResetPasswordClick = viewModel::onResetPasswordClick,
-            onBackClick = viewModel::onBackClick
+            onBackClick = viewModel::onBackClick,
+            onHelpButtonClick = viewModel::onHelpButtonClick
         )
     }
 }
@@ -49,13 +50,15 @@ fun LoginSiteCredentialsScreen(
     onPasswordChanged: (String) -> Unit,
     onContinueClick: () -> Unit,
     onResetPasswordClick: () -> Unit,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onHelpButtonClick: () -> Unit
 ) {
     Scaffold(
         topBar = {
-            Toolbar(
+            ToolbarWithHelpButton(
                 title = stringResource(id = R.string.log_in),
-                onNavigationButtonClick = onBackClick
+                onNavigationButtonClick = onBackClick,
+                onHelpButtonClick = onHelpButtonClick
             )
         }
     ) { paddingValues ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -189,6 +189,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                             errorDescription = exception.message
                         )
                     }
+
                     else -> {
                         val wooError = (exception as? WooException)?.error
                         trackLoginFailure(
@@ -210,6 +211,12 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     fun onBackClick() {
         triggerEvent(Exit)
+    }
+
+    fun onHelpButtonClick() {
+        state.value?.let {
+            triggerEvent(ShowHelpScreen(siteAddress, it.username))
+        }
     }
 
     fun onWooInstallationAttempted() = launch {
@@ -262,5 +269,10 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     data class ShowApplicationPasswordsUnavailableScreen(
         val siteAddress: String,
         val isJetpackConnected: Boolean
+    ) : MultiLiveEvent.Event()
+
+    data class ShowHelpScreen(
+        val siteAddress: String,
+        val username: String?
     ) : MultiLiveEvent.Event()
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8551 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR is meant to add a Zendesk tag when users face an issue with login using site credentials, but when I started working on it, I noticed the site credentials screen is missing a help button (my fault initially 🤦), so I fixed this too.

Remark: the help button in Compose seems to have a different color than the legacy screens, I didn't want to fix this now.

### Testing instructions
1. Open the app.
2. Enter the address of a non-Jetpack screen.
3. From the site credentials screen, click on the Help button.
4. Create a support ticket.
5. Check the ticket in Zendesk, and confirm the presence of the tag `application_password_login_error`

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
