### PR TITLE
Enable onboarding list for relase builds too

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 -----
 - [*] Jetpack benefit banner and dialog are now available on the dashboard screen after logging in with site credentials. [https://github.com/woocommerce/woocommerce-android/pull/8596]
 - [*] Fixed item's stock status labels on product picker lists [https://github.com/woocommerce/woocommerce-android/pull/8627]
+- [***] Adds a new onboarding list on my store tab to guide the user setting up their store [https://github.com/woocommerce/woocommerce-android/pull/8645]
 
 12.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -33,12 +33,12 @@ enum class FeatureFlag {
             ORDER_CREATION_CUSTOMER_SEARCH,
             UNIFIED_ORDER_EDITING,
             NATIVE_STORE_CREATION_FLOW,
-            IPP_FEEDBACK_BANNER -> true
+            IPP_FEEDBACK_BANNER,
+            STORE_CREATION_ONBOARDING -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             IPP_TAP_TO_PAY,
-            STORE_CREATION_ONBOARDING,
             FREE_TRIAL_M2,
             REST_API_I2,
             ANALYTICS_HUB_FEEDBACK_BANNER -> PackageUtils.isDebugBuild()


### PR DESCRIPTION
### Description
Enables Onboarding for release builds

### Testing instructions
Nothing specific to test here. We can smoke test the onboarding once all the PRs related to the project are merged. 
PRs related to this project can be found [here](https://github.com/woocommerce/woocommerce-android/pulls?q=is%3Apr+label%3A%22feature%3A+store+onboarding%22)

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
