### PR TITLE
Fix "clear selection" button behavior

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -189,15 +189,13 @@ private fun ProductList(
                 .padding(horizontal = dimensionResource(dimen.minor_100))
                 .fillMaxWidth()
         ) {
-            if (state.selectedItemsCount > 0) {
-                WCTextButton(
-                    onClick = onClearButtonClick,
-                    text = stringResource(id = string.product_selector_clear_button_title),
-                    allCaps = false,
-                    modifier = Modifier.align(Alignment.CenterStart)
-                )
-            }
-
+            WCTextButton(
+                onClick = onClearButtonClick,
+                text = stringResource(id = string.product_selector_clear_button_title),
+                allCaps = false,
+                enabled = state.selectedItemsCount > 0,
+                modifier = Modifier.align(Alignment.CenterStart)
+            )
             WCTextButton(
                 onClick = onFilterButtonClick,
                 text = StringUtils.getQuantityString(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
@@ -120,14 +120,13 @@ private fun VariationList(
                 .padding(horizontal = dimensionResource(dimen.minor_100))
                 .fillMaxWidth()
         ) {
-            if (state.selectedItemsCount > 0) {
-                WCTextButton(
-                    onClick = onClearButtonClick,
-                    text = stringResource(id = R.string.product_selector_clear_button_title),
-                    allCaps = false,
-                    modifier = Modifier.align(Alignment.CenterStart)
-                )
-            }
+            WCTextButton(
+                onClick = onClearButtonClick,
+                text = stringResource(id = R.string.product_selector_clear_button_title),
+                allCaps = false,
+                enabled = state.selectedItemsCount > 0,
+                modifier = Modifier.align(Alignment.CenterStart)
+            )
         }
         LazyColumn(
             state = listState,


### PR DESCRIPTION
### `ProductSelector`'s "Clear selection" button improvement.

Closes: #8692
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes behavior of "Clear button" in the Product Selector component's Variation Selector screen. Previous implementation was disturbing the UX of the variation list because it was moving the layout up and down when a user was selecting and unselecting items. As [discussed](https://appsqualityp2.wordpress.com/2023/03/16/test-charter-speedy-ipp-product-multi-selection-ios-and-android/#comment-1771) we decided not to hide the clear button completely but to keep it in a disabled state instead. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Go to the variation selector screen, e.g. Orders > + > + Add products > tap on variable product

Observe that the "clear button" is in a disabled state in case there are no variations selected and it's enabled when variations are selected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/4527432/229147859-a4152c36-9639-4a89-9354-3e9c96b3cd6d.mp4"> | <video src="https://user-images.githubusercontent.com/4527432/229147969-4ac3258e-d618-44ac-a260-efec550dccc9.mp4"> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
