### PR TITLE
[TTP] Add BETA feature toggle only 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -104,6 +104,7 @@ object AppPrefs {
         UPDATE_SIMULATED_READER_OPTION,
         ENABLE_SIMULATED_INTERAC,
         CUSTOM_DOMAINS_SOURCE,
+        IS_TAP_TO_PAY_BETA_ENABLED,
     }
 
     /**
@@ -220,6 +221,10 @@ object AppPrefs {
     var isCouponsEnabled: Boolean
         get() = getBoolean(IS_COUPONS_ENABLED, false)
         set(value) = setBoolean(IS_COUPONS_ENABLED, value)
+
+    var isTapToPayEnabled: Boolean
+        get() = getBoolean(DeletablePrefKey.IS_TAP_TO_PAY_BETA_ENABLED, false)
+        set(value) = setBoolean(DeletablePrefKey.IS_TAP_TO_PAY_BETA_ENABLED, value)
 
     var isSimulatedReaderEnabled: Boolean
         get() = getBoolean(DeletablePrefKey.USE_SIMULATED_READER, false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailable.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailable.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments.taptopay
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
 import com.woocommerce.android.cardreader.connection.ReaderType
@@ -9,14 +10,14 @@ import com.woocommerce.android.util.SystemVersionUtilsWrapper
 import javax.inject.Inject
 
 class IsTapToPayAvailable @Inject constructor(
-    private val isTapToPayEnabled: IsTapToPayEnabled,
+    private val appPrefs: AppPrefs = AppPrefs,
     private val deviceFeatures: DeviceFeatures,
     private val systemVersionUtilsWrapper: SystemVersionUtilsWrapper,
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
 ) {
     operator fun invoke(countryCode: String) =
         when {
-            !isTapToPayEnabled() -> Result.NotAvailable.TapToPayDisabled
+            !appPrefs.isTapToPayEnabled -> Result.NotAvailable.TapToPayDisabled
             !systemVersionUtilsWrapper.isAtLeastP() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
             !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -136,6 +136,14 @@ class AppSettingsActivity :
         }
     }
 
+    override fun onTapToPayOptionChanged(enabled: Boolean) {
+        if (AppPrefs.isTapToPayEnabled != enabled) {
+            isBetaOptionChanged = true
+            AppPrefs.isTapToPayEnabled = enabled
+            setResult(RESULT_CODE_BETA_OPTIONS_CHANGED)
+        }
+    }
+
     override fun finishLogout() {
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
         statsWidgetUpdaters.updateTodayWidget()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.prefs
 import android.os.Bundle
 import android.view.View
 import android.widget.CompoundButton
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
@@ -11,10 +12,17 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_ADDONS_BETA_FEATURES_SWITCH_TOGGLED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSettingsBetaBinding
+import com.woocommerce.android.ui.payments.taptopay.IsTapToPayEnabled
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
+    @Inject
+    lateinit var tapToPayEnabled: IsTapToPayEnabled
+
     companion object {
         const val TAG = "beta-features"
     }
@@ -29,6 +37,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         with(FragmentSettingsBetaBinding.bind(view)) {
             bindProductAddonsToggle()
             bindCouponsToggle()
+            bindTapToPayToggle()
         }
     }
 
@@ -53,6 +62,19 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         switchCouponsToggle.setOnCheckedChangeListener { switch, isChecked ->
             settingsListener?.onCouponsOptionChanged(isChecked)
                 ?: handleToggleChangeFailure(switch, isChecked)
+        }
+    }
+
+    private fun FragmentSettingsBetaBinding.bindTapToPayToggle() {
+        if (tapToPayEnabled()) {
+            switchTapToPayToggle.isVisible = true
+            switchTapToPayToggle.isChecked = AppPrefs.isTapToPayEnabled
+            switchTapToPayToggle.setOnCheckedChangeListener { switch, isChecked ->
+                settingsListener?.onTapToPayOptionChanged(isChecked)
+                    ?: handleToggleChangeFailure(switch, isChecked)
+            }
+        } else {
+            switchTapToPayToggle.isVisible = false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -68,6 +68,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         fun onRequestLogout()
         fun onProductAddonsOptionChanged(enabled: Boolean)
         fun onCouponsOptionChanged(enabled: Boolean)
+        fun onTapToPayOptionChanged(enabled: Boolean)
     }
 
     private lateinit var settingsListener: AppSettingsListener

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -21,6 +21,14 @@
         app:toggleOptionDesc="@string/coupon_beta_features_subheading"
         app:toggleOptionTitle="@string/coupon_beta_features_heading" />
 
+
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+        android:id="@+id/switchTapToPayToggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:toggleOptionDesc="@string/card_reader_tap_to_pay_beta_features_subheading"
+        app:toggleOptionTitle="@string/card_reader_tap_to_pay_beta_features_heading" />
+
     <View style="@style/Woo.Divider" />
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1182,6 +1182,8 @@
     <string name="card_reader_tap_to_pay_explanation_where_to_find"> You can find Tap to Pay on Android in\nMenu > Payments, or Collect Payment and\nchoose Tap to Pay.</string>
     <string name="card_reader_tap_to_pay_explanation_try_payment">Try a payment</string>
     <string name="card_reader_tap_to_pay_explanation_test_payment_error">Something went wrong. Please try again later.</string>
+    <string name="card_reader_tap_to_pay_beta_features_heading">Tap To Pay</string>
+    <string name="card_reader_tap_to_pay_beta_features_subheading">Test out Tap To Pay in the app</string>
 
     <!--
             Card Reader Type Selection

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailableTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailableTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments.taptopay
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
@@ -15,7 +16,7 @@ class IsTapToPayAvailableTest {
     private val systemVersionUtilsWrapper = mock<SystemVersionUtilsWrapper> {
         on { isAtLeastP() }.thenReturn(true)
     }
-    private val isTapToPayEnabled: IsTapToPayEnabled = mock()
+    private val appPrefs: AppPrefs = mock()
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider = mock {
         on { provideCountryConfigFor("US") }.thenReturn(CardReaderConfigForUSA)
         on { provideCountryConfigFor("CA") }.thenReturn(CardReaderConfigForCanada)
@@ -23,16 +24,16 @@ class IsTapToPayAvailableTest {
     }
 
     @Test
-    fun `given device has no NFC, when invoking, then nfc disabled returned`() {
+    fun `given device has no NFC and ttp enabled, when invoking, then nfc disabled returned`() {
         val deviceFeatures = mock<DeviceFeatures> {
             whenever(it.isNFCAvailable()).thenReturn(false)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
-        whenever(isTapToPayEnabled.invoke()).thenReturn(true)
+        whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = IsTapToPayAvailable(
-            isTapToPayEnabled,
+            appPrefs,
             deviceFeatures,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
@@ -42,16 +43,16 @@ class IsTapToPayAvailableTest {
     }
 
     @Test
-    fun `given device has no Google Play Services, when invoking, then GPS not available`() {
+    fun `given device has no Google Play Services and ttp enabled, when invoking, then GPS not available`() {
         val deviceFeatures = mock<DeviceFeatures> {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(false)
         }
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
-        whenever(isTapToPayEnabled.invoke()).thenReturn(true)
+        whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = IsTapToPayAvailable(
-            isTapToPayEnabled,
+            appPrefs,
             deviceFeatures,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
@@ -61,16 +62,16 @@ class IsTapToPayAvailableTest {
     }
 
     @Test
-    fun `given device has os less than Android 9, when invoking, then system is not supported returned`() {
+    fun `given device has os less than Android 9 and ttp enabled, when invoking, then system is not supported returned`() {
         val context = mock<DeviceFeatures> {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(false)
-        whenever(isTapToPayEnabled.invoke()).thenReturn(true)
+        whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = IsTapToPayAvailable(
-            isTapToPayEnabled,
+            appPrefs,
             context,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
@@ -80,16 +81,16 @@ class IsTapToPayAvailableTest {
     }
 
     @Test
-    fun `given country other than US, when invoking, then country is not supported returned`() {
+    fun `given country other than US and ttp enabled, when invoking, then country is not supported returned`() {
         val context = mock<DeviceFeatures> {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
-        whenever(isTapToPayEnabled.invoke()).thenReturn(true)
+        whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = IsTapToPayAvailable(
-            isTapToPayEnabled,
+            appPrefs,
             context,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
@@ -105,10 +106,10 @@ class IsTapToPayAvailableTest {
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
-        whenever(isTapToPayEnabled.invoke()).thenReturn(false)
+        whenever(appPrefs.isTapToPayEnabled).thenReturn(false)
 
         val result = IsTapToPayAvailable(
-            isTapToPayEnabled,
+            appPrefs,
             context,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
@@ -118,16 +119,16 @@ class IsTapToPayAvailableTest {
     }
 
     @Test
-    fun `given device satisfies all the requirements, when invoking, then tpp available returned`() {
+    fun `given device satisfies all the requirements and ttp enabled, when invoking, then tpp available returned`() {
         val context = mock<DeviceFeatures> {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
-        whenever(isTapToPayEnabled.invoke()).thenReturn(true)
+        whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = IsTapToPayAvailable(
-            isTapToPayEnabled,
+            appPrefs,
             context,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8671
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds feature toggle to the beta feature screen so eventually we can have "soft" lunch of the feature
Notice that TTP and this toggle are disabled at the moment on the release builds

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* On debug build open settings -> Beta feature -> enable TTP. Notice that TTP is enabled now
* On release build notice that the toggle is not visible and the users won't be able to see TTP in the app

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/4923871/228500840-8affc95d-e1bd-4a4c-aa23-fb5a314eeb3b.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
