### PR TITLE
Popup to my store tab when navigating back from onboarding tasks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.content.Intent
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.NavGraphProductsDirections
@@ -9,6 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Product.Image
+import com.woocommerce.android.ui.products.AddProductSource.STORE_ONBOARDING
 import com.woocommerce.android.ui.products.GroupedProductListType.GROUPED
 import com.woocommerce.android.ui.products.ProductNavigationTarget.AddProductAttribute
 import com.woocommerce.android.ui.products.ProductNavigationTarget.AddProductAttributeTerms
@@ -279,11 +281,20 @@ class ProductNavigator @Inject constructor() {
             }
 
             is ViewProductAdd -> {
-                val action = NavGraphMainDirections.actionGlobalProductDetailFragment(
+                val directions = NavGraphMainDirections.actionGlobalProductDetailFragment(
                     isAddProduct = true,
                     source = target.source
                 )
-                fragment.findNavController().navigateSafely(action)
+
+                fragment.findNavController().navigateSafely(
+                    directions = directions,
+                    navOptions =
+                    if (target.source == STORE_ONBOARDING)
+                        NavOptions.Builder()
+                            .setPopUpTo(R.id.dashboard, false)
+                            .build()
+                    else null
+                )
             }
 
             is ViewProductDownloads -> {

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -478,10 +478,12 @@
         android:label="StoreOnboardingFragment">
         <action
             android:id="@+id/action_onboardingFragment_to_launchStoreFragment"
-            app:destination="@id/launchStoreFragment" />
+            app:destination="@id/launchStoreFragment"
+            app:popUpTo="@id/dashboard" />
         <action
             android:id="@+id/action_storeOnboardingFragment_to_nav_graph_domain_change"
-            app:destination="@id/nav_graph_domain_change">
+            app:destination="@id/nav_graph_domain_change"
+            app:popUpTo="@id/dashboard">
             <argument
                 android:name="source"
                 android:defaultValue="STORE_ONBOARDING"
@@ -489,7 +491,8 @@
         </action>
         <action
             android:id="@+id/action_storeOnboardingFragment_to_aboutYourStoreFragment"
-            app:destination="@id/aboutYourStoreFragment" />
+            app:destination="@id/aboutYourStoreFragment"
+            app:popUpTo="@id/dashboard" />
         <action
             android:id="@+id/action_storeOnboardingFragment_to_productTypesBottomSheet"
             app:destination="@id/productTypesBottomSheetFragment"
@@ -508,7 +511,8 @@
         </action>
         <action
             android:id="@+id/action_storeOnboardingFragment_to_getPaidFragment"
-            app:destination="@id/getPaidFragment" />
+            app:destination="@id/getPaidFragment"
+            app:popUpTo="@id/dashboard" />
     </fragment>
     <fragment
         android:id="@+id/launchStoreFragment"


### PR DESCRIPTION
When navigating back from any of the onboarding tasks being opened from onboarding list full screen, we want to land in MyStore tab. This ensures the list gets refreshed right away after completing any of the tasks.

<!-- Remember about a good descriptive title. -->

Do not merge until this PR has been merged and `trunk` is the parent branch. 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Ensures that `StoreOnboardingFragment` is popped out of the stack when navigating to any of the onboarding tasks. This guarantees that after an onboarding task is completed or if we navigate back from one, the user lands on My Store tab and the onboarding list is refresshed. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Open My Store tab
- Click on "View all" button from onboarding list
- Open each of the onboarding tasks and when navigating back check you land on My Store tab

