### PR TITLE
[REST API] Align native site credentials login with latest FluxC changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.JetpackActivationSiteCredentialsViewState
@@ -117,7 +118,7 @@ fun JetpackActivationSiteCredentialsScreen(
                     onValueChange = onPasswordChanged,
                     label = stringResource(id = R.string.password),
                     isError = viewState.errorMessage != null,
-                    helperText = viewState.errorMessage?.let { stringResource(id = it) },
+                    helperText = viewState.errorMessage?.getText(),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
                         onDone = { onContinueClick() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -83,7 +83,7 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         _viewState.update { it.copy(isLoading = true) }
 
         val state = _viewState.value
-        wpApiSiteRepository.login(
+        wpApiSiteRepository.loginAndFetchSite(
             url = navArgs.siteUrl,
             username = state.username,
             password = state.password

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -50,7 +50,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     private val applicationPasswordsUnavailableEvents = MutableSharedFlow<WPAPINetworkError>(extraBufferCapacity = 1)
 
     private val wpApiSiteRepository: WPApiSiteRepository = mock {
-        onBlocking { login(eq(siteAddress), any(), any()) } doReturn Result.success(testSite)
+        onBlocking { loginAndFetchSite(eq(siteAddress), any(), any()) } doReturn Result.success(testSite)
         onBlocking { checkIfUserIsEligible(testSite) } doReturn Result.success(true)
         onBlocking { getSiteByLocalId(testSite.id) } doReturn testSite
     }
@@ -147,7 +147,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     fun `given incorrect credentials, when submitting, then show error`() = testBlocking {
         val returnedErrorMessage = "Username or password incorrect"
         setup {
-            whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword)).thenReturn(
+            whenever(wpApiSiteRepository.loginAndFetchSite(siteAddress, testUsername, testPassword)).thenReturn(
                 Result.failure(
                     OnChangedException(
                         SiteError(
@@ -181,7 +181,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     @Test
     fun `given site without Woo, when submitting, then show error screen`() = testBlocking {
         setup {
-            whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
+            whenever(wpApiSiteRepository.loginAndFetchSite(siteAddress, testUsername, testPassword))
                 .thenReturn(Result.success(testSite.apply { hasWooCommerce = false }))
         }
 
@@ -230,7 +230,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             viewModel.onWooInstallationAttempted()
         }
 
-        verify(wpApiSiteRepository).login(any(), any(), any())
+        verify(wpApiSiteRepository).loginAndFetchSite(any(), any(), any())
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2683-4d430b3217d45362b8957c8b9d6a2156a0abe4bf'
+    fluxCVersion = 'trunk-83435c76ecae2de474c01a10e61ae2564a62b913'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.19.0'
+    fluxCVersion = '2683-4d430b3217d45362b8957c8b9d6a2156a0abe4bf'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8598 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
In https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2683, we update the WP API login flow to separate the authentication from the site fetching.
This PR updates the client logic to align with this change. 

### Testing instructions
Repeat steps from #8562 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
