### PR TITLE
[trunk fix] Update Free Trial copy argument type

### DIFF
--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -16,7 +16,7 @@ Language: ar
     <string name="upgrades_upgrade_now">قم بالترقية الآن</string>
     <string name="upgrades_report_subscription_issue">الإبلاغ بمشكلة في الاشتراك</string>
     <string name="free_trial_upgrade_now">قم بالترقية الآن</string>
-    <string name="free_trial_days_left">يتبقى ⁦%1$d⁩ من الأيام في الإصدار التجريبي لديك.</string>
+    <string name="free_trial_days_left">يتبقى ⁦%1$s⁩ من الأيام في الإصدار التجريبي لديك.</string>
     <string name="free_trial_trial_ended">انتهى الإصدار التجريبي</string>
     <string name="free_trial_your_trial_ended">انتهى الإصدار التجريبي الخاص بك.</string>
     <string name="store_onboarding_launch_store_generic_error_description">عذرًا، حدثت بعض الأخطاء غير المتوقعة.</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -16,7 +16,7 @@ Language: de
     <string name="upgrades_upgrade_now">Jetzt Upgrade durchführen</string>
     <string name="upgrades_report_subscription_issue">Problem mit Abonnement melden</string>
     <string name="free_trial_upgrade_now">Jetzt Upgrade durchführen</string>
-    <string name="free_trial_days_left">Noch %1$d Tage bis zum Ablauf deines Gratis-Tests.</string>
+    <string name="free_trial_days_left">Noch %1$s Tage bis zum Ablauf deines Gratis-Tests.</string>
     <string name="free_trial_trial_ended">Gratis-Test abgelaufen</string>
     <string name="free_trial_your_trial_ended">Dein Gratis-Test ist abgelaufen.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Ups, es sind unerwartete Fehler aufgetreten.</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -16,7 +16,7 @@ Language: es
     <string name="upgrades_upgrade_now">Mejora tu plan ahora</string>
     <string name="upgrades_report_subscription_issue">Notificar un problema de suscripción</string>
     <string name="free_trial_upgrade_now">Mejora tu plan ahora</string>
-    <string name="free_trial_days_left">El período de prueba finaliza en %1$d días.</string>
+    <string name="free_trial_days_left">El período de prueba finaliza en %1$s días.</string>
     <string name="free_trial_trial_ended">Período de prueba finalizado</string>
     <string name="free_trial_your_trial_ended">Tu período de prueba ha finalizado.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Ups, han ocurrido algunos errores inesperados.</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -16,7 +16,7 @@ Language: fr
     <string name="upgrades_upgrade_now">Choisir une option payante maintenant</string>
     <string name="upgrades_report_subscription_issue">Signaler un problème d’abonnement</string>
     <string name="free_trial_upgrade_now">Choisir une option payante maintenant</string>
-    <string name="free_trial_days_left">%1$d jours d’essai restants</string>
+    <string name="free_trial_days_left">%1$s jours d’essai restants</string>
     <string name="free_trial_trial_ended">L’essai est terminé</string>
     <string name="free_trial_your_trial_ended">Votre essai est terminé.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Oups. des erreurs inattendues se sont produites.</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -16,7 +16,7 @@ Language: he_IL
     <string name="upgrades_upgrade_now">זה הזמן לשדרג</string>
     <string name="upgrades_report_subscription_issue">לדווח על בעיה במינוי</string>
     <string name="free_trial_upgrade_now">זה הזמן לשדרג</string>
-    <string name="free_trial_days_left">נותרו ⁦%1$d⁩ ימים בתקופת הניסיון שלך.</string>
+    <string name="free_trial_days_left">נותרו ⁦%1$s⁩ ימים בתקופת הניסיון שלך.</string>
     <string name="free_trial_trial_ended">תקופת הניסיון הסתיימה</string>
     <string name="free_trial_your_trial_ended">תקופת הניסיון שלך הסתיימה.</string>
     <string name="store_onboarding_launch_store_generic_error_description">אופס, אירעו כמה שגיאות לא צפויות.</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -16,7 +16,7 @@ Language: id
     <string name="upgrades_upgrade_now">Upgrade sekarang</string>
     <string name="upgrades_report_subscription_issue">Laporkan masalah langganan</string>
     <string name="free_trial_upgrade_now">Upgrade Sekarang</string>
