### PR TITLE
Use migrateAddOn on WooCommerce tables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.23.0'
+    fluxCVersion = '2.23.1'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
### Description
This small PR updates the FluxC version to the one fixing the issue of using `migrate` to update the schema of a WooCommerce table. The use of `migrate` instead of `migrateAddOn` caused WordPress and Jetpack to crash.

FluxC [fix](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2701)

> The WordPress and Jetpack apps are crashing when updating to the [current beta version (22.1)](https://github.com/wordpress-mobile/WordPress-Android/releases/tag/22.1-rc-1) from a previous version because the WellSQL migration tries to alter a table that does not exist in those apps: WCProductVariationModel.

> This fix prevents the issue by replacing the migrate function with the specific migrateAddOn(ADDON_WOOCOMMERCE, version) for this version migration since this table is only added in that condition.
