### PR TITLE
Merge release/12.8-rc-1 into trunk (`beta`)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+12.9
+-----
+
+
 12.8
 -----
 - [*][Internal] Do not show full screen input for the payment amount for simple payments flow. [https://github.com/woocommerce/woocommerce-android/pull/8517]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,9 +74,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "12.7"
+            versionName "12.8-rc-1"
         }
-        versionCode 394
+        versionCode 395
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_128"
+msgid ""
+"12.8:\n"
+"This release includes a lot of improvements to the order creation functionality. It's possible to select multiple products at one go & an improved faster search & filter option. We also fixed a few bugs and made several enhancements for accessibility of the Analytics section. Furthermore, WordPress.com users can now easily view the details of their plans by accessing the new 'Upgrades' screen in the Menu.\n"
+msgstr ""
+
 msgctxt "release_note_127"
 msgid ""
 "12.7:\n"
 "This release has several fixes and improvements that makes it easier for you to manage your store from the app. Please continue to send us feedback – we are listening!\n"
-msgstr ""
-
-msgctxt "release_note_126"
-msgid ""
-"12.6:\n"
-"Did you know you can create an order from the app? We made a few improvements to order creation to make your experience smoother. Please keep sending your feedback! We read every one of them!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,7 +1,1 @@
-- [*][Internal] Do not show full screen input for the payment amount for simple payments flow. [https://github.com/woocommerce/woocommerce-android/pull/8517]
-- [*][Internal] Fix the wording for the cases when we don't have due date on stripe pending requirements state for IPP [https://github.com/woocommerce/woocommerce-android/pull/8516]
-- [**] Added product multi-selection in order creation flow [https://github.com/woocommerce/woocommerce-android/pull/8557]
-- [*] Improved product selector component to allow filtering out redundant products [https://github.com/woocommerce/woocommerce-android/pull/8557]
-- [**] Added local search feature in the products selector component (available in orders creation and coupon edition flows) [https://github.com/woocommerce/woocommerce-android/pull/8391]
-- [*] Analytics Hub: Improved Accessibility
-
+This release includes a lot of improvements to the order creation functionality. It's possible to select multiple products at one go & an improved faster search & filter option. We also fixed a few bugs and made several enhancements for accessibility of the Analytics section. Furthermore, WordPress.com users can now easily view the details of their plans by accessing the new 'Upgrades' screen in the Menu.

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,7 @@
-This release has several fixes and improvements that makes it easier for you to manage your store from the app. Please continue to send us feedback – we are listening!
+- [*][Internal] Do not show full screen input for the payment amount for simple payments flow. [https://github.com/woocommerce/woocommerce-android/pull/8517]
+- [*][Internal] Fix the wording for the cases when we don't have due date on stripe pending requirements state for IPP [https://github.com/woocommerce/woocommerce-android/pull/8516]
+- [**] Added product multi-selection in order creation flow [https://github.com/woocommerce/woocommerce-android/pull/8557]
+- [*] Improved product selector component to allow filtering out redundant products [https://github.com/woocommerce/woocommerce-android/pull/8557]
+- [**] Added local search feature in the products selector component (available in orders creation and coupon edition flows) [https://github.com/woocommerce/woocommerce-android/pull/8391]
+- [*] Analytics Hub: Improved Accessibility
+

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="refunds">Refunds</string>
     <string name="domain">Domain</string>
     <string name="domains">Domains</string>
+    <string name="something_went_wrong_try_again">Something went wrong, Please try again later.</string>
     <string name="shipping_labels">Shipping Labels</string>
     <string name="product_variations">Variations</string>
     <string name="product_variation_options">%1$s (%2$s options)</string>
@@ -102,6 +103,7 @@
     <string name="more_menu_button_store">View Store</string>
     <string name="more_menu_button_coupons">Coupons</string>
     <string name="more_menu_button_reviews">Reviews</string>
+    <string name="more_menu_button_upgrades">Upgrades</string>
     <string name="more_menu_avatar">User profile picture</string>
     <string name="version_with_name_param">Version %s</string>
     <string name="share_store_button">Share your store</string>
@@ -345,6 +347,10 @@
     <string name="login_jetpack_installation_enter_wpcom_password">Enter the password of your WordPress.com account to install Jetpack</string>
     <string name="login_jetpack_installation_continue_magic_link">Or continue using Magic Link</string>
     <string name="login_jetpack_installation_magic_link_failure">An error occurred while fetching your website, please retry!</string>
+    <string name="login_site_credentials_invalid_response">Login failed with an unexpected response from your site. We are working on fixing this issue.</string>
+    <string name="login_site_credentials_custom_login_url">Unable to login because we cannot identify your store\'s login URL</string>
+    <string name="login_site_credentials_custom_admin_url">Unable to login because we cannot identify your store\'s admin URL</string>
+    <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>
 
     <!--
         My Store View
@@ -508,7 +514,7 @@
     <string name="order_creation_add_customer">Add customer details</string>
     <string name="order_creation_add_customer_note">Add note</string>
     <string name="order_creation_products">Products</string>
-    <string name="order_creation_add_products">Add product</string>
+    <string name="order_creation_add_products">Add products</string>
     <string name="order_creation_add_fee">Add fee</string>
     <string name="order_creation_customer_details">Customer details</string>
     <string name="order_creation_product_stock_quantity">%s in stock</string>
@@ -554,6 +560,7 @@
     <string name="domains_your_domains">Your site domains</string>
     <string name="domains_add_domain_button_title">Add a domain</string>
     <string name="domains_select_domain">Select domain</string>
+    <string name="domains_search_domains">Search domains</string>
     <string name="domains_redirect_notice">The domain purchased will redirect users to</string>
     <string name="domains_generic_error_title">Unable to load site domains</string>
     <string name="domains_access_error_title">Only store administrators can access domain settings</string>
@@ -1157,6 +1164,7 @@
     <string name="card_reader_onboarding_with_pending_requirements">There is an issue that requires your attention. Please &lt;a href=\'\'&gt;take a look&lt;/a&gt;</string>
     <string name="card_reader_tap_to_pay">Tap To Pay</string>
     <string name="card_reader_tap_to_pay_description">Use your phone to accept card payments</string>
+    <string name="card_reader_tap_to_pay_not_available_error">Tap to Pay is not available for your store or device</string>
 
     <!--
            Card Reader Tap To Pay Explanation
@@ -1172,8 +1180,6 @@
     <!--
             Card Reader Type Selection
         -->
-    <string name="card_reader_type_selection_title">Select reader type</string>
-    <string name="card_reader_type_selection_description">Your phone can be used as a card reader, or you can connect to an external reader via bluetooth</string>
     <string name="card_reader_type_selection_tap_to_pay">Tap To Pay</string>
     <string name="card_reader_type_selection_bluetooth_reader">Bluetooth Reader</string>
 
@@ -3137,6 +3143,18 @@
     <string name="store_onboarding_full_screen_transition_name">Onboarding full screen</string>
     <string name="store_onboarding_collapsed_transition_name">Onboarding collapsed list</string>
     <string name="store_onboarding_menu_share_feedback">Share feedback</string>
+    <string name="store_onboarding_upgrade_plan_to_launch_store_banner_text">To launch your store, you need to upgrade to our plan. &lt;u&gt;Upgrade&lt;/u&gt;</string>
+    <string name="store_onboarding_launch_store_button">Publish my store</string>
+    <string name="store_onboarding_launch_store_share_url_button">Share URL</string>
+    <string name="store_onboarding_launch_store_back_to_store_button">Back to My Store</string>
+    <string name="store_onboarding_launch_preview_title">Preview</string>
+    <string name="store_onboarding_launched_title">Your store is live!</string>
+    <string name="store_onboarding_launch_store_task_private_tag">Private</string>
+    <string name="store_onboarding_share_url_error">Unable to share store url</string>
+    <string name="store_onboarding_store_already_launched_error_title">Could not launch your store</string>
+    <string name="store_onboarding_store_already_launched_error_description">We found that the store has already launched.</string>
+    <string name="store_onboarding_launch_store_generic_error_title">Unexpected error</string>
+    <string name="store_onboarding_launch_store_generic_error_description">Oops, some unexpected errors happened.</string>
 
     <!--
     Support Request
@@ -3161,4 +3179,26 @@
     <string name="support_request_dialog_action">Got It!</string>
     <string name="support_request_error_title">Something went wrong</string>
     <string name="support_request_error_message">Sorry, we cannot create support requests right now, please try again later.</string>
+
+    <!--
+    Free trial
+    -->
+    <string name="free_trial_your_trial_ended">Your trial has ended.</string>
+    <string name="free_trial_trial_ended">Trial ended</string>
+    <string name="free_trial_days_left">%1$d days left in your trial.</string>
+    <string name="free_trial_upgrade_now">Upgrade Now</string>
+
+    <!--
+    Upgrades
+    -->
+    <string name="upgrades_report_subscription_issue">Report subscription issue</string>
+    <string name="upgrades_upgrade_now">Upgrade now</string>
+    <string name="upgrades_current_plan">Current: %s</string>
+    <string name="upgrades_troubleshooting">Troubleshooting</string>
+    <string name="upgrades_title">Upgrades</string>
+    <string name="upgrades_subscription_status">Subscription status</string>
+    <string name="upgrades_upgradeable_caption">You are in the %1$d-day free trial. The free trial will end in %2$d days. Upgrade to unlock new features and keep your store running..</string>
+    <string name="upgrades_trial_ended_caption">Your free trial has ended and have limited access to all the features. Subscribe to %1$s now.</string>
+    <string name="upgrades_non_upgradeable_caption">You are a %1$s subscriber! You have access to all our features until %2$s. </string>
+    <string name="upgrades_error_fetching_data">Error while fetching plan details</string>
 </resources>


### PR DESCRIPTION
- [ ] `build.gradle` file on `WooCommerce` module updated  with version bump. (13b9ae4156f1278d440b5cd8cced7e4d97411880)
- [ ] `release notes` related files updated. (b0169df59447bfb96d6dc44c62a63e275496ccd8 + bc902e459c5c7a3aa8d6836e6fdce06c24e624f9 + f3e87b241cc8f0cbb46b4399ed4c2a18e88b3db1 + 3f71243220682911768308bb60982589a840f0f2)
- [ ] `new strings` frozen/copied into `fastlane/resources/values/strings.xml`. (dc760845986d04f8e4908a17fa6b48076d46a025)
- [ ] `12.8-rc-1` WCAndroid beta submitted to Google for review (`Full rollout`).