### PR TITLE
Business logic for sorting products by recently sold

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
@@ -3,16 +3,17 @@ package com.woocommerce.android.extensions
 import kotlinx.coroutines.flow.Flow
 
 @Suppress("LongParameterList")
-inline fun <T1, T2, T3, T4, T5, T6, R> combine(
+inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,
     flow3: Flow<T3>,
     flow4: Flow<T4>,
     flow5: Flow<T5>,
     flow6: Flow<T6>,
-    crossinline transform: suspend (T1, T2, T3, T4, T5, T6) -> R
+    flow7: Flow<T7>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R
 ): Flow<R> {
-    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6) { args: Array<*> ->
+    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7) { args: Array<*> ->
         @Suppress("UNCHECKED_CAST", "MagicNumber")
         transform(
             args[0] as T1,
@@ -21,6 +22,7 @@ inline fun <T1, T2, T3, T4, T5, T6, R> combine(
             args[3] as T4,
             args[4] as T5,
             args[5] as T6,
+            args[6] as T7,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -367,7 +367,8 @@ fun ProductListPreview() {
             loadingState = IDLE,
             filterState = FilterState(),
             searchQuery = "",
-            popularProducts = emptyList()
+            popularProducts = emptyList(),
+            recentProducts = emptyList(),
         ),
         {},
         {},
@@ -388,6 +389,7 @@ fun ProductListEmptyPreview() {
             filterState = FilterState(),
             searchQuery = "",
             popularProducts = emptyList(),
+            recentProducts = emptyList(),
         ),
         {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -95,6 +95,7 @@ class ProductSelectorViewModel @Inject constructor(
         }
     }
     private val popularProducts: MutableStateFlow<List<Product>> = MutableStateFlow(emptyList())
+    private val recentProducts: MutableStateFlow<List<Product>> = MutableStateFlow(emptyList())
 
     private var fetchProductsJob: Job? = null
     private var loadMoreJob: Job? = null
@@ -129,8 +130,13 @@ class ProductSelectorViewModel @Inject constructor(
         monitorProductFilters()
         viewModelScope.launch {
             loadPopularProducts()
+            loadRecentProducts()
             fetchProducts(forceRefresh = true)
         }
+    }
+
+    private suspend fun loadRecentProducts() {
+        val recentlySoldOrders = getRecentlySoldOrders().take(5)
     }
 
     private suspend fun loadPopularProducts() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -179,8 +179,8 @@ class ProductSelectorViewModel @Inject constructor(
     private fun getProductIdsFromRecentlySoldOrders(
         recentlySoldOrdersList: List<OrderEntity>
     ) = recentlySoldOrdersList.flatMap { orderEntity ->
-            orderEntity.getLineItemList().mapNotNull { it.productId }
-        }
+        orderEntity.getLineItemList().mapNotNull { it.productId }
+    }
 
     private fun Product.toUiModel(selectedItems: Collection<SelectedItem>): ProductListItem {
         fun getProductSelection(): SelectionState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -178,17 +178,9 @@ class ProductSelectorViewModel @Inject constructor(
 
     private fun getProductIdsFromRecentlySoldOrders(
         recentlySoldOrdersList: List<OrderEntity>
-    ): List<Long> {
-        val productIds = mutableListOf<Long>()
-        recentlySoldOrdersList.forEach { orderEntity ->
-            orderEntity.getLineItemList().forEach { lineItem ->
-                lineItem.productId?.let { productId ->
-                    productIds.add(productId)
-                }
-            }
+    ) = recentlySoldOrdersList.flatMap { orderEntity ->
+            orderEntity.getLineItemList().mapNotNull { it.productId }
         }
-        return productIds
-    }
 
     private fun Product.toUiModel(selectedItems: Collection<SelectedItem>): ProductListItem {
         fun getProductSelection(): SelectionState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
@@ -138,7 +137,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private suspend fun loadRecentProducts() {
-        val recentlySoldOrders = getRecentlySoldOrders().take(NO_OF_PRODUCTS)
+        val recentlySoldOrders = getRecentlySoldOrders().take(NUMBER_OF_SUGGESTED_ITEMS)
         recentProducts.value = productsMapper.mapProductIdsToProduct(
             getProductIdsFromRecentlySoldOrders(
                 recentlySoldOrders

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -140,7 +140,7 @@ class ProductSelectorViewModel @Inject constructor(
     private suspend fun loadRecentProducts() {
         val recentlySoldOrders = getRecentlySoldOrders().take(NO_OF_PRODUCTS)
         recentProducts.value = productsMapper.mapProductIdsToProduct(
-            getProductIdFromRecentlySoldOrders(
+            getProductIdsFromRecentlySoldOrders(
                 recentlySoldOrders
             )
         )
@@ -176,7 +176,7 @@ class ProductSelectorViewModel @Inject constructor(
         return popularProductsMap
     }
 
-    private fun getProductIdFromRecentlySoldOrders(
+    private fun getProductIdsFromRecentlySoldOrders(
         recentlySoldOrdersList: List<OrderEntity>
     ): List<Long> {
         val productIds = mutableListOf<Long>()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -138,7 +138,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private suspend fun loadRecentProducts() {
-        val recentlySoldOrders = getRecentlySoldOrders().take(5)
+        val recentlySoldOrders = getRecentlySoldOrders().take(NO_OF_PRODUCTS)
         recentProducts.value = productsMapper.mapProductIdsToProduct(
             getProductIdFromRecentlySoldOrders(
                 recentlySoldOrders

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -184,7 +184,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 productsMapper,
             )
 
-            verify(productsMapper).mapProductIdsToProduct(argumentCaptor.capture())
+            verify(productsMapper, times(2)).mapProductIdsToProduct(argumentCaptor.capture())
             assertThat(argumentCaptor.firstValue).isEqualTo(
                 listOf(2445L, 2448L, 2447L, 2444L, 2446L)
             )
@@ -228,7 +228,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 productsMapper,
             )
 
-            verify(productsMapper).mapProductIdsToProduct(argumentCaptor.capture())
+            verify(productsMapper, times(2)).mapProductIdsToProduct(argumentCaptor.capture())
             assertThat(argumentCaptor.firstValue).isEqualTo(
                 listOf(2445L, 2448L, 2447L, 2444L, 2446L)
             )
@@ -244,6 +244,49 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             ).initSavedStateHandle()
             val recentOrdersList = generateTestOrders()
             whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(recentOrdersList)
+            val argumentCaptor = argumentCaptor<List<Long>>()
+
+            ProductSelectorViewModel(
+                navArgs,
+                currencyFormatter,
+                wooCommerceStore,
+                orderStore,
+                selectedSite,
+                listHandler,
+                variationSelectorRepository,
+                resourceProvider,
+                productsMapper,
+            )
+
+            verify(productsMapper, times(2)).mapProductIdsToProduct(argumentCaptor.capture())
+            assertThat(argumentCaptor.firstValue).isEqualTo(
+                listOf(2444L, 2446L, 2449L, 2450L, 2451L)
+            )
+        }
+    }
+
+    @Test
+    fun `given recent products, when view model created, then only filter recent products from the orders that are already paid`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+            ).initSavedStateHandle()
+            val ordersThatAreNotPaidYet = mutableListOf<OrderEntity>()
+            repeat(10) {
+                ordersThatAreNotPaidYet.add(
+                    OrderTestUtils.generateOrder(
+                        lineItems = generateLineItems(
+                            name = "ACME Bike",
+                            productId = "1111"
+                        ),
+                        datePaid = ""
+                    ),
+                )
+            }
+            val recentOrdersList = generateTestOrders()
+            val totalOrders = ordersThatAreNotPaidYet + recentOrdersList
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
             val argumentCaptor = argumentCaptor<List<Long>>()
 
             ProductSelectorViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -18,6 +18,7 @@ import org.junit.Test
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.OrderEntity
@@ -230,6 +231,36 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             verify(productsMapper).mapProductIdsToProduct(argumentCaptor.capture())
             assertThat(argumentCaptor.firstValue).isEqualTo(
                 listOf(2445L, 2448L, 2447L, 2444L, 2446L)
+            )
+        }
+    }
+
+    @Test
+    fun `given recent products, when view model created, then verify recent products are sorted in descending order`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+            ).initSavedStateHandle()
+            val recentOrdersList = generateTestOrders()
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(recentOrdersList)
+            val argumentCaptor = argumentCaptor<List<Long>>()
+
+            ProductSelectorViewModel(
+                navArgs,
+                currencyFormatter,
+                wooCommerceStore,
+                orderStore,
+                selectedSite,
+                listHandler,
+                variationSelectorRepository,
+                resourceProvider,
+                productsMapper,
+            )
+
+            verify(productsMapper, times(2)).mapProductIdsToProduct(argumentCaptor.capture())
+            assertThat(argumentCaptor.firstValue).isEqualTo(
+                listOf(2444L, 2446L, 2449L, 2450L, 2451L)
             )
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8569 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR includes the business logic required to get the products sorted by recently sold. To understand how recently sold products are calculated, please refer to this post: pdfdoF-2At-p2

This PR doesn't include any UI. Just the business logic. The business logic is not used anywhere at this point.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Nothing to test as the business logic is not integrated. Just make sure the CI is happy.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->