### PR TITLE
Beta Fix: hide the Jetpack installation for REST API users

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
@@ -56,7 +57,8 @@ class MainSettingsPresenter @Inject constructor(
 
     override fun setupJetpackInstallOption() {
         val supportsJetpackInstallation = selectedSite.connectionType.let {
-            it == SiteConnectionType.JetpackConnectionPackage || it == SiteConnectionType.ApplicationPasswords
+            it == SiteConnectionType.JetpackConnectionPackage ||
+                (FeatureFlag.REST_API_I2.isEnabled() && it == SiteConnectionType.ApplicationPasswords)
         }
         appSettingsFragmentView?.handleJetpackInstallOption(supportsJetpackInstallation = supportsJetpackInstallation)
         jetpackMonitoringJob?.cancel()

--- a/WooCommerce/src/main/res/layout/activity_app_settings.xml
+++ b/WooCommerce/src/main/res/layout/activity_app_settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/main_content"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">


### PR DESCRIPTION
Closes: #8605 Closes: #8606
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR closes the above issues, it adds the following changes:
1. It correctly checks for the FeatureFlag#REST_API_I2 before showing the Jetpack installation in the settings screen.
2. It adds support for using SnackBars using the `uiMessageResolver` in the `AppSettingsActivity`, this was a simple change of the id of the root layout.

cc @ParaskP7 

### Testing instructions
#### TC 1: confirm the FeatureFlag check
1. Checkout this branch, then force the feature flag FeatureFlag#REST_API_I2 to be false.
2. Open the app, then sign in to a non-Jetpack site.
3. Open the settings.
4. Confirm the "Install Jetpack" button is hidden.

#### TC 2: Snackbars in AppSettingsActivity don't crash
1. Make sure FeatureFlag#REST_API_I2 is enabled.
2. Open the app, then sign in to a non-Jetpack site.
3. Open the settings.
4. Click on "Install Jetpack"
5. When reaching the WordPress.com email screen, enable flight mode.
6. Enter an email, then click on Continue.
7. Confirm a SnackBar is shown, and the app doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
