### PR TITLE
Only used metadata in product variations model

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetailsMapper.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.model
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import org.wordpress.android.fluxc.model.WCMetaData
+import org.wordpress.android.fluxc.model.WCProductVariationModel.SubscriptionMetadataKeys
 import java.math.BigDecimal
 
 object SubscriptionDetailsMapper {
@@ -12,38 +14,38 @@ object SubscriptionDetailsMapper {
 
         val subscriptionInformation = jsonArray
             .mapNotNull { it as? JsonObject }
-            .filter { jsonObject -> jsonObject[MetadataKeys.KEY].asString in SubscriptionDetailsKeys.Keys }
+            .filter { jsonObject -> jsonObject[WCMetaData.KEY].asString in SubscriptionMetadataKeys.ALL_KEYS }
             .associate { jsonObject ->
-                jsonObject[MetadataKeys.KEY].asString to jsonObject[MetadataKeys.VALUE].asString
+                jsonObject[WCMetaData.KEY].asString to jsonObject[WCMetaData.VALUE].asString
             }
 
         return if (subscriptionInformation.isNotEmpty()) {
-            val price = subscriptionInformation[SubscriptionDetailsKeys.SUBSCRIPTION_PRICE]?.toBigDecimalOrNull()
+            val price = subscriptionInformation[SubscriptionMetadataKeys.SUBSCRIPTION_PRICE]?.toBigDecimalOrNull()
                 ?: BigDecimal.ZERO
 
-            val periodString = subscriptionInformation[SubscriptionDetailsKeys.SUBSCRIPTION_PERIOD] ?: ""
+            val periodString = subscriptionInformation[SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD] ?: ""
             val period = SubscriptionPeriod.fromValue(periodString)
 
             val periodIntervalString =
-                subscriptionInformation[SubscriptionDetailsKeys.SUBSCRIPTION_PERIOD_INTERVAL] ?: ""
+                subscriptionInformation[SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL] ?: ""
             val periodInterval = periodIntervalString.toIntOrNull() ?: 0
 
-            val lengthString = subscriptionInformation[SubscriptionDetailsKeys.SUBSCRIPTION_LENGTH] ?: ""
+            val lengthString = subscriptionInformation[SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH] ?: ""
             val lengthInt = lengthString.toIntOrNull()
             val length = if (lengthInt != null && lengthInt > 0) lengthInt else null
 
             val signUpFee =
-                subscriptionInformation[SubscriptionDetailsKeys.SUBSCRIPTION_SIGN_UP_FEE]?.toBigDecimalOrNull()
+                subscriptionInformation[SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE]?.toBigDecimalOrNull()
 
-            val trialPeriodString = subscriptionInformation[SubscriptionDetailsKeys.SUBSCRIPTION_TRIAL_PERIOD]
+            val trialPeriodString = subscriptionInformation[SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD]
             val trialPeriod = trialPeriodString?.let { SubscriptionPeriod.fromValue(trialPeriodString) }
 
-            val trialLengthString = subscriptionInformation[SubscriptionDetailsKeys.SUBSCRIPTION_TRIAL_LENGTH] ?: ""
+            val trialLengthString = subscriptionInformation[SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH] ?: ""
             val trialLengthInt = trialLengthString.toIntOrNull()
             val trialLength = if (trialLengthInt != null && trialLengthInt > 0) trialLengthInt else null
 
             val oneTimeShipping =
-                subscriptionInformation[SubscriptionDetailsKeys.SUBSCRIPTION_ONE_TIME_SHIPPING] == "yes"
+                subscriptionInformation[SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING] == "yes"
 
             SubscriptionDetails(
                 price = price,
@@ -57,31 +59,4 @@ object SubscriptionDetailsMapper {
             )
         } else null
     }
-}
-
-object MetadataKeys {
-    const val ID = "id"
-    const val KEY = "key"
-    const val VALUE = "value"
-}
-
-object SubscriptionDetailsKeys {
-    const val SUBSCRIPTION_PRICE = "_subscription_price"
-    const val SUBSCRIPTION_PERIOD = "_subscription_period"
-    const val SUBSCRIPTION_PERIOD_INTERVAL = "_subscription_period_interval"
-    const val SUBSCRIPTION_LENGTH = "_subscription_length"
-    const val SUBSCRIPTION_SIGN_UP_FEE = "_subscription_sign_up_fee"
-    const val SUBSCRIPTION_TRIAL_PERIOD = "_subscription_trial_period"
-    const val SUBSCRIPTION_TRIAL_LENGTH = "_subscription_trial_length"
-    const val SUBSCRIPTION_ONE_TIME_SHIPPING = "_subscription_one_time_shipping"
-    val Keys = listOf(
-        SUBSCRIPTION_PRICE,
-        SUBSCRIPTION_TRIAL_LENGTH,
-        SUBSCRIPTION_SIGN_UP_FEE,
-        SUBSCRIPTION_PERIOD,
-        SUBSCRIPTION_PERIOD_INTERVAL,
-        SUBSCRIPTION_LENGTH,
-        SUBSCRIPTION_TRIAL_PERIOD,
-        SUBSCRIPTION_ONE_TIME_SHIPPING
-    )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2684-eb046559185e00a2bcfb39b2ab32b7f975f8e422'
+    fluxCVersion = '2687-bb6100081da6be99e9898bb698f3d9ac574df926'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
⚠️ This PR depends on this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2687)

Closes: #8621 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR uses the new FluxC version that strips all not used metadata values from the Product Variations metadata.

### Testing instructions

1. Open the Product List Screen
2. Tap on a variable subscription product
3. Check that the Variations / Variations attributes cards are shown
4. Tap on the Variations card
5. Check that all Subscription Variations are shown
6. Tap on the different Subscription Variations
7. Check that the subscription card is shown
8. Tap on the subscription card
9. Check that the app navigates to the subscription details screen and that the subscription details are shown

### Images/gif

https://user-images.githubusercontent.com/18119390/226401132-82a112a3-9543-4cc4-a829-58b3476d5a69.mp4

#### Only used metadata is saved in the local database
![dlGBXv.png](https://user-images.githubusercontent.com/18119390/226814343-c25abd91-f566-4009-abec-b47589966353.png)

