### PR TITLE
[Product Selector] Fix selected items state serializing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
@@ -20,7 +20,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
@@ -79,7 +79,7 @@ class CouponRestrictionsFragment : BaseFragment(), BackPressListener {
         handleResult<String>(EmailRestrictionFragment.ALLOWED_EMAILS) {
             viewModel.onAllowedEmailsUpdated(it)
         }
-        handleResult<Set<ProductSelectorViewModel.SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
+        handleResult<Collection<SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
             viewModel.onExcludedProductChanged(it)
         }
         handleResult<Set<Long>>(ProductCategorySelectorFragment.PRODUCT_CATEGORY_SELECTOR_RESULT) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Coupon.CouponRestrictions
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProductCategories
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditExcludedProducts
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -109,7 +109,7 @@ class CouponRestrictionsViewModel @Inject constructor(
 
     fun onExcludeProductsButtonClick() {
         restrictionsDraft.value.excludedProductIds.map { productOrVariationId ->
-            ProductSelectorViewModel.SelectedItem.ProductOrVariation(productOrVariationId)
+            SelectedItem.ProductOrVariation(productOrVariationId)
         }.let {
             triggerEvent(EditExcludedProducts(it))
         }
@@ -119,7 +119,7 @@ class CouponRestrictionsViewModel @Inject constructor(
         triggerEvent(EditExcludedProductCategories(restrictionsDraft.value.excludedCategoryIds))
     }
 
-    fun onExcludedProductChanged(excludedProductItems: Set<ProductSelectorViewModel.SelectedItem>) {
+    fun onExcludedProductChanged(excludedProductItems: Collection<SelectedItem>) {
         restrictionsDraft.update {
             it.copy(excludedProductIds = excludedProductItems.map { it.id })
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -18,7 +18,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -83,7 +83,7 @@ class EditCouponFragment : BaseFragment() {
             viewModel.onRestrictionsUpdated(it)
         }
 
-        handleResult<Set<ProductSelectorViewModel.SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
+        handleResult<Collection<SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
             viewModel.onSelectedProductsUpdated(it)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -19,8 +19,8 @@ import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditIn
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenCouponRestrictions
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
 import com.woocommerce.android.ui.products.ParameterRepository
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorRestriction
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -156,7 +156,7 @@ class EditCouponViewModel @Inject constructor(
     fun onSelectProductsButtonClick() {
         couponDraft.value?.let {
             it.productIds.map { productOrVariationId ->
-                ProductSelectorViewModel.SelectedItem.ProductOrVariation(productOrVariationId)
+                SelectedItem.ProductOrVariation(productOrVariationId)
             }.let { selectedItems ->
                 triggerEvent(
                     EditIncludedProducts(
@@ -171,7 +171,7 @@ class EditCouponViewModel @Inject constructor(
         }
     }
 
-    fun onSelectedProductsUpdated(productItems: Set<ProductSelectorViewModel.SelectedItem>) {
+    fun onSelectedProductsUpdated(productItems: Collection<SelectedItem>) {
         couponDraft.update {
             it?.copy(productIds = productItems.map { it.id })
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -41,7 +41,7 @@ import com.woocommerce.android.ui.orders.creation.views.OrderCreateEditSectionVi
 import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog.Companion.KEY_ORDER_STATUS_RESULT
 import com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -404,7 +404,7 @@ class OrderCreateEditFormFragment :
             key = KEY_ORDER_STATUS_RESULT,
             entryId = R.id.orderCreationFragment
         ) { viewModel.onOrderStatusChanged(Order.Status.fromValue(it.newStatus)) }
-        handleResult<Set<ProductSelectorViewModel.SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
+        handleResult<Collection<SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
             viewModel.onProductsSelected(it)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -59,8 +59,8 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductStockStatus
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorRestriction
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem.Product
 import com.woocommerce.android.ui.products.selector.variationIds
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -243,7 +243,7 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
-    fun onProductsSelected(selectedItems: Set<ProductSelectorViewModel.SelectedItem>) {
+    fun onProductsSelected(selectedItems: Collection<SelectedItem>) {
         tracker.track(
             ORDER_PRODUCT_ADD,
             mapOf(KEY_FLOW to flow)
@@ -266,13 +266,13 @@ class OrderCreateEditViewModel @Inject constructor(
                 }
 
                 val itemsToAdd = selectedItems.filter { selectedItem ->
-                    if (selectedItem is ProductSelectorViewModel.SelectedItem.ProductVariation) {
+                    if (selectedItem is SelectedItem.ProductVariation) {
                         none { it.variationId == selectedItem.variationId }
                     } else {
                         none { it.productId == selectedItem.id }
                     }
                 }.map {
-                    if (it is ProductSelectorViewModel.SelectedItem.ProductVariation) {
+                    if (it is SelectedItem.ProductVariation) {
                         createOrderItem(it.productId, it.variationId)
                     } else {
                         createOrderItem(it.id)
@@ -331,7 +331,7 @@ class OrderCreateEditViewModel @Inject constructor(
     fun onAddProductClicked() {
         val selectedItems = orderDraft.value?.items?.map { item ->
             if (item.isVariation) {
-                ProductSelectorViewModel.SelectedItem.ProductVariation(item.productId, item.variationId)
+                SelectedItem.ProductVariation(item.productId, item.variationId)
             } else {
                 Product(item.productId)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.products.ProductFilterResult
 import com.woocommerce.android.ui.products.ProductListFragment.Companion.PRODUCT_FILTER_RESULT_KEY
 import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductNavigator
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorFragment
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel.VariationSelectionResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -67,7 +68,7 @@ class ProductSelectorFragment : BaseFragment() {
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(
                         PRODUCT_SELECTOR_RESULT,
-                        event.data as Set<ProductSelectorViewModel.SelectedItem>
+                        event.data as Collection<SelectedItem>
                     )
                 }
                 is ProductNavigationTarget -> navigator.navigate(this, event)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -75,7 +75,11 @@ class ProductSelectorViewModel @Inject constructor(
 
     private val searchQuery = savedState.getStateFlow(this, "")
     private val loadingState = MutableStateFlow(IDLE)
-    private val selectedItems = savedState.getStateFlow(viewModelScope, navArgs.selectedItems.toList())
+    private val selectedItems = savedState.getStateFlow(
+        viewModelScope,
+        navArgs.selectedItems.toList(),
+        "key_selected_items"
+    )
     private val filterState = savedState.getStateFlow(viewModelScope, FilterState())
     private val productsRestrictions = navArgs.restrictions
     private val products = listHandler.productsFlow.map { products ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -75,7 +75,7 @@ class ProductSelectorViewModel @Inject constructor(
 
     private val searchQuery = savedState.getStateFlow(this, "")
     private val loadingState = MutableStateFlow(IDLE)
-    private val selectedItems = savedState.getStateFlow(viewModelScope, navArgs.selectedItems.toSet())
+    private val selectedItems = savedState.getStateFlow(viewModelScope, navArgs.selectedItems.toList())
     private val filterState = savedState.getStateFlow(viewModelScope, FilterState())
     private val productsRestrictions = navArgs.restrictions
     private val products = listHandler.productsFlow.map { products ->
@@ -118,7 +118,7 @@ class ProductSelectorViewModel @Inject constructor(
         }
     }
 
-    private fun Product.toUiModel(selectedItems: Set<SelectedItem>): ProductListItem {
+    private fun Product.toUiModel(selectedItems: Collection<SelectedItem>): ProductListItem {
         fun getProductSelection(): SelectionState {
             return if (productType == VARIABLE && numVariations > 0) {
                 val intersection = variationIds.intersect(selectedItems.variationIds.toSet())
@@ -166,7 +166,7 @@ class ProductSelectorViewModel @Inject constructor(
     fun onClearButtonClick() {
         launch {
             delay(STATE_UPDATE_DELAY) // let the animation play out before hiding the button
-            selectedItems.value = emptySet()
+            selectedItems.value = emptyList()
         }
     }
 
@@ -374,7 +374,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 }
 
-val Set<ProductSelectorViewModel.SelectedItem>.variationIds: List<Long>
+val Collection<ProductSelectorViewModel.SelectedItem>.variationIds: List<Long>
     get() {
         return filterIsInstance<ProductSelectorViewModel.SelectedItem.ProductOrVariation>().map { it.id } +
             filterIsInstance<ProductSelectorViewModel.SelectedItem.ProductVariation>().map { it.variationId }


### PR DESCRIPTION
This PR fixes 

<!-- Remember about a good descriptive title. -->

Closes: #8623 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Bug: when in the Product selector screen (e.g. Orders > + > + Add products) and having some items selected and going out of the app (e.g. moving app to background) the app crashes.

The current implementation of `ProductSelectorViewModel` handles state of selected items using `Set` data structure. It turnes out the `Set` of `Parcelable` instances is not parcelable itself, resulting in the exception:
```kotlin
android.os.BadParcelableException: Parcelable encountered IOException writing serializable object (name = java.util.LinkedHashSet)
```
That's why I'm changing to using the `List` instead.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to the Product selector screen (e.g. Orders > + > + Add products)
2. Select some items
3. Go out of the app, and go back to the app
4. Verify that state of the selected items is preserved

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
