### PR TITLE
Update resource name

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -1563,7 +1563,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         // WHEN
         initViewModel()
         (viewModel.viewStateData.getOrAwaitValue()).rows.find {
-            it.label == UiStringRes(R.string.card_reader_tap_to_pay)
+            it.label == UiStringRes(R.string.card_reader_test_tap_to_pay)
         }!!.onClick!!.invoke()
 
         // THEN


### PR DESCRIPTION
### Description
This small PR changes the resource name `card_reader_tap_to_pay` -> `card_reader_test_tap_to_pay` which was breaking the unit tests task.

### Testing instructions
Check that all test passes should be OK