### PR TITLE
Refresh onboarding list on My store on resume and on pull to refresh

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding
 
+import com.woocommerce.android.WooException
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.values
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.TaskDto
 import org.wordpress.android.fluxc.store.OnboardingStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -13,20 +15,27 @@ import org.wordpress.android.fluxc.store.SiteStore.LaunchSiteErrorType.ALREADY_L
 import org.wordpress.android.fluxc.store.SiteStore.LaunchSiteErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.LaunchSiteErrorType.UNAUTHORIZED
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class StoreOnboardingRepository @Inject constructor(
     private val onboardingStore: OnboardingStore,
     private val selectedSite: SelectedSite,
     private val siteStore: SiteStore
 ) {
-    suspend fun fetchOnboardingTasks(): List<OnboardingTask> {
+
+    var onboardingTasksCacheFlow: MutableStateFlow<List<OnboardingTask>> = MutableStateFlow(emptyList())
+
+    suspend fun fetchOnboardingTasks(): Result<Unit> {
+        WooLog.d(WooLog.T.ONBOARDING, "Fetching onboarding tasks")
         val result = onboardingStore.fetchOnboardingTasks(selectedSite.get())
         return when {
             result.isError -> {
-                WooLog.i(WooLog.T.ONBOARDING, "TODO ERROR HANDLING fetchOnboardingTasks")
-                emptyList()
+                WooLog.i(WooLog.T.ONBOARDING, "Error fetching onboarding tasks: ${result.error}")
+                Result.failure(WooException(result.error))
             }
             else -> {
+                WooLog.d(WooLog.T.ONBOARDING, "Success fetching onboarding tasks")
                 val mobileSupportedTasks = result.model?.map { it.toOnboardingTask() }
                     ?.filter { it.type != MOBILE_UNSUPPORTED }
                     ?.sortedBy { it.type.order }
@@ -46,8 +55,8 @@ class StoreOnboardingRepository @Inject constructor(
                         )
                     )
                 }
-
-                return mobileSupportedTasks
+                onboardingTasksCacheFlow.emit(mobileSupportedTasks)
+                Result.success(Unit)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -51,9 +51,7 @@ class StoreOnboardingViewModel @Inject constructor(
     }
 
     override fun onResume(owner: LifecycleOwner) {
-        launch {
-            onboardingRepository.fetchOnboardingTasks()
-        }
+        refreshOnboardingList()
     }
 
     private fun mapToOnboardingTaskState(task: OnboardingTask) =
@@ -85,6 +83,16 @@ class StoreOnboardingViewModel @Inject constructor(
             CustomizeDomainTaskRes -> triggerEvent(NavigateToDomains)
             LaunchStoreTaskRes -> triggerEvent(NavigateToLaunchStore)
             SetupPaymentsTaskRes -> WooLog.d(ONBOARDING, "TODO")
+        }
+    }
+
+    fun onPullToRefresh() {
+        refreshOnboardingList()
+    }
+
+    private fun refreshOnboardingList() {
+        launch {
+            onboardingRepository.fetchOnboardingTasks()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.login.storecreation.onboarding
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
@@ -26,7 +28,7 @@ import javax.inject.Inject
 class StoreOnboardingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val onboardingRepository: StoreOnboardingRepository
-) : ScopedViewModel(savedStateHandle) {
+) : ScopedViewModel(savedStateHandle), DefaultLifecycleObserver {
     companion object {
         const val NUMBER_ITEMS_IN_COLLAPSED_MODE = 3
     }
@@ -45,6 +47,12 @@ class StoreOnboardingViewModel @Inject constructor(
                         tasks = tasks.map { mapToOnboardingTaskState(it) },
                     )
                 }
+        }
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        launch {
+            onboardingRepository.fetchOnboardingTasks()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -140,6 +140,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         binding.myStoreRefreshLayout.setOnRefreshListener {
             binding.myStoreRefreshLayout.isRefreshing = false
             myStoreViewModel.onSwipeToRefresh()
+            storeOnboardingViewModel.onPullToRefresh()
             binding.myStoreStats.clearStatsHeaderValues()
             binding.myStoreStats.clearChartData()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -128,6 +128,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         lifecycle.addObserver(myStoreViewModel.performanceObserver)
+        lifecycle.addObserver(storeOnboardingViewModel)
         super.onCreate(savedInstanceState)
     }
 
@@ -404,6 +405,11 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         _tabLayout = null
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun onDestroy() {
+        lifecycle.removeObserver(storeOnboardingViewModel)
+        super.onDestroy()
     }
 
     private fun showStats(revenueStatsModel: RevenueStatsUiModel?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -139,7 +139,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
 
         binding.myStoreRefreshLayout.setOnRefreshListener {
             binding.myStoreRefreshLayout.isRefreshing = false
-            myStoreViewModel.onSwipeToRefresh()
+            myStoreViewModel.onPullToRefresh()
             storeOnboardingViewModel.onPullToRefresh()
             binding.myStoreStats.clearStatsHeaderValues()
             binding.myStoreStats.clearChartData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -271,7 +271,7 @@ class MyStoreViewModel @Inject constructor(
         }
     }
 
-    fun onSwipeToRefresh() {
+    fun onPullToRefresh() {
         fetchJitms()
         usageTracksEventEmitter.interacted()
         analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_PULLED_TO_REFRESH)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -184,7 +184,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             givenNetworkConnectivity(connected = true)
 
-            sut.onSwipeToRefresh()
+            sut.onPullToRefresh()
 
             verify(getStats).invoke(refresh = true, DEFAULT_STATS_GRANULARITY)
             verify(getTopPerformers).fetchTopPerformers(
@@ -200,7 +200,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             givenNetworkConnectivity(connected = true)
 
-            sut.onSwipeToRefresh()
+            sut.onPullToRefresh()
 
             verify(analyticsTrackerWrapper).track(AnalyticsEvent.DASHBOARD_PULLED_TO_REFRESH)
         }
@@ -445,7 +445,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
             whenever(selectedSite.get()).thenReturn(SiteModel())
             whenViewModelIsCreated()
 
-            sut.onSwipeToRefresh()
+            sut.onPullToRefresh()
 
             // called twice, on view model init and on pull to refresh
             verify(jitmStore, times(2)).fetchJitmMessage(any(), any(), any())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8531 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Refresh onboarding list: 
- Whenever MyStore tab is resumed
- On pull to refresh from my store tab

`StoreOnboardingFragment` won't trigger any refreshed. I believe is very corner case that the user completes any task from the web while this screen is opened.

Also, I think we should update navigation so that whenever a task is opened from `StoreOnboardingFragment` we pop this fragment out of the stack and navigate back always to my store screen. Wdyt? Not to be done in this PR though. 

### Testing instructions
- Log into the app with pending tasks on the onboarding list
- Using `wc-admin` complete one of the tasks (add product or get paid tasks are usually the most straight forward ones to complete)
- Pull to refresh from My store tab and check the onboarding list gets updated 
- Complete another task
- Navigate away from My store tab and then navigate back to My store tab and check the list gets updated 
- You can also check the logs to verify that the app fetches fresh data using `WooCommerce-ONBOARDING` tag you should see: 
```
Fetching onboarding tasks
OnboardingStore: fetchOnboardingTasks
Success fetching onboarding tasks
```
