### PR TITLE
Onboarding: Domain change task

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingFragment.kt
@@ -67,6 +67,11 @@ class StoreOnboardingFragment : BaseFragment() {
                     findNavController().navigateSafely(
                         directions = StoreOnboardingFragmentDirections.actionOnboardingFragmentToLaunchStoreFragment()
                     )
+                is StoreOnboardingViewModel.NavigateToDomains ->
+                    findNavController().navigateSafely(
+                        directions = StoreOnboardingFragmentDirections
+                            .actionStoreOnboardingFragmentToNavGraphDomainChange()
+                    )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -82,7 +82,7 @@ class StoreOnboardingViewModel @Inject constructor(
         when (task.taskUiResources) {
             AboutYourStoreTaskRes -> WooLog.d(ONBOARDING, "TODO")
             AddProductTaskRes -> WooLog.d(ONBOARDING, "TODO")
-            CustomizeDomainTaskRes -> WooLog.d(ONBOARDING, "TODO")
+            CustomizeDomainTaskRes -> triggerEvent(NavigateToDomains)
             LaunchStoreTaskRes -> triggerEvent(NavigateToLaunchStore)
             SetupPaymentsTaskRes -> WooLog.d(ONBOARDING, "TODO")
         }
@@ -138,4 +138,5 @@ class StoreOnboardingViewModel @Inject constructor(
     object NavigateToOnboardingFullScreen : MultiLiveEvent.Event()
     object NavigateToSurvey : MultiLiveEvent.Event()
     object NavigateToLaunchStore : MultiLiveEvent.Event()
+    object NavigateToDomains : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -234,6 +234,10 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                     findNavController().navigateSafely(
                         directions = MyStoreFragmentDirections.actionMyStoreToLaunchStoreFragment()
                     )
+                is StoreOnboardingViewModel.NavigateToDomains ->
+                    findNavController().navigateSafely(
+                        directions = MyStoreFragmentDirections.actionDashboardToNavGraphDomainChange()
+                    )
             }
         }
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -39,6 +39,9 @@
         <action
             android:id="@+id/action_myStore_to_launchStoreFragment"
             app:destination="@id/launchStoreFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_nav_graph_domain_change"
+            app:destination="@id/nav_graph_domain_change" />
     </fragment>
     <fragment
         android:id="@+id/orders"
@@ -440,10 +443,14 @@
         <action
             android:id="@+id/action_onboardingFragment_to_launchStoreFragment"
             app:destination="@id/launchStoreFragment" />
+        <action
+            android:id="@+id/action_storeOnboardingFragment_to_nav_graph_domain_change"
+            app:destination="@id/nav_graph_domain_change" />
     </fragment>
     <fragment
         android:id="@+id/launchStoreFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.onboarding.launchstore.LaunchStoreFragment"
         android:label="LaunchStoreFragment" />
+    <include app:graph="@navigation/nav_graph_domain_change" />
 
 </navigation>


### PR DESCRIPTION
Fixes #8583. 

This PR implements the domain change onboarding task click handler and it adds the navigation from the task list to the domain change screen.

<img src="https://user-images.githubusercontent.com/1522856/226045732-69036a59-d850-40e3-9a54-4b26341a043e.png" width="300" />

**To test:**
1. Select (an atomic) site that has not completed the domains task list (make sure you are an admin)
2. Go to the dashboard tab
3. If the "Customize your domain" task is visible, tap on it (otherwise skip to step 6)
4. Verify the domains screen is opened
5. Go back to the dashboard 
6. Tap on the View all button under the tasks
7. Tap on the "Customize your domain" task
8. Verify the domains screen is opened