### PR TITLE
Send Tracks events for Upgrade flow result (triggered from Preview)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreFragment.kt
@@ -37,6 +37,11 @@ class LaunchStoreFragment : BaseFragment() {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        lifecycle.addObserver(viewModel)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         rootView = ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -52,6 +57,11 @@ class LaunchStoreFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
+    }
+
+    override fun onDestroyView() {
+        lifecycle.removeObserver(viewModel)
+        super.onDestroyView()
     }
 
     private fun setupObservers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreScreen.kt
@@ -129,7 +129,12 @@ fun LaunchStoreScreen(
                     )
                 }
             } else {
-                WebView(state.siteUrl, userAgent, authenticator)
+                WebView(
+                    state.siteUrl,
+                    userAgent,
+                    authenticator,
+                    isReadOnly = false
+                )
             }
         }
         ActionsFooter(state, onLaunchStoreClicked, onShareStoreUrl, onBackToStoreClicked)
@@ -140,7 +145,8 @@ fun LaunchStoreScreen(
 private fun WebView(
     url: String,
     userAgent: UserAgent,
-    authenticator: WPComWebViewAuthenticator
+    authenticator: WPComWebViewAuthenticator,
+    isReadOnly: Boolean
 ) {
     WCWebView(
         url = url,
@@ -148,7 +154,7 @@ private fun WebView(
         wpComAuthenticator = authenticator,
         captureBackPresses = false,
         loadWithOverviewMode = true,
-        isReadOnly = true,
+        isReadOnly = isReadOnly,
         progressIndicator = Circular(
             stringResource(id = string.store_creation_installation_rendering_preview_label)
         ),
@@ -247,7 +253,12 @@ fun SitePreview(
                     shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)),
                 )
         ) {
-            WebView(url, userAgent, authenticator)
+            WebView(
+                url,
+                userAgent,
+                authenticator,
+                isReadOnly = true
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
@@ -35,9 +35,6 @@ class LaunchStoreViewModel @Inject constructor(
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent
 ) : ScopedViewModel(savedStateHandle) {
-    private companion object {
-        const val PLANS_URL = "https://wordpress.com/plans/"
-    }
 
     private val _viewState = MutableStateFlow(
         LaunchStoreState(
@@ -92,11 +89,7 @@ class LaunchStoreViewModel @Inject constructor(
             FREE_TRIAL_UPGRADE_NOW_TAPPED,
             mapOf(AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_BANNER)
         )
-        triggerEvent(
-            UpgradeToEcommercePlan(
-                url = PLANS_URL + selectedSite.get().siteId
-            )
-        )
+        triggerEvent(UpgradeToEcommercePlan)
     }
 
     fun onBackPressed() {
@@ -117,6 +110,6 @@ class LaunchStoreViewModel @Inject constructor(
         val displayUrl: String
     )
 
-    data class UpgradeToEcommercePlan(val url: String) : MultiLiveEvent.Event()
+    object UpgradeToEcommercePlan : MultiLiveEvent.Event()
     data class ShareStoreUrl(val url: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding.launchstore
 
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
@@ -34,7 +36,7 @@ class LaunchStoreViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent
-) : ScopedViewModel(savedStateHandle) {
+) : ScopedViewModel(savedStateHandle), DefaultLifecycleObserver {
 
     private val _viewState = MutableStateFlow(
         LaunchStoreState(
@@ -46,6 +48,12 @@ class LaunchStoreViewModel @Inject constructor(
         )
     )
     val viewState = _viewState.asLiveData()
+
+    override fun onResume(owner: LifecycleOwner) {
+        _viewState.value = _viewState.value.copy(
+            isTrialPlan = selectedSite.get().isFreeTrial
+        )
+    }
 
     fun launchStore() {
         _viewState.value = _viewState.value.copy(isLoading = true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8736
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR introduces usage of StartUpgradeFlow use case from the Preview screen. This change will result with the Tracks events sent in case if user successfully upgrades a plan or abandones it during the process, when it started from the Preview screen.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [ ] With a site in Free Trial, open the "Preview" and press "Upgrade" on the top banner. Upgrade the site and verify that there's `plan_upgrade_success` event recorded.
- [ ] With a site in Free Trial, open the "Preview" and press "Upgrade" on the top banner. Abandon the process and verify that there's `plan_upgrade_abandoned` event recorded.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5845095/229747009-661543dd-042d-411c-9150-59d87fe950c7.mp4

### Questions
@JorgeMucientes I've got two questions:

- is Kiwi planning to handle the "post successful upgrade" flow? After this PR, as you can see in the video, we'll navigate the user back to the "Preview" screen but the state of the Preview doesn't seem to refresh properly. If it's not in Kiwi scope, then Eagle will do this - we just have to sync on that 🙂
- I don't know if it's a known issue but I can't scroll the site which is in the preview.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
