### PR TITLE
Free Trial: Skip the domain picker view when the Free Trial feature flag is activate

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -44,12 +45,18 @@ class StoreNamePickerFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is MultiLiveEvent.Event.NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
-                is StoreNamePickerViewModel.NavigateToNextStep -> findNavController().navigateSafely(
-                    StoreNamePickerFragmentDirections.actionStoreNamePickerFragmentToDomainPickerFragment(
-                        event.domainInitialQuery
-                    )
-                )
+                is StoreNamePickerViewModel.NavigateToNextStep -> navigateToNextStep(event)
             }
         }
+    }
+
+    private fun navigateToNextStep(event: StoreNamePickerViewModel.NavigateToNextStep) {
+        if (FeatureFlag.FREE_TRIAL_M2.isEnabled()) {
+            StoreNamePickerFragmentDirections.actionStoreNamePickerFragmentToStoreProfilerCategoryFragment()
+        } else {
+            StoreNamePickerFragmentDirections.actionStoreNamePickerFragmentToDomainPickerFragment(
+                event.domainInitialQuery
+            )
+        }.let { findNavController().navigateSafely(it) }
     }
 }


### PR DESCRIPTION
Summary
==========
A quick fix addressing a change introduced in https://github.com/woocommerce/woocommerce-android/pull/8613 where the Domain picker was getting called back after the Store name selection. We should skip the domain picker for the Free Trial as it's not a feature for sites on this kind of plan.


How to Test
==========
1. Start the Store Creation flow and make sure the domain picker is not presented in any way
2. Verify that the Free Trial store creation works as expected

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.