### PR TITLE
Rename recent to last_sold

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -209,7 +209,7 @@ private fun displayProductsSection(
         ProductType.RECENT -> Triple(
             state.recentProducts,
             stringResource(id = string.product_selector_recent_products_heading),
-            ProductSourceForTracking.RECENT
+            ProductSourceForTracking.LAST_SOLD
         )
     }
     Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -533,5 +533,4 @@ enum class ProductSourceForTracking {
     LAST_SOLD,
     ALPHABETICAL,
     SEARCH,
-    FILTER,
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -530,7 +530,7 @@ val Collection<ProductSelectorViewModel.SelectedItem>.variationIds: List<Long>
     }
 enum class ProductSourceForTracking {
     POPULAR,
-    RECENT,
+    LAST_SOLD,
     ALPHABETICAL,
     SEARCH,
     FILTER,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -863,7 +863,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 VariationSelectorViewModel.VariationSelectionResult(
                     productId = 0L,
                     selectedVariationIds = setOf(1L),
-                    productSourceForTracking = ProductSourceForTracking.FILTER
+                    productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
                 )
             )
             sut.onDoneButtonClick()
@@ -873,7 +873,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 mapOf(
                     KEY_PRODUCT_COUNT to 1,
                     KEY_PRODUCT_SELECTOR_SOURCE to listOf(
-                        ProductSourceForTracking.FILTER.name
+                        ProductSourceForTracking.ALPHABETICAL.name
                     ),
                     KEY_PRODUCT_SELECTOR_FILTER_STATUS to true,
                 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -540,7 +540,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             val sut = createViewModel(navArgs)
             sut.onProductClick(
                 item = generateProductListItem(id = 0L),
-                productSourceForTracking = ProductSourceForTracking.RECENT
+                productSourceForTracking = ProductSourceForTracking.LAST_SOLD
             )
             sut.onProductClick(
                 item = generateProductListItem(id = 1L),
@@ -553,7 +553,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 mapOf(
                     KEY_PRODUCT_COUNT to 2,
                     KEY_PRODUCT_SELECTOR_SOURCE to listOf(
-                        ProductSourceForTracking.RECENT.name,
+                        ProductSourceForTracking.LAST_SOLD.name,
                         ProductSourceForTracking.POPULAR.name
                     ),
                     KEY_PRODUCT_SELECTOR_FILTER_STATUS to false,
@@ -576,7 +576,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             val sut = createViewModel(navArgs)
             sut.onProductClick(
                 item = generateProductListItem(id = 0L),
-                productSourceForTracking = ProductSourceForTracking.RECENT
+                productSourceForTracking = ProductSourceForTracking.LAST_SOLD
             )
             sut.onProductClick(
                 item = generateProductListItem(id = 2L),
@@ -593,7 +593,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 mapOf(
                     KEY_PRODUCT_COUNT to 3,
                     KEY_PRODUCT_SELECTOR_SOURCE to listOf(
-                        ProductSourceForTracking.RECENT.name,
+                        ProductSourceForTracking.LAST_SOLD.name,
                         ProductSourceForTracking.ALPHABETICAL.name,
                         ProductSourceForTracking.POPULAR.name
                     ),
@@ -754,7 +754,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 VariationSelectorViewModel.VariationSelectionResult(
                     productId = 0L,
                     selectedVariationIds = setOf(1L),
-                    productSourceForTracking = ProductSourceForTracking.RECENT
+                    productSourceForTracking = ProductSourceForTracking.LAST_SOLD
                 )
             )
             sut.onDoneButtonClick()
@@ -764,7 +764,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 mapOf(
                     KEY_PRODUCT_COUNT to 1,
                     KEY_PRODUCT_SELECTOR_SOURCE to listOf(
-                        ProductSourceForTracking.RECENT.name
+                        ProductSourceForTracking.LAST_SOLD.name
                     ),
                     KEY_PRODUCT_SELECTOR_FILTER_STATUS to false,
                 )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8762 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR renames the source "recent" to "last_sold". Reason being the "Recent" section was renamed to "Last Sold" and the source property would cause confusion when analyzing the metrics if it is different.

This PR also removes the unused `Filter` source.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to the product selector screen (menu -> orders -> click on + button -> Add products button)
2. Select any product from the "Last Sold" section
3. Click on "Done" button
4. Ensure the source property in the tracks has "last_sold"

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
