### PR TITLE
Fix cut-off avatar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -242,6 +243,7 @@ private fun MoreMenuUserAvatar(avatarUrl: String) {
     bitmapState.value?.let {
         Image(
             bitmap = it.asImageBitmap(),
+            contentScale = ContentScale.Crop,
             contentDescription = stringResource(id = string.more_menu_avatar),
             modifier = circledModifier
         )


### PR DESCRIPTION
Fixes #8525. This PR crops the avatar image to make it a perfect circle.

![image](https://user-images.githubusercontent.com/1522856/225148122-64e7d4a6-8c62-4f82-bb55-ba0cadc2f487.png)

**To test:**
1. Log in
2. Go to More menu
3. Verify the avatar image is a perfect circle