### PR TITLE
 Gift cards in order detail analytics

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -230,6 +230,8 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED,
     ORDER_DETAIL_WAITING_TIME_LOADED,
     ORDER_VIEW_CUSTOM_FIELDS_TAPPED,
+    ORDER_DETAILS_SUBSCRIPTIONS_SHOWN,
+    ORDER_DETAILS_GIFT_CARD_SHOWN,
 
     // - Order detail editing
     ORDER_DETAIL_EDIT_FLOW_STARTED,
@@ -516,7 +518,6 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     EXTERNAL_PRODUCT_LINK_SETTINGS_DONE_BUTTON_TAPPED,
 
     // -- Product subscriptions
-    ORDER_DETAILS_SUBSCRIPTIONS_SHOWN,
     PRODUCT_DETAILS_VIEW_SUBSCRIPTIONS_TAPPED,
 
     // -- Product attributes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -688,6 +688,9 @@ class OrderDetailViewModel @Inject constructor(
                 ?.let { result ->
                     val giftCardSummaries = result.model ?: return@let
                     _giftCards.value = giftCardSummaries
+                    if (giftCardSummaries.isNotEmpty()) {
+                        trackerWrapper.track(AnalyticsEvent.ORDER_DETAILS_GIFT_CARD_SHOWN)
+                    }
                 }
         }
     }


### PR DESCRIPTION
Closes: #8612

### Why
We are adding read-only support for the Gift Cards extension

### Description
This PR adds and tracks the `ORDER_DETAILS_GIFT_CARD_SHOWN` on the order details screen whenever we display the information for a gift card applied/redeemed to an order.

* `woocommerceandroid_order_details_gift_card_shown` event [registration](https://github.com/Automattic/tracks-events-registration/pull/1494)

### Testing instructions
1. Place an order with a redeemed gift card.
2. Open the Orders tab
3. Select the order with the redeemed gift card
4. Check that the gift card information is displayed in the order details screen
5. Check that the `ORDER_DETAILS_GIFT_CARD_SHOWN` event is sent

### Images/gif
```
🔵 Tracked: order_details_gift_card_shown, Properties: {"blog_id":214253715,"is_wpcom_store":true,"is_debug":true}
```
