### PR TITLE
Feature/8533 onboarding list miscellaneus

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -179,7 +179,7 @@ object AppPrefs {
         // Was the Tap To Pay used at least once
         TTP_WAS_USED_AT_LEAST_ONCE,
 
-        //Whether onboarding tasks have been completed or not for a given site
+        // Whether onboarding tasks have been completed or not for a given site
         STORE_ONBOARDING_TASKS_COMPLETED,
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.UPDATE_SIMULATED_READER_OPTION
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.ONBOARDING_CAROUSEL_DISPLAYED
+import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_ONBOARDING_TASKS_COMPLETED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.extensions.packageInfo
@@ -177,6 +178,9 @@ object AppPrefs {
 
         // Was the Tap To Pay used at least once
         TTP_WAS_USED_AT_LEAST_ONCE,
+
+        //Whether onboarding tasks have been completed or not for a given site
+        STORE_ONBOARDING_TASKS_COMPLETED,
     }
 
     fun init(context: Context) {
@@ -941,6 +945,21 @@ object AppPrefs {
     fun setTTPWasUsedAtLeastOnce() {
         setBoolean(UndeletablePrefKey.TTP_WAS_USED_AT_LEAST_ONCE, true)
     }
+
+    fun markOnboardingTaskCompletedFor(siteId: Int) {
+        setBoolean(
+            key = getStoreOnboardingKeyFor(siteId),
+            value = true
+        )
+    }
+
+    fun areOnboardingTaskCompletedFor(siteId: Int) = getBoolean(
+        key = getStoreOnboardingKeyFor(siteId),
+        default = false
+    )
+
+    private fun getStoreOnboardingKeyFor(siteId: Int) =
+        PrefKeyString("$STORE_ONBOARDING_TASKS_COMPLETED:$siteId")
 
     /**
      * Remove all user and site-related preferences.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -315,4 +315,10 @@ class AppPrefsWrapper @Inject constructor() {
             }
         }
     }
+
+    fun markAllOnboardingTasksCompleted(siteId: Int) {
+        AppPrefs.markOnboardingTaskCompletedFor(siteId)
+    }
+
+    fun isOnboardingCompleted(siteId: Int): Boolean = AppPrefs.areOnboardingTaskCompletedFor(siteId)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -112,6 +112,7 @@ class StoreOnboardingRepository @Inject constructor(
         LAUNCH_YOUR_STORE(id = "launch_site", order = 3),
         CUSTOMIZE_DOMAIN(id = "add_domain", order = 4),
         WC_PAYMENTS(id = "woocommerce-payments", order = 5),
+        PAYMENTS(id = "payments", order = 5), // WC_PAYMENT and PAYMENTS are considered the same task on mobile
         MOBILE_UNSUPPORTED(id = "mobile-unsupported", order = -1)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -27,7 +27,7 @@ class StoreOnboardingRepository @Inject constructor(
 
     var onboardingTasksCacheFlow: MutableStateFlow<List<OnboardingTask>> = MutableStateFlow(emptyList())
 
-    suspend fun fetchOnboardingTasksIfNotCompleted() {
+    suspend fun fetchOnboardingTasks() {
         WooLog.d(WooLog.T.ONBOARDING, "Fetching onboarding tasks")
         val result = onboardingStore.fetchOnboardingTasks(selectedSite.get())
         return when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding
 
-import com.woocommerce.android.WooException
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
@@ -21,19 +21,18 @@ import javax.inject.Singleton
 class StoreOnboardingRepository @Inject constructor(
     private val onboardingStore: OnboardingStore,
     private val selectedSite: SelectedSite,
-    private val siteStore: SiteStore
+    private val siteStore: SiteStore,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
 
     var onboardingTasksCacheFlow: MutableStateFlow<List<OnboardingTask>> = MutableStateFlow(emptyList())
 
-    suspend fun fetchOnboardingTasks(): Result<Unit> {
+    suspend fun fetchOnboardingTasksIfNotCompleted() {
         WooLog.d(WooLog.T.ONBOARDING, "Fetching onboarding tasks")
         val result = onboardingStore.fetchOnboardingTasks(selectedSite.get())
         return when {
-            result.isError -> {
+            result.isError ->
                 WooLog.i(WooLog.T.ONBOARDING, "Error fetching onboarding tasks: ${result.error}")
-                Result.failure(WooException(result.error))
-            }
             else -> {
                 WooLog.d(WooLog.T.ONBOARDING, "Success fetching onboarding tasks")
                 val mobileSupportedTasks = result.model?.map { it.toOnboardingTask() }
@@ -55,11 +54,20 @@ class StoreOnboardingRepository @Inject constructor(
                         )
                     )
                 }
+                if (mobileSupportedTasks.all { it.isComplete }) {
+                    WooLog.d(
+                        WooLog.T.ONBOARDING,
+                        "All onboarding tasks are completed for siteId: ${selectedSite.getSelectedSiteId()}"
+                    )
+                    appPrefsWrapper.markAllOnboardingTasksCompleted(selectedSite.getSelectedSiteId())
+                }
                 onboardingTasksCacheFlow.emit(mobileSupportedTasks)
-                Result.success(Unit)
             }
         }
     }
+
+    fun isOnboardingCompleted(): Boolean =
+        appPrefsWrapper.isOnboardingCompleted(selectedSite.getSelectedSiteId())
 
     suspend fun launchStore(): LaunchStoreResult {
         WooLog.d(WooLog.T.ONBOARDING, "Launching store")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -250,10 +250,12 @@ private fun TaskItem(
                 style = MaterialTheme.typography.body1,
             )
         }
-        Image(
-            painter = painterResource(R.drawable.ic_arrow_right),
-            contentDescription = ""
-        )
+        if (!task.isCompleted) {
+            Image(
+                painter = painterResource(R.drawable.ic_arrow_right),
+                contentDescription = ""
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -135,7 +135,7 @@ fun StoreOnboardingCollapsed(
                     .padding(top = dimensionResource(id = R.dimen.major_100))
                     .fillMaxWidth()
             )
-            if (onboardingState.tasks.size > NUMBER_ITEMS_IN_COLLAPSED_MODE) {
+            if (onboardingState.tasks.size > NUMBER_ITEMS_IN_COLLAPSED_MODE || taskToDisplay.size == 1) {
                 Text(
                     modifier = Modifier
                         .clickable { onViewAllClicked() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -27,7 +27,7 @@ import javax.inject.Inject
 @HiltViewModel
 class StoreOnboardingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val onboardingRepository: StoreOnboardingRepository
+    private val onboardingRepository: StoreOnboardingRepository,
 ) : ScopedViewModel(savedStateHandle), DefaultLifecycleObserver {
     companion object {
         const val NUMBER_ITEMS_IN_COLLAPSED_MODE = 3
@@ -38,7 +38,6 @@ class StoreOnboardingViewModel @Inject constructor(
 
     init {
         launch {
-            onboardingRepository.fetchOnboardingTasks()
             onboardingRepository.onboardingTasksCacheFlow
                 .collectLatest { tasks ->
                     _viewState.value = OnboardingState(
@@ -91,8 +90,10 @@ class StoreOnboardingViewModel @Inject constructor(
     }
 
     private fun refreshOnboardingList() {
-        launch {
-            onboardingRepository.fetchOnboardingTasks()
+        if (!onboardingRepository.isOnboardingCompleted()) {
+            launch {
+                onboardingRepository.fetchOnboardingTasksIfNotCompleted()
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.CUSTOMIZE_DOMAIN
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.PAYMENTS
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.WC_PAYMENTS
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
@@ -59,7 +60,8 @@ class StoreOnboardingViewModel @Inject constructor(
             ADD_FIRST_PRODUCT -> OnboardingTaskUi(AddProductTaskRes, isCompleted = task.isComplete)
             LAUNCH_YOUR_STORE -> OnboardingTaskUi(LaunchStoreTaskRes, isCompleted = task.isComplete)
             CUSTOMIZE_DOMAIN -> OnboardingTaskUi(CustomizeDomainTaskRes, isCompleted = task.isComplete)
-            WC_PAYMENTS -> OnboardingTaskUi(SetupPaymentsTaskRes, isCompleted = task.isComplete)
+            WC_PAYMENTS,
+            PAYMENTS -> OnboardingTaskUi(SetupPaymentsTaskRes, isCompleted = task.isComplete)
             MOBILE_UNSUPPORTED -> error("Unknown task type is not allowed in UI layer")
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -94,6 +94,8 @@ class StoreOnboardingViewModel @Inject constructor(
             launch {
                 onboardingRepository.fetchOnboardingTasksIfNotCompleted()
             }
+        } else {
+            _viewState.value = _viewState.value?.copy(show = false)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -94,7 +94,7 @@ class StoreOnboardingViewModel @Inject constructor(
     private fun refreshOnboardingList() {
         if (!onboardingRepository.isOnboardingCompleted()) {
             launch {
-                onboardingRepository.fetchOnboardingTasksIfNotCompleted()
+                onboardingRepository.fetchOnboardingTasks()
             }
         } else {
             _viewState.value = _viewState.value?.copy(show = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -185,7 +185,8 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     }
 
     private fun applyBannerComposeUI(state: BannerState) {
-        if (state is BannerState.DisplayBannerState) {
+        // Show banners only if onboarding list is not displayed
+        if (state is BannerState.DisplayBannerState && !binding.storeOnboardingView.isVisible) {
             binding.jitmView.apply {
                 binding.jitmView.show()
                 // Dispose of the Composition when the view's LifecycleOwner is destroyed


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8533
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Add the following changes: 

- [x] Save on disk once all task from the list are completed to never show again the onboarding list for that site and to avoid making unnecessary requests to the API if all tasks are already completed 
- [x] Show payments task for both API keys: `payments` and `woocommerce-payments`
- [x] Hide the banner about adding your first product, as we are already displaying this as part of the onboarding list

<img width="300"  src="https://user-images.githubusercontent.com/2663464/226842957-ed471d57-74a8-4b7a-8789-cf2fb257bb7a.png"> 

- [x] Hide chevron for completed tasks

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Scenario 1: All task completed
- Open the app an see how the onboarding list is displayed
- Complete all tasks for a site. The fastest way to do this is to create a jurassinc ninka site and complete the tasks from `wc-core`
- Navigate back to the app (if you had it opened all the time, pull to refresh). Check how the onboarding list is hidden, since all task are completed
- Check that whenever you open the app, or navigate to MyStore tab, or pull to refresh, the app never fetches onboarding tasks from the API for that given site. You can use Flipper for this or simple check this logs are not logged ever again for the current site: 
```
WooCommerce-ONBOARDING  com.woocommerce.android              D  Fetching onboarding tasks
WordPress-API           com.woocommerce.android              D  OnboardingStore: fetchOnboardingTasks
WooCommerce-ONBOARDING  com.woocommerce.android              D  Success fetching onboarding tasks
```

Scenario 2: Show payments task for both types
- Switch between WP.com store and self-hosted store (like a jurassic ninja site) and check the payments task is displayed for both sites. 

Scenario 3: Hide any banner when onboarding list is shown

- I don't know how to force JITM messages to display a banner, but [the code](https://github.com/woocommerce/woocommerce-android/pull/8634/commits/9803ffc31f2a0fc69ce8349469b981139d24fce8) for this is simple, so I think is safe to merge untested.

Scenario 4: Hide chevron when task is completed

- I think testing this is self explanatory :) 


