### PR TITLE
REST API: Pre-select a site after Jetpack installation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -121,10 +121,10 @@ class JetpackActivationRepository @Inject constructor(
         siteStore.getSitesByNameOrUrlMatching(baseUrl).forEach {
             if (it.origin != SiteModel.ORIGIN_WPCOM_REST) {
                 dispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(it))
+            } else {
+                selectedSite.set(it)
             }
         }
-
-        selectedSite.set(jetpackSite)
     }
 
     @Suppress("ReturnCount", "MagicNumber")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -171,13 +171,28 @@ private fun ProgressState(
             )
         }
         Spacer(modifier = Modifier.weight(1f))
+        var showLoading by remember { mutableStateOf(false) }
         AnimatedVisibility(
             visible = viewState.isDone,
             enter = slideInVertically { fullHeight -> fullHeight },
             exit = slideOutVertically { fullHeight -> fullHeight }
         ) {
-            WCColoredButton(onClick = onContinueClick, modifier = Modifier.fillMaxWidth()) {
-                Text(text = stringResource(id = R.string.login_jetpack_installation_go_to_store_button))
+            WCColoredButton(
+                onClick = {
+                    showLoading = true
+                    onContinueClick()
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !showLoading
+            ) {
+                if (showLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(size = dimensionResource(id = R.dimen.major_150)),
+                        color = colorResource(id = R.color.color_on_primary_surface),
+                    )
+                } else {
+                    Text(text = stringResource(id = R.string.login_jetpack_installation_go_to_store_button))
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #8735. 

The original implementation was already selecting a site, however, it was the one that didn't have Jetpack installed.

**To test:**
1. Start with a self-hosted site that doesn't have Jetpack
2. Log in, tap on the Jetpack banner and proceed with the plugin installation
3. After it finishes successfully, tap on the `Go to store` button
4. Notice the original site is already selected, the Jetpack banner is gone and `Install Jetpack option` is gone from the Settings