### PR TITLE
Free Trial: Support non free trial expired plan in Subscription view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/domain/CalculatePlanRemainingPeriod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/domain/CalculatePlanRemainingPeriod.kt
@@ -6,7 +6,7 @@ import java.time.Period
 import java.time.ZonedDateTime
 import javax.inject.Inject
 
-class CalculateRemainingTrialPeriod @Inject constructor(
+class CalculatePlanRemainingPeriod @Inject constructor(
     private val selectedSite: SelectedSite
 ) {
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/trial/DetermineTrialStatusBarState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/trial/DetermineTrialStatusBarState.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.plans.trial
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.main.MainActivityViewModel.BottomBarState
-import com.woocommerce.android.ui.plans.domain.CalculateRemainingTrialPeriod
+import com.woocommerce.android.ui.plans.domain.CalculatePlanRemainingPeriod
 import com.woocommerce.android.ui.plans.domain.FreeTrialExpiryDateResult.Error
 import com.woocommerce.android.ui.plans.domain.FreeTrialExpiryDateResult.ExpiryAt
 import com.woocommerce.android.ui.plans.domain.FreeTrialExpiryDateResult.NotTrial
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class DetermineTrialStatusBarState @Inject constructor(
     private val sitePlanRepository: SitePlanRepository,
     private val selectedSite: SelectedSite,
-    private val calculateRemainingTrialPeriod: CalculateRemainingTrialPeriod,
+    private val calculatePlanRemainingPeriod: CalculatePlanRemainingPeriod,
 ) {
 
     operator fun invoke(bottomBarState: Flow<BottomBarState>): Flow<TrialStatusBarState> =
@@ -34,7 +34,7 @@ class DetermineTrialStatusBarState @Inject constructor(
     private suspend fun fetchFreeTrialDetails(): TrialStatusBarState {
         return when (val result = sitePlanRepository.fetchFreeTrialExpiryDate(selectedSite.get())) {
             is ExpiryAt -> {
-                val expireIn = calculateRemainingTrialPeriod(result.date)
+                val expireIn = calculatePlanRemainingPeriod(result.date)
                 TrialStatusBarState.Visible(expireIn.days)
             }
             NotTrial, is Error -> TrialStatusBarState.Hidden

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
@@ -31,9 +31,9 @@ import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.E
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.HasPlan
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Loading
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.NonUpgradeable
+import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.PlanEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialInProgress
-import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Upgradeable
 import java.time.Period
 
 @Composable
@@ -104,7 +104,7 @@ fun UpgradesScreen(
                             style = MaterialTheme.typography.caption,
                             text = when (state) {
                                 Loading, Error -> ""
-                                is Upgradeable -> stringResource(
+                                is PlanEnded -> stringResource(
                                     R.string.upgrades_current_plan_ended_caption,
                                     state.name
                                 )
@@ -196,7 +196,7 @@ private fun NonUpgradeable() {
 @Composable
 private fun Upgradeable() {
     WooThemeWithBackground {
-        UpgradesScreen(state = Upgradeable("eCommerce ended"), {}, {})
+        UpgradesScreen(state = PlanEnded("eCommerce ended"), {}, {})
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.L
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.NonUpgradeable
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialInProgress
+import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Upgradeable
 import java.time.Period
 
 @Composable
@@ -103,6 +104,11 @@ fun UpgradesScreen(
                             style = MaterialTheme.typography.caption,
                             text = when (state) {
                                 Loading, Error -> ""
+                                is Upgradeable -> stringResource(
+                                    R.string.upgrades_current_plan_ended_caption,
+                                    state.name,
+                                    state.currentPlanEndDate
+                                )
                                 is NonUpgradeable -> stringResource(
                                     R.string.upgrades_non_upgradeable_caption,
                                     state.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
@@ -106,8 +106,7 @@ fun UpgradesScreen(
                                 Loading, Error -> ""
                                 is Upgradeable -> stringResource(
                                     R.string.upgrades_current_plan_ended_caption,
-                                    state.name,
-                                    state.currentPlanEndDate
+                                    state.name
                                 )
                                 is NonUpgradeable -> stringResource(
                                     R.string.upgrades_non_upgradeable_caption,
@@ -188,6 +187,16 @@ private fun NonUpgradeable() {
             NonUpgradeable("eCommerce", "March 2, 2023"),
             {}, {}
         )
+    }
+}
+
+@Preview(name = "Light mode")
+@Preview(name = "RTL mode", locale = "ar")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun Upgradeable() {
+    WooThemeWithBackground {
+        UpgradesScreen(state = Upgradeable("eCommerce ended"), {}, {})
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
@@ -194,7 +194,7 @@ private fun NonUpgradeable() {
 @Preview(name = "RTL mode", locale = "ar")
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-private fun Upgradeable() {
+private fun PlanEnded() {
     WooThemeWithBackground {
         UpgradesScreen(state = PlanEnded("eCommerce ended"), {}, {})
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
@@ -99,8 +99,7 @@ class UpgradesViewModel @Inject constructor(
         sitePlan.mapAsViewState(
             isExpired = {
                 Upgradeable(
-                    name = prettifiedName,
-                    currentPlanEndDate = expirationDate.toLocalDate().formatStyleFull(),
+                    name = resourceProvider.getString(R.string.upgrades_plan_ended_name, prettifiedName)
                 )
             },
             isNotExpired = {
@@ -130,9 +129,9 @@ class UpgradesViewModel @Inject constructor(
             }
         )
 
-    private fun SitePlan.mapAsViewState(
-        isNotExpired: SitePlan.(Period) -> UpgradesViewState.HasPlan,
-        isExpired: SitePlan.() -> UpgradesViewState.HasPlan
+    private inline fun SitePlan.mapAsViewState(
+        crossinline isNotExpired: SitePlan.(Period) -> UpgradesViewState.HasPlan,
+        crossinline isExpired: SitePlan.() -> UpgradesViewState.HasPlan
     ): UpgradesViewState.HasPlan {
         val daysUntilExpiration = calculatePlanRemainingPeriod(expirationDate)
         return when {
@@ -166,8 +165,7 @@ class UpgradesViewModel @Inject constructor(
         ) : HasPlan
 
         data class Upgradeable(
-            override val name: String,
-            val currentPlanEndDate: String,
+            override val name: String
         ) : HasPlan
 
         data class NonUpgradeable(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
@@ -140,6 +140,11 @@ class UpgradesViewModel @Inject constructor(
             val daysLeftInFreeTrial: String
         ) : HasPlan
 
+        data class Upgradeable(
+            override val name: String,
+            val currentPlanEndDate: String,
+        ) : HasPlan
+
         data class NonUpgradeable(
             override val name: String,
             val currentPlanEndDate: String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.zendesk.ZendeskTags
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.plans.domain.CalculateRemainingTrialPeriod
+import com.woocommerce.android.ui.plans.domain.CalculatePlanRemainingPeriod
 import com.woocommerce.android.ui.plans.domain.FREE_TRIAL_PERIOD
 import com.woocommerce.android.ui.plans.domain.FREE_TRIAL_UPGRADE_PLAN
 import com.woocommerce.android.ui.plans.domain.SitePlan
@@ -38,7 +38,7 @@ class UpgradesViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val selectedSite: SelectedSite,
     private val planRepository: SitePlanRepository,
-    private val calculateRemainingTrialPeriod: CalculateRemainingTrialPeriod,
+    private val calculatePlanRemainingPeriod: CalculatePlanRemainingPeriod,
     private val resourceProvider: ResourceProvider,
     private val tracks: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedState) {
@@ -115,9 +115,9 @@ class UpgradesViewModel @Inject constructor(
         isNotExpired: () -> UpgradesViewState,
         isExpired: () -> UpgradesViewState
     ) {
-        val remainingTrialPeriod = calculateRemainingTrialPeriod(expirationDate)
+        val daysUntilExpiration = calculatePlanRemainingPeriod(expirationDate)
         when {
-            remainingTrialPeriod.isZero || remainingTrialPeriod.isNegative -> isExpired()
+            daysUntilExpiration.isZero || daysUntilExpiration.isNegative -> isExpired()
             else -> isNotExpired()
         }
     }
@@ -132,7 +132,7 @@ class UpgradesViewModel @Inject constructor(
         }
 
     private fun SitePlan.createFreeTrialViewState(): UpgradesViewState.HasPlan {
-        val remainingTrialPeriod = calculateRemainingTrialPeriod(expirationDate)
+        val remainingTrialPeriod = calculatePlanRemainingPeriod(expirationDate)
         return if (remainingTrialPeriod.isZero || remainingTrialPeriod.isNegative) {
             TrialEnded(
                 name = resourceProvider.getString(R.string.free_trial_trial_ended)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
@@ -24,9 +24,9 @@ import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesEvent.OpenS
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Error
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Loading
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.NonUpgradeable
+import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.PlanEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialInProgress
-import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.PlanEnded
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
@@ -26,7 +26,7 @@ import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.L
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.NonUpgradeable
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialInProgress
-import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Upgradeable
+import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.PlanEnded
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -98,9 +98,7 @@ class UpgradesViewModel @Inject constructor(
     private fun createOtherPlansViewStateFrom(sitePlan: SitePlan) =
         sitePlan.mapAsViewState(
             isExpired = {
-                Upgradeable(
-                    name = resourceProvider.getString(R.string.upgrades_plan_ended_name, prettifiedName)
-                )
+                PlanEnded(name = resourceProvider.getString(R.string.upgrades_plan_ended_name, prettifiedName))
             },
             isNotExpired = {
                 NonUpgradeable(
@@ -164,7 +162,7 @@ class UpgradesViewModel @Inject constructor(
             val daysLeftInFreeTrial: String
         ) : HasPlan
 
-        data class Upgradeable(
+        data class PlanEnded(
             override val name: String
         ) : HasPlan
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3205,4 +3205,5 @@
     <string name="upgrades_non_upgradeable_caption">You are a %1$s subscriber! You have access to all our features until %2$s. </string>
     <string name="upgrades_current_plan_ended_caption">Your subscription has ended and you have limited access to all the features.</string>
     <string name="upgrades_error_fetching_data">Error while fetching plan details</string>
+    <string name="upgrades_plan_ended_name">%s ended</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3203,5 +3203,6 @@
     <string name="upgrades_upgradeable_caption">You are in the %1$d-day free trial. The free trial will end in %2$s. Upgrade to unlock new features and keep your store running.</string>
     <string name="upgrades_trial_ended_caption">Your free trial has ended and have limited access to all the features. Subscribe to %1$s now.</string>
     <string name="upgrades_non_upgradeable_caption">You are a %1$s subscriber! You have access to all our features until %2$s. </string>
+    <string name="upgrades_current_plan_ended_caption">Your subscription has ended and you have limited access to all the features.</string>
     <string name="upgrades_error_fetching_data">Error while fetching plan details</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3203,7 +3203,7 @@
     <string name="upgrades_upgradeable_caption">You are in the %1$d-day free trial. The free trial will end in %2$s. Upgrade to unlock new features and keep your store running.</string>
     <string name="upgrades_trial_ended_caption">Your free trial has ended and have limited access to all the features. Subscribe to %1$s now.</string>
     <string name="upgrades_non_upgradeable_caption">You are a %1$s subscriber! You have access to all our features until %2$s. </string>
-    <string name="upgrades_current_plan_ended_caption">Your subscription has ended and you have limited access to all the features.</string>
+    <string name="upgrades_current_plan_ended_caption">Your subscription has ended, and you have limited access to all the features.</string>
     <string name="upgrades_error_fetching_data">Error while fetching plan details</string>
     <string name="upgrades_plan_ended_name">%s ended</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.extensions.formatStyleFull
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.zendesk.ZendeskTags
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.plans.domain.CalculateRemainingTrialPeriod
+import com.woocommerce.android.ui.plans.domain.CalculatePlanRemainingPeriod
 import com.woocommerce.android.ui.plans.domain.FREE_TRIAL_PERIOD
 import com.woocommerce.android.ui.plans.domain.FREE_TRIAL_PLAN_ID
 import com.woocommerce.android.ui.plans.domain.SitePlan
@@ -40,7 +40,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
     lateinit var sut: UpgradesViewModel
     lateinit var selectedSite: SelectedSite
     lateinit var planRepository: SitePlanRepository
-    lateinit var remainingTrialPeriodUseCase: CalculateRemainingTrialPeriod
+    lateinit var remainingTrialPeriodUseCase: CalculatePlanRemainingPeriod
     var resourceProvider: ResourceProvider = mock()
     var tracks: AnalyticsTrackerWrapper = mock()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
@@ -17,9 +17,9 @@ import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesEvent
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Error
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.NonUpgradeable
+import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.PlanEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialInProgress
-import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Upgradeable
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -176,7 +176,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
             // Then
             assertThat(viewModelState).isNotNull
             assertThat(viewModelState).isEqualTo(
-                Upgradeable(
+                PlanEnded(
                     name = "$TEST_SITE_NAME ended",
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.E
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.NonUpgradeable
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialEnded
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.TrialInProgress
+import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesViewState.Upgradeable
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -132,7 +133,31 @@ class UpgradesViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when SitePlan is NOT free trial, then state is set to NonUpgradeable`() =
+    fun `when SitePlan is NOT free trial with remaining days, then state is set to NonUpgradeable`() =
+        testBlocking {
+            // Given
+            createSut(
+                type = SitePlan.Type.OTHER,
+                remainingTrialPeriod = Period.ofDays(1)
+            )
+            var viewModelState: UpgradesViewState? = null
+            sut.upgradesState.observeForever {
+                viewModelState = it
+            }
+
+            // Then
+            assertThat(viewModelState).isNotNull
+            assertThat(viewModelState).isEqualTo(
+                NonUpgradeable(
+                    name = FREE_TRIAL_TEST_SITE_NAME,
+                    currentPlanEndDate = SITE_PLAN_EXPIRATION_DATE
+                        .toLocalDate().formatStyleFull()
+                )
+            )
+        }
+
+    @Test
+    fun `when SitePlan is NOT free trial WITHOUT remaining days, then state is set to NonUpgradeable`() =
         testBlocking {
             // Given
             createSut(
@@ -147,7 +172,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
             // Then
             assertThat(viewModelState).isNotNull
             assertThat(viewModelState).isEqualTo(
-                NonUpgradeable(
+                Upgradeable(
                     name = FREE_TRIAL_TEST_SITE_NAME,
                     currentPlanEndDate = SITE_PLAN_EXPIRATION_DATE
                         .toLocalDate().formatStyleFull()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
@@ -72,7 +72,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
             assertThat(viewModelState).isNotNull
             assertThat(viewModelState).isEqualTo(
                 TrialInProgress(
-                    name = FREE_TRIAL_TEST_SITE_NAME,
+                    name = TEST_SITE_NAME,
                     freeTrialDuration = FREE_TRIAL_PERIOD,
                     daysLeftInFreeTrial = "1 day"
                 )
@@ -100,7 +100,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
             assertThat(viewModelState).isNotNull
             assertThat(viewModelState).isEqualTo(
                 TrialInProgress(
-                    name = FREE_TRIAL_TEST_SITE_NAME,
+                    name = TEST_SITE_NAME,
                     freeTrialDuration = FREE_TRIAL_PERIOD,
                     daysLeftInFreeTrial = "10 days"
                 )
@@ -149,7 +149,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
             assertThat(viewModelState).isNotNull
             assertThat(viewModelState).isEqualTo(
                 NonUpgradeable(
-                    name = FREE_TRIAL_TEST_SITE_NAME,
+                    name = TEST_SITE_NAME,
                     currentPlanEndDate = SITE_PLAN_EXPIRATION_DATE
                         .toLocalDate().formatStyleFull()
                 )
@@ -160,6 +160,10 @@ class UpgradesViewModelTest : BaseUnitTest() {
     fun `when SitePlan is NOT free trial WITHOUT remaining days, then state is set to NonUpgradeable`() =
         testBlocking {
             // Given
+            resourceProvider = mock {
+                on { getString(any(), eq(TEST_SITE_NAME)) } doReturn "$TEST_SITE_NAME ended"
+            }
+
             createSut(
                 type = SitePlan.Type.OTHER,
                 remainingTrialPeriod = Period.ZERO
@@ -173,9 +177,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
             assertThat(viewModelState).isNotNull
             assertThat(viewModelState).isEqualTo(
                 Upgradeable(
-                    name = FREE_TRIAL_TEST_SITE_NAME,
-                    currentPlanEndDate = SITE_PLAN_EXPIRATION_DATE
-                        .toLocalDate().formatStyleFull()
+                    name = "$TEST_SITE_NAME ended",
                 )
             )
         }
@@ -294,7 +296,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
         remainingTrialPeriod: Period = Period.ofDays(10)
     ) {
         val sitePlan = SitePlan(
-            name = "WordPress.com $FREE_TRIAL_TEST_SITE_NAME",
+            name = "WordPress.com $TEST_SITE_NAME",
             expirationDate = SITE_PLAN_EXPIRATION_DATE,
             type = type
         )
@@ -344,7 +346,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
     }
 
     companion object {
-        private const val FREE_TRIAL_TEST_SITE_NAME = "Free Trial site"
+        private const val TEST_SITE_NAME = "Free Trial site"
         private const val TRIAL_ENDED_TEST_SITE_NAME = "Trial ended test site"
         private val SITE_PLAN_EXPIRATION_DATE = ZonedDateTime.now()
     }


### PR DESCRIPTION
Summary
==========
Fix issue #8614 by introducing the scenario to the Subscription view where the Site plan is not a free trial and is upgradeable. 

Screenshots
==========
| iOS  | Android |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5920403/226718647-703efef5-95a1-498f-bc90-e1c1fe59e695.png) | <img width="374" alt="image" src="https://user-images.githubusercontent.com/5920403/226718343-c48bdec2-9e3d-42cf-89d4-7da0d318ced4.png"> |

How to Test
==========
⚠️ Since we don't have any way available right now to acquire a non-free trial site plan that has expired, I recommend hardcoding the scenario in the `SitePlanRepository#fetchCurrentPlanDetails` function response.

1. Go to the menu in the app main bottom bar and select the `Upgrades` section
2. Once inside the Subscription view, verify if the expected view from the screenshot above is presented

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.