### PR TITLE
Free Trial: Remove store creation code from Store Name Picker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerFragment.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToDomainPicker
-import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToStoreInstallation
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToStoreProfiler
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToSummary
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -50,7 +49,6 @@ class StoreNamePickerFragment : BaseFragment() {
                 is MultiLiveEvent.Event.NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
                 is NavigateToDomainPicker -> navigateToDomainPicker(event.domainInitialQuery)
                 is NavigateToStoreProfiler -> navigateToStoreProfiler()
-                is NavigateToStoreInstallation -> navigateToInstallation()
                 is NavigateToSummary -> navigateToSummary()
             }
         }
@@ -58,11 +56,6 @@ class StoreNamePickerFragment : BaseFragment() {
 
     private fun navigateToSummary() {
         StoreNamePickerFragmentDirections.actionStoreNamePickerFragmentToSummaryFragment()
-            .let { findNavController().navigateSafely(it) }
-    }
-
-    private fun navigateToInstallation() {
-        StoreNamePickerFragmentDirections.actionStoreNamePickerFragmentToInstallationFragment()
             .let { findNavController().navigateSafely(it) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -32,34 +30,23 @@ import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorScreen
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
-import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.StoreNamePickerState
 
 @Composable
 fun StoreNamePickerScreen(viewModel: StoreNamePickerViewModel) {
-    viewModel.storePickerState.observeAsState().value.let { state ->
-        when (state) {
-            is StoreNamePickerState.Contentful -> StoreNamePickerScreen(
-                state = state,
-                onCancelPressed = viewModel::onCancelPressed,
-                onHelpPressed = viewModel::onHelpPressed,
-                onStoreNameChanged = viewModel::onStoreNameChanged,
-                onContinueClicked = viewModel::onContinueClicked
-            )
-            else -> {
-                StoreCreationErrorScreen(
-                    errorType = StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED,
-                    onArrowBackPressed = viewModel::onExitTriggered
-                )
-            }
-        }
+    viewModel.storeName.observeAsState().value?.let { storeName ->
+        StoreNamePickerScreen(
+            storeName = storeName,
+            onCancelPressed = viewModel::onCancelPressed,
+            onHelpPressed = viewModel::onHelpPressed,
+            onStoreNameChanged = viewModel::onStoreNameChanged,
+            onContinueClicked = viewModel::onContinueClicked
+        )
     }
 }
 
 @Composable
 private fun StoreNamePickerScreen(
-    state: StoreNamePickerState.Contentful,
+    storeName: String,
     onCancelPressed: () -> Unit,
     onHelpPressed: () -> Unit,
     onStoreNameChanged: (String) -> Unit,
@@ -72,7 +59,7 @@ private fun StoreNamePickerScreen(
         )
     }) { padding ->
         NamePickerForm(
-            state = state,
+            storeName = storeName,
             onStoreNameChanged = onStoreNameChanged,
             onContinueClicked = onContinueClicked,
             modifier = Modifier
@@ -86,7 +73,7 @@ private fun StoreNamePickerScreen(
 
 @Composable
 private fun NamePickerForm(
-    state: StoreNamePickerState.Contentful,
+    storeName: String,
     onStoreNameChanged: (String) -> Unit,
     onContinueClicked: () -> Unit,
     modifier: Modifier = Modifier
@@ -118,7 +105,7 @@ private fun NamePickerForm(
                 modifier = Modifier
                     .focusRequester(focusRequester)
                     .padding(top = dimensionResource(id = R.dimen.major_100)),
-                value = state.storeName,
+                value = storeName,
                 onValueChange = onStoreNameChanged,
                 label = stringResource(id = R.string.store_creation_store_name_hint),
                 singleLine = true,
@@ -128,16 +115,9 @@ private fun NamePickerForm(
         WCColoredButton(
             modifier = Modifier.fillMaxWidth(),
             onClick = onContinueClicked,
-            enabled = state.storeName.isNotBlank()
+            enabled = storeName.isNotBlank()
         ) {
-            if (state.isCreatingStore) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(size = dimensionResource(id = R.dimen.major_150)),
-                    color = colorResource(id = R.color.color_on_primary_surface),
-                )
-            } else {
-                Text(text = stringResource(id = R.string.continue_button))
-            }
+            Text(text = stringResource(id = R.string.continue_button))
         }
     }
     // Request focus on store name field when entering screen
@@ -154,7 +134,7 @@ private fun NamePickerForm(
 fun NamePickerPreview() {
     WooThemeWithBackground {
         NamePickerForm(
-            state = StoreNamePickerState.Contentful("White Christmas Tress", false),
+            storeName = "White Christmas Tress",
             onContinueClicked = {},
             onStoreNameChanged = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.NewStore
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -77,17 +76,7 @@ class StoreNamePickerViewModel @Inject constructor(
 
     data class NavigateToDomainPicker(val domainInitialQuery: String) : MultiLiveEvent.Event()
 
-    object NavigateToStoreInstallation : MultiLiveEvent.Event()
-
     object NavigateToStoreProfiler : MultiLiveEvent.Event()
 
     object NavigateToSummary : MultiLiveEvent.Event()
-
-    sealed class StoreNamePickerState {
-        data class Contentful(
-            val storeName: String,
-            val isCreatingStore: Boolean
-        ) : StoreNamePickerState()
-        data class Error(val type: StoreCreationErrorType) : StoreNamePickerState()
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -7,10 +7,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
 import com.woocommerce.android.util.FeatureFlag
@@ -18,29 +14,21 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
 import javax.inject.Inject
 
 @HiltViewModel
 class StoreNamePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val newStore: NewStore,
-    private val createStore: CreateFreeTrialStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
-    private val storeName = savedState.getStateFlow(scope = this, initialValue = "")
+    private val _storeName = savedState.getStateFlow(scope = this, initialValue = "")
+    val storeName = _storeName.asLiveData()
 
     private val canCreateFreeTrialStore
         get() = FeatureFlag.FREE_TRIAL_M2.isEnabled() &&
             FeatureFlag.STORE_CREATION_PROFILER.isEnabled().not()
-
-    val storePickerState = combine(
-        storeName,
-        createStore.state,
-        ::mapStoreNamePickerState
-    ).asLiveData()
 
     init {
         analyticsTrackerWrapper.track(
@@ -73,7 +61,7 @@ class StoreNamePickerViewModel @Inject constructor(
     }
 
     fun onStoreNameChanged(newName: String) {
-        storeName.value = newName
+        _storeName.value = newName
     }
 
     fun onContinueClicked() {
@@ -83,35 +71,8 @@ class StoreNamePickerViewModel @Inject constructor(
         } else if (FeatureFlag.STORE_CREATION_PROFILER.isEnabled()) {
             triggerEvent(NavigateToStoreProfiler)
         } else {
-            triggerEvent(NavigateToDomainPicker(storeName.value))
+            triggerEvent(NavigateToDomainPicker(_storeName.value))
         }
-    }
-
-    /**
-     * We're currently not using this method anymore,
-     * but we need to keep it until we have a final decision on
-     * the store free trial creation flow steps.
-     */
-    @Suppress("UnusedPrivateMember")
-    private suspend fun startFreeTrialSiteCreation() {
-        createStore(
-            storeDomain = newStore.data.domain,
-            storeName = newStore.data.name
-        ).filterNotNull().collect {
-            newStore.update(siteId = it)
-            triggerEvent(NavigateToStoreInstallation)
-        }
-    }
-
-    private fun mapStoreNamePickerState(
-        storeName: String,
-        createStoreState: StoreCreationState
-    ) = when (createStoreState) {
-        is Failed -> StoreNamePickerState.Error(createStoreState.type)
-        else -> StoreNamePickerState.Contentful(
-            storeName = storeName,
-            isCreatingStore = createStoreState is Loading
-        )
     }
 
     data class NavigateToDomainPicker(val domainInitialQuery: String) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -33,10 +33,6 @@
             android:id="@+id/action_storeNamePickerFragment_to_domainPickerFragment"
             app:destination="@id/domainPickerFragment" />
         <action
-            android:id="@+id/action_storeNamePickerFragment_to_installationFragment"
-            app:destination="@id/installationFragment"
-            app:popUpTo="@id/nav_graph_store_creation" />
-        <action
             android:id="@+id/action_storeNamePickerFragment_to_summaryFragment"
             app:destination="@id/summaryFragment"
             app:popUpTo="@id/nav_graph_store_creation" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin
-import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToSummary
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
@@ -24,7 +23,6 @@ import org.mockito.kotlin.verify
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     private lateinit var sut: StoreNamePickerViewModel
-    private lateinit var newStore: NewStore
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private lateinit var prefsWrapper: AppPrefsWrapper
     private val savedState = SavedStateHandle()
@@ -39,11 +37,10 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         prefsWrapper = mock()
-        newStore = mock()
         analyticsTracker = mock()
         sut = StoreNamePickerViewModel(
             savedStateHandle = savedState,
-            newStore = newStore,
+            newStore = mock(),
             analyticsTrackerWrapper = analyticsTracker,
             prefsWrapper = prefsWrapper
         )
@@ -70,6 +67,14 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         prefsWrapper = mock {
             on { getStoreCreationSource() } doReturn storeCreationSource
         }
+        analyticsTracker = mock()
+
+        sut = StoreNamePickerViewModel(
+            savedStateHandle = savedState,
+            newStore = mock(),
+            analyticsTrackerWrapper = analyticsTracker,
+            prefsWrapper = prefsWrapper
+        )
 
         var latestEvent: MultiLiveEvent.Event? = null
         sut.event.observeForever { latestEvent = it }
@@ -78,6 +83,13 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         sut.onCancelPressed()
 
         // Then
+        verify(analyticsTracker).track(
+            AnalyticsEvent.SITE_CREATION_STEP,
+            mapOf(
+                AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_NAME
+            )
+        )
+
         verify(analyticsTracker).track(
             AnalyticsEvent.SITE_CREATION_DISMISSED,
             mapOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -6,31 +6,24 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
-import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState
 import com.woocommerce.android.ui.login.storecreation.NewStore
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
 import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToSummary
-import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.StoreNamePickerState
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     private lateinit var sut: StoreNamePickerViewModel
-    private lateinit var createStore: CreateFreeTrialStore
     private lateinit var newStore: NewStore
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private lateinit var prefsWrapper: AppPrefsWrapper
@@ -46,115 +39,28 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         prefsWrapper = mock()
-        createSut()
-    }
-
-    @Test
-    fun `when onContinueClicked starts loading, then the state is updated to reflect it`() = testBlocking {
-        // Given
-        createSut(StoreCreationState.Loading)
-
-        var latestState: StoreNamePickerState? = null
-        sut.storePickerState.observeForever { latestState = it }
-
-        // When
-        sut.onStoreNameChanged("Store name")
-        sut.onContinueClicked()
-
-        // Then
-        verify(newStore).update(name = "Store name")
-        verify(createStore, never()).invoke(
-            expectedSiteCreationData.domain,
-            expectedSiteCreationData.title
-        )
-        assertThat(latestState).isEqualTo(
-            StoreNamePickerState.Contentful(
-                storeName = "Store name",
-                isCreatingStore = true
-            )
+        newStore = mock()
+        analyticsTracker = mock()
+        sut = StoreNamePickerViewModel(
+            savedStateHandle = savedState,
+            newStore = newStore,
+            analyticsTrackerWrapper = analyticsTracker,
+            prefsWrapper = prefsWrapper
         )
     }
 
     @Test
-    fun `when onContinueClicked happens and store creation succeed, then free trial store creation starts`() = testBlocking {
+    fun `when onContinueClicked happens, then free trial Summary event is triggered`() {
         // Given
         var latestEvent: MultiLiveEvent.Event? = null
         sut.event.observeForever { latestEvent = it }
 
-        var latestState: StoreNamePickerState? = null
-        sut.storePickerState.observeForever { latestState = it }
-
         // When
         sut.onStoreNameChanged("Store name")
         sut.onContinueClicked()
 
         // Then
-        verify(newStore).update(name = "Store name")
-        verify(newStore, never()).update(siteId = 123)
-        verify(createStore, never()).invoke(
-            expectedSiteCreationData.domain,
-            expectedSiteCreationData.title
-        )
         assertThat(latestEvent).isEqualTo(NavigateToSummary)
-        assertThat(latestState).isEqualTo(
-            StoreNamePickerState.Contentful(
-                storeName = "Store name",
-                isCreatingStore = false
-            )
-        )
-    }
-
-    @Test
-    fun `when onContinueClicked happens and store creation fails, then error state is triggered`() = testBlocking {
-        // Given
-        val storeCreationErrorType = StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED
-        createSut(StoreCreationState.Failed(storeCreationErrorType))
-
-        var latestEvent: MultiLiveEvent.Event? = null
-        var latestState: StoreNamePickerState? = null
-
-        sut.event.observeForever { latestEvent = it }
-        sut.storePickerState.observeForever { latestState = it }
-
-        // When
-        sut.onStoreNameChanged("Store name")
-        sut.onContinueClicked()
-
-        // Then
-        verify(newStore).update(name = "Store name")
-        verify(createStore, never()).invoke(
-            expectedSiteCreationData.domain,
-            expectedSiteCreationData.title
-        )
-        assertThat(latestEvent).isEqualTo(NavigateToSummary)
-        assertThat(latestState).isEqualTo(StoreNamePickerState.Error(storeCreationErrorType))
-    }
-
-    @Test
-    fun `when onStoreNameChanges happens, then viewState is updated as expected`() = testBlocking {
-        // Given
-        val viewStateChanges = mutableListOf<StoreNamePickerState>()
-        sut.storePickerState.observeForever {
-            viewStateChanges.add(it)
-        }
-
-        // When
-        sut.onStoreNameChanged("Store name")
-
-        // Then
-        assertThat(viewStateChanges).hasSize(2)
-        assertThat(viewStateChanges[0]).isEqualTo(
-            StoreNamePickerState.Contentful(
-                storeName = "",
-                isCreatingStore = false
-            )
-        )
-        assertThat(viewStateChanges[1]).isEqualTo(
-            StoreNamePickerState.Contentful(
-                storeName = "Store name",
-                isCreatingStore = false
-            )
-        )
     }
 
     @Test
@@ -164,7 +70,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
         prefsWrapper = mock {
             on { getStoreCreationSource() } doReturn storeCreationSource
         }
-        createSut()
+
         var latestEvent: MultiLiveEvent.Event? = null
         sut.event.observeForever { latestEvent = it }
 
@@ -218,23 +124,5 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
 
         // Then
         assertThat(latestEvent).isEqualTo(MultiLiveEvent.Event.NavigateToHelpScreen(HelpOrigin.STORE_CREATION))
-    }
-
-    private fun createSut(
-        expectedCreationState: StoreCreationState = StoreCreationState.Finished
-    ) {
-        createStore = mock {
-            on { state } doReturn MutableStateFlow(expectedCreationState)
-        }
-
-        newStore = mock()
-        analyticsTracker = mock()
-        sut = StoreNamePickerViewModel(
-            savedStateHandle = savedState,
-            newStore = newStore,
-            createStore = createStore,
-            analyticsTrackerWrapper = analyticsTracker,
-            prefsWrapper = prefsWrapper
-        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -6,9 +6,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin
-import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToSummary
-import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -26,13 +24,6 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private lateinit var prefsWrapper: AppPrefsWrapper
     private val savedState = SavedStateHandle()
-
-    private val expectedSiteCreationData = SiteCreationData(
-        siteDesign = PlansViewModel.NEW_SITE_THEME,
-        domain = "test domain",
-        title = "test title",
-        segmentId = null
-    )
 
     @Before
     fun setUp() {


### PR DESCRIPTION
Fix issue #8781 

Summary
==========
After introducing the Free Trial Summary, we should worry about creating the Free Trial store only from there. This PR aims to remove all the complexity related to the store creation feature from the `Store name picker` fragment, compose view, and View Model.

How to Test
==========
1. Simply test the Free Trial store creation flow and verify it's working exactly as the `trunk` version.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.