### PR TITLE
Shipping Labels: Require phone number for origin address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -10,7 +10,7 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
         val address: Address,
         val type: AddressType,
         val validationResult: ValidationResult?,
-        val requiresPhoneNumber: Boolean
+        val isCustomsFormRequired: Boolean
     ) : CreateShippingLabelEvent()
 
     data class ShowSuggestedAddress(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -206,7 +206,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                             address = event.address,
                             addressType = event.type,
                             validationResult = event.validationResult,
-                            requiresPhoneNumber = event.requiresPhoneNumber
+                            isCustomsFormRequired = event.isCustomsFormRequired
                         )
                     findNavController().navigateSafely(action)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -181,7 +181,7 @@ class CreateShippingLabelViewModel @Inject constructor(
                                 sideEffect.address,
                                 sideEffect.type,
                                 sideEffect.validationResult,
-                                sideEffect.requiresPhoneNumber
+                                sideEffect.isCustomsFormRequired
                             )
                         )
                         is SideEffect.ShowAddressSuggestion -> triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -100,7 +100,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 val result = addressValidator.validateAddress(
                     address,
                     arguments.addressType,
-                    arguments.requiresPhoneNumber
+                    arguments.isCustomsFormRequired
                 )
                 handleValidationResult(address, result)
                 viewState = viewState.copy(isValidationProgressDialogVisible = false)
@@ -341,7 +341,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
             companyField = OptionalField(content = args.address.company),
             address1Field = Address1Field(args.address.address1),
             address2Field = OptionalField(args.address.address2),
-            phoneField = PhoneField(args.address.phone, args.requiresPhoneNumber, args.addressType),
+            phoneField = PhoneField(args.address.phone, args.isCustomsFormRequired, args.addressType),
             cityField = RequiredField(args.address.city),
             zipField = RequiredField(args.address.postcode),
             stateField = LocationField(args.address.state.asLocation()),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
@@ -137,14 +137,20 @@ class ShippingLabelAddressValidator @Inject constructor(
 }
 
 /**
- * Checks whether the phone number is valid or not, depending on the [addressType], the check is:
- * - [ORIGIN]: Checks whether the phone number contains 10 digits exactly after deleting an optional 1 as
- *             the area code.
- * - [DESTINATION]: Checks whether the phone has any digits.
+ * Checks whether the phone number is valid or not, depending on the [addressType] and [isCustomsFormRequired].
+ * The logic of the check is:
+ * - [ORIGIN]:
+ *    - If a customs form is required, then checks whether the phone number contains 10 digits exactly after deleting
+ *      an optional 1 as the area code.
+ *      As EasyPost is permissive for the presence of other characters, we delete all other characters before checking,
+ *      and that's similar to what the web client does.
+ *      Source: https://github.com/Automattic/woocommerce-services/issues/1351
+ *    - If no customs form is required, then checks whether the phone number is not blank.
+ *      Check ticket for discussion on why https://github.com/woocommerce/woocommerce-android/issues/8578
  *
- * As EasyPost is permissive for the presence of other characters, we delete all other characters before checking,
- * and that's similar to what the web client does.
- * Source: https://github.com/Automattic/woocommerce-services/issues/1351
+ * - [DESTINATION]:
+ *   - If a customs form is required, then checks whether the phone has any digits.
+ *   - If no customs form is required, then the phone number not required, so no validation is needed.
  */
 @Suppress("MagicNumber")
 fun String.isValidPhoneNumber(addressType: AddressType, isCustomsFormRequired: Boolean): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -607,13 +607,13 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         private fun updateForInternationalRequirements(): StepsState {
             val originAddressStep = if (isCustomsFormRequired &&
-                !originAddressStep.data.phone.isValidPhoneNumber(ORIGIN)
+                !originAddressStep.data.phone.isValidPhoneNumber(ORIGIN, isCustomsFormRequired)
             ) {
                 originAddressStep.copy(status = READY)
             } else originAddressStep
 
             val shippingAddressStep = if (isCustomsFormRequired &&
-                !shippingAddressStep.data.phone.isValidPhoneNumber(DESTINATION)
+                !shippingAddressStep.data.phone.isValidPhoneNumber(DESTINATION, isCustomsFormRequired)
             ) {
                 shippingAddressStep.copy(status = READY)
             } else shippingAddressStep

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -178,7 +178,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     SideEffect.OpenAddressEditor(
                         address = data.stepsState.originAddressStep.data,
                         type = ORIGIN,
-                        requiresPhoneNumber = data.isCustomsFormRequired
+                        isCustomsFormRequired = data.isCustomsFormRequired
                     )
                 )
             }
