### PR TITLE
Fix crash on More Menu screen when site is not selected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
@@ -31,7 +31,7 @@ class MoreMenuRepository @Inject constructor(
             currentWooCoreVersion.semverCompareTo(INBOX_MINIMUM_SUPPORTED_VERSION) >= 0
         }
 
-    fun isUpgradesEnabled(): Boolean = selectedSite.get().isWpComStore
+    fun isUpgradesEnabled(): Boolean = selectedSite.getIfExists()?.isWpComStore ?: false
 
     fun observeCouponBetaSwitch() = appPrefsWrapper.observePrefs()
         .onStart { emit(Unit) }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepositoryTest.kt
@@ -1,0 +1,68 @@
+package com.woocommerce.android.ui.moremenu.domain
+
+import com.woocommerce.android.tools.SelectedSite
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.wordpress.android.fluxc.model.SiteModel
+
+class MoreMenuRepositoryTest {
+
+    lateinit var sut: MoreMenuRepository
+
+    val selectedSite: SelectedSite = mock()
+
+    @Before
+    fun setUp() {
+        sut = MoreMenuRepository(
+            selectedSite,
+            mock(),
+            mock()
+        )
+    }
+
+    @Test
+    fun `show upgrades button when store is WPCOM`() {
+        // given
+        selectedSite.stub {
+            on { getIfExists() } doReturn SiteModel().apply { setIsWpComStore(true) }
+        }
+
+        // when
+        val isUpgradesEnabled = sut.isUpgradesEnabled()
+
+        // then
+        assertThat(isUpgradesEnabled).isTrue
+    }
+
+    @Test
+    fun `hide upgrades button when store is not WPCOM`() {
+        // given
+        selectedSite.stub {
+            on { getIfExists() } doReturn SiteModel().apply { setIsWpComStore(false) }
+        }
+
+        // when
+        val isUpgradesEnabled = sut.isUpgradesEnabled()
+
+        // then
+        assertThat(isUpgradesEnabled).isFalse
+    }
+
+    @Test
+    fun `hide upgrades button when store is not selected`() {
+        // given
+        selectedSite.stub {
+            on { getIfExists() } doReturn null
+        }
+
+        // when
+        val isUpgradesEnabled = sut.isUpgradesEnabled()
+
+        // then
+        assertThat(isUpgradesEnabled).isFalse
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8718
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a crash which occured when user opened the More Menu screen with no selected site. I don't know how to reproduce this scenario but, looking at statistics of the bug in Sentry, this might be a corner case.

This PR should fix the problem.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
As we don't have reproduction steps, there's no need for tests.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
