### PR TITLE
Free Trial: Make store profiler flow switchable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -1,17 +1,17 @@
 package com.woocommerce.android.ui.login.storecreation
 
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Finished
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS
 import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_LANGUAGE_ID
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_THEME
-import java.util.TimeZone
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
+import java.util.TimeZone
+import javax.inject.Inject
 
 class CreateFreeTrialStore @Inject constructor(
     private val repository: StoreCreationRepository
@@ -31,7 +31,7 @@ class CreateFreeTrialStore @Inject constructor(
             TimeZone.getDefault().id
         ).recoverIfSiteExists(storeDomain)
 
-        when(result) {
+        when (result) {
             is StoreCreationResult.Success -> {
                 _state.value = Finished
                 emit(result.data)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -37,6 +37,8 @@ class CreateFreeTrialStore @Inject constructor(
 
         if (result is StoreCreationResult.Success<Long>) {
             emit(result.data)
+        } else {
+            emit(null)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -7,12 +7,14 @@ import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SIT
 import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_LANGUAGE_ID
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_THEME
+import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import java.util.TimeZone
 import javax.inject.Inject
 
+@ViewModelScoped
 class CreateFreeTrialStore @Inject constructor(
     private val repository: StoreCreationRepository
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -9,4 +9,41 @@ class CreateFreeTrialStore @Inject constructor(
     private val repository: StoreCreationRepository
 ) {
     private val error = MutableStateFlow<StoreCreationErrorType?>(null)
+
+    suspend fun createFreeTrialSite(
+        storeDomain: String,
+        storeName: String
+    ): StoreCreationResult<Long> {
+        suspend fun StoreCreationResult<Long>.recoverIfSiteExists(): StoreCreationResult<Long> {
+            return if ((this as? StoreCreationResult.Failure<Long>)?.type == StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS) {
+                repository.getSiteByUrl(storeDomain)?.let { site ->
+                    StoreCreationResult.Success(site.siteId)
+                } ?: this
+            } else {
+                this
+            }
+        }
+
+        return repository.createNewFreeTrialSite(
+            StoreCreationRepository.SiteCreationData(
+                siteDesign = PlansViewModel.NEW_SITE_THEME,
+                domain = storeDomain,
+                title = storeName,
+                segmentId = null
+            ),
+            PlansViewModel.NEW_SITE_LANGUAGE_ID,
+            TimeZone.getDefault().id
+        ).recoverIfSiteExists()
+    }
+
+    private suspend fun <T : Any?> StoreCreationResult<T>.ifSuccessfulThen(
+        successAction: suspend (T) -> Unit
+    ) {
+        when (this) {
+            is StoreCreationResult.Success -> successAction(this.data)
+            is StoreCreationResult.Failure -> {
+                error.emit(this.type)
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -15,8 +15,8 @@ class CreateFreeTrialStore @Inject constructor(
     val state: StateFlow<StoreCreationState> = _state
 
     suspend operator fun invoke(
-        storeDomain: String,
-        storeName: String
+        storeDomain: String?,
+        storeName: String?
     ) {
         _state.value = Loading
 
@@ -37,7 +37,7 @@ class CreateFreeTrialStore @Inject constructor(
     }
 
     private suspend fun StoreCreationResult<Long>.recoverIfSiteExists(
-        storeDomain: String
+        storeDomain: String?
     ) = run { this as? StoreCreationResult.Failure<Long> }
         ?.takeIf { it.type == SITE_ADDRESS_ALREADY_EXISTS }
         ?.let { repository.getSiteByUrl(storeDomain) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -14,7 +14,7 @@ class CreateFreeTrialStore @Inject constructor(
     private val _state = MutableStateFlow<StoreCreationState>(StoreCreationState.Idle)
     val state: StateFlow<StoreCreationState> = _state
 
-    suspend fun createFreeTrialSite(
+    suspend operator fun invoke(
         storeDomain: String,
         storeName: String
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.login.storecreation
+
+import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
+import java.util.TimeZone
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class CreateFreeTrialStore @Inject constructor(
+    private val repository: StoreCreationRepository
+) {
+    private val error = MutableStateFlow<StoreCreationErrorType?>(null)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -6,17 +6,19 @@ import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
 import java.util.TimeZone
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class CreateFreeTrialStore @Inject constructor(
     private val repository: StoreCreationRepository
 ) {
-    val state = MutableStateFlow<StoreCreationState>(StoreCreationState.Idle)
+    private val _state = MutableStateFlow<StoreCreationState>(StoreCreationState.Idle)
+    val state: StateFlow<StoreCreationState> = _state
 
     suspend fun createFreeTrialSite(
         storeDomain: String,
         storeName: String
     ) {
-        state.value = Loading
+        _state.value = Loading
 
         val result = repository.createNewFreeTrialSite(
             StoreCreationRepository.SiteCreationData(
@@ -29,7 +31,7 @@ class CreateFreeTrialStore @Inject constructor(
             TimeZone.getDefault().id
         )
 
-        state.value = result
+        _state.value = result
             .recoverIfSiteExists(storeDomain)
             .asCreationState()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -1,7 +1,8 @@
 package com.woocommerce.android.ui.login.storecreation
 
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Success
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Finished
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_LANGUAGE_ID
@@ -51,14 +52,14 @@ class CreateFreeTrialStore @Inject constructor(
         ?: this
 
     private fun StoreCreationResult<Long>.asCreationState() = when (this) {
-        is StoreCreationResult.Success -> Success
-        is StoreCreationResult.Failure -> StoreCreationState.Error(this.type)
+        is StoreCreationResult.Success -> Finished
+        is StoreCreationResult.Failure -> Failed(this.type)
     }
 
     sealed class StoreCreationState {
         object Idle : StoreCreationState()
         object Loading : StoreCreationState()
-        object Success : StoreCreationState()
-        data class Error(val type: StoreCreationErrorType) : StoreCreationState()
+        object Finished : StoreCreationState()
+        data class Failed(val type: StoreCreationErrorType) : StoreCreationState()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -19,6 +19,14 @@ class CreateFreeTrialStore @Inject constructor(
     private val _state = MutableStateFlow<StoreCreationState>(StoreCreationState.Idle)
     val state: StateFlow<StoreCreationState> = _state
 
+    /**
+     * Triggers the creation of a new free trial site given a domain and a name.
+     * If the site already exists, it will try to retrieve the site ID from the API.
+     *
+     *  @return a [flow] that will emit the Store ID if the creation is successful, null otherwise
+     *
+     *  To observe the creation progress, use [state]
+     */
     suspend operator fun invoke(
         storeDomain: String?,
         storeName: String?

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -19,11 +19,11 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.Locale
 import javax.inject.Inject
-import kotlinx.coroutines.flow.filterNotNull
 
 @HiltViewModel
 class CountryPickerViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Error
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
@@ -95,7 +95,7 @@ class StoreNamePickerViewModel @Inject constructor(
         storeName: String,
         createStoreState: StoreCreationState
     ) = when (createStoreState) {
-        is Error -> StoreNamePickerState.Error(createStoreState.type)
+        is Failed -> StoreNamePickerState.Error(createStoreState.type)
         else -> StoreNamePickerState.Contentful(
             storeName = storeName,
             isCreatingStore = createStoreState is Loading

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -7,40 +7,40 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Error
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Success
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS
-import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository
-import com.woocommerce.android.ui.login.storecreation.StoreCreationResult
-import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import java.util.TimeZone
 import javax.inject.Inject
+import kotlinx.coroutines.flow.mapNotNull
 
 @HiltViewModel
 class StoreNamePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val newStore: NewStore,
-    private val repository: StoreCreationRepository,
+    private val createStore: CreateFreeTrialStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val storeName = savedState.getStateFlow(scope = this, initialValue = "")
-    private val isCreatingStore = savedState.getStateFlow(scope = this, initialValue = false)
-    private val error = MutableStateFlow<StoreCreationErrorType?>(null)
 
     val storePickerState = combine(
-        storeName, isCreatingStore, error
-    ) { storeName, isCreatingStore, error ->
-        error?.let { StoreNamePickerState.Error(it) }
-            ?: StoreNamePickerState.Contentful(storeName, isCreatingStore)
+        storeName, createStore.state
+    ) { storeName, createStoreState ->
+        when (createStoreState) {
+            is Error -> StoreNamePickerState.Error(createStoreState.type)
+            is Loading -> StoreNamePickerState.Contentful(storeName, true)
+            else -> StoreNamePickerState.Contentful(storeName, false)
+        }
     }.asLiveData()
 
     init {
@@ -50,6 +50,15 @@ class StoreNamePickerViewModel @Inject constructor(
                 AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_NAME
             )
         )
+
+        launch {
+            createStore.state
+                .mapNotNull { it as? Success }
+                .collect {
+                    newStore.update(siteId = it.siteId)
+                    triggerEvent(NavigateToStoreInstallation)
+                }
+        }
     }
 
     fun onCancelPressed() {
@@ -86,46 +95,10 @@ class StoreNamePickerViewModel @Inject constructor(
     }
 
     private suspend fun startFreeTrialSiteCreation() {
-        isCreatingStore.value = true
-        createFreeTrialSite().ifSuccessfulThen {
-            newStore.update(siteId = it)
-            isCreatingStore.value = false
-            triggerEvent(NavigateToStoreInstallation)
-        }
-    }
-
-    private suspend fun createFreeTrialSite(): StoreCreationResult<Long> {
-        suspend fun StoreCreationResult<Long>.recoverIfSiteExists(): StoreCreationResult<Long> {
-            return if ((this as? StoreCreationResult.Failure<Long>)?.type == SITE_ADDRESS_ALREADY_EXISTS) {
-                repository.getSiteByUrl(newStore.data.domain)?.let { site ->
-                    StoreCreationResult.Success(site.siteId)
-                } ?: this
-            } else {
-                this
-            }
-        }
-
-        return repository.createNewFreeTrialSite(
-            StoreCreationRepository.SiteCreationData(
-                siteDesign = PlansViewModel.NEW_SITE_THEME,
-                domain = newStore.data.domain,
-                title = newStore.data.name,
-                segmentId = null
-            ),
-            PlansViewModel.NEW_SITE_LANGUAGE_ID,
-            TimeZone.getDefault().id
-        ).recoverIfSiteExists()
-    }
-
-    private suspend fun <T : Any?> StoreCreationResult<T>.ifSuccessfulThen(
-        successAction: suspend (T) -> Unit
-    ) {
-        when (this) {
-            is StoreCreationResult.Success -> successAction(this.data)
-            is StoreCreationResult.Failure -> {
-                error.emit(this.type)
-            }
-        }
+        createStore(
+            storeDomain = newStore.data.domain,
+            storeName = newStore.data.name
+        )
     }
 
     data class NavigateToDomainPicker(val domainInitialQuery: String) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -19,9 +19,9 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlinx.coroutines.flow.filterNotNull
 
 @HiltViewModel
 class StoreNamePickerViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Error
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.NewStore
@@ -33,16 +34,10 @@ class StoreNamePickerViewModel @Inject constructor(
     private val storeName = savedState.getStateFlow(scope = this, initialValue = "")
 
     val storePickerState = combine(
-        storeName, createStore.state
-    ) { storeName, createStoreState ->
-        when (createStoreState) {
-            is Error -> StoreNamePickerState.Error(createStoreState.type)
-            else -> StoreNamePickerState.Contentful(
-                storeName = storeName,
-                isCreatingStore = createStoreState is Loading
-            )
-        }
-    }.asLiveData()
+        storeName,
+        createStore.state,
+        ::mapStoreNamePickerState
+    ).asLiveData()
 
     init {
         analyticsTrackerWrapper.track(
@@ -94,6 +89,17 @@ class StoreNamePickerViewModel @Inject constructor(
             newStore.update(siteId = it)
             triggerEvent(NavigateToStoreInstallation)
         }
+    }
+
+    private fun mapStoreNamePickerState(
+        storeName: String,
+        createStoreState: StoreCreationState
+    ) = when (createStoreState) {
+        is Error -> StoreNamePickerState.Error(createStoreState.type)
+        else -> StoreNamePickerState.Contentful(
+            storeName = storeName,
+            isCreatingStore = createStoreState is Loading
+        )
     }
 
     data class NavigateToDomainPicker(val domainInitialQuery: String) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -20,7 +20,8 @@ enum class FeatureFlag {
     STORE_CREATION_ONBOARDING,
     FREE_TRIAL_M2,
     REST_API_I2,
-    ANALYTICS_HUB_FEEDBACK_BANNER;
+    ANALYTICS_HUB_FEEDBACK_BANNER,
+    STORE_CREATION_PROFILER;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -43,7 +44,8 @@ enum class FeatureFlag {
             REST_API_I2,
             ANALYTICS_HUB_FEEDBACK_BANNER -> PackageUtils.isDebugBuild()
 
-            IAP_FOR_STORE_CREATION -> false
+            IAP_FOR_STORE_CREATION,
+            STORE_CREATION_PROFILER -> false
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -101,8 +101,8 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
     @Test
     fun `when createFreeTrialSite fails with SITE_ADDRESS_ALREADY_EXISTS, then the site is retrieved`() = testBlocking {
         // Given
-        val siteDomain = "test domain"
-        val siteTitle = "test title"
+        val siteDomain = "test existent domain"
+        val siteTitle = "test existent title"
         val expectedSiteCreationData = SiteCreationData(
             siteDesign = PlansViewModel.NEW_SITE_THEME,
             domain = siteDomain,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -1,20 +1,57 @@
 package com.woocommerce.android.ui.login.storecreation
 
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.model.SiteModel
 
-internal class CreateFreeTrialStoreTest {
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class CreateFreeTrialStoreTest: BaseUnitTest() {
     private lateinit var sut: CreateFreeTrialStore
     private lateinit var storeCreationRepository: StoreCreationRepository
 
     @Before
     fun setUp() {
         createSut()
+    }
+
+    @Test
+    fun `when createFreeTrialSite is called correctly, then free trial store creation starts`() = testBlocking {
+        // Given
+        val siteDomain = "test domain"
+        val siteTitle = "test title"
+        val expectedCreationResult = StoreCreationResult.Success(123L)
+        createSut(siteDomain, siteTitle, expectedCreationResult)
+
+        // When
+        val result = sut.createFreeTrialSite(siteDomain, siteTitle)
+
+        // Then
+        assertThat(result).isEqualTo(expectedCreationResult)
+    }
+
+    @Test
+    fun `when createFreeTrialSite fails, then the error is returned`() = testBlocking {
+        // Given
+        val siteDomain = "test domain"
+        val siteTitle = "test title"
+        val expectedCreationResult = StoreCreationResult.Failure<Long>(
+            StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED
+        )
+        createSut(siteDomain, siteTitle, expectedCreationResult)
+
+        // When
+        val result = sut.createFreeTrialSite(siteDomain, siteTitle)
+
+        // Then
+        assertThat(result).isEqualTo(expectedCreationResult)
     }
 
     private fun createSut(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -43,7 +42,6 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
 
         // When
         sut.createFreeTrialSite(siteDomain, siteTitle)
-        advanceUntilIdle()
 
         // Then
         verify(storeCreationRepository).createNewFreeTrialSite(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.model.SiteModel
 
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class CreateFreeTrialStoreTest: BaseUnitTest() {
+internal class CreateFreeTrialStoreTest : BaseUnitTest() {
     private lateinit var sut: CreateFreeTrialStore
     private lateinit var storeCreationRepository: StoreCreationRepository
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -1,0 +1,48 @@
+package com.woocommerce.android.ui.login.storecreation
+
+import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
+import org.junit.Before
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
+
+internal class CreateFreeTrialStoreTest {
+    private lateinit var sut: CreateFreeTrialStore
+    private lateinit var storeCreationRepository: StoreCreationRepository
+
+    @Before
+    fun setUp() {
+        createSut()
+    }
+
+    private fun createSut(
+        siteDomain: String = "test domain",
+        siteTitle: String = "test title",
+        expectedCreationResult: StoreCreationResult<Long> = StoreCreationResult.Success(123)
+    ) {
+        val expectedSiteCreationData = StoreCreationRepository.SiteCreationData(
+            siteDesign = PlansViewModel.NEW_SITE_THEME,
+            domain = siteDomain,
+            title = siteTitle,
+            segmentId = null
+        )
+
+        val siteModel = SiteModel().apply { siteId = 123 }
+
+        storeCreationRepository = mock {
+            onBlocking {
+                createNewFreeTrialSite(
+                    eq(expectedSiteCreationData),
+                    eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
+                    any()
+                )
+            } doReturn expectedCreationResult
+
+            onBlocking { getSiteByUrl(expectedSiteCreationData.domain) } doReturn siteModel
+        }
+
+        sut = CreateFreeTrialStore(storeCreationRepository)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -41,7 +41,7 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut.createFreeTrialSite(siteDomain, siteTitle)
+        sut(siteDomain, siteTitle)
 
         // Then
         verify(storeCreationRepository).createNewFreeTrialSite(
@@ -78,7 +78,7 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut.createFreeTrialSite(siteDomain, siteTitle)
+        sut(siteDomain, siteTitle)
 
         // Then
         verify(storeCreationRepository).createNewFreeTrialSite(
@@ -120,7 +120,7 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut.createFreeTrialSite(siteDomain, siteTitle)
+        sut(siteDomain, siteTitle)
 
         // Then
         verify(storeCreationRepository).createNewFreeTrialSite(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -78,6 +78,36 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
         assertThat(result).isEqualTo(expectedCreationResult)
     }
 
+    @Test
+    fun `when createFreeTrialSite fails with SITE_ADDRESS_ALREADY_EXISTS, then the site is retrieved`() = testBlocking {
+        // Given
+        val siteDomain = "test domain"
+        val siteTitle = "test title"
+        val expectedSiteCreationData = SiteCreationData(
+            siteDesign = PlansViewModel.NEW_SITE_THEME,
+            domain = siteDomain,
+            title = siteTitle,
+            segmentId = null
+        )
+        createSut(
+            siteDomain,
+            siteTitle,
+            StoreCreationResult.Failure(StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS)
+        )
+
+        // When
+        val result = sut.createFreeTrialSite(siteDomain, siteTitle)
+
+        // Then
+        verify(storeCreationRepository).createNewFreeTrialSite(
+            eq(expectedSiteCreationData),
+            eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
+            any()
+        )
+        verify(storeCreationRepository).getSiteByUrl(siteDomain)
+        assertThat(result).isEqualTo(StoreCreationResult.Success(123L))
+    }
+
     private fun createSut(
         siteDomain: String = "test domain",
         siteTitle: String = "test title",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.storecreation
 
+import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,6 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.model.SiteModel
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -28,12 +30,23 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
         val siteDomain = "test domain"
         val siteTitle = "test title"
         val expectedCreationResult = StoreCreationResult.Success(123L)
+        val expectedSiteCreationData = SiteCreationData(
+            siteDesign = PlansViewModel.NEW_SITE_THEME,
+            domain = siteDomain,
+            title = siteTitle,
+            segmentId = null
+        )
         createSut(siteDomain, siteTitle, expectedCreationResult)
 
         // When
         val result = sut.createFreeTrialSite(siteDomain, siteTitle)
 
         // Then
+        verify(storeCreationRepository).createNewFreeTrialSite(
+            eq(expectedSiteCreationData),
+            eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
+            any()
+        )
         assertThat(result).isEqualTo(expectedCreationResult)
     }
 
@@ -45,12 +58,23 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
         val expectedCreationResult = StoreCreationResult.Failure<Long>(
             StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED
         )
+        val expectedSiteCreationData = SiteCreationData(
+            siteDesign = PlansViewModel.NEW_SITE_THEME,
+            domain = siteDomain,
+            title = siteTitle,
+            segmentId = null
+        )
         createSut(siteDomain, siteTitle, expectedCreationResult)
 
         // When
         val result = sut.createFreeTrialSite(siteDomain, siteTitle)
 
         // Then
+        verify(storeCreationRepository).createNewFreeTrialSite(
+            eq(expectedSiteCreationData),
+            eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
+            any()
+        )
         assertThat(result).isEqualTo(expectedCreationResult)
     }
 
@@ -59,7 +83,7 @@ internal class CreateFreeTrialStoreTest: BaseUnitTest() {
         siteTitle: String = "test title",
         expectedCreationResult: StoreCreationResult<Long> = StoreCreationResult.Success(123)
     ) {
-        val expectedSiteCreationData = StoreCreationRepository.SiteCreationData(
+        val expectedSiteCreationData = SiteCreationData(
             siteDesign = PlansViewModel.NEW_SITE_THEME,
             domain = siteDomain,
             title = siteTitle,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -226,7 +227,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
 
     private fun createSutWith(
         expectedSiteCreationData: SiteCreationData,
-        expectedCreationState: StoreCreationState = StoreCreationState.Success(123)
+        expectedCreationState: StoreCreationState = StoreCreationState.Success
     ) {
         newStore = mock {
             on { data } doReturn NewStore.NewStoreData(
@@ -247,6 +248,11 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
                 )
             } doAnswer {
                 creationStateFlow.value = expectedCreationState
+                if (expectedCreationState is StoreCreationState.Success) {
+                    flowOf(123)
+                } else {
+                    flowOf(null)
+                }
             }
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -98,32 +98,6 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when onContinueClicked happens and site address already exists, then store creation is recovered`() = testBlocking {
-        // Given
-        val storeCreationErrorType = StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS
-        createSutWith(
-            expectedSiteCreationData,
-            StoreCreationState.Error(storeCreationErrorType)
-        )
-
-        var latestEvent: MultiLiveEvent.Event? = null
-        sut.event.observeForever { latestEvent = it }
-
-        // When
-        sut.onStoreNameChanged("Store name")
-        sut.onContinueClicked()
-
-        // Then
-        verify(newStore).update(name = "Store name")
-        verify(newStore).update(siteId = 123)
-        verify(createStore).invoke(
-            expectedSiteCreationData.domain,
-            expectedSiteCreationData.title
-        )
-        assertThat(latestEvent).isEqualTo(NavigateToStoreInstallation)
-    }
-
-    @Test
     fun `when onStoreNameChanges happens, then viewState is updated as expected`() = testBlocking {
         // Given
         val viewStateChanges = mutableListOf<StoreNamePickerState>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -6,31 +6,30 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
-import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository
 import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
-import com.woocommerce.android.ui.login.storecreation.StoreCreationResult
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToStoreInstallation
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.StoreNamePickerState
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.wordpress.android.fluxc.model.SiteModel
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     private lateinit var sut: StoreNamePickerViewModel
-    private lateinit var storeCreationRepository: StoreCreationRepository
+    private lateinit var createStore: CreateFreeTrialStore
     private lateinit var newStore: NewStore
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private lateinit var prefsWrapper: AppPrefsWrapper
@@ -62,10 +61,9 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         // Then
         verify(newStore).update(name = "Store name")
         verify(newStore).update(siteId = 123)
-        verify(storeCreationRepository).createNewFreeTrialSite(
-            eq(expectedSiteCreationData),
-            eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
-            any()
+        verify(createStore).invoke(
+            expectedSiteCreationData.domain,
+            expectedSiteCreationData.title
         )
         assertThat(latestEvent).isEqualTo(NavigateToStoreInstallation)
     }
@@ -76,7 +74,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         val storeCreationErrorType = StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED
         createSutWith(
             expectedSiteCreationData,
-            StoreCreationResult.Failure(storeCreationErrorType, "error message")
+            StoreCreationState.Error(storeCreationErrorType)
         )
 
         var latestEvent: MultiLiveEvent.Event? = null
@@ -91,12 +89,10 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
 
         // Then
         verify(newStore).update(name = "Store name")
-        verify(storeCreationRepository).createNewFreeTrialSite(
-            eq(expectedSiteCreationData),
-            eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
-            any()
+        verify(createStore).invoke(
+            expectedSiteCreationData.domain,
+            expectedSiteCreationData.title
         )
-
         assertThat(latestEvent).isNull()
         assertThat(latestState).isEqualTo(StoreNamePickerState.Error(storeCreationErrorType))
     }
@@ -107,7 +103,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         val storeCreationErrorType = StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS
         createSutWith(
             expectedSiteCreationData,
-            StoreCreationResult.Failure(storeCreationErrorType, "error message")
+            StoreCreationState.Error(storeCreationErrorType)
         )
 
         var latestEvent: MultiLiveEvent.Event? = null
@@ -120,12 +116,10 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         // Then
         verify(newStore).update(name = "Store name")
         verify(newStore).update(siteId = 123)
-        verify(storeCreationRepository).createNewFreeTrialSite(
-            eq(expectedSiteCreationData),
-            eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
-            any()
+        verify(createStore).invoke(
+            expectedSiteCreationData.domain,
+            expectedSiteCreationData.title
         )
-        verify(storeCreationRepository).getSiteByUrl(expectedSiteCreationData.domain)
         assertThat(latestEvent).isEqualTo(NavigateToStoreInstallation)
     }
 
@@ -220,9 +214,8 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
 
     private fun createSutWith(
         expectedSiteCreationData: SiteCreationData,
-        expectedCreationResult: StoreCreationResult<Long> = StoreCreationResult.Success(123)
+        expectedCreationState: StoreCreationState = StoreCreationState.Success(123)
     ) {
-        val siteModel = SiteModel().apply { siteId = 123 }
         newStore = mock {
             on { data } doReturn NewStore.NewStoreData(
                 domain = expectedSiteCreationData.domain,
@@ -230,16 +223,19 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
             )
         }
 
-        storeCreationRepository = mock {
-            onBlocking {
-                createNewFreeTrialSite(
-                    eq(expectedSiteCreationData),
-                    eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
-                    any()
-                )
-            } doReturn expectedCreationResult
+        val creationStateFlow = MutableStateFlow<StoreCreationState>(StoreCreationState.Idle)
 
-            onBlocking { getSiteByUrl(expectedSiteCreationData.domain) } doReturn siteModel
+        createStore = mock {
+            on { state } doReturn creationStateFlow
+
+            onBlocking {
+                invoke(
+                    expectedSiteCreationData.domain,
+                    expectedSiteCreationData.title
+                )
+            } doAnswer {
+                creationStateFlow.value = expectedCreationState
+            }
         }
 
         analyticsTracker = mock()
@@ -247,7 +243,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         sut = StoreNamePickerViewModel(
             savedStateHandle = savedState,
             newStore = newStore,
-            repository = storeCreationRepository,
+            createStore = createStore,
             analyticsTrackerWrapper = analyticsTracker,
             prefsWrapper = prefsWrapper
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -113,7 +113,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         val storeCreationErrorType = StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED
         createSutWith(
             expectedSiteCreationData,
-            StoreCreationState.Error(storeCreationErrorType)
+            StoreCreationState.Failed(storeCreationErrorType)
         )
 
         var latestEvent: MultiLiveEvent.Event? = null
@@ -227,7 +227,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
 
     private fun createSutWith(
         expectedSiteCreationData: SiteCreationData,
-        expectedCreationState: StoreCreationState = StoreCreationState.Success
+        expectedCreationState: StoreCreationState = StoreCreationState.Finished
     ) {
         newStore = mock {
             on { data } doReturn NewStore.NewStoreData(
@@ -248,7 +248,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
                 )
             } doAnswer {
                 creationStateFlow.value = expectedCreationState
-                if (expectedCreationState is StoreCreationState.Success) {
+                if (expectedCreationState is StoreCreationState.Finished) {
                     flowOf(123)
                 } else {
                     flowOf(null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -49,10 +49,42 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when onContinueClicked starts loading, then the state is updated to reflect it`() = testBlocking {
+        // Given
+        createSutWith(
+            expectedSiteCreationData,
+            StoreCreationState.Loading
+        )
+
+        var latestState: StoreNamePickerState? = null
+        sut.storePickerState.observeForever { latestState = it }
+
+        // When
+        sut.onStoreNameChanged("Store name")
+        sut.onContinueClicked()
+
+        // Then
+        verify(newStore).update(name = "Store name")
+        verify(createStore).invoke(
+            expectedSiteCreationData.domain,
+            expectedSiteCreationData.title
+        )
+        assertThat(latestState).isEqualTo(
+            StoreNamePickerState.Contentful(
+                storeName = "Store name",
+                isCreatingStore = true
+            )
+        )
+    }
+
+    @Test
     fun `when onContinueClicked happens and store creation succeed, then free trial store creation starts`() = testBlocking {
         // Given
         var latestEvent: MultiLiveEvent.Event? = null
         sut.event.observeForever { latestEvent = it }
+
+        var latestState: StoreNamePickerState? = null
+        sut.storePickerState.observeForever { latestState = it }
 
         // When
         sut.onStoreNameChanged("Store name")
@@ -66,6 +98,12 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
             expectedSiteCreationData.title
         )
         assertThat(latestEvent).isEqualTo(NavigateToStoreInstallation)
+        assertThat(latestState).isEqualTo(
+            StoreNamePickerState.Contentful(
+                storeName = "Store name",
+                isCreatingStore = false
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
Summary
==========
This PR adds a `Store Profiler` Feature Flag that allows us to switch when using the Store Profiler group of views working alongside the Free Trial feature. This aims to enable us to easily switch between activating the Store Profiler or not without worrying about changing actual behaviors as things get experimented with.

Also, this PR centralizes the Free Trial store creation logic inside a single Use Case class called `CreateFreeTrialStore` that can be easily reused in any Store Creation ViewModel with proper unit test coverage.

Captures
==========

### Store Profiler **ENABLED**

| Free Trial Flow | Standard Store Creation Flow |
| ------------- | ------------- |
| https://user-images.githubusercontent.com/5920403/229667527-48192106-d9f1-49b0-9599-04f1d37c2467.mp4 | https://user-images.githubusercontent.com/5920403/229667653-470b3db4-8147-48e6-8f22-6383fde2a669.mp4 |

### Store Profiler **DISABLED**

| Free Trial Flow | Standard Store Creation Flow |
| ------------- | ------------- |
| https://user-images.githubusercontent.com/5920403/229667451-f94d3256-ad8b-449b-923a-ceacf26ecd46.mp4 | https://user-images.githubusercontent.com/5920403/229667588-173b660f-bead-424f-97a9-fb610b1504ac.mp4 |


How to Test
==========
Adjust the `FeatureFlag` class to activate and deactivate the Free Trial and Store Profiler features to see if they follow the expected configuration.

### Scenario 1 - Free Trial **ENABLED** and Store Profiler **ENABLED**
### Scenario 2 - Free Trial **ENABLED** and Store Profiler **DISABLED**
### Scenario 3 - Free Trial **DISABLED** and Store Profiler **ENABLED**
### Scenario 4 - Free Trial **DISABLED** and Store Profiler **DISABLED**


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
