### PR TITLE
[REST API] Remove webview-based Jetpack activation as the native activation is now ready.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsDialog.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.R.style
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -73,10 +72,6 @@ class JetpackBenefitsDialog : DialogFragment() {
                             jetpackStatus = event.jetpackStatus
                         )
                     )
-                }
-
-                is JetpackBenefitsViewModel.OpenWpAdminJetpackActivation -> {
-                    ChromeCustomTabUtils.launchUrl(requireContext(), event.activationUrl)
                 }
 
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsScreen.kt
@@ -42,8 +42,7 @@ fun JetpackBenefitsScreen(viewModel: JetpackBenefitsViewModel) {
         JetpackBenefitsScreen(
             viewState = it,
             onInstallClick = viewModel::onInstallClick,
-            onDismissClick = viewModel::onDismiss,
-            onOpenWPAdminJetpackActivationClick = viewModel::onOpenWpAdminJetpackActivationClicked
+            onDismissClick = viewModel::onDismiss
         )
     }
 }
@@ -52,8 +51,7 @@ fun JetpackBenefitsScreen(viewModel: JetpackBenefitsViewModel) {
 fun JetpackBenefitsScreen(
     viewState: JetpackBenefitsViewModel.ViewState,
     onInstallClick: () -> Unit = {},
-    onDismissClick: () -> Unit = {},
-    onOpenWPAdminJetpackActivationClick: () -> Unit = {}
+    onDismissClick: () -> Unit = {}
 ) {
     Column(
         modifier = Modifier
@@ -129,10 +127,6 @@ fun JetpackBenefitsScreen(
                     )
                 )
             }
-        }
-
-        WCColoredButton(onClick = onOpenWPAdminJetpackActivationClick, modifier = Modifier.fillMaxWidth()) {
-            Text(text = stringResource(R.string.jetpack_benefits_open_wpadmin))
         }
 
         WCOutlinedButton(onClick = onDismissClick, modifier = Modifier.fillMaxWidth()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.jetpack.benefits
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R.string
-import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_BENEFITS_DIALOG_WPADMIN_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_INSTALL_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.JetpackStatus
@@ -26,10 +25,6 @@ class JetpackBenefitsViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val fetchJetpackStatus: FetchJetpackStatus
 ) : ScopedViewModel(savedStateHandle) {
-    companion object {
-        private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect"
-        private const val JETPACK_CONNECTED_REDIRECT_URL = "woocommerce://jetpack-connected"
-    }
 
     private val _viewState = MutableStateFlow(
         ViewState(
@@ -71,17 +66,6 @@ class JetpackBenefitsViewModel @Inject constructor(
 
     fun onDismiss() = triggerEvent(Exit)
 
-    fun onOpenWpAdminJetpackActivationClicked() {
-        AnalyticsTracker.track(
-            stat = JETPACK_BENEFITS_DIALOG_WPADMIN_BUTTON_TAPPED,
-            properties = mapOf(AnalyticsTracker.KEY_JETPACK_INSTALLATION_SOURCE to "benefits_modal")
-        )
-
-        val url = "$JETPACK_CONNECT_URL?url=${selectedSite.get().url}" +
-            "&mobile_redirect=$JETPACK_CONNECTED_REDIRECT_URL&from=mobile"
-        triggerEvent(OpenWpAdminJetpackActivation(url))
-    }
-
     data class ViewState(
         val isUsingJetpackCP: Boolean,
         val isLoadingDialogShown: Boolean,
@@ -93,5 +77,4 @@ class JetpackBenefitsViewModel @Inject constructor(
         val siteUrl: String,
         val jetpackStatus: JetpackStatus
     ) : Event()
-    data class OpenWpAdminJetpackActivation(val activationUrl: String) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -34,13 +34,13 @@ enum class FeatureFlag {
             UNIFIED_ORDER_EDITING,
             NATIVE_STORE_CREATION_FLOW,
             IPP_FEEDBACK_BANNER,
-            STORE_CREATION_ONBOARDING -> true
+            STORE_CREATION_ONBOARDING,
+            REST_API_I2 -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             IPP_TAP_TO_PAY,
             FREE_TRIAL_M2,
-            REST_API_I2,
             ANALYTICS_HUB_FEEDBACK_BANNER -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2276,7 +2276,6 @@
     <string name="jetpack_benefits_modal_multiple_stores_title">Multiple stores</string>
     <string name="jetpack_benefits_modal_multiple_stores_subtitle">Get access to all of your WooCommerce stores.</string>
     <string name="jetpack_benefits_modal_login">Log In to Continue</string>
-    <string name="jetpack_benefits_open_wpadmin">Open wp-admin</string>
 
     <string name="jetpack_install_start_title">Install Jetpack</string>
     <string name="jetpack_install_start_subtitle">Install the free Jetpack plugin to &lt;strong&gt;%s&lt;/strong&gt; to experience the best mobile experience.</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8699
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Now that the native Jetpack installation flow to REST API login is available, this PR removes the temporarily added webview-based Jetpack installation flow that was added in #8596

This PR also sets the feature flag for REST API i2 (native Jetpack installation) to always be true, so it's ready to be released.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Do a REST API login with a test site that has no Jetpack,
2. Tap Jetpack banner on My Store screen,
3. Make sure "Log In to Continue" button is shown, and "Open in wp-admin" button is not shown.
