### PR TITLE
[REST API] Improve login error messages, and tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -49,7 +49,7 @@ class WPApiSiteRepository @Inject constructor(
                         message = "Fetching site $url failed, error: ${result.error.type}, ${result.error.message}"
                     )
 
-                    Result.failure(OnChangedException(result.error))
+                    Result.failure(OnChangedException(result.error, message = result.error.message))
                 }
                 else -> {
                     WooLog.d(WooLog.T.LOGIN, "Site $url fetch succeeded")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -128,7 +128,7 @@ fun LoginSiteCredentialsScreen(
             },
             onDismissRequest = onErrorDialogDismissed,
             buttons = {
-                Row(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))) {
+                Row(modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))) {
                     WCTextButton(onClick = onHelpButtonClick) {
                         Text(text = stringResource(id = R.string.login_site_address_more_help))
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.login.sitecredentials
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,6 +12,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -27,6 +29,7 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.component.getText
 
 @Composable
 fun LoginSiteCredentialsScreen(viewModel: LoginSiteCredentialsViewModel) {
@@ -38,7 +41,8 @@ fun LoginSiteCredentialsScreen(viewModel: LoginSiteCredentialsViewModel) {
             onContinueClick = viewModel::onContinueClick,
             onResetPasswordClick = viewModel::onResetPasswordClick,
             onBackClick = viewModel::onBackClick,
-            onHelpButtonClick = viewModel::onHelpButtonClick
+            onHelpButtonClick = viewModel::onHelpButtonClick,
+            onErrorDialogDismissed = viewModel::onErrorDialogDismissed
         )
     }
 }
@@ -51,7 +55,8 @@ fun LoginSiteCredentialsScreen(
     onContinueClick: () -> Unit,
     onResetPasswordClick: () -> Unit,
     onBackClick: () -> Unit,
-    onHelpButtonClick: () -> Unit
+    onHelpButtonClick: () -> Unit,
+    onErrorDialogDismissed: () -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -84,7 +89,6 @@ fun LoginSiteCredentialsScreen(
                     value = viewState.username,
                     onValueChange = onUsernameChanged,
                     label = stringResource(id = R.string.username),
-                    isError = viewState.errorMessage != null,
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
                 )
@@ -92,8 +96,6 @@ fun LoginSiteCredentialsScreen(
                     value = viewState.password,
                     onValueChange = onPasswordChanged,
                     label = stringResource(id = R.string.password),
-                    isError = viewState.errorMessage != null,
-                    helperText = viewState.errorMessage?.let { stringResource(id = it) },
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
                         onDone = { onContinueClick() }
@@ -117,6 +119,28 @@ fun LoginSiteCredentialsScreen(
             }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
+    }
+
+    if (viewState.errorDialogMessage != null) {
+        AlertDialog(
+            text = {
+                Text(text = viewState.errorDialogMessage.getText())
+            },
+            onDismissRequest = onErrorDialogDismissed,
+            buttons = {
+                Row(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))) {
+                    WCTextButton(onClick = onHelpButtonClick) {
+                        Text(text = stringResource(id = R.string.login_site_address_more_help))
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    WCTextButton(
+                        onClick = onErrorDialogDismissed
+                    ) {
+                        Text(text = stringResource(id = android.R.string.ok))
+                    }
+                }
+            }
+        )
     }
 
     if (viewState.isLoading) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -129,7 +129,12 @@ fun LoginSiteCredentialsScreen(
             onDismissRequest = onErrorDialogDismissed,
             buttons = {
                 Row(modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))) {
-                    WCTextButton(onClick = onHelpButtonClick) {
+                    WCTextButton(
+                        onClick = {
+                            onErrorDialogDismissed()
+                            onHelpButtonClick()
+                        }
+                    ) {
                         Text(text = stringResource(id = R.string.login_site_address_more_help))
                     }
                     Spacer(modifier = Modifier.weight(1f))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -175,7 +175,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                     step = Step.AUTHENTICATION,
                     errorContext = error.javaClass.simpleName,
                     errorType = siteError?.wpApiError?.errorType?.name ?: siteError?.type?.name,
-                    errorDescription = exception.message
+                    errorDescription = exception.message,
+                    statusCode = siteError?.wpApiError?.statusCode
                 )
             }
         )
@@ -249,17 +250,26 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         fetchUserInfo()
     }
 
