### PR TITLE
Only displayable metadata fields in Custom Fields screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -299,9 +299,9 @@ class OrderDetailRepository @Inject constructor(
         )?.isEligible ?: false
     }
 
-    suspend fun orderHasMetadata(orderId: Long) = orderStore.hasOrderMetadata(orderId, selectedSite.get())
+    suspend fun orderHasMetadata(orderId: Long) = orderStore.hasDisplayableOrderMetadata(orderId, selectedSite.get())
 
-    suspend fun getOrderMetadata(orderId: Long) = orderStore.getOrderMetadata(orderId, selectedSite.get())
+    suspend fun getOrderMetadata(orderId: Long) = orderStore.getDisplayableOrderMetadata(orderId, selectedSite.get())
 
     companion object {
         const val PRODUCT_SUBSCRIPTION_TYPE = "subscription"

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2692-b902ca2b72d19d86c1af1e067a4fd17e352a8fe4'
+    fluxCVersion = '2693-12bd3d561fcf03ce57633ea07048c7875e4645c5'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2693-12bd3d561fcf03ce57633ea07048c7875e4645c5'
+    fluxCVersion = '2693-ab5498031a07741f1963bdb567a249b8c1e11e20'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ Depends on [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2693)
### Why
Because of the changes introduced to display renewal subscription information, we began storing non-displayable metadata in order metadata fields.
### Description
This small PR uses the new order metadata functions to get custom field information. With this change, it will only take into account the order's `displayable` attributes cached locally.

### Testing instructions
1. Open the Orders tab
2. Select a renewal subscription order
3. Tap on view custom fields
4. Check that no metadata with a key starting with "_" is shown in the Custom fields screen

### Images/gif

https://user-images.githubusercontent.com/18119390/228134365-cf2154cc-fd61-450a-9dd9-0f303e13acb7.mp4
