### PR TITLE
[UI Tests] Added 3 new Products search e2e tests that use real WPCOM API.

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "woocommerce-android",
   "branch": "trunk",
-  "pinned_hash": "d2f314b7e34e5cd8fdcdce61ef0fcebcfb40bf75",
+  "pinned_hash": "011c528eeece87a22d0ecc780250fc3ec8a86acf",
   "files_to_copy": [
     {
       "file": "android/WCAndroid/gradle.properties",

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/MockingInterceptor.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/MockingInterceptor.kt
@@ -6,6 +6,8 @@ import okhttp3.Response
 import java.io.IOException
 import javax.inject.Singleton
 
+var useMockedAPI: Boolean = true
+
 @Singleton
 class MockingInterceptor : Interceptor {
     @Throws(IOException::class)
@@ -13,7 +15,7 @@ class MockingInterceptor : Interceptor {
         val request = chain.request()
 
         // Redirect all WordPress.com REST API requests to local mock server
-        if (request.url.host == "public-api.wordpress.com") {
+        if (useMockedAPI && request.url.host == "public-api.wordpress.com") {
             val newUrl = request.url.newBuilder()
                 .scheme("http")
                 .host("localhost")

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/DataClasses.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/DataClasses.kt
@@ -44,14 +44,16 @@ data class ReviewData(
 }
 
 data class ProductData(
-    val id: Int,
+    val id: Int = -1,
     val name: String,
     val stockStatusRaw: String,
     val priceDiscountedRaw: String,
-    val priceRegularRaw: String,
-    val typeRaw: String,
-    val rating: Int,
-    val reviewsCount: Int
+    val priceRegularRaw: String = "",
+    val typeRaw: String = "",
+    val rating: Int = -1,
+    val reviewsCount: Int = -1,
+    val sku: String = "",
+    val variations: String = ""
 ) {
     val stockStatus = productStatusesMap[stockStatusRaw]
     val price = getPriceDescription()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.R
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
+import org.hamcrest.Matchers
 import org.hamcrest.Matchers.`is`
 import tools.fastlane.screengrab.Screengrab
 import java.util.function.Supplier
@@ -123,6 +124,17 @@ open class Screen {
         idleFor(500) // allow for transitions
     }
 
+    fun clickByTextAndId(text: String, id: Int) {
+        val element = onView(
+            Matchers.allOf(
+                withText(text),
+                withId(id)
+            )
+        )
+
+        clickOn(element)
+    }
+
     fun scrollTo(elementID: Int) {
         waitForElementToBeDisplayed(elementID)
 
@@ -172,7 +184,7 @@ open class Screen {
         idleFor(1000) // allow for transitions
     }
 
-    private fun clickOn(viewInteraction: ViewInteraction) {
+    fun clickOn(viewInteraction: ViewInteraction) {
         waitForElementToBeDisplayed(viewInteraction)
         idleFor(500) // allow for transitions
         viewInteraction.perform(ViewActions.click(ViewActions.closeSoftKeyboard()))

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.e2e.screens.moremenu
 
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -26,5 +27,11 @@ class MoreMenuScreen : Screen(MORE_MENU_VIEW) {
             getTranslatedString(R.string.settings)
         ).performClick()
         return SettingsScreen()
+    }
+
+    fun assertStoreTitle(composeTestRule: ComposeTestRule, storeTitle: String): MoreMenuScreen {
+        composeTestRule.onNodeWithText(storeTitle)
+            .assertIsDisplayed()
+        return MoreMenuScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductFilterScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductFilterScreen.kt
@@ -1,0 +1,50 @@
+package com.woocommerce.android.e2e.screens.products
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.matcher.ViewMatchers
+import com.woocommerce.android.R
+import com.woocommerce.android.e2e.helpers.util.Screen
+import org.hamcrest.Matchers
+
+class ProductFilterScreen : Screen {
+
+    companion object {
+        const val TOOLBAR = R.id.toolbar
+    }
+
+    constructor() : super(TOOLBAR)
+
+    fun filterByPropertyAndValue(property: String, value: String): ProductFilterScreen {
+        clickByTextAndId(property, R.id.filterItemName)
+        clickByTextAndId(value, R.id.filterOptionItem_name)
+        return this
+    }
+
+    fun clearFilters(): ProductFilterScreen {
+        clickOn(R.id.menu_clear)
+        return this
+    }
+
+    fun tapShowProducts(): ProductListScreen {
+        val showProductButton = Espresso.onView(
+            Matchers.allOf(
+                Matchers.anyOf(
+                    ViewMatchers.withId(R.id.filterList_btnShowProducts),
+                    ViewMatchers.withId(R.id.filterOptionList_btnShowProducts)
+                ),
+                ViewMatchers.isCompletelyDisplayed(),
+            )
+        )
+
+        clickOn(showProductButton)
+        return ProductListScreen()
+    }
+
+    fun leaveFilterScreen(): ProductListScreen {
+        if (isElementDisplayed(R.id.filterList) || isElementDisplayed(R.id.filterOptionList)) {
+            tapShowProducts()
+        }
+
+        return ProductListScreen()
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
@@ -1,0 +1,179 @@
+@file:Suppress("DEPRECATION")
+
+package com.woocommerce.android.e2e.tests.ui
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.rule.ActivityTestRule
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.e2e.helpers.InitializationRule
+import com.woocommerce.android.e2e.helpers.TestBase
+import com.woocommerce.android.e2e.helpers.useMockedAPI
+import com.woocommerce.android.e2e.helpers.util.ProductData
+import com.woocommerce.android.e2e.screens.TabNavComponent
+import com.woocommerce.android.e2e.screens.login.WelcomeScreen
+import com.woocommerce.android.e2e.screens.products.ProductFilterScreen
+import com.woocommerce.android.e2e.screens.products.ProductListScreen
+import com.woocommerce.android.ui.login.LoginActivity
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+
+@HiltAndroidTest
+class ProductsRealAPI : TestBase() {
+    @get:Rule(order = 0)
+    val rule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeTestRule = createComposeRule()
+
+    @get:Rule(order = 2)
+    val initRule = InitializationRule()
+
+    @get:Rule(order = 3)
+    var activityRule = ActivityTestRule(LoginActivity::class.java)
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setUpClass() {
+            useMockedAPI = false
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDownClass() {
+            useMockedAPI = true
+        }
+    }
+
+    @Before
+    fun setUp() {
+        WelcomeScreen
+            .skipCarouselIfNeeded()
+            .selectLogin()
+            .proceedWith(BuildConfig.E2E_REAL_API_URL)
+            .proceedWith(BuildConfig.E2E_REAL_API_EMAIL)
+            .proceedWith(BuildConfig.E2E_REAL_API_PASSWORD)
+
+        TabNavComponent()
+            .gotoProductsScreen()
+    }
+
+    @After
+    fun tearDown() {
+        ProductListScreen()
+            .leaveSearchMode()
+
+        ProductFilterScreen()
+            .leaveFilterScreen()
+
+        WelcomeScreen
+            .logoutIfNeeded(composeTestRule)
+    }
+
+    private val productSalad = ProductData(
+        name = "Chicken Teriyaki Salad",
+        stockStatusRaw = "instock",
+        priceDiscountedRaw = "7",
+        sku = "SLD-CHK-TRK"
+    )
+
+    private val productCappuccino = ProductData(
+        name = "Cappuccino",
+        stockStatusRaw = "instock",
+        variations = " • 6 variations",
+        priceDiscountedRaw = "2",
+        sku = "CF-CPC"
+    )
+
+    private val productCappuccinoAlmondMedium = ProductData(
+        name = "Cappuccino",
+        stockStatusRaw = "instock",
+        priceDiscountedRaw = "3",
+        sku = "CF-CPC-ALM-M"
+    )
+
+    private val productCappuccinoAlmondLarge = ProductData(
+        name = "Cappuccino",
+        stockStatusRaw = "instock",
+        priceDiscountedRaw = "4",
+        sku = "CF-CPC-ALM-L"
+    )
+
+    @Test
+    fun e2eRealApiProductsSearchUsual() {
+        ProductListScreen()
+            // Make sure all products are listed
+            .assertProductCard(productCappuccino)
+            .assertProductCard(productSalad)
+            .assertProductsCount(2)
+            // Start search
+            .openSearchPane()
+            .tapSearchAllProducts()
+            // Search for 'productCappuccino'
+            .enterSearchTerm(productCappuccino.name)
+            .assertProductCard(productCappuccino)
+            .assertProductsCount(1)
+            // Search for 'productSalad'
+            .enterSearchTerm(productSalad.name)
+            .assertProductCard(productSalad)
+            .assertProductsCount(1)
+            // Search for non-existing product
+            .enterSearchTerm("Unexisting Product")
+            .assertProductsCount(0)
+            // Leave search and make sure all products are listed
+            .leaveSearchMode()
+            .assertProductCard(productCappuccino)
+            .assertProductCard(productSalad)
+            .assertProductsCount(2)
+    }
+
+    @Test
+    fun e2eRealApiProductsSearchBySKU() {
+        ProductListScreen()
+            .openSearchPane()
+            .tapSearchSKU()
+            // Search for a simple product SKU
+            .enterSearchTerm(productSalad.sku)
+            .assertProductCard(productSalad)
+            .assertProductsCount(1)
+            // Search for variations sharing a part of SKU
+            .enterSearchTerm(productCappuccino.sku + "-ALM")
+            .assertProductCard(productCappuccinoAlmondMedium)
+            .assertProductCard(productCappuccinoAlmondLarge)
+            .assertProductsCount(2)
+            // Search for exact variation SKU
+            .enterSearchTerm(productCappuccinoAlmondLarge.sku)
+            .assertProductCard(productCappuccinoAlmondLarge)
+            .assertProductsCount(1)
+            .leaveSearchMode()
+    }
+
+    @Test
+    fun e2eRealApiProductsFilter() {
+        ProductListScreen()
+            // Filter by "Product type" = "Simple"
+            .tapFilters()
+            .filterByPropertyAndValue("Product type", "Simple")
+            .tapShowProducts()
+            .assertProductCard(productSalad)
+            .assertProductsCount(1)
+            // Check that "Clear" button works
+            .tapFilters()
+            .clearFilters()
+            .tapShowProducts()
+            .assertProductCard(productSalad)
+            .assertProductCard(productCappuccino)
+            .assertProductsCount(2)
+            // Filter by "Stock status" = "Out of Stock" and expect to see zero products
+            .tapFilters()
+            .filterByPropertyAndValue("Stock status", "Out of stock")
+            .tapShowProducts()
+            .assertProductsCount(0)
+    }
+}

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -42,6 +42,10 @@ wc.screenshots.url = example.com
 wc.screenshots.username = user@example.com
 wc.screenshots.password = password
 
+wc.e2e.real.api.url = example.com
+wc.e2e.real.api.email = user@example.com
+wc.e2e.real.api.password = password
+
 # The type of in app update FLEXIBLE = 0; IMMEDIATE = 1
 wc.in_app_update_type = 0
 


### PR DESCRIPTION
This PR is created in order to avoid merging #8636, which has the same changes, but additionally has _way too many unnecessary commits_ that I tried after resolving some conflicts and updating from `trunk`.

### Why?
For better history, here are the PRs which this one is based on:
1. #8636
2. #8657 
4. #8681
5. #8682

Each of them has useful review notes and discussions. All four were reviewed and accepted.

Once the base PR (#8636) was approved, I still waited with a merge because I waited for more potential inputs from developers. Meanwhile, I automated several more tests (other 3 PRs), which were branching off #8636, and merged them into the PR branch once they were accepted.

By that time, the main PR became quite outdated and had several conflicts. I went for accepting the versions from `trunk`  and then updated from `trunk`, with the intention to regenerate some of the conflicted files. Without getting too much into detail, it all went very wrong since then, the app stopped being able to build from the PR, and I failed to gracefully solve it, and all the "try to fix" commits in #8638 made it really bloated.

**_I decided it will be cleaner (and faster) to replicate all the changes from PRs above from scratch, in a separate PR._**

### Description
This PR repeats all the changes from 4 aforementioned PRs, and here's a summary of what the added code does (digested from descriptions for mentioned 4 PRs):

- Adds a possibility to selectively run UI tests either against a mocked API (WireMock) or the real API.
- Adds a Products List simple search E2E test, named `e2eRealApiProductsSearchUsual`. SKU search / Filtering will be added separately.
- Adds Products Search test, named `e2eRealApiProductsSearchBySKU`. This time search is done by SKU value.
- Adds a Product Filter test, named `e2eRealApiProductsFilter` and a file for Filter screen.

### Testing instructions
- Make sure all tests run locally and on CI