### PR TITLE
[TTP] change text on ttp button and feedback in the payments hub

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -217,12 +217,8 @@ class CardReaderHubViewModel @Inject constructor(
             add(
                 NonToggleableListItem(
                     icon = R.drawable.ic_baseline_contactless,
-                    label = UiStringRes(R.string.card_reader_tap_to_pay),
-                    description = if (appPrefs.isTTPWasUsedAtLeastOnce()) {
-                        UiStringRes(R.string.card_reader_tap_to_pay_description_used)
-                    } else {
-                        UiStringRes(R.string.card_reader_tap_to_pay_description_not_used)
-                    },
+                    label = UiStringRes(R.string.card_reader_test_tap_to_pay),
+                    description = UiStringRes(R.string.card_reader_tap_to_pay_description),
                     index = 5,
                     onClick = ::onTapTooPayClicked,
                     shortDivider = shouldShowTTPFeedbackRequest,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1166,10 +1166,9 @@
     <string name="card_reader_icon_content_description">Card Reader Image</string>
     <string name="card_reader_onboarding_not_finished">We’ve noticed that you have not yet finished In-Person Payments setup. &lt;a href=\'\'&gt;Continue setup&lt;/a&gt;</string>
     <string name="card_reader_onboarding_with_pending_requirements">There is an issue that requires your attention. Please &lt;a href=\'\'&gt;take a look&lt;/a&gt;</string>
-    <string name="card_reader_tap_to_pay">Tap To Pay</string>
+    <string name="card_reader_test_tap_to_pay">Test Your Tap To Pay</string>
+    <string name="card_reader_tap_to_pay_description">You can test Tap To Pay with a small\namount here.</string>
     <string name="card_reader_tap_to_pay_share_feedback">Share Tap to Pay feedback</string>
-    <string name="card_reader_tap_to_pay_description_not_used">Use your phone to accept card\npayments. Try it now.</string>
-    <string name="card_reader_tap_to_pay_description_used">Use your phone to accept card payments.</string>
     <string name="card_reader_tap_to_pay_not_available_error">Tap to Pay is not available for your store or device</string>
 
     <!--

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -1247,7 +1247,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given ttp available and not used, when view model started, then show ttp row with not used description`() =
+    fun `given ttp available and not used, when view model started, then show ttp row with description`() =
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
@@ -1264,14 +1264,14 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
             assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).anyMatch {
                 it is NonToggleableListItem &&
                     it.icon == R.drawable.ic_baseline_contactless &&
-                    it.label == UiStringRes(R.string.card_reader_tap_to_pay) &&
-                    it.description == UiStringRes(R.string.card_reader_tap_to_pay_description_not_used) &&
+                    it.label == UiStringRes(R.string.card_reader_test_tap_to_pay) &&
+                    it.description == UiStringRes(R.string.card_reader_tap_to_pay_description) &&
                     it.index == 5
             }
         }
 
     @Test
-    fun `given ttp available and used, when view model started, then show ttp row with used description`() =
+    fun `given ttp available, when view model started, then show ttp row with used description`() =
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
@@ -1291,8 +1291,8 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
             assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).anyMatch {
                 it is NonToggleableListItem &&
                     it.icon == R.drawable.ic_baseline_contactless &&
-                    it.label == UiStringRes(R.string.card_reader_tap_to_pay) &&
-                    it.description == UiStringRes(R.string.card_reader_tap_to_pay_description_used) &&
+                    it.label == UiStringRes(R.string.card_reader_test_tap_to_pay) &&
+                    it.description == UiStringRes(R.string.card_reader_tap_to_pay_description) &&
                     it.index == 5
             }
         }
@@ -1442,7 +1442,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).noneMatch {
-            it.label == UiStringRes(R.string.card_reader_tap_to_pay)
+            it.label == UiStringRes(R.string.card_reader_test_tap_to_pay)
         }
     }
 
@@ -1457,7 +1457,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).noneMatch {
-            it.label == UiStringRes(R.string.card_reader_tap_to_pay)
+            it.label == UiStringRes(R.string.card_reader_test_tap_to_pay)
         }
     }
 
@@ -1472,7 +1472,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).noneMatch {
-            it.label == UiStringRes(R.string.card_reader_tap_to_pay)
+            it.label == UiStringRes(R.string.card_reader_test_tap_to_pay)
         }
     }
 
@@ -1487,7 +1487,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).noneMatch {
-            it.label == UiStringRes(R.string.card_reader_tap_to_pay)
+            it.label == UiStringRes(R.string.card_reader_test_tap_to_pay)
         }
     }
 
@@ -1502,7 +1502,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).noneMatch {
-            it.label == UiStringRes(R.string.card_reader_tap_to_pay)
+            it.label == UiStringRes(R.string.card_reader_test_tap_to_pay)
         }
     }
     // endregion
@@ -1552,7 +1552,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         // WHEN
         initViewModel()
         (viewModel.viewStateData.getOrAwaitValue()).rows.find {
-            it.label == UiStringRes(R.string.card_reader_tap_to_pay)
+            it.label == UiStringRes(R.string.card_reader_test_tap_to_pay)
         }!!.onClick!!.invoke()
 
         // THEN
@@ -1568,7 +1568,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         val rows = (viewModel.viewStateData.getOrAwaitValue()).rows
         assertThat(
             rows.filterIsInstance<NonToggleableListItem>()
-                .filter { it.label != UiStringRes(R.string.card_reader_tap_to_pay) }
+                .filter { it.label != UiStringRes(R.string.card_reader_test_tap_to_pay) }
                 .map { it.description }
         ).allMatch { it == null }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -1247,30 +1247,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given ttp available and not used, when view model started, then show ttp row with description`() =
-        testBlocking {
-            // GIVEN
-            whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(isTapToPayAvailable("US")).thenReturn(Available)
-            whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(false)
-
-            // WHEN
-            initViewModel()
-
-            // THEN
-            assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).anyMatch {
-                it is GapBetweenSections && it.index == 4
-            }
-            assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).anyMatch {
-                it is NonToggleableListItem &&
-                    it.icon == R.drawable.ic_baseline_contactless &&
-                    it.label == UiStringRes(R.string.card_reader_test_tap_to_pay) &&
-                    it.description == UiStringRes(R.string.card_reader_tap_to_pay_description) &&
-                    it.index == 5
-            }
-        }
-
-    @Test
     fun `given ttp available, when view model started, then show ttp row with used description`() =
         testBlocking {
             // GIVEN


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8686
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Changes the text to better inform people about that TTP in the payments hub just for testing

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Open the payments hub and verify the new text

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src=https://user-images.githubusercontent.com/4923871/228795033-28320244-a99c-45e7-a7fc-d661a5972db6.png width=300/>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