-    <string name="free_trial_days_left">Masa percobaan Anda tersisa %1$d hari.</string>
+    <string name="free_trial_days_left">Masa percobaan Anda tersisa %1$s hari.</string>
     <string name="free_trial_trial_ended">Masa percobaan berakhir</string>
     <string name="free_trial_your_trial_ended">Masa percobaan Anda telah berakhir.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Waduh, terjadi error tak terduga.</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -16,7 +16,7 @@ Language: it
     <string name="upgrades_upgrade_now">Aggiorna ora</string>
     <string name="upgrades_report_subscription_issue">Segnala il problema con l\'abbonamento</string>
     <string name="free_trial_upgrade_now">Aggiorna ora</string>
-    <string name="free_trial_days_left">%1$d giorni di prova rimasti.</string>
+    <string name="free_trial_days_left">%1$s giorni di prova rimasti.</string>
     <string name="free_trial_trial_ended">Prova terminata</string>
     <string name="free_trial_your_trial_ended">La tua prova è terminata.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Ops, si sono verificati alcuni errori imprevisti.</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -16,7 +16,7 @@ Language: ja_JP
     <string name="upgrades_upgrade_now">今すぐアップグレード</string>
     <string name="upgrades_report_subscription_issue">購読に関する問題を報告</string>
     <string name="free_trial_upgrade_now">今すぐアップグレード</string>
-    <string name="free_trial_days_left">お試し期間はあと%1$d日です。</string>
+    <string name="free_trial_days_left">お試し期間はあと%1$s日です。</string>
     <string name="free_trial_trial_ended">お試し期間終了</string>
     <string name="free_trial_your_trial_ended">お試し期間が終了しました。</string>
     <string name="store_onboarding_launch_store_generic_error_description">予期しないエラーが発生しました。</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -16,7 +16,7 @@ Language: ko_KR
     <string name="upgrades_upgrade_now">지금 업그레이드</string>
     <string name="upgrades_report_subscription_issue">구독 문제 신고</string>
     <string name="free_trial_upgrade_now">지금 업그레이드</string>
-    <string name="free_trial_days_left">평가판이 %1$d일 남았습니다.</string>
+    <string name="free_trial_days_left">평가판이 %1$s일 남았습니다.</string>
     <string name="free_trial_trial_ended">평가판 종료됨</string>
     <string name="free_trial_your_trial_ended">평가판이 종료되었습니다.</string>
     <string name="store_onboarding_launch_store_generic_error_description">죄송합니다. 예기치 않은 오류가 발생했습니다.</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -16,7 +16,7 @@ Language: nl
     <string name="upgrades_upgrade_now">Upgrade nu</string>
     <string name="upgrades_report_subscription_issue">Meld probleem met abonnement</string>
     <string name="free_trial_upgrade_now">Upgrade nu</string>
-    <string name="free_trial_days_left">%1$d dagen resterend van je proefversie</string>
+    <string name="free_trial_days_left">%1$s dagen resterend van je proefversie</string>
     <string name="free_trial_trial_ended">Einde proefabonnement</string>
     <string name="free_trial_your_trial_ended">Je proefversie is beëindigd.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Oeps, er zijn onverwachte fouten opgetreden.</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -16,7 +16,7 @@ Language: pt_BR
     <string name="upgrades_upgrade_now">Faça upgrade agora mesmo</string>
     <string name="upgrades_report_subscription_issue">Relatar problema de assinatura</string>
     <string name="free_trial_upgrade_now">Faça upgrade agora mesmo</string>
