### PR TITLE
[Mobile Payments] Extend In-Person Payments availability to the UK

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - [**] Fix adding variable subscription products to an order [https://github.com/woocommerce/woocommerce-android/pull/8798]
 - [*] Added RTL languages support in search fields [https://github.com/woocommerce/woocommerce-android/pull/8770]
 - [*][internal] Visual improvements to the Payments Hub Screen [https://github.com/woocommerce/woocommerce-android/pull/8768]
+- [****] Extend support of in-person card reader payments to the UK [https://github.com/woocommerce/woocommerce-android/pull/8662]
 
 13.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
@@ -301,7 +301,7 @@ sealed class PaymentFlowError(@StringRes val message: Int) {
     object Server : PaymentFlowError(R.string.card_reader_payment_failed_server_error_state)
     object Generic : PaymentFlowError(R.string.card_reader_payment_failed_unexpected_error_state)
     object Canceled : PaymentFlowError(R.string.card_reader_payment_failed_canceled)
-    object AmountTooSmall : Declined(R.string.card_reader_payment_failed_amount_too_small), NonRetryableError
+    data class AmountTooSmall(@StringRes val errorMessage: Int) : Declined(errorMessage), NonRetryableError
 
     object Unknown : Declined(R.string.card_reader_payment_failed_unknown)
     sealed class Declined(message: Int) : PaymentFlowError(message) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -17,6 +17,7 @@ enum class FeatureFlag {
     IAP_FOR_STORE_CREATION,
     IPP_TAP_TO_PAY,
     IPP_FEEDBACK_BANNER,
+    IPP_UK,
     STORE_CREATION_ONBOARDING,
     FREE_TRIAL_M2,
     REST_API_I2,
@@ -44,6 +45,7 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             IPP_TAP_TO_PAY,
+            IPP_UK,
             ANALYTICS_HUB_FEEDBACK_BANNER,
             GIFT_CARD_READ_ONLY_SUPPORT,
             QUANTITY_RULES_READ_ONLY_SUPPORT -> PackageUtils.isDebugBuild()

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1254,7 +1254,8 @@
     <string name="card_reader_payment_failed_server_error_state">No connection to server</string>
     <string name="card_reader_payment_failed_collecting_payment_timed_out_state">Card declined</string>
     <string name="card_reader_payment_failed_unexpected_error_state">Sorry, this payment couldn\’t be processed</string>
-    <string name="card_reader_payment_failed_amount_too_small">Amount must be at least $0.50</string>
+    <string name="card_reader_payment_failed_amount_too_small_us_ca">Amount must be at least $0.50</string>
+    <string name="card_reader_payment_failed_amount_too_small_uk">Amount must be at least £0.30</string>
     <string name="card_reader_payment_failed_temporary">Trying again may succeed</string>
     <string name="card_reader_payment_failed_fraud">Try another means of payment</string>
     <string name="card_reader_payment_failed_generic">Payment was declined for an unspecified reason</string>

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
@@ -5,7 +5,7 @@ class CardReaderConfigFactory {
         return when (countryCode) {
             "US" -> CardReaderConfigForUSA
             "CA" -> CardReaderConfigForCanada
-            "UK" -> CardReaderConfigForUK
+            "GB" -> CardReaderConfigForGB
             else -> CardReaderConfigForUnsupportedCountry
         }
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
@@ -5,6 +5,7 @@ class CardReaderConfigFactory {
         return when (countryCode) {
             "US" -> CardReaderConfigForUSA
             "CA" -> CardReaderConfigForCanada
+            "UK" -> CardReaderConfigForUK
             else -> CardReaderConfigForUnsupportedCountry
         }
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForGB.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForGB.kt
@@ -5,9 +5,9 @@ import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMeth
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-object CardReaderConfigForUK : CardReaderConfigForSupportedCountry(
+object CardReaderConfigForGB : CardReaderConfigForSupportedCountry(
     currency = "GBP",
-    countryCode = "UK",
+    countryCode = "GB",
     supportedReaders = listOf(ReaderType.ExternalReader.StripeM2),
     paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
     supportedExtensions = listOf(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForGB.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForGB.kt
@@ -12,12 +12,8 @@ object CardReaderConfigForGB : CardReaderConfigForSupportedCountry(
     paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
     supportedExtensions = listOf(
         SupportedExtension(
-            type = SupportedExtensionType.STRIPE,
-            supportedSince = "6.2.0"
-        ),
-        SupportedExtension(
             type = SupportedExtensionType.WC_PAY,
-            supportedSince = "3.2.1"
+            supportedSince = "4.4.0"
         ),
     ),
 )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForGB.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForGB.kt
@@ -8,7 +8,7 @@ import kotlinx.parcelize.Parcelize
 object CardReaderConfigForGB : CardReaderConfigForSupportedCountry(
     currency = "GBP",
     countryCode = "GB",
-    supportedReaders = listOf(ReaderType.ExternalReader.StripeM2),
+    supportedReaders = listOf(ReaderType.ExternalReader.WisePade3),
     paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
     supportedExtensions = listOf(
         SupportedExtension(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForUK.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForUK.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+object CardReaderConfigForUK : CardReaderConfigForSupportedCountry(
+    currency = "GBP",
+    countryCode = "UK",
+    supportedReaders = listOf(ReaderType.ExternalReader.StripeM2),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "3.2.1"
+        ),
+    ),
+)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
* Added UK-specific card reader config:
  * Supported plugins: WCPay (min version 4.4.0)
  * Supported card readers: WisePad 3
  * Supported payment methods: CARD_PRESENT
* Handled `AmountTooSmall` error according to UK-specific requirements (min amount is GBP 0.3 vs $0.5 in the US & CA)
* Hid option to collect payment with card reader under `IPP_UK` feature flag

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Test collecting payments in the UK-based store with WisePad 3 card reader. 
You can ping me or CesarVC to add you to a British store.

Basic scenarios to test:
* Create a new order w/ products, fees, and shipping and collect payment using card reader
* Refund the order total
* Collect payment via the Payments hub from the "Menu" page
* Verify correct error message is shown when trying to collect too small value (< 0.3 GBP)

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
