### PR TITLE
[Product Selector] Fix stock status and stock quantity displaying

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 12.9
 -----
-
+- [*] Fixed item's stock status labels on product picker lists [https://github.com/woocommerce/woocommerce-android/pull/8627]
 
 12.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -138,8 +138,12 @@ class ProductSelectorViewModel @Inject constructor(
                 if (productType == VARIABLE) {
                     resourceProvider.getString(string.product_stock_status_instock_with_variations, numVariations)
                 } else {
-                    val quantity = if (stockQuantity.isInteger()) stockQuantity.toInt() else stockQuantity
-                    resourceProvider.getString(string.product_stock_status_instock_quantified, quantity.toString())
+                    if (isStockManaged) {
+                        val quantity = if (stockQuantity.isInteger()) stockQuantity.toInt() else stockQuantity
+                        resourceProvider.getString(string.product_stock_status_instock_quantified, quantity.toString())
+                    } else {
+                        resourceProvider.getString(string.product_stock_status_instock)
+                    }
                 }
             }
             NotAvailable, is Custom -> null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -138,12 +138,7 @@ class ProductSelectorViewModel @Inject constructor(
                 if (productType == VARIABLE) {
                     resourceProvider.getString(string.product_stock_status_instock_with_variations, numVariations)
                 } else {
-                    if (isStockManaged) {
-                        val quantity = if (stockQuantity.isInteger()) stockQuantity.toInt() else stockQuantity
-                        resourceProvider.getString(string.product_stock_status_instock_quantified, quantity.toString())
-                    } else {
-                        resourceProvider.getString(string.product_stock_status_instock)
-                    }
+                    getStockStatusLabel()
                 }
             }
             NotAvailable, is Custom -> null
@@ -165,6 +160,16 @@ class ProductSelectorViewModel @Inject constructor(
             selectedVariationIds = variationIds.intersect(selectedItems.variationIds.toSet()),
             selectionState = getProductSelection()
         )
+    }
+
+    private fun Product.getStockStatusLabel() = if (isStockManaged) {
+        val quantity = if (stockQuantity.isInteger()) stockQuantity.toInt() else stockQuantity
+        resourceProvider.getString(
+            string.product_stock_status_instock_quantified,
+            quantity.toString()
+        )
+    } else {
+        resourceProvider.getString(string.product_stock_status_instock)
     }
 
     fun onClearButtonClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
@@ -98,8 +98,12 @@ class VariationSelectorViewModel @Inject constructor(
     private suspend fun ProductVariation.toUiModel(selectedIds: Set<Long>): VariationListItem {
         val stockStatus = when (stockStatus) {
             InStock -> {
-                val quantity = if (stockQuantity.isInteger()) stockQuantity.toInt() else stockQuantity
-                resourceProvider.getString(string.product_stock_status_instock_quantified, quantity.toString())
+                if (isStockManaged) {
+                    val quantity = if (stockQuantity.isInteger()) stockQuantity.toInt() else stockQuantity
+                    resourceProvider.getString(string.product_stock_status_instock_quantified, quantity.toString())
+                } else {
+                    resourceProvider.getString(string.product_stock_status_instock)
+                }
             }
             NotAvailable, is Custom -> null
             else -> resourceProvider.getString(stockStatus.stringResource)


### PR DESCRIPTION
This PR fixes stock status labels of product & variation items in the ProductSelector component.

<!-- Remember about a good descriptive title. -->

Closes: #8626 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The previous implementation was suitable for the case when the `isStockManaged` property of a product or variation is `true`. However, in case the item was not stock-managed, while its stock status was set to `In stock`, we were displaying the incorrect message: `0 items in stock`.

This PR fixes stock label which is displayed in the case the `isStockManaged` is false while the stock status is `In stock` - both for product and variation items.

### Testing instructions
1. Open product selector component (e.g. Orders > + > + Add products)
2. Verify that products that are stock-managed show labels with stock quantity (e.g. "10 in stock")
3. Verify that products that are **not** stock-managed and have stock status **In stock** show generic stock status - In stock
4. Verify that products with stock status **Out of stock** show correct label - Out of stock

### Images/gif
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20230322-153822](https://user-images.githubusercontent.com/4527432/226940314-eae1dc62-507e-4ff8-9447-83f11ceadecd.png)  | ![Screenshot_20230322-153603](https://user-images.githubusercontent.com/4527432/226940452-4429213b-786e-49f6-ac75-608709fe9e36.png)  |
| ![Screenshot_20230322-153830](https://user-images.githubusercontent.com/4527432/226940694-7292e480-d08f-4114-a022-4ec14641ff22.png)  |  ![Screenshot_20230322-153554](https://user-images.githubusercontent.com/4527432/226940921-e5c8d143-7f17-477f-9ddc-0327e0c0f849.png) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