-    private fun trackLoginFailure(step: Step, errorContext: String?, errorType: String?, errorDescription: String?) {
+    private fun trackLoginFailure(
+        step: Step,
+        errorContext: String?,
+        errorType: String?,
+        errorDescription: String?,
+        statusCode: Int? = null
+    ) {
         loginAnalyticsListener.trackFailure(
             message = errorDescription
         )
 
         analyticsTracker.track(
             LOGIN_SITE_CREDENTIALS_LOGIN_FAILED,
-            mapOf(AnalyticsTracker.KEY_STEP to step.name.lowercase()),
+            mapOf(
+                AnalyticsTracker.KEY_STEP to step.name.lowercase(),
+                AnalyticsTracker.KEY_NETWORK_STATUS_CODE to statusCode?.toString().orEmpty()
+            ),
             errorContext = errorContext,
             errorType = errorType,
-            errorDescription = errorDescription
+            errorDescription = errorDescription,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
-import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -48,7 +47,6 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     private val wpApiSiteRepository: WPApiSiteRepository,
     private val selectedSite: SelectedSite,
     private val loginAnalyticsListener: LoginAnalyticsListener,
-    private val resourceProvider: ResourceProvider,
     applicationPasswordsNotifier: ApplicationPasswordsNotifier,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val appPrefs: AppPrefsWrapper

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -346,8 +346,8 @@
     <string name="login_jetpack_installation_continue_magic_link">Or continue using Magic Link</string>
     <string name="login_jetpack_installation_magic_link_failure">An error occurred while fetching your website, please retry!</string>
     <string name="login_site_credentials_invalid_response">Login failed with an unexpected response from your site. We are working on fixing this issue.</string>
-    <string name="login_site_credentials_custom_login_url">Login failed because the access to wp-login.php page on your site is blocked.</string>
-    <string name="login_site_credentials_custom_admin_url">Login failed because the access to /wp-admin/ page on your site is blocked.</string>
+    <string name="login_site_credentials_custom_login_url">Unable to login because we cannot identify your store\'s login URL</string>
+    <string name="login_site_credentials_custom_admin_url">Unable to login because we cannot identify your store\'s admin URL</string>
     <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -345,6 +345,10 @@
     <string name="login_jetpack_installation_enter_wpcom_password">Enter the password of your WordPress.com account to install Jetpack</string>
     <string name="login_jetpack_installation_continue_magic_link">Or continue using Magic Link</string>
     <string name="login_jetpack_installation_magic_link_failure">An error occurred while fetching your website, please retry!</string>
+    <string name="login_site_credentials_invalid_response">Login failed with an unexpected response from your site. We are working on fixing this issue.</string>
+    <string name="login_site_credentials_custom_login_url">Login failed because the access to wp-login.php page on your site is blocked.</string>
+    <string name="login_site_credentials_custom_admin_url">Login failed because the access to /wp-admin/ page on your site is blocked.</string>
+    <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>
 
     <!--
         My Store View

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2677-b8e012e8db9165efd9de400850136b52af54ced9'
+    fluxCVersion = '2.19.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.18.0'
+    fluxCVersion = '2677-b8e012e8db9165efd9de400850136b52af54ced9'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8560
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR improves the site credentials error messages, and adds more data to the tracking events.
The work is based on the FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2677.

I updated the login error from being an inline error message to use a dialog, this allows offering the button "need more help" directly like what iOS does.

### Testing instructions
(Copied with some modifications from https://github.com/woocommerce/woocommerce-ios/pull/9125, thanks @itsmeichigo)

##### Custom wp-login.php
1. Install [WP Hide](https://wordpress.org/plugins/wp-hide-security-enhancer/) plugin on your test site.
2. In wp-admin side bar, navigate to WP Hide > Hide Admin.
3. Enter your custom login URL and select Show in "Block default wp-login.php" option and save the changes.
4. On the app, try log in to your test site with any credentials.
5. Notice an alert saying "Login failed because the access to the wp-login.php page on your site is blocked." **(to be updated)**
6. In Logcat notice the event: `Tracked: login_site_credentials_login_failed, Properties: {"error_context":"SiteError","step":"authentication","network_status_code":"404","error_type":"CUSTOM_LOGIN_URL","is_debug":true}`

##### Custom admin URL
Android handles this gracefully now p1678898799819319-slack-C046HDZL87J

##### JavaScript required
1. On the app, try log in to a site with custom javascript on their login page (or try this p1678258552518089/1678174641.255659-slack-C03URUK5C).
2. Enter any random credentials.
3. Notice an error message: "Login failed with an unexpected response from your site. We are working on fixing this issue."
4. In Xcode console: `Tracked: login_site_credentials_login_failed, Properties: {"step":"authentication","error_context":"SiteError","error_description":"","network_status_code":"200",,"error_type":"INVALID_RESPONSE"}`

##### Testing sites with captcha on their wp-login.php page:
(If you want, ping me and I'll provide a site already setup)
1. Install the [Login reCaptcha](https://wordpress.org/plugins/login-recaptcha/) plugin on your test site and configure it.
2. On the app, try log in to your site with any credentials.
3. Notice that login fails with an error message that matches the error text on your login page (e.g: "ERROR : Please check the ReCaptcha box")
4. Notice in Xcode console: `login_site_credentials_login_failed, Properties: {"step":"authentication","network_status_code":"200","error_context":"SiteError","error_description":"ERROR : Please check the ReCaptcha box.","error_type":"NOT_AUTHENTICATED"}`

##### Testing incorrect credentials:
1. Disable all security plugins on your site.
2. Log in to your site with incorrect credentials.
3. Notice that login fails with an error message that matches the error text on your login page (e.g: "Error: The username sdfsdf is not registered on this site. If you are unsure of your username, try your email address instead.")
4. Notice in Xcode console: `Tracked: login_site_credentials_login_failed, Properties: {"step":"authentication","network_status_code":"200","error_context":"SiteError","error_description":"Error: The username demods is not registered on this site. If you are unsure of your username, try your email address instead.","error_type":"NOT_AUTHENTICATED","is_debug":true}`
5. Try again with the correct credentials, you should be logged in successfully.

### Images/gif
<img width=360 src="https://user-images.githubusercontent.com/1657201/225397924-e6e2a684-92cc-4747-9bfc-6e3cf70144fd.png" />

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