-    <string name="free_trial_days_left">%1$d dias restantes do seu teste.</string>
+    <string name="free_trial_days_left">%1$s dias restantes do seu teste.</string>
     <string name="free_trial_trial_ended">Período de teste expirado</string>
     <string name="free_trial_your_trial_ended">Seu período de teste terminou.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Ops! Houve alguns erros inesperados.</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -16,7 +16,7 @@ Language: ru
     <string name="upgrades_upgrade_now">Перейти на платную подписку</string>
     <string name="upgrades_report_subscription_issue">Сообщить о проблеме с подпиской</string>
     <string name="free_trial_upgrade_now">Перейти на платную подписку</string>
-    <string name="free_trial_days_left">Осталось %1$d дн. до окончания пробного периода.</string>
+    <string name="free_trial_days_left">Осталось %1$s дн. до окончания пробного периода.</string>
     <string name="free_trial_trial_ended">Конец пробного периода</string>
     <string name="free_trial_your_trial_ended">Пробный период закончился.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Произошли неожиданные ошибки.</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -16,7 +16,7 @@ Language: sv_SE
     <string name="upgrades_upgrade_now">Uppgradera nu</string>
     <string name="upgrades_report_subscription_issue">Rapportera prenumerationsproblem</string>
     <string name="free_trial_upgrade_now">Uppgradera nu</string>
-    <string name="free_trial_days_left">%1$d dagar kvar av din provperiod.</string>
+    <string name="free_trial_days_left">%1$s dagar kvar av din provperiod.</string>
     <string name="free_trial_trial_ended">Provperioden avslutades</string>
     <string name="free_trial_your_trial_ended">Din provperiod har avslutats.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Hoppsan, det uppstod några oväntade fel.</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -16,7 +16,7 @@ Language: tr
     <string name="upgrades_upgrade_now">Hemen yükseltin</string>
     <string name="upgrades_report_subscription_issue">Abonelik sorunu bildir</string>
     <string name="free_trial_upgrade_now">Hemen Yükseltin</string>
-    <string name="free_trial_days_left">Deneme sürenizin %1$d günü kaldı.</string>
+    <string name="free_trial_days_left">Deneme sürenizin %1$s günü kaldı.</string>
     <string name="free_trial_trial_ended">Deneme süresi sonu</string>
     <string name="free_trial_your_trial_ended">Deneme süreniz sona erdi.</string>
     <string name="store_onboarding_launch_store_generic_error_description">Hay aksi, beklenmeyen bazı hatalar oluştu.</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -16,7 +16,7 @@ Language: zh_CN
     <string name="upgrades_upgrade_now">立即升级</string>
     <string name="upgrades_report_subscription_issue">报告订阅问题</string>
     <string name="free_trial_upgrade_now">立即升级</string>
-    <string name="free_trial_days_left">%1$d 天后免费试用结束。</string>
+    <string name="free_trial_days_left">%1$s 天后免费试用结束。</string>
     <string name="free_trial_trial_ended">试用已结束</string>
     <string name="free_trial_your_trial_ended">您的试用已结束。</string>
     <string name="store_onboarding_launch_store_generic_error_description">糟糕，发生意外错误。</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -16,7 +16,7 @@ Language: zh_TW
     <string name="upgrades_upgrade_now">立即升級</string>
     <string name="upgrades_report_subscription_issue">回報訂閱問題</string>
     <string name="free_trial_upgrade_now">立即升級</string>
-    <string name="free_trial_days_left">試用期尚餘 %1$d 天</string>
+    <string name="free_trial_days_left">試用期尚餘 %1$s 天</string>
     <string name="free_trial_trial_ended">試用結束</string>
     <string name="free_trial_your_trial_ended">你的試用已結束。</string>
     <string name="store_onboarding_launch_store_generic_error_description">糟糕，發生了一些未預期的錯誤。</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates argument type from d (int) to s (string) for languages other than english. This fixes failing "lint" step on trunk introduced in #8632.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