@@ -188,7 +188,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     SideEffect.OpenAddressEditor(
                         address = data.stepsState.shippingAddressStep.data,
                         type = DESTINATION,
-                        requiresPhoneNumber = data.isCustomsFormRequired
+                        isCustomsFormRequired = data.isCustomsFormRequired
                     )
                 )
             }
@@ -244,7 +244,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                         address = data.stepsState.originAddressStep.data,
                         type = ORIGIN,
                         validationResult = event.validationResult,
-                        requiresPhoneNumber = data.isCustomsFormRequired
+                        isCustomsFormRequired = data.isCustomsFormRequired
                     )
                 )
             }
@@ -266,7 +266,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     SideEffect.OpenAddressEditor(
                         address = event.address,
                         type = ORIGIN,
-                        requiresPhoneNumber = data.isCustomsFormRequired
+                        isCustomsFormRequired = data.isCustomsFormRequired
                     )
                 )
             }
@@ -311,7 +311,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                         address = data.stepsState.shippingAddressStep.data,
                         type = DESTINATION,
                         validationResult = event.validationResult,
-                        requiresPhoneNumber = data.isCustomsFormRequired
+                        isCustomsFormRequired = data.isCustomsFormRequired
                     )
                 )
             }
@@ -333,7 +333,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     SideEffect.OpenAddressEditor(
                         address = event.address,
                         type = DESTINATION,
-                        requiresPhoneNumber = data.isCustomsFormRequired
+                        isCustomsFormRequired = data.isCustomsFormRequired
                     )
                 )
             }
@@ -804,7 +804,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
             val address: Address,
             val type: AddressType,
             val validationResult: ValidationResult? = null,
-            val requiresPhoneNumber: Boolean
+            val isCustomsFormRequired: Boolean
         ) : SideEffect()
 
         data class ShowPackageOptions(

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -92,7 +92,7 @@
             app:argType="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator$ValidationResult"
             app:nullable="true" />
         <argument
-            android:name="requiresPhoneNumber"
+            android:name="isCustomsFormRequired"
             app:argType="boolean" />
         <action
             android:id="@+id/action_editShippingLabelAddressFragment_to_shippingLabelAddressSuggestionFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -886,7 +886,7 @@
     <string name="shipping_label_address_suggestion_banner">We have slightly modified the address entered. If correct, please use the suggested address to ensure accurate delivery.</string>
     <string name="shipping_label_address_suggestion_entered_address">Entered address</string>
     <string name="shipping_label_address_suggestion_suggested_address">Suggested address</string>
-    <string name="shipping_label_address_phone_required">A phone number is required because this shipment requires a customs form</string>
+    <string name="shipping_label_address_phone_required">A phone number is required</string>
     <string name="shipping_label_origin_address_phone_invalid">Customs forms require a 10-digit phone number</string>
     <string name="shipping_label_destination_address_phone_invalid">Please enter a valid phone number</string>
     <string name="shipping_label_address_data_invalid_snackbar_message">Certain required fields are blank.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -305,7 +305,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
 
         stateFlow.value = Transition(State.OriginAddressValidation(data), null)
 
-        verify(addressValidator).validateAddress(originAddress, ORIGIN, requiresPhoneNumber = false)
+        verify(addressValidator).validateAddress(originAddress, ORIGIN, isCustomsFormRequired = false)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -88,7 +88,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
             address = address,
             addressType = addressType,
             validationResult = validationResult,
-            requiresPhoneNumber = isPhoneRequired
+            isCustomsFormRequired = isPhoneRequired
         ).initSavedStateHandle()
 
     private lateinit var viewModel: EditShippingLabelAddressViewModel


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8578 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes #8578 by making the phone in the Origin address always required, and to align with the web, the requirements are:
1. If a customs form is required, then a validation to check if the phone has 10 digits will be performed.
2. Otherwise we just need a non-empty value.

Reviewing commit by commit would be easier to follow, the first commit was just for renaming a variable.

cc @ParaskP7

### Testing instructions
1. Make sure your store is ready for shipping label purchase.
2. Open an order eligible for shipping labels, and that has a local address (same country).
4. Confirm the origin address requires entering a phone number.
5. Continue the purchase, and confirm the rates load without issues.

### Images/gif
https://user-images.githubusercontent.com/1657201/226695693-7a8a4d6e-83ef-4c7c-98b6-9a5782da6f64.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
