### PR TITLE
Fix `OrdersUITest` compose test rule

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/ProductSelectorScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/ProductSelectorScreen.kt
@@ -1,40 +1,36 @@
 package com.woocommerce.android.e2e.screens.orders
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
-import com.woocommerce.android.ui.login.LoginActivity
 
 class ProductSelectorScreen : Screen(R.id.product_selector_compose_view) {
     fun assertProductsSelectorScreen(
-        composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<LoginActivity>, LoginActivity>
+        composeTestRule: ComposeContentTestRule
     ): ProductSelectorScreen {
-        val screenTitle =
-            composeTestRule.activity.getString(R.string.coupon_conditions_products_select_products_title)
+        val screenTitle = getTranslatedString(R.string.coupon_conditions_products_select_products_title)
         Espresso.onView(ViewMatchers.withText(screenTitle)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
-        val searchHintText = composeTestRule.activity.getString(R.string.product_selector_search_hint)
-        composeTestRule.onNodeWithText(searchHintText)
-            .assertIsDisplayed()
+        val searchHintText = getTranslatedString(R.string.product_selector_search_hint)
+        composeTestRule.onNodeWithText(searchHintText).assertIsDisplayed()
 
         return this
     }
 
     fun selectProduct(
-        composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<LoginActivity>, LoginActivity>,
+        composeTestRule: ComposeContentTestRule,
         productName: String
     ): UnifiedOrderScreen {
         composeTestRule.onNodeWithText(productName).performClick()
-        val selectButtonText = composeTestRule.activity.getString(R.string.product_selector_select_button_title_one, 1)
-        composeTestRule.onNodeWithText(selectButtonText)
-            .performClick()
+        val selectButtonText = String.format(getTranslatedString(R.string.product_selector_select_button_title_one), 1)
+        composeTestRule.onNodeWithText(selectButtonText).performClick()
+
         return UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -2,7 +2,7 @@
 
 package com.woocommerce.android.e2e.tests.ui
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.e2e.helpers.InitializationRule
@@ -27,7 +27,7 @@ class OrdersUITest : TestBase() {
     val rule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeTestRule = createAndroidComposeRule<LoginActivity>()
+    val composeTestRule = createComposeRule()
 
     @get:Rule(order = 2)
     val initRule = InitializationRule()


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/woocommerce/woocommerce-android/pull/8519#discussion_r1134962650) with compose test rule in `OrdersUITest` discovered by @jostnes.

#### Details
Removed `AndroidComposeTestRule` and replaced with `ComposeContentTestRule`.

#### Testing
UI tests should be passing - both running the whole suite with `./gradlew connectedWasabiDebugAndroidTest` and running the single method `OrdersUITest:: e2eCreateOrderTest` with play button in Android Studio.
