### PR TITLE
Support subscription renewal orders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/subscription/SubscriptionRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/subscription/SubscriptionRestClient.kt
@@ -21,6 +21,16 @@ class SubscriptionRestClient @Inject constructor(private val wooNetwork: WooNetw
         ).toWooPayload()
     }
 
+    suspend fun fetchSubscriptionsById(site: SiteModel, subscriptionId: Long): WooPayload<SubscriptionDto> {
+        val url = WOOCOMMERCE.subscriptions.id(subscriptionId).pathV3
+
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = SubscriptionDto::class.java
+        ).toWooPayload()
+    }
+
     @Suppress("PropertyName", "VariableNaming")
     class SubscriptionDto : Response {
         val id: Long? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/subscription/SubscriptionRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/subscription/SubscriptionRepository.kt
@@ -37,4 +37,23 @@ class SubscriptionRepository @Inject constructor(
             }
         }
     }
+
+    suspend fun fetchSubscriptionsById(
+        subscriptionId: Long,
+        site: SiteModel = selectedSite.get()
+    ): WooResult<Subscription> {
+        return withContext(dispatchers.io) {
+            val response = subscriptionRestClient.fetchSubscriptionsById(site, subscriptionId)
+            when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+                response.result != null -> {
+                    val subscription = subscriptionMapper.toAppModel(response.result!!)
+                    WooResult(subscription)
+                }
+                else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN))
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/GetOrderSubscriptions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/GetOrderSubscriptions.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.orders.details
+
+import com.woocommerce.android.WooException
+import com.woocommerce.android.model.Subscription
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.common.subscription.SubscriptionRepository
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.WCMetaData
+import org.wordpress.android.fluxc.store.WCOrderStore
+import javax.inject.Inject
+
+class GetOrderSubscriptions @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val orderStore: WCOrderStore,
+    private val subscriptionRepository: SubscriptionRepository,
+    private val dispatchers: CoroutineDispatchers,
+) {
+    suspend operator fun invoke(orderId: Long): Result<List<Subscription>> {
+        return withContext(dispatchers.io) {
+            val renewalId = getRenewalId(orderId)
+            if (renewalId != null) {
+                getRenewalSubscription(renewalId)
+            } else {
+                getSubscriptions(orderId)
+            }
+        }
+    }
+
+    private suspend fun getRenewalId(orderId: Long): Long? {
+        val metadataList = orderStore.getOrderMetadata(orderId, selectedSite.get())
+        val renewal = metadataList.find { metadata ->
+            metadata.key == WCMetaData.SubscriptionMetadataKeys.SUBSCRIPTION_RENEWAL
+        }
+        return renewal?.value?.toLongOrNull()
+    }
+
+    private suspend fun getRenewalSubscription(subscriptionId: Long): Result<List<Subscription>> {
+        val result = subscriptionRepository.fetchSubscriptionsById(
+            site = selectedSite.get(),
+            subscriptionId = subscriptionId
+        )
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            result.model != null -> Result.success(listOf(result.model!!))
+            else -> Result.failure(Exception("Error fetching renewal subscription"))
+        }
+    }
+
+    private suspend fun getSubscriptions(orderId: Long): Result<List<Subscription>> {
+        val result = subscriptionRepository.fetchSubscriptionsByOrderId(
+            site = selectedSite.get(),
+            orderId = orderId
+        )
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            result.model != null -> Result.success(result.model!!)
+            else -> Result.failure(Exception("Error fetching subscriptions"))
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -13,6 +13,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
+import androidx.transition.TransitionManager
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialContainerTransform
 import com.woocommerce.android.FeedbackPrefs
@@ -285,6 +286,7 @@ class OrderDetailFragment :
                 subscriptions = subscriptions,
                 currencyFormatter = currencyFormatter
             )
+            TransitionManager.beginDelayedTransition(binding.orderDetailContainer)
             visibility = if (subscriptions.isNotEmpty()) View.VISIBLE else View.GONE
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -16,12 +16,10 @@ import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.model.ShippingLabelMapper
-import com.woocommerce.android.model.Subscription
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.model.toOrderStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.common.subscription.SubscriptionRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.ORDERS
@@ -48,8 +46,7 @@ class OrderDetailRepository @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val dispatchers: CoroutineDispatchers,
     private val orderMapper: OrderMapper,
