### PR TITLE
Free Trial: Connect summary to store creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerFragment.kt
@@ -14,7 +14,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.NavigateToDomainPickerStep
-import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.NavigateToInstallationStep
+import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.NavigateToSummaryStep
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
@@ -50,14 +50,14 @@ class CountryPickerFragment : BaseFragment() {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is MultiLiveEvent.Event.NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
                 is NavigateToDomainPickerStep -> navigateToDomainPickerStep()
-                is NavigateToInstallationStep -> navigateToInstallationStep()
+                is NavigateToSummaryStep -> navigateToInstallationStep()
             }
         }
     }
 
     private fun navigateToInstallationStep() {
         findNavController().navigateSafely(
-            CountryPickerFragmentDirections.actionCountryPickerFragmentToInstallationFragment()
+            CountryPickerFragmentDirections.actionCountryPickerFragmentToSummaryFragment()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -96,16 +96,27 @@ class CountryPickerViewModel @Inject constructor(
     fun onContinueClicked() {
         launch {
             if (FeatureFlag.FREE_TRIAL_M2.isEnabled()) {
-                createStore(
-                    storeDomain = newStore.data.domain,
-                    storeName = newStore.data.name,
-                ).filterNotNull().collect {
-                    newStore.update(siteId = it)
-                    triggerEvent(NavigateToInstallationStep)
-                }
+                triggerEvent(NavigateToSummaryStep)
             } else {
                 triggerEvent(NavigateToDomainPickerStep)
             }
+        }
+    }
+
+
+    /**
+     * We're currently not using this method anymore,
+     * but we need to keep it until we have a final decision on
+     * the store free trial creation flow steps.
+     */
+    @Suppress("UnusedPrivateMember")
+    private suspend fun startFreeTrialSiteCreation() {
+        createStore(
+            storeDomain = newStore.data.domain,
+            storeName = newStore.data.name,
+        ).filterNotNull().collect {
+            newStore.update(siteId = it)
+            triggerEvent(NavigateToSummaryStep)
         }
     }
 
@@ -132,7 +143,7 @@ class CountryPickerViewModel @Inject constructor(
         )
 
     object NavigateToDomainPickerStep : MultiLiveEvent.Event()
-    object NavigateToInstallationStep : MultiLiveEvent.Event()
+    object NavigateToSummaryStep : MultiLiveEvent.Event()
 
     sealed class CountryPickerState {
         data class Contentful(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -103,7 +103,6 @@ class CountryPickerViewModel @Inject constructor(
         }
     }
 
-
     /**
      * We're currently not using this method anymore,
      * but we need to keep it until we have a final decision on

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToDomainPicker
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToStoreInstallation
+import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToStoreProfiler
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToSummary
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -48,6 +49,7 @@ class StoreNamePickerFragment : BaseFragment() {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is MultiLiveEvent.Event.NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
                 is NavigateToDomainPicker -> navigateToDomainPicker(event.domainInitialQuery)
+                is NavigateToStoreProfiler -> navigateToStoreProfiler()
                 is NavigateToStoreInstallation -> navigateToInstallation()
                 is NavigateToSummary -> navigateToSummary()
             }
@@ -61,6 +63,11 @@ class StoreNamePickerFragment : BaseFragment() {
 
     private fun navigateToInstallation() {
         StoreNamePickerFragmentDirections.actionStoreNamePickerFragmentToInstallationFragment()
+            .let { findNavController().navigateSafely(it) }
+    }
+
+    private fun navigateToStoreProfiler() {
+        StoreNamePickerFragmentDirections.actionStoreNamePickerFragmentToStoreProfilerCategoryFragment()
             .let { findNavController().navigateSafely(it) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -87,6 +87,12 @@ class StoreNamePickerViewModel @Inject constructor(
         }
     }
 
+    /**
+     * We're currently not using this method anymore,
+     * but we need to keep it until we have a final decision on
+     * the store free trial creation flow steps.
+     */
+    @Suppress("UnusedPrivateMember")
     private suspend fun startFreeTrialSiteCreation() {
         createStore(
             storeDomain = newStore.data.domain,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -80,9 +79,9 @@ class StoreNamePickerViewModel @Inject constructor(
     fun onContinueClicked() {
         newStore.update(name = storeName.value)
         if (canCreateFreeTrialStore) {
-            launch { startFreeTrialSiteCreation() }
+            triggerEvent(NavigateToSummary)
         } else if (FeatureFlag.STORE_CREATION_PROFILER.isEnabled()) {
-            triggerEvent(NavigateToDomainPicker(storeName.value))
+            triggerEvent(NavigateToStoreProfiler)
         } else {
             triggerEvent(NavigateToDomainPicker(storeName.value))
         }
@@ -112,6 +111,8 @@ class StoreNamePickerViewModel @Inject constructor(
     data class NavigateToDomainPicker(val domainInitialQuery: String) : MultiLiveEvent.Event()
 
     object NavigateToStoreInstallation : MultiLiveEvent.Event()
+
+    object NavigateToStoreProfiler : MultiLiveEvent.Event()
 
     object NavigateToSummary : MultiLiveEvent.Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
@@ -11,11 +11,15 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class StoreCreationSummaryFragment : BaseFragment() {
     private val viewModel: StoreCreationSummaryViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
@@ -2,10 +2,13 @@ package com.woocommerce.android.ui.login.storecreation.summary
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,6 +26,22 @@ class StoreCreationSummaryFragment : BaseFragment() {
         setContent {
             WooThemeWithBackground {
                 StoreCreationSummaryScreen(viewModel)
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupEventObservers()
+    }
+
+    private fun setupEventObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is StoreCreationSummaryViewModel.OnCancelPressed -> findNavController().popBackStack()
+                is StoreCreationSummaryViewModel.OnStoreCreationSuccess -> findNavController().navigateSafely(
+                    StoreCreationSummaryFragmentDirections.actionSummaryFragmentToInstallationFragment()
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryScreen.kt
@@ -245,3 +245,15 @@ fun StoreCreationSummary() {
         )
     }
 }
+
+@Preview(name = "Loading mode")
+@Composable
+fun StoreCreationSummaryLoading() {
+    WooThemeWithBackground {
+        StoreCreationSummaryScreen(
+            onCancelPressed = {},
+            onTryForFreeButtonPressed = {},
+            isLoading = true
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryScreen.kt
@@ -14,12 +14,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -40,16 +42,20 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun StoreCreationSummaryScreen(viewModel: StoreCreationSummaryViewModel) {
-    StoreCreationSummaryScreen(
-        onCancelPressed = viewModel::onCancelPressed,
-        onTryForFreeButtonPressed = viewModel::onTryForFreeButtonPressed
-    )
+    viewModel.isLoading.observeAsState().value?.let { isLoading ->
+        StoreCreationSummaryScreen(
+            onCancelPressed = viewModel::onCancelPressed,
+            onTryForFreeButtonPressed = viewModel::onTryForFreeButtonPressed,
+            isLoading = isLoading
+        )
+    }
 }
 
 @Composable
 private fun StoreCreationSummaryScreen(
     onCancelPressed: () -> Unit,
-    onTryForFreeButtonPressed: () -> Unit
+    onTryForFreeButtonPressed: () -> Unit,
+    isLoading: Boolean
 ) {
     Scaffold(topBar = {
         Toolbar(onNavigationButtonClick = onCancelPressed)
@@ -88,7 +94,8 @@ private fun StoreCreationSummaryScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
-                onTryForFreeButtonPressed = onTryForFreeButtonPressed
+                onTryForFreeButtonPressed = onTryForFreeButtonPressed,
+                isLoading = isLoading
             )
         }
     }
@@ -179,7 +186,8 @@ private fun FeatureRow(
 @Composable
 private fun SummaryBottom(
     modifier: Modifier,
-    onTryForFreeButtonPressed: () -> Unit
+    onTryForFreeButtonPressed: () -> Unit,
+    isLoading: Boolean
 ) {
     val primaryPurple = colorResource(id = R.color.color_primary)
     val buttonColors = ButtonDefaults.buttonColors(
@@ -201,7 +209,14 @@ private fun SummaryBottom(
             onClick = onTryForFreeButtonPressed,
             colors = buttonColors
         ) {
-            Text(stringResource(id = R.string.free_trial_summary_try_button))
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(size = dimensionResource(id = R.dimen.major_150)),
+                    color = colorResource(id = R.color.color_on_primary_surface),
+                )
+            } else {
+                Text(stringResource(id = R.string.free_trial_summary_try_button))
+            }
         }
         Text(
             text = stringResource(id = R.string.free_trial_summary_credit_card_message),
@@ -225,7 +240,8 @@ fun StoreCreationSummary() {
     WooThemeWithBackground {
         StoreCreationSummaryScreen(
             onCancelPressed = {},
-            onTryForFreeButtonPressed = {}
+            onTryForFreeButtonPressed = {},
+            isLoading = false
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -13,8 +13,10 @@ class StoreCreationSummaryViewModel @Inject constructor(
     private val createStore: CreateFreeTrialStore
 ) : ScopedViewModel(savedStateHandle) {
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
-    fun onTryForFreeButtonPressed() { triggerEvent(OnTryForFreeButtonPressed) }
+    fun onTryForFreeButtonPressed() { triggerEvent(OnStoreCreationSuccess) }
 
     object OnCancelPressed : MultiLiveEvent.Event()
-    object OnTryForFreeButtonPressed : MultiLiveEvent.Event()
+    object OnStoreCreationSuccess : MultiLiveEvent.Event()
+
+    object OnStoreCreationFailure: MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
 @HiltViewModel
@@ -24,8 +25,17 @@ class StoreCreationSummaryViewModel @Inject constructor(
     ).asLiveData()
 
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
-    fun onTryForFreeButtonPressed() { triggerEvent(OnStoreCreationSuccess) }
-
+    fun onTryForFreeButtonPressed() {
+        launch {
+            createStore(
+                storeDomain = newStore.data.domain,
+                storeName = newStore.data.name,
+            ).collect {
+                newStore.update(siteId = it)
+                triggerEvent(OnStoreCreationSuccess)
+            }
+        }
+    }
 
     @Parcelize
     data class ViewState(val isLoading: Boolean) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -9,10 +9,10 @@ import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class StoreCreationSummaryViewModel @Inject constructor(
@@ -47,5 +47,5 @@ class StoreCreationSummaryViewModel @Inject constructor(
 
     object OnCancelPressed : MultiLiveEvent.Event()
     object OnStoreCreationSuccess : MultiLiveEvent.Event()
-    object OnStoreCreationFailure: MultiLiveEvent.Event()
+    object OnStoreCreationFailure : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.storecreation.summary
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
@@ -9,6 +10,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.parcelize.Parcelize
 
 @HiltViewModel
 class StoreCreationSummaryViewModel @Inject constructor(
@@ -24,7 +26,9 @@ class StoreCreationSummaryViewModel @Inject constructor(
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
     fun onTryForFreeButtonPressed() { triggerEvent(OnStoreCreationSuccess) }
 
-    data class ViewState(val isLoading: Boolean)
+
+    @Parcelize
+    data class ViewState(val isLoading: Boolean) : Parcelable
 
     object OnCancelPressed : MultiLiveEvent.Event()
     object OnStoreCreationSuccess : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -28,7 +28,7 @@ class StoreCreationSummaryViewModel @Inject constructor(
             createStore(
                 storeDomain = newStore.data.domain,
                 storeName = newStore.data.name,
-            ).collect {siteId ->
+            ).collect { siteId ->
                 siteId?.let {
                     newStore.update(siteId = it)
                     triggerEvent(OnStoreCreationSuccess)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.storecreation.summary
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -8,7 +9,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class StoreCreationSummaryViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val createStore: CreateFreeTrialStore
 ) : ScopedViewModel(savedStateHandle) {
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
     fun onTryForFreeButtonPressed() { triggerEvent(OnTryForFreeButtonPressed) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.login.storecreation.summary
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
+import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,6 +11,7 @@ import javax.inject.Inject
 @HiltViewModel
 class StoreCreationSummaryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val newStore: NewStore,
     private val createStore: CreateFreeTrialStore
 ) : ScopedViewModel(savedStateHandle) {
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -3,13 +3,11 @@ package com.woocommerce.android.ui.login.storecreation.summary
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -24,23 +22,17 @@ class StoreCreationSummaryViewModel @Inject constructor(
         .map { it is Loading }
         .asLiveData()
 
-    init {
-        launch {
-            createStore.state
-                .filter { it is Failed }
-                .collect { triggerEvent(OnStoreCreationFailure) }
-        }
-    }
-
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
     fun onTryForFreeButtonPressed() {
         launch {
             createStore(
                 storeDomain = newStore.data.domain,
                 storeName = newStore.data.name,
-            ).collect {
-                newStore.update(siteId = it)
-                triggerEvent(OnStoreCreationSuccess)
+            ).collect {siteId ->
+                siteId?.let {
+                    newStore.update(siteId = it)
+                    triggerEvent(OnStoreCreationSuccess)
+                } ?: triggerEvent(OnStoreCreationFailure)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -3,12 +3,14 @@ package com.woocommerce.android.ui.login.storecreation.summary
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -21,6 +23,14 @@ class StoreCreationSummaryViewModel @Inject constructor(
     val isLoading = createStore.state
         .map { it is Loading }
         .asLiveData()
+
+    init {
+        launch {
+            createStore.state
+                .filter { it is Failed }
+                .collect { triggerEvent(OnStoreCreationFailure) }
+        }
+    }
 
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
     fun onTryForFreeButtonPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.login.storecreation.summary
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -14,11 +16,17 @@ class StoreCreationSummaryViewModel @Inject constructor(
     private val newStore: NewStore,
     private val createStore: CreateFreeTrialStore
 ) : ScopedViewModel(savedStateHandle) {
+    val viewState = savedState.getStateFlow(
+        scope = this,
+        initialValue = ViewState(isLoading = false)
+    ).asLiveData()
+
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
     fun onTryForFreeButtonPressed() { triggerEvent(OnStoreCreationSuccess) }
 
+    data class ViewState(val isLoading: Boolean)
+
     object OnCancelPressed : MultiLiveEvent.Event()
     object OnStoreCreationSuccess : MultiLiveEvent.Event()
-
     object OnStoreCreationFailure: MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -124,5 +124,10 @@
     <fragment
         android:id="@+id/summaryFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryFragment"
-        android:label="SummaryFragment" />
+        android:label="SummaryFragment" >
+        <action
+            android:id="@+id/action_summaryFragment_to_installationFragment"
+            app:destination="@id/installationFragment"
+            app:popUpTo="@id/nav_graph_store_creation" />
+    </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -83,6 +83,10 @@
             android:id="@+id/action_countryPickerFragment_to_installationFragment"
             app:destination="@id/installationFragment"
             app:popUpTo="@id/nav_graph_store_creation" />
+        <action
+            android:id="@+id/action_countryPickerFragment_to_summaryFragment"
+            app:destination="@id/summaryFragment"
+            app:popUpTo="@id/nav_graph_store_creation" />
     </fragment>
 
     <fragment

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.ui.login.storecreation.summary
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
+    lateinit var sut: StoreCreationSummaryViewModel
+    lateinit var createStore: CreateFreeTrialStore
+    private val savedState = SavedStateHandle()
+
+    private fun createSut(
+        expectedDomain: String,
+        expectedTitle: String,
+        expectedCreationState: StoreCreationState = StoreCreationState.Finished
+    ) {
+        val creationStateFlow = MutableStateFlow<StoreCreationState>(StoreCreationState.Idle)
+
+        createStore = mock {
+            on { state } doReturn creationStateFlow
+
+            onBlocking {
+                invoke(expectedDomain, expectedTitle)
+            } doAnswer {
+                creationStateFlow.value = expectedCreationState
+                if (expectedCreationState is StoreCreationState.Finished) {
+                    flowOf(123)
+                } else {
+                    flowOf(null)
+                }
+            }
+        }
+
+        sut = StoreCreationSummaryViewModel(
+            savedStateHandle = savedState,
+            createStore = createStore
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SITE_CREATION_FAILED
+import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnCancelPressed
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationFailure
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationSuccess
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -155,6 +156,23 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
 
         // Then
         assertThat(isLoading).isFalse
+    }
+
+    @Test
+    fun `when onCancelPressed happens, then trigger expected event`() = testBlocking {
+        // Given
+        val expectedDomain = "test domain"
+        val expectedTitle = "test title"
+        createSut(expectedDomain, expectedTitle, StoreCreationState.Idle)
+
+        var lastReceivedEvent: MultiLiveEvent.Event? = null
+        sut.event.observeForever { lastReceivedEvent = it }
+
+        // When
+        sut.onCancelPressed()
+
+        // Then
+        assertThat(lastReceivedEvent).isEqualTo(OnCancelPressed)
     }
 
     private fun createSut(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SITE_CREATION_FAILED
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationFailure
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationSuccess
-import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.ViewState
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -98,16 +97,14 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
         val expectedTitle = "test title"
         createSut(expectedDomain, expectedTitle, StoreCreationState.Idle)
 
-        val viewStateUpdates = mutableListOf<ViewState>()
-        sut.viewState.observeForever { viewStateUpdates.add(it) }
+        var isLoading: Boolean? = null
+        sut.isLoading.observeForever { isLoading = it }
 
         // When
         sut.onTryForFreeButtonPressed()
 
         // Then
-        assertThat(viewStateUpdates).containsExactly(
-            ViewState(isLoading = false)
-        )
+       assertThat(isLoading).isFalse
     }
 
     @Test
@@ -117,17 +114,14 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
         val expectedTitle = "test title"
         createSut(expectedDomain, expectedTitle, StoreCreationState.Loading)
 
-        val viewStateUpdates = mutableListOf<ViewState>()
-        sut.viewState.observeForever { viewStateUpdates.add(it) }
+        var isLoading: Boolean? = null
+        sut.isLoading.observeForever { isLoading = it }
 
         // When
         sut.onTryForFreeButtonPressed()
 
         // Then
-        assertThat(viewStateUpdates).containsExactly(
-            ViewState(isLoading = false),
-            ViewState(isLoading = true)
-        )
+        assertThat(isLoading).isTrue
     }
 
     @Test
@@ -137,16 +131,14 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
         val expectedTitle = "test title"
         createSut(expectedDomain, expectedTitle, StoreCreationState.Failed(SITE_CREATION_FAILED))
 
-        val viewStateUpdates = mutableListOf<ViewState>()
-        sut.viewState.observeForever { viewStateUpdates.add(it) }
+        var isLoading: Boolean? = null
+        sut.isLoading.observeForever { isLoading = it }
 
         // When
         sut.onTryForFreeButtonPressed()
 
         // Then
-        assertThat(viewStateUpdates).containsExactly(
-            ViewState(isLoading = false)
-        )
+        assertThat(isLoading).isFalse
     }
 
     @Test
@@ -156,16 +148,14 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
         val expectedTitle = "test title"
         createSut(expectedDomain, expectedTitle, StoreCreationState.Finished)
 
-        val viewStateUpdates = mutableListOf<ViewState>()
-        sut.viewState.observeForever { viewStateUpdates.add(it) }
+        var isLoading: Boolean? = null
+        sut.isLoading.observeForever { isLoading = it }
 
         // When
         sut.onTryForFreeButtonPressed()
 
         // Then
-        assertThat(viewStateUpdates).containsExactly(
-            ViewState(isLoading = false)
-        )
+        assertThat(isLoading).isFalse
     }
 
     private fun createSut(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
+internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
     private lateinit var sut: StoreCreationSummaryViewModel
     private lateinit var createStore: CreateFreeTrialStore
     private lateinit var newStore: NewStore
@@ -70,7 +70,6 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
         // When
         sut.onTryForFreeButtonPressed()
 
-
         // Then
         assertThat(lastReceivedEvent).isEqualTo(OnStoreCreationFailure)
     }
@@ -104,7 +103,7 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
         sut.onTryForFreeButtonPressed()
 
         // Then
-       assertThat(isLoading).isFalse
+        assertThat(isLoading).isFalse
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.login.storecreation.summary
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
+import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SITE_CREATION_FAILED
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationFailure
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationSuccess
@@ -21,8 +21,9 @@ import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
-    lateinit var sut: StoreCreationSummaryViewModel
-    lateinit var createStore: CreateFreeTrialStore
+    private lateinit var sut: StoreCreationSummaryViewModel
+    private lateinit var createStore: CreateFreeTrialStore
+    private lateinit var newStore: NewStore
     private val savedState = SavedStateHandle()
 
     @Test
@@ -76,11 +77,18 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
     ) {
         val creationStateFlow = MutableStateFlow<StoreCreationState>(StoreCreationState.Idle)
 
+        newStore = mock {
+            on { data } doReturn NewStore.NewStoreData(
+                domain = expectedDomain,
+                name = expectedTitle
+            )
+        }
+
         createStore = mock {
             on { state } doReturn creationStateFlow
 
             onBlocking {
-                invoke(expectedDomain, expectedTitle)
+                invoke(newStore.data.domain, newStore.data.name)
             } doAnswer {
                 creationStateFlow.value = expectedCreationState
                 if (expectedCreationState is StoreCreationState.Finished) {
@@ -93,7 +101,8 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
 
         sut = StoreCreationSummaryViewModel(
             savedStateHandle = savedState,
-            createStore = createStore
+            createStore = createStore,
+            newStore = newStore
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -50,8 +50,10 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
         var lastReceivedEvent: MultiLiveEvent.Event? = null
         sut.event.observeForever { lastReceivedEvent = it }
 
+        // When
         sut.onTryForFreeButtonPressed()
 
+        // Then
         assertThat(lastReceivedEvent).isEqualTo(OnStoreCreationSuccess)
     }
 
@@ -65,15 +67,34 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
         var lastReceivedEvent: MultiLiveEvent.Event? = null
         sut.event.observeForever { lastReceivedEvent = it }
 
+        // When
         sut.onTryForFreeButtonPressed()
 
+
+        // Then
         assertThat(lastReceivedEvent).isEqualTo(OnStoreCreationFailure)
+    }
+
+    @Test
+    fun `when store creation succeeds, then set site id`() = testBlocking {
+        // Given
+        val expectedDomain = "test domain"
+        val expectedTitle = "test title"
+        val expectedSiteId = 321321321L
+        createSut(expectedDomain, expectedTitle, StoreCreationState.Finished, expectedSiteId)
+
+        // When
+        sut.onTryForFreeButtonPressed()
+
+        // Then
+        verify(newStore).update(siteId = expectedSiteId)
     }
 
     private fun createSut(
         expectedDomain: String,
         expectedTitle: String,
-        expectedCreationState: StoreCreationState
+        expectedCreationState: StoreCreationState,
+        createdSiteId: Long = 123
     ) {
         val creationStateFlow = MutableStateFlow<StoreCreationState>(StoreCreationState.Idle)
 
@@ -92,7 +113,7 @@ internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
             } doAnswer {
                 creationStateFlow.value = expectedCreationState
                 if (expectedCreationState is StoreCreationState.Finished) {
-                    flowOf(123)
+                    flowOf(createdSiteId)
                 } else {
                     flowOf(null)
                 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -4,16 +4,32 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class StoreCreationSummaryViewModelTest: BaseUnitTest() {
     lateinit var sut: StoreCreationSummaryViewModel
     lateinit var createStore: CreateFreeTrialStore
     private val savedState = SavedStateHandle()
+
+    @Test
+    fun `when onTryForFreeButtonPressed is called, then start the store creation`() = testBlocking {
+        val expectedDomain = "test domain"
+        val expectedTitle = "test title"
+        createSut(expectedDomain, expectedTitle)
+
+        sut.onTryForFreeButtonPressed()
+
+        verify(createStore).invoke(expectedDomain, expectedTitle)
+    }
 
     private fun createSut(
         expectedDomain: String,


### PR DESCRIPTION
Summary
==========
Fix issue #8757 by connecting the Free Trial creation summary to all possible store creation flow.

Capture
==========
https://user-images.githubusercontent.com/5920403/230453654-c938e07c-7362-4c75-a0dc-96d6e8410fec.mp4


How to Test
==========
1. Try to Create a Free Trial store and make sure there's no way to create it without interacting with the Summary view.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.