### PR TITLE
Merge release/12.9-rc-1 into trunk (`beta`)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+13.0
+-----
+
+
 12.9
 -----
 - [*] Jetpack benefit banner and dialog are now available on the dashboard screen after logging in with site credentials. [https://github.com/woocommerce/woocommerce-android/pull/8596]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,9 +74,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "12.8"
+            versionName "12.9-rc-1"
         }
-        versionCode 396
+        versionCode 397
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_129"
+msgid ""
+"12.9:\n"
+"For this release, we focused on making your experience smoother when managing products. Additionally, it's now possible to install Jetpack from the app if you would like additional functionality such as push notifications and visitor stats. Keep your feedback coming!\n"
+msgstr ""
+
 msgctxt "release_note_128"
 msgid ""
 "12.8:\n"
 "This release includes a lot of improvements to the order creation functionality. It's possible to select multiple products at one go & an improved faster search & filter option. We also fixed a few bugs and made several enhancements for accessibility of the Analytics section. We’ve added a new Upgrades section to WordPress.com users.\n"
-msgstr ""
-
-msgctxt "release_note_127"
-msgid ""
-"12.7:\n"
-"This release has several fixes and improvements that makes it easier for you to manage your store from the app. Please continue to send us feedback – we are listening!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,4 +1,1 @@
-- [*] Jetpack benefit banner and dialog are now available on the dashboard screen after logging in with site credentials. [https://github.com/woocommerce/woocommerce-android/pull/8596]
-- [*] Fixed item's stock status labels on product picker lists [https://github.com/woocommerce/woocommerce-android/pull/8627]
-- [***] Adds a new onboarding list on my store tab to guide the user setting up their store [https://github.com/woocommerce/woocommerce-android/pull/8645]
-
+For this release, we focused on making your experience smoother when managing products. Additionally, it's now possible to install Jetpack from the app if you would like additional functionality such as push notifications and visitor stats. Keep your feedback coming!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,4 @@
-This release includes a lot of improvements to the order creation functionality. It's possible to select multiple products at one go & an improved faster search & filter option. We also fixed a few bugs and made several enhancements for accessibility of the Analytics section. We’ve added a new Upgrades section to WordPress.com users.
+- [*] Jetpack benefit banner and dialog are now available on the dashboard screen after logging in with site credentials. [https://github.com/woocommerce/woocommerce-android/pull/8596]
+- [*] Fixed item's stock status labels on product picker lists [https://github.com/woocommerce/woocommerce-android/pull/8627]
+- [***] Adds a new onboarding list on my store tab to guide the user setting up their store [https://github.com/woocommerce/woocommerce-android/pull/8645]
+

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -9,7 +9,6 @@ Language: ar
     <string name="upgrades_error_fetching_data">حدث خطأ في أثناء إحضار تفاصيل الخطة</string>
     <string name="upgrades_non_upgradeable_caption">أنت أحد المشتركين في ⁦%1$s⁩! لقد وصلت إلى كل ميزاتنا حتى ⁦%2$s⁩. </string>
     <string name="upgrades_trial_ended_caption">انتهى الإصدار التجريبي المجاني الخاص بك وأصبح لديك وصول محدود إلى كل الميزات. اشترك في ⁦%1$s⁩ الآن.</string>
-    <string name="upgrades_upgradeable_caption">أنت في الإصدار التجريبي المجاني الذي تبلغ مدته ⁦%1$d⁩. سينتهي الإصدار التجريبي المجاني في غضون ⁦%2$d⁩ من الأيام. يمكنك الترقية لفتح ميزات جديدة والاستمرار في تشغيل متجرك.</string>
     <string name="upgrades_subscription_status">حالة الاشتراك</string>
     <string name="upgrades_title">ترقيات</string>
     <string name="upgrades_troubleshooting">حل المشكلات</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -9,7 +9,6 @@ Language: de
     <string name="upgrades_error_fetching_data">Fehler beim Abrufen der Tarifdetails</string>
     <string name="upgrades_non_upgradeable_caption">Du hast %1$s abonniert! Bis zum %2$s kannst du auf alle Funktionen zugreifen. </string>
     <string name="upgrades_trial_ended_caption">Dein Gratis-Test ist abgelaufen und du hast nun eingeschränkten Zugriff auf alle Funktionen. Abonniere jetzt %1$s.</string>
-    <string name="upgrades_upgradeable_caption">Du nutzt gerade den %1$d-tägigen Gratis-Test. Der Gratis-Test endet in %2$d Tagen. Führe ein Upgrade durch, um von neuen Funktionen zu profitieren und deinen Shop weiterhin erfolgreich zu betreiben.</string>
     <string name="upgrades_subscription_status">Abonnement-Status</string>
     <string name="upgrades_title">Upgrades</string>
     <string name="upgrades_troubleshooting">Problembehandlung</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -9,7 +9,6 @@ Language: es
     <string name="upgrades_error_fetching_data">Error al obtener los detalles de tu plan</string>
     <string name="upgrades_non_upgradeable_caption">¡Ya te has suscrito a %1$s! Tienes acceso a todas las funciones hasta el %2$s. </string>
     <string name="upgrades_trial_ended_caption">Tu prueba gratuita ha finalizado, por lo que solo tienes acceso limitado a las funciones. Suscríbete a %1$s ahora.</string>
-    <string name="upgrades_upgradeable_caption">Estás en el día %1$d de tu prueba gratuita. Tu prueba gratuita termina en %2$d días. Mejora tu plan para descubrir nuevas funciones y mantener tu tienda en funcionamiento.</string>
     <string name="upgrades_subscription_status">Estado de la suscripción</string>
     <string name="upgrades_title">Mejoras</string>
     <string name="upgrades_troubleshooting">Solución de problemas</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -9,7 +9,6 @@ Language: fr
     <string name="upgrades_error_fetching_data">Erreur lors de l’extraction des détails du plan</string>
     <string name="upgrades_non_upgradeable_caption">Vous êtes abonné à %1$s ! Vous avez accès à toutes nos fonctionnalités jusqu’au %2$s. </string>
     <string name="upgrades_trial_ended_caption">Votre période d’essai est terminée. Vous avez un accès limité à toutes les fonctionnalités. Abonnez-vous à %1$s maintenant.</string>
-    <string name="upgrades_upgradeable_caption">Il vous reste %1$d jour de période d’essai. Votre période d’essai se termine dans %2$d jours. Souscrivez à des options payantes pour accéder à de nouvelles fonctionnalités et continuer à gérer votre boutique.</string>
     <string name="upgrades_subscription_status">État de l’abonnement</string>
     <string name="upgrades_title">Options payantes</string>
     <string name="upgrades_troubleshooting">Résolution des problèmes</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -9,7 +9,6 @@ Language: he_IL
     <string name="upgrades_error_fetching_data">שגיאה בהבאת הפרטים של התוכנית.</string>
     <string name="upgrades_non_upgradeable_caption">נרשמת למינוי על ⁦%1$s⁩ בהצלחה! יש לך גישה לכל האפשרויות עד ⁦%2$s⁩. </string>
     <string name="upgrades_trial_ended_caption">תקופת ההתנסות שלך הסתיימה ולכן הגישה שלך לכל האפשרויות הוגבלה. כדאי להירשם למינוי על ⁦%1$s⁩ עכשיו.</string>
-    <string name="upgrades_upgradeable_caption">התחלת תקופת ניסיון בחינם של ⁦%1$d⁩ ימים. תקופת הניסיון תסתיים בעוד ⁦%2$d⁩ ימים. כדאי לשדרג כדי להשתמש באפשרויות חדשות ולהמשיך להפעיל את החנות שלך…</string>
     <string name="upgrades_subscription_status">סטטוס מינוי</string>
     <string name="upgrades_title">שדרוגים</string>
     <string name="upgrades_troubleshooting">פתרון בעיות</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -9,7 +9,6 @@ Language: id
     <string name="upgrades_error_fetching_data">Error saat mengambil detail paket</string>
     <string name="upgrades_non_upgradeable_caption">Sekarang Anda menjadi pelanggan %1$s! Anda memiliki akses ke semua fitur kami hingga %2$s. </string>
     <string name="upgrades_trial_ended_caption">Masa percobaan gratis Anda telah berakhir, menyisakan akses fitur secara terbatas. Berlangganan %1$s sekarang.</string>
-    <string name="upgrades_upgradeable_caption">Anda dalam masa percobaan gratis %1$d hari. Masa percobaan gratis akan berakhir dalam %2$d hari. Upgrade untuk membuka fitur-fitur baru dan menjaga toko Anda tetap berjalan.</string>
     <string name="upgrades_subscription_status">Status langganan</string>
     <string name="upgrades_title">Upgrade</string>
     <string name="upgrades_troubleshooting">Pemecahan Masalah</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -9,7 +9,6 @@ Language: it
     <string name="upgrades_error_fetching_data">Errore durante il recupero dei dettagli del piano.</string>
     <string name="upgrades_non_upgradeable_caption">Ora sei un abbonato %1$s. Hai accesso a tutte le nostre funzionalità fino al giorno %2$s. </string>
     <string name="upgrades_trial_ended_caption">La tua prova gratuita è terminata e hai accesso limitato a tutte le funzionalità. Abbonati a %1$s ora.</string>
-    <string name="upgrades_upgradeable_caption">Ti trovi nel periodo di prova gratuita di %1$d giorni. La prova gratuita terminerà tra %2$d giorni. Aggiorna per sbloccare le nuove funzionalità e mantenere operativo il tuo negozio..</string>
     <string name="upgrades_subscription_status">Stato dell\'abbonamento</string>
     <string name="upgrades_title">Miglioramenti</string>
     <string name="upgrades_troubleshooting">Risoluzione dei problemi</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -9,7 +9,6 @@ Language: ja_JP
     <string name="upgrades_error_fetching_data">プラン詳細を取得中にエラーが発生しました</string>
     <string name="upgrades_non_upgradeable_caption">%1$s を購読しています。 %2$s まですべての機能をご利用いただけます。 </string>
     <string name="upgrades_trial_ended_caption">お試し期間が終了したため、ご利用いただける機能に制限がかかります。 今すぐ %1$s を購読しましょう。</string>
-    <string name="upgrades_upgradeable_caption">%1$d日間のお試し期間が開始しました。 お試し期間は%2$d日後に終了します。 アップグレードして新しい機能を追加し、ストアの運営を継続しましょう。</string>
     <string name="upgrades_subscription_status">定期購入ステータス</string>
     <string name="upgrades_title">アップグレード</string>
     <string name="upgrades_troubleshooting">トラブルシューティング</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -9,7 +9,6 @@ Language: ko_KR
     <string name="upgrades_error_fetching_data">요금제 상세 정보를 가져오는 중 오류 발생</string>
     <string name="upgrades_non_upgradeable_caption">%1$s 구독자이십니다. %2$s까지 모든 기능에 접근하실 수 있습니다. </string>
     <string name="upgrades_trial_ended_caption">무료 평가판이 종료되었으며 모든 기능에 대한 접근이 제한되었습니다. 지금 %1$s을(를) 구독하세요.</string>
-    <string name="upgrades_upgradeable_caption">%1$d일 무료 평가판을 사용 중이십니다. %2$d일 후 무료 평가판이 종료됩니다. 업그레이드하여 새로운 기능을 잠금 해제하고 스토어를 계속 실행하세요.</string>
     <string name="upgrades_subscription_status">구독 상태</string>
     <string name="upgrades_title">업그레이드</string>
     <string name="upgrades_troubleshooting">문제 해결</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -9,7 +9,6 @@ Language: nl
     <string name="upgrades_error_fetching_data">Fout bij het ophalen van de abonnementsgegevens</string>
     <string name="upgrades_non_upgradeable_caption">Je bent een %1$s abonnee! Tot %2$s heb je toegang tot al onze functies. </string>
     <string name="upgrades_trial_ended_caption">Je proefversie is verlopen waardoor je nu maar beperkt toegang hebt tot alle functies. Nu abonneren op %1$s.</string>
-    <string name="upgrades_upgradeable_caption">Je gebruikt de gratis proefversie van %1$d dagen. Je gratis proefversie loopt af over %2$d dagen. Meld je aan voor een abonnement om nieuwe functies te ontgrendelen en je winkel draaiende te houden.</string>
     <string name="upgrades_subscription_status">Abonnementsstatus</string>
     <string name="upgrades_title">Upgrades</string>
     <string name="upgrades_troubleshooting">Probleemoplossing</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -9,7 +9,6 @@ Language: pt_BR
     <string name="upgrades_error_fetching_data">Erro ao buscar detalhes do plano</string>
     <string name="upgrades_non_upgradeable_caption">Você é um assinante %1$s! Você tem acesso a todos as nossas funcionalidades até %2$s. </string>
     <string name="upgrades_trial_ended_caption">Seu teste gratuito terminou e agora você tem acesso limitado a todas as funcionalidades. Assine o %1$s agora mesmo.</string>
-    <string name="upgrades_upgradeable_caption">Você está no teste gratuito de %1$d dias. O teste gratuito terminará em %2$d dias. Faça upgrade para desbloquear novas funcionalidades e manter sua loja na ativa.</string>
     <string name="upgrades_subscription_status">Status da assinatura</string>
     <string name="upgrades_title">Upgrades</string>
     <string name="upgrades_troubleshooting">Solução de problemas</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -9,7 +9,6 @@ Language: ru
     <string name="upgrades_error_fetching_data">Ошибка при получении сведений о плане</string>
     <string name="upgrades_non_upgradeable_caption">Вы оформили подписку на %1$s! У вас есть доступ ко всем функциям до %2$s. </string>
     <string name="upgrades_trial_ended_caption">У вас закончился пробный период, доступ к функциям ограничен. Подпишитесь на %1$s прямо сейчас.</string>
-    <string name="upgrades_upgradeable_caption">У вас идет %1$d-дневный пробный период. Бесплатный пробный период заканчивается через %2$d дн. Перейдите на платный тарифный план, чтобы получить доступ к новым функциям и использовать их в магазине.</string>
     <string name="upgrades_subscription_status">Статус подписки</string>
     <string name="upgrades_title">Платные услуги</string>
     <string name="upgrades_troubleshooting">Устранение неполадок</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -9,7 +9,6 @@ Language: sv_SE
     <string name="upgrades_error_fetching_data">Det gick inte att hämta paketinformationen</string>
     <string name="upgrades_non_upgradeable_caption">Du är %1$s-prenumerant. Du har tillgång till alla våra funktioner fram till %2$s. </string>
     <string name="upgrades_trial_ended_caption">Din kostnadsfria provperiod har avslutats och du har begränsad åtkomst till alla funktionerna. Prenumerera på %1$s nu.</string>
-    <string name="upgrades_upgradeable_caption">Du har en kostnadsfri provperiod på %1$d dagar. Den kostnadsfria provperioden löper ut om %2$d dagar. Uppgradera för att låsa upp nya funktioner och hålla igång din butik.</string>
     <string name="upgrades_subscription_status">Prenumerationsstatus</string>
     <string name="upgrades_title">Uppgraderingar</string>
     <string name="upgrades_troubleshooting">Felsökning</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -9,7 +9,6 @@ Language: tr
     <string name="upgrades_error_fetching_data">Paket ayrıntıları getirilirken hata oluştu</string>
     <string name="upgrades_non_upgradeable_caption">%1$s abonesisiniz! %2$s tarihine kadar tüm özelliklerimize erişebilirsiniz. </string>
     <string name="upgrades_trial_ended_caption">Ücretsiz deneme süreniz sona erdi ve tüm özelliklere erişiminiz sınırlandırıldı. Şimdi %1$s abonesi olun.</string>
-    <string name="upgrades_upgradeable_caption">%1$d günlük ücretsiz deneme süresindesiniz. Ücretsiz deneme süresi %2$d gün sonra sona erecek. Yeni özelliklerin kilidini açmak ve mağazanızın çalışmaya devam etmesini sağlamak için yükseltin.</string>
     <string name="upgrades_subscription_status">Abonelik durumu</string>
     <string name="upgrades_title">Yükseltmeler</string>
     <string name="upgrades_troubleshooting">Sorun giderme</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -9,7 +9,6 @@ Language: zh_CN
     <string name="upgrades_error_fetching_data">获取套餐详细信息时出现错误</string>
     <string name="upgrades_non_upgradeable_caption">您已订阅 %1$s！ %2$s前，您可以访问我们的所有功能。 </string>
     <string name="upgrades_trial_ended_caption">您的免费试用已结束，已被限制访问所有功能。 立即订阅 %1$s。</string>
-    <string name="upgrades_upgradeable_caption">您的免费试用版还剩 %1$d 天。 您的免费试用版将于 %2$d 天后到期。 升级套餐，解锁新功能并持续运营商店。</string>
     <string name="upgrades_subscription_status">订阅状态</string>
     <string name="upgrades_title">升级</string>
     <string name="upgrades_troubleshooting">故障排除</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -9,7 +9,6 @@ Language: zh_TW
     <string name="upgrades_error_fetching_data">擷取計畫詳細資料時發生錯誤</string>
     <string name="upgrades_non_upgradeable_caption">你是第 %1$s 名訂閱者！ 你可存取我們的所有功能，直到 %2$s 為止。 </string>
     <string name="upgrades_trial_ended_caption">你的免費試用已結束，且對於功能的存取受限。 歡迎立即訂閱 %1$s。</string>
-    <string name="upgrades_upgradeable_caption">你正在使用 %1$d 天免費試用。 免費試用將於 %2$d 天內結束， 升級以便解鎖新功能並維持你的商店運作…</string>
     <string name="upgrades_subscription_status">訂購項目狀態</string>
     <string name="upgrades_title">升級</string>
     <string name="upgrades_troubleshooting">疑難排解</string>

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-50d7a76ebce56e74541195774ba46b7d39010317'
+    fluxCVersion = '2.20.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -440,6 +440,9 @@
     <string name="analytics_session_card_title">Sessions</string>
     <string name="analytics_conversion_subtitle">Conversion Rate</string>
     <string name="analytics_visitors_subtitle">Visitors</string>
+    <string name="analytics_item">item</string>
+    <string name="analytics_items">items</string>
+    <string name="analytics_list_item_products_sold">%1$s, %2$s, %3$s, %4$s sold</string>
 
     <string name="analytics_wip_title">See your stats, revenue and more from your device!</string>
     <string name="analytics_wip_message">We\'ve been working on making it possible to display significant store information from your device! Could it be better? Please help us improve this feature by sharing your feedback with us</string>
@@ -886,7 +889,7 @@
     <string name="shipping_label_address_suggestion_banner">We have slightly modified the address entered. If correct, please use the suggested address to ensure accurate delivery.</string>
     <string name="shipping_label_address_suggestion_entered_address">Entered address</string>
     <string name="shipping_label_address_suggestion_suggested_address">Suggested address</string>
-    <string name="shipping_label_address_phone_required">A phone number is required because this shipment requires a customs form</string>
+    <string name="shipping_label_address_phone_required">A phone number is required</string>
     <string name="shipping_label_origin_address_phone_invalid">Customs forms require a 10-digit phone number</string>
     <string name="shipping_label_destination_address_phone_invalid">Please enter a valid phone number</string>
     <string name="shipping_label_address_data_invalid_snackbar_message">Certain required fields are blank.</string>
@@ -2260,6 +2263,7 @@
     <string name="jetpack_benefits_modal_multiple_stores_title">Multiple stores</string>
     <string name="jetpack_benefits_modal_multiple_stores_subtitle">Get access to all of your WooCommerce stores.</string>
     <string name="jetpack_benefits_modal_login">Log In to Continue</string>
+    <string name="jetpack_benefits_open_wpadmin">Open wp-admin</string>
 
     <string name="jetpack_install_start_title">Install Jetpack</string>
     <string name="jetpack_install_start_subtitle">Install the free Jetpack plugin to &lt;strong&gt;%s&lt;/strong&gt; to experience the best mobile experience.</string>
@@ -2937,6 +2941,7 @@
     <string name="store_creation_installation_success">Your store has been created!</string>
     <string name="store_creation_installation_manage_store_button">Manage my store</string>
     <string name="store_creation_installation_show_preview_button">Store preview</string>
+    <string name="store_creation_installation_rendering_preview_label">Rendering preview…</string>
     <string name="store_creation_store_name_caption">About your store</string>
     <string name="store_creation_store_name_title">What’s your store name?</string>
     <string name="store_creation_store_name_subtitle">Don’t worry you can always change it later. </string>
@@ -3127,6 +3132,7 @@
     Store onboarding
     -->
     <string name="store_onboarding_title">Store setup</string>
+    <string name="store_onboarding_task_about_your_store_toolbar_title">About your store</string>
     <string name="store_onboarding_task_about_your_store_title">Tell us more about your store</string>
     <string name="store_onboarding_task_about_your_store_description">We’ll use the info to get a head start on your shipping, tax, and payments settings.</string>
     <string name="store_onboarding_task_add_product_title">Add your first product </string>
@@ -3155,6 +3161,8 @@
     <string name="store_onboarding_store_already_launched_error_description">We found that the store has already launched.</string>
     <string name="store_onboarding_launch_store_generic_error_title">Unexpected error</string>
     <string name="store_onboarding_launch_store_generic_error_description">Oops, some unexpected errors happened.</string>
+    <string name="store_onboarding_get_paid_title">Payments Setup</string>
+    <string name="store_onboarding_get_paid_loading_label">Loading…</string>
 
     <!--
     Support Request
@@ -3187,6 +3195,8 @@
     <string name="free_trial_trial_ended">Trial ended</string>
     <string name="free_trial_days_left">%1$d days left in your trial.</string>
     <string name="free_trial_upgrade_now">Upgrade Now</string>
+    <string name="free_trial_one_day_left">1 day</string>
+    <string name="free_trial_days_left_plural">%1$d days</string>
 
     <!--
     Upgrades
@@ -3197,8 +3207,10 @@
     <string name="upgrades_troubleshooting">Troubleshooting</string>
     <string name="upgrades_title">Upgrades</string>
     <string name="upgrades_subscription_status">Subscription status</string>
-    <string name="upgrades_upgradeable_caption">You are in the %1$d-day free trial. The free trial will end in %2$d days. Upgrade to unlock new features and keep your store running..</string>
+    <string name="upgrades_upgradeable_caption">You are in the %1$d-day free trial. The free trial will end in %2$s. Upgrade to unlock new features and keep your store running.</string>
     <string name="upgrades_trial_ended_caption">Your free trial has ended and have limited access to all the features. Subscribe to %1$s now.</string>
     <string name="upgrades_non_upgradeable_caption">You are a %1$s subscriber! You have access to all our features until %2$s. </string>
+    <string name="upgrades_current_plan_ended_caption">Your subscription has ended, and you have limited access to all the features.</string>
     <string name="upgrades_error_fetching_data">Error while fetching plan details</string>
+    <string name="upgrades_plan_ended_name">%s ended</string>
 </resources>


### PR DESCRIPTION
- [x] `build.gradle` file on `WooCommerce` module updated  with version bump. (fd95ecd0f6b5af01f82a07f81b5f7fe48992c28c)
- [x] `release notes` related files updated. (0d3c765b5e93dd57aa364f61e6feb700b37ac379 + e13b2ad570acb19ebf3c0d1fa697e3ef863f0cd7 + 1cc56a6e9e6544a7a5d14835185bbe80ec620884 + ceba67c28aebfb7bcb1c0a08d583e8582a7c66af)
- [x] `new strings` frozen/copied into `fastlane/resources/values/strings.xml`. (85d1e8f2244aab72e433edc4009279cea782f02d)
- [x] `12.9-rc-1` WCAndroid beta submitted to Google for review (`Full rollout`).

EXTRAS:
- [x] `fluxc` version bump. (43d55dc2ad44a3f3d696251d1ba02368785ab354)
- [x] `lint` error fix. (13b36332c1a9ce8b11bbe33a8ed90ffc7f9d6df6) Cc @ThomazFB 