### PR TITLE
feat: set the correct theme during free trial site creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.login.storecreation.plans.BillingPeriod.ECOMME
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.PlanInfo.Feature
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.ViewState.ErrorState
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.ViewState.LoadingState
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.SiteIndependentCurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -60,7 +61,8 @@ class PlansViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle, iapManager) {
     companion object {
         const val NEW_SITE_LANGUAGE_ID = "en"
-        const val NEW_SITE_THEME = "premium/tsubaki"
+        val NEW_SITE_THEME =
+            if (FeatureFlag.FREE_TRIAL_M2.isEnabled()) "pub/twentytwentytwo" else "premium/tsubaki"
         const val CART_URL = "https://wordpress.com/checkout"
         const val WEBVIEW_SUCCESS_TRIGGER_KEYWORD = "https://wordpress.com/checkout/thank-you/"
         const val WEBVIEW_EXIT_TRIGGER_KEYWORD = "https://woocommerce.com/"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8709 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR sets the correct `theme` for Free Trial site creation and leaves the old theme for the previous flow.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Create a Free Trial site and make sure that the newly created site has the `Tsubaki` theme. 


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
