### PR TITLE
Variation list read only mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -572,9 +572,9 @@ class ProductDetailCardBuilder(
                     PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
                 )
             }
-        } else {
+        } else if (isVariableSubscription.not()) {
             emptyVariations()
-        }
+        } else null
     }
 
     private fun Product.emptyVariations() =
@@ -709,6 +709,10 @@ class ProductDetailCardBuilder(
 
     private fun Product.warning(): ProductProperty? {
         val variations = variationRepository.getProductVariationList(this.remoteId)
+
+        if (variations.isEmpty() && productType == VARIABLE_SUBSCRIPTION) {
+            return ProductProperty.Warning(resources.getString(string.no_variable_subscription_warning))
+        }
 
         val missingPriceVariation = variations
             .find { it.regularPrice == null || it.regularPrice == BigDecimal.ZERO }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -549,7 +549,8 @@ class ProductDetailCardBuilder(
     }
 
     // show product variations only if product type is variable and if there are variations for the product
-    private fun Product.variations(): ProductProperty {
+    private fun Product.variations(): ProductProperty? {
+        val isVariableSubscription = this.productType == VARIABLE_SUBSCRIPTION
         return if (this.numVariations > 0 && this.variationEnabledAttributes.isNotEmpty()) {
             val content = StringUtils.getQuantityString(
                 resourceProvider = resources,
@@ -564,7 +565,10 @@ class ProductDetailCardBuilder(
                 drawable.ic_gridicons_types
             ) {
                 viewModel.onEditProductCardClicked(
-                    ViewProductVariations(this.remoteId),
+                    ViewProductVariations(
+                        remoteId = this.remoteId,
+                        isReadOnlyMode = isVariableSubscription
+                    ),
                     PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -19,7 +19,8 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 sealed class ProductNavigationTarget : Event() {
     data class ShareProduct(val url: String, val title: String) : ProductNavigationTarget()
     data class ViewProductVariations(
-        val remoteId: Long
+        val remoteId: Long,
+        val isReadOnlyMode: Boolean = false
     ) : ProductNavigationTarget()
 
     data class ViewProductInventory(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -83,7 +83,8 @@ class ProductNavigator @Inject constructor() {
             is ViewProductVariations -> {
                 val action = ProductDetailFragmentDirections
                     .actionProductDetailFragmentToVariationListFragment(
-                        target.remoteId
+                        target.remoteId,
+                        target.isReadOnlyMode
                     )
                 fragment.findNavController().navigateSafely(action)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -188,6 +188,9 @@ class VariationListFragment :
                     hideProgressDialog()
                 }
             }
+            new.isAddVariationButtonVisible.takeIfNotEqualTo(old?.isAddVariationButtonVisible) { isVisible ->
+                binding.addVariationButton.isVisible = isVisible
+            }
         }
 
         viewModel.variationList.observe(viewLifecycleOwner) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -77,6 +77,8 @@ class VariationListViewModel @Inject constructor(
     private val navArgs: VariationListFragmentArgs by savedState.navArgs()
     private val remoteProductId = navArgs.remoteProductId
 
+    private val isReadOnlyMode = navArgs.isReadOnlyMode
+
     private val _variationList = MutableLiveData<List<ProductVariation>>()
     val variationList: LiveData<List<ProductVariation>> = Transformations.map(_variationList) { variations ->
         val isEmpty = viewState.parentProduct?.variationEnabledAttributes?.isEmpty() == true
@@ -92,7 +94,7 @@ class VariationListViewModel @Inject constructor(
         }
     }
 
-    val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
+    val viewStateLiveData = LiveDataDelegate(savedState, ViewState(isAddVariationButtonVisible = isReadOnlyMode.not()))
     private var viewState by viewStateLiveData
 
     private var loadingJob: Job? = null
@@ -247,11 +249,14 @@ class VariationListViewModel @Inject constructor(
             if (fetchedVariations.isEmpty()) {
                 if (!loadMore) {
                     _variationList.value = emptyList()
-                    viewState = viewState.copy(isEmptyViewVisible = true, isVariationsOptionsMenuEnabled = false)
+                    viewState = viewState.copy(
+                        isEmptyViewVisible = true,
+                        isVariationsOptionsMenuEnabled = false
+                    )
                 }
             } else {
                 _variationList.value = combineData(fetchedVariations)
-                viewState = viewState.copy(isVariationsOptionsMenuEnabled = true)
+                viewState = viewState.copy(isVariationsOptionsMenuEnabled = isReadOnlyMode.not())
             }
         } else {
             triggerEvent(ShowSnackbar(string.offline_error))
@@ -262,6 +267,7 @@ class VariationListViewModel @Inject constructor(
             isLoadingMore = false
         )
     }
+
     private fun combineData(variations: List<ProductVariation>): List<ProductVariation> {
         val currencyCode = variationRepository.getCurrencyCode()
         variations.map { variation ->
@@ -351,6 +357,7 @@ class VariationListViewModel @Inject constructor(
         val parentProduct: Product? = null,
         val isVariationsOptionsMenuEnabled: Boolean = false,
         val isBulkUpdateProgressDialogShown: Boolean = false,
+        val isAddVariationButtonVisible: Boolean = true
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -118,6 +118,10 @@
                 android:name="variationsToUpdate"
                 app:argType="com.woocommerce.android.model.ProductVariation[]" />
         </action>
+        <argument
+            android:name="isReadOnlyMode"
+            app:argType="boolean"
+            android:defaultValue="false" />
 
     </fragment>
     <dialog

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3172,6 +3172,7 @@
     <string name="subscription_no_sign_up_fee">No sign up fee</string>
     <string name="subscription_no_trial">No trial period</string>
     <string name="subscription_details_info_notice">You can edit product subscriptions in the web dashboard.</string>
+    <string name="no_variable_subscription_warning">You can only add variable subscriptions in the web dashboard.</string>
     <!--
     Subscription status
     -->


### PR DESCRIPTION
### Why
We are working on read-only support for the WooCommerce Subscriptions extension.

### Description
This PR implements a read-only mode on the variations list screen to prevent merchants from trying to add a new subscription variation. Because we are not supporting editing subscription settings from the app in this first iteration, allowing the creation of new subscription variations ended with a variation without the subscription information. This PR fixes this behavior by hiding editing operations from the variations list screen.

### Testing instructions
TC1
1. Open the Products tab
2. Select a Variable Subscription with variations
3. Check that the Variations List Screen is shown without the Add Variation button or the more menu (3 dots)

TC2
1. Open the Products tab
2. Select a Variable Product with variations
3. Check that the Variations List Screen is shown and that the Add Variation button and the more menu (3 dots) are visible

TC3
1. Open the Products tab
2. Select a Variable Subscription without variations
3. Check that a warning is displayed indicating that variable subscription can only be added on the web dashboard

### Images/gif
| Read only mode | Without Variations |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/18119390/228581196-2bff584b-9d6e-4da2-8846-8e6ac705d53d.png" /> | <img width="300" src="https://user-images.githubusercontent.com/18119390/228581307-7ce006d3-08f6-427f-a522-3fc858a00934.png" />  |