-    private val shippingLabelMapper: ShippingLabelMapper,
-    private val subscriptionRepository: SubscriptionRepository
+    private val shippingLabelMapper: ShippingLabelMapper
 ) {
     suspend fun fetchOrderById(orderId: Long): Order? {
         val result = withTimeoutOrNull(AppConstants.REQUEST_TIMEOUT) {
@@ -300,18 +297,6 @@ class OrderDetailRepository @Inject constructor(
             canCreatePaymentMethod = true,
             canCreateCustomsForm = true
         )?.isEligible ?: false
-    }
-
-    suspend fun getOrderSubscriptions(orderId: Long): Result<List<Subscription>> {
-        val result = subscriptionRepository.fetchSubscriptionsByOrderId(
-            site = selectedSite.get(),
-            orderId = orderId
-        )
-        return when {
-            result.isError -> Result.failure(WooException(result.error))
-            result.model != null -> Result.success(result.model!!)
-            else -> Result.failure(Exception("Error fetching subscriptions"))
-        }
     }
 
     suspend fun orderHasMetadata(orderId: Long) = orderStore.hasOrderMetadata(orderId, selectedSite.get())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -103,7 +103,8 @@ class OrderDetailViewModel @Inject constructor(
     private val cardReaderTracker: CardReaderTracker,
     private val trackerWrapper: AnalyticsTrackerWrapper,
     private val shippingLabelOnboardingRepository: ShippingLabelOnboardingRepository,
-    private val orderDetailsTransactionLauncher: OrderDetailsTransactionLauncher
+    private val orderDetailsTransactionLauncher: OrderDetailsTransactionLauncher,
+    private val getOrderSubscriptions: GetOrderSubscriptions
 ) : ScopedViewModel(savedState), OnProductFetchedListener {
     private val navArgs: OrderDetailFragmentArgs by savedState.navArgs()
 
@@ -660,7 +661,7 @@ class OrderDetailViewModel @Inject constructor(
     private suspend fun fetchOrderSubscriptions() {
         val plugin = pluginsInformation[WooCommerceStore.WooPlugin.WOO_SUBSCRIPTIONS.pluginName]
         if (plugin == null || plugin.isOperational) {
-            orderDetailRepository.getOrderSubscriptions(navArgs.orderId).getOrNull()?.let { subscription ->
+            getOrderSubscriptions(navArgs.orderId).getOrNull()?.let { subscription ->
                 _subscriptions.value = subscription
                 if (subscription.isNotEmpty()) {
                     trackerWrapper.track(AnalyticsEvent.ORDER_DETAILS_SUBSCRIPTIONS_SHOWN)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.PreviewReceipt
+import com.woocommerce.android.ui.orders.details.GetOrderSubscriptions
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentArgs
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
@@ -136,6 +137,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         isOrderDetailSkeletonShown = false
     )
 
+    private val getOrderSubscriptions: GetOrderSubscriptions = mock()
+
     private fun createViewModel() {
         viewModel = spy(
             OrderDetailViewModel(
@@ -152,7 +155,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 cardReaderTracker,
                 analyticsTraWrapper,
                 shippingLabelOnboardingRepository,
-                orderDetailsTransactionLauncher
+                orderDetailsTransactionLauncher,
+                getOrderSubscriptions
             )
         )
     }
@@ -1637,14 +1641,14 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             version = "1.0.0"
         )
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
-        doReturn(emptyList<Subscription>()).whenever(orderDetailRepository).getOrderSubscriptions(any())
+        doReturn(emptyList<Subscription>()).whenever(getOrderSubscriptions).invoke(any())
         doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         createViewModel()
 
         viewModel.start()
 
-        verify(orderDetailRepository).getOrderSubscriptions(any())
+        verify(getOrderSubscriptions).invoke(any())
     }
 
     @Test
@@ -1660,7 +1664,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(orderDetailRepository, never()).getOrderSubscriptions(any())
+        verify(getOrderSubscriptions, never()).invoke(any())
     }
 
     @Test
@@ -1675,7 +1679,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         val result = listOf(subscription)
 
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
-        doReturn(result).whenever(orderDetailRepository).getOrderSubscriptions(any())
+        doReturn(result).whenever(getOrderSubscriptions).invoke(any())
         doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         createViewModel()
@@ -1696,7 +1700,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         val result = emptyList<Subscription>()
 
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
-        doReturn(result).whenever(orderDetailRepository).getOrderSubscriptions(any())
+        doReturn(result).whenever(getOrderSubscriptions).invoke(any())
         doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         createViewModel()
@@ -1717,7 +1721,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         val result = null
 
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
-        doReturn(result).whenever(orderDetailRepository).getOrderSubscriptions(any())
+        doReturn(result).whenever(getOrderSubscriptions).invoke(any())
         doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         createViewModel()

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2687-bb6100081da6be99e9898bb698f3d9ac574df926'
+    fluxCVersion = '2692-b902ca2b72d19d86c1af1e067a4fd17e352a8fe4'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ This PR depends on [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2692)
Closes: #8658

### Description
This PR adds support to see subscription information in renewal orders. It does that by using the SUBSCRIPTION_RENEWAL metadata field to fetch the subscription information.

### Testing instructions
1. Open the Orders tab
2. Select a renewal order
3. Check that the subscription information is shown

### Images/gif

https://user-images.githubusercontent.com/18119390/228089314-7d5c4cf5-7200-4839-8575-75a180ff7314.mp4
