### PR TITLE
Quantity rules empty state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -737,6 +737,7 @@ class ProductDetailCardBuilder(
         val properties = buildMap {
             putIfNotNull(resources.getString(string.min_quantity) to rules.min?.toString())
             putIfNotNull(resources.getString(string.max_quantity) to rules.max?.toString())
+            if (size < 2) putIfNotNull(resources.getString(string.group_of) to rules.groupOf?.toString())
         }
 
         return PropertyGroup(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductQuantityRulesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductQuantityRulesFragment.kt
@@ -38,9 +38,9 @@ class ProductQuantityRulesFragment : BaseProductFragment(R.layout.fragment_produ
     }
 
     private fun initializeViews(quantityRules: QuantityRules) {
-        binding.minQuantityValue.text = quantityRules.min.toString()
-        binding.maxQuantityValue.text = quantityRules.max.toString()
-        binding.groupOfValue.text = quantityRules.groupOf.toString()
+        binding.minQuantityValue.text = quantityRules.min?.toString() ?: getString(R.string.empty_min_quantity)
+        binding.maxQuantityValue.text = quantityRules.max?.toString() ?: getString(R.string.empty_max_quantity)
+        binding.groupOfValue.text = quantityRules.groupOf?.toString() ?: getString(R.string.empty_group_of)
     }
 
     override fun getFragmentTitle() = getString(R.string.product_quantity_rules_title)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -332,6 +332,7 @@ class VariationDetailCardBuilder(
         val properties = buildMap {
             putIfNotNull(resources.getString(string.min_quantity) to rules.min?.toString())
             putIfNotNull(resources.getString(string.max_quantity) to rules.max?.toString())
+            if (size < 2) putIfNotNull(resources.getString(string.group_of) to rules.groupOf?.toString())
         }
 
         return PropertyGroup(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3320,4 +3320,8 @@
     <string name="group_of">Group of</string>
     <string name="quantity_rules_info_notice">You can edit product\'s quantity rules in the web dashboard.</string>
 
+    <string name="empty_min_quantity">No minimum</string>
+    <string name="empty_max_quantity">No maximum</string>
+    <string name="empty_group_of">Not grouped</string>
+
 </resources>


### PR DESCRIPTION
### Description
This small PR enhances the empty state on the quantity rules description and the quantity rules card. Now when the quantity rules when containing less than 2 rules will show the _group of_ rule (if present) on the quantities rules card. Now on null/empty rules on the quantities rules screen, the screen will display: [No minimum, No maximum, Not grouped] instead of `null`.

### Testing instructions
1. Set quantity rules for different products (simple / variable), leaving some rules on null
2. Check that the quantity rules card contains at most 2 rules
3. Check that empty rules display the empty state description instead of `null`

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/18119390/230650590-77741640-f74b-4d8a-9fb9-b341847cb208.mp4
