### PR TITLE
[FIX] Clear preferences before each test to make them order independent

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -14,6 +14,7 @@ class AppPrefsTest {
     @Before
     fun setup() {
         AppPrefs.init(InstrumentationRegistry.getInstrumentation().targetContext.applicationContext)
+        AppPrefs.getPreferences().edit().clear().commit()
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As was noticed [here](https://github.com/woocommerce/woocommerce-android/pull/8575#issuecomment-1473672398) `AppPrefsTest` is dependent on the order of how the tests are run. Here I clean the state so it will be independent

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
No changes aside from tests

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
