### PR TITLE
feat: introduce PlanUpgradeStartFragment to handle upgrade plan logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewScreen.kt
@@ -15,7 +15,19 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.Disp
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.DisplayMode.REGULAR
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCWebView
+import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartViewModel
 import org.wordpress.android.fluxc.network.UserAgent
+
+@Composable
+fun PlanUpgradeViewScreen(viewViewModel: PlanUpgradeStartViewModel) {
+    WPComWebViewScreen(
+        viewState = viewViewModel.viewState,
+        wpcomWebViewAuthenticator = viewViewModel.wpComWebViewAuthenticator,
+        userAgent = viewViewModel.userAgent,
+        onUrlLoaded = viewViewModel::onUrlLoaded,
+        onClose = viewViewModel::onClose
+    )
+}
 
 @Composable
 fun WPComWebViewScreen(viewViewModel: WPComWebViewViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/dispatcher/PlanUpgradeStartFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/dispatcher/PlanUpgradeStartFragment.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.login.storecreation.dispatcher
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateBackWithNotice
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.common.wpcomwebview.PlanUpgradeViewScreen
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PlanUpgradeStartFragment : BaseFragment() {
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: PlanUpgradeStartViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    PlanUpgradeViewScreen(viewModel)
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithNotice(
+                    PLAN_UPGRADE_SUCCEED
+                )
+
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+            }
+        }
+    }
+
+    companion object {
+        const val PLAN_UPGRADE_SUCCEED = "plan-upgrade-succeed"
+    }
+
+    enum class PlanUpgradeStartSource {
+        BANNER, UPGRADES_SCREEN
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/dispatcher/PlanUpgradeStartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/dispatcher/PlanUpgradeStartViewModel.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.login.storecreation.dispatcher
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_BANNER
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_UPGRADES_SCREEN
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel
+import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment.PlanUpgradeStartSource.BANNER
+import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment.PlanUpgradeStartSource.UPGRADES_SCREEN
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.wordpress.android.fluxc.network.UserAgent
+import javax.inject.Inject
+
+@HiltViewModel
+class PlanUpgradeStartViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    val userAgent: UserAgent,
+    selectedSite: SelectedSite,
+    private val tracks: AnalyticsTrackerWrapper
+) : ScopedViewModel(savedStateHandle) {
+
+    private val navArgs: PlanUpgradeStartFragmentArgs by savedStateHandle.navArgs()
+    private val tracksProperties =
+        mapOf(
+            KEY_SOURCE to when (navArgs.source) {
+                BANNER -> VALUE_BANNER
+                UPGRADES_SCREEN -> VALUE_UPGRADES_SCREEN
+            }
+        )
+
+    private companion object {
+        private const val URL_TO_TRIGGER_EXIT = "my-plan/trial-upgraded"
+    }
+
+    val viewState =
+        WPComWebViewViewModel.ViewState(
+            urlToLoad = "https://wordpress.com/plans/${selectedSite.get().siteId}",
+            title = null,
+            displayMode = WPComWebViewViewModel.DisplayMode.MODAL,
+            captureBackButton = true
+        )
+
+    fun onUrlLoaded(url: String) {
+        if (url.contains(URL_TO_TRIGGER_EXIT, ignoreCase = true)) {
+            tracks.track(AnalyticsEvent.PLAN_UPGRADE_SUCCESS, tracksProperties)
+            triggerEvent(MultiLiveEvent.Event.ExitWithResult(Unit))
+        }
+    }
+
+    fun onClose() {
+        tracks.track(AnalyticsEvent.PLAN_UPGRADE_ABANDONED, tracksProperties)
+        triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -44,7 +44,6 @@ import com.woocommerce.android.extensions.active
 import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.expand
-import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Notification
@@ -56,7 +55,6 @@ import com.woocommerce.android.ui.appwidgets.WidgetUpdater
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.main.BottomNavigationPosition.MORE
@@ -221,13 +219,6 @@ class MainActivity :
                 showBottomNav()
             } else {
                 hideBottomNav()
-            }
-
-            f.handleNotice(WPComWebViewFragment.WEBVIEW_RESULT) {
-                presenter.onPlanUpgraded()
-            }
-            f.handleNotice(WPComWebViewFragment.WEBVIEW_DISMISSED) {
-                presenter.onPlanUpgradeDismissed()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/domain/StartUpgradeFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/domain/StartUpgradeFlow.kt
@@ -3,22 +3,18 @@ package com.woocommerce.android.ui.plans.domain
 import androidx.navigation.NavController
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
 class StartUpgradeFlow @AssistedInject constructor(
-    @Assisted private val navController: NavController,
-    private val selectedSite: SelectedSite,
+    @Assisted private val navController: NavController
 ) {
 
-    operator fun invoke() {
+    operator fun invoke(source: PlanUpgradeStartFragment.PlanUpgradeStartSource) {
         navController.navigateSafely(
-            NavGraphMainDirections.actionGlobalWPComWebViewFragment(
-                urlToLoad = "https://wordpress.com/plans/${selectedSite.get().siteId}",
-                urlsToTriggerExit = arrayOf(
-                    "my-plan/trial-upgraded"
-                )
+            NavGraphMainDirections.actionGlobalPlanUpgradeStartFragment(
+                source = source
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/trial/TrialStatusBarFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/trial/TrialStatusBarFormatter.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.FREE_TRIAL_UPGRADE_NOW_T
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_BANNER
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment
 import com.woocommerce.android.ui.plans.domain.StartUpgradeFlow
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.widgets.WooClickableSpan
@@ -40,7 +41,7 @@ class TrialStatusBarFormatter @AssistedInject constructor(
             .inSpans(
                 WooClickableSpan(customLinkColor = context.getColor(R.color.free_trial_banner_link_text)) {
                     analyticsTrackerWrapper.track(FREE_TRIAL_UPGRADE_NOW_TAPPED, mapOf(KEY_SOURCE to VALUE_BANNER))
-                    startUpgradeFlow.invoke()
+                    startUpgradeFlow.invoke(PlanUpgradeStartFragment.PlanUpgradeStartSource.BANNER)
                 },
                 UnderlineSpan(),
             ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesFragment.kt
@@ -12,9 +12,9 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment.Companion.WEBVIEW_DISMISSED
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment.Companion.WEBVIEW_RESULT
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment
+import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment.Companion.PLAN_UPGRADE_SUCCEED
 import com.woocommerce.android.ui.plans.di.StartUpgradeFlowFactory
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesEvent.OpenSubscribeNow
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesEvent.OpenSupportRequestForm
@@ -51,16 +51,15 @@ class UpgradesFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is OpenSubscribeNow -> {
-                    startUpgradeFlowFactory.create(navController = findNavController()).invoke()
+                    startUpgradeFlowFactory.create(navController = findNavController()).invoke(
+                        PlanUpgradeStartFragment.PlanUpgradeStartSource.UPGRADES_SCREEN
+                    )
                 }
                 is OpenSupportRequestForm -> startSupportRequestFormActivity(event)
             }
         }
-        handleNotice(WEBVIEW_RESULT) {
+        handleNotice(PLAN_UPGRADE_SUCCEED) {
             viewModel.onPlanUpgraded()
-        }
-        handleNotice(WEBVIEW_DISMISSED) {
-            viewModel.onPlanUpgradeDismissed()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
@@ -69,14 +69,9 @@ class UpgradesViewModel @Inject constructor(
     }
 
     fun onPlanUpgraded() {
-        tracks.track(AnalyticsEvent.PLAN_UPGRADE_SUCCESS, tracksProperties)
         launch {
             loadSubscriptionState()
         }
-    }
-
-    fun onPlanUpgradeDismissed() {
-        tracks.track(AnalyticsEvent.PLAN_UPGRADE_ABANDONED, tracksProperties)
     }
 
     private fun loadSubscriptionState() {

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -497,5 +497,16 @@
         android:name="com.woocommerce.android.ui.login.storecreation.onboarding.aboutyourstore.AboutYourStoreFragment"
         android:label="AboutYourStoreFragment" />
     <include app:graph="@navigation/nav_graph_domain_change" />
-
+    <fragment
+        android:id="@+id/planUpgradeStartFragment"
+        android:name="com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment"
+        android:label="PlanUpgradeStartFragment">
+        <argument
+            android:name="source"
+            app:argType="com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment$PlanUpgradeStartSource"
+            app:nullable="false" />
+    </fragment>
+    <action
+        android:id="@+id/action_global_planUpgradeStartFragment"
+        app:destination="@id/planUpgradeStartFragment" />
 </navigation>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
@@ -243,30 +243,6 @@ class UpgradesViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when onPlanUpgraded is called, then the expected track event is called`() {
-        // When
-        sut.onPlanUpgraded()
-
-        // Then
-        verify(tracks).track(
-            AnalyticsEvent.PLAN_UPGRADE_SUCCESS,
-            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_UPGRADES_SCREEN)
-        )
-    }
-
-    @Test
-    fun `when onPlanUpgradeDismissed is called, then the expected track event is called`() {
-        // When
-        sut.onPlanUpgradeDismissed()
-
-        // Then
-        verify(tracks).track(
-            AnalyticsEvent.PLAN_UPGRADE_ABANDONED,
-            mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_UPGRADES_SCREEN)
-        )
-    }
-
-    @Test
     fun `when onReportSubscriptionIssueClicked is called, then the expected track event is called`() {
         // When
         sut.onReportSubscriptionIssueClicked()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8704 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes an issue of unwanted reports for "successful plan upgrade" events we've observed in a couple of days.

Internal references:
- pe5pgL-2B8-p2
- p1680190905407279-slack-C02KUCFCSFP
- p1680191509671019-slack-C02KUCFCSFP

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

| Starting point | action | expected event |
|--------|--------|--------|
| Banner | upgrade plan | `plan_upgrade_success` |
| Banner | dismiss upgrade screen | `plan_upgrade_abandoned` |
| Upgrades screen | upgrade plan | `plan_upgrade_success` | 
| Upgrades screen | dismiss upgrade screen | `plan_upgrade_abandoned` | 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->