### PR TITLE
Free Trial: Remove store creation code from Store Country Picker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
@@ -33,11 +33,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.CountryPickerState
 import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.StoreCreationCountry
 
 @Composable
 fun CountryPickerScreen(viewModel: CountryPickerViewModel) {
-    viewModel.availableCountries.observeAsState().value?.let { availableCountries ->
+    viewModel.countryPickerState.observeAsState().value?.let { viewState ->
         Scaffold(topBar = {
             ToolbarWithHelpButton(
                 onNavigationButtonClick = viewModel::onArrowBackPressed,
@@ -45,8 +46,7 @@ fun CountryPickerScreen(viewModel: CountryPickerViewModel) {
             )
         }) { padding ->
             CountryPickerForm(
-                availableCountries = availableCountries,
-                storeName = viewModel.storeName,
+                state = viewState,
                 onContinueClicked = viewModel::onContinueClicked,
                 onCountrySelected = viewModel::onCountrySelected,
                 modifier = Modifier
@@ -59,8 +59,7 @@ fun CountryPickerScreen(viewModel: CountryPickerViewModel) {
 
 @Composable
 private fun CountryPickerForm(
-    availableCountries: List<StoreCreationCountry>,
-    storeName: String,
+    state: CountryPickerState.Contentful,
     onContinueClicked: () -> Unit,
     onCountrySelected: (StoreCreationCountry) -> Unit,
     modifier: Modifier = Modifier,
@@ -77,15 +76,15 @@ private fun CountryPickerForm(
         ) {
             val configuration = LocalConfiguration.current
             if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                CountryPickerHeaderContent(availableCountries, storeName)
+                CountryPickerHeaderContent(state.countries, state.storeName)
             }
             LazyColumn {
                 if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
                     item {
-                        CountryPickerHeaderContent(availableCountries, storeName)
+                        CountryPickerHeaderContent(state.countries, state.storeName)
                     }
                 }
-                itemsIndexed(availableCountries) { _, country ->
+                itemsIndexed(state.countries) { _, country ->
                     CountryItem(
                         country = country,
                         onCountrySelected = onCountrySelected,
@@ -212,33 +211,36 @@ private fun CountryItem(
 fun CountryPickerPreview() {
     WooThemeWithBackground {
         CountryPickerForm(
-            availableCountries = listOf(
-                StoreCreationCountry(
-                    name = "Canada",
-                    code = "CA",
-                    emojiFlag = "\uD83C\uDDE8\uD83C\uDDE6",
-                    isSelected = false
+            state = CountryPickerState.Contentful(
+                countries = listOf(
+                    StoreCreationCountry(
+                        name = "Canada",
+                        code = "CA",
+                        emojiFlag = "\uD83C\uDDE8\uD83C\uDDE6",
+                        isSelected = false
+                    ),
+                    StoreCreationCountry(
+                        name = "Spain",
+                        code = "ES",
+                        emojiFlag = "\uD83C\uDDEA\uD83C\uDDF8",
+                        isSelected = false
+                    ),
+                    StoreCreationCountry(
+                        name = "United States",
+                        code = "US",
+                        emojiFlag = "\uD83C\uDDFA\uD83C\uDDF8",
+                        isSelected = false
+                    ),
+                    StoreCreationCountry(
+                        name = "Italy",
+                        code = "IT",
+                        emojiFlag = "\uD83C\uDDEE\uD83C\uDDF9",
+                        isSelected = false
+                    )
                 ),
-                StoreCreationCountry(
-                    name = "Spain",
-                    code = "ES",
-                    emojiFlag = "\uD83C\uDDEA\uD83C\uDDF8",
-                    isSelected = false
-                ),
-                StoreCreationCountry(
-                    name = "United States",
-                    code = "US",
-                    emojiFlag = "\uD83C\uDDFA\uD83C\uDDF8",
-                    isSelected = false
-                ),
-                StoreCreationCountry(
-                    name = "Italy",
-                    code = "IT",
-                    emojiFlag = "\uD83C\uDDEE\uD83C\uDDF9",
-                    isSelected = false
-                )
+                storeName = "Store name",
+                creatingStoreInProgress = false
             ),
-            storeName = "Store name",
             onContinueClicked = {},
             onCountrySelected = {},
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
@@ -12,11 +12,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
@@ -35,35 +33,25 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorScreen
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
-import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.CountryPickerState
 import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.StoreCreationCountry
 
 @Composable
 fun CountryPickerScreen(viewModel: CountryPickerViewModel) {
-    viewModel.countryPickerState.observeAsState().value?.let { countryPickerContent ->
-        when (countryPickerContent) {
-            is CountryPickerState.Contentful -> {
-                Scaffold(topBar = {
-                    ToolbarWithHelpButton(
-                        onNavigationButtonClick = viewModel::onArrowBackPressed,
-                        onHelpButtonClick = viewModel::onHelpPressed
-                    )
-                }) { padding ->
-                    CountryPickerForm(
-                        countryPickerState = countryPickerContent,
-                        onContinueClicked = viewModel::onContinueClicked,
-                        onCountrySelected = viewModel::onCountrySelected,
-                        modifier = Modifier
-                            .background(MaterialTheme.colors.surface)
-                            .padding(padding)
-                    )
-                }
-            }
-            is CountryPickerState.Error -> StoreCreationErrorScreen(
-                errorType = StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED,
-                onArrowBackPressed = viewModel::onExitTriggered
+    viewModel.availableCountries.observeAsState().value?.let { availableCountries ->
+        Scaffold(topBar = {
+            ToolbarWithHelpButton(
+                onNavigationButtonClick = viewModel::onArrowBackPressed,
+                onHelpButtonClick = viewModel::onHelpPressed
+            )
+        }) { padding ->
+            CountryPickerForm(
+                availableCountries = availableCountries,
+                storeName = viewModel.storeName,
+                onContinueClicked = viewModel::onContinueClicked,
+                onCountrySelected = viewModel::onCountrySelected,
+                modifier = Modifier
+                    .background(MaterialTheme.colors.surface)
+                    .padding(padding)
             )
         }
     }
@@ -71,7 +59,8 @@ fun CountryPickerScreen(viewModel: CountryPickerViewModel) {
 
 @Composable
 private fun CountryPickerForm(
-    countryPickerState: CountryPickerState.Contentful,
+    availableCountries: List<StoreCreationCountry>,
+    storeName: String,
     onContinueClicked: () -> Unit,
     onCountrySelected: (StoreCreationCountry) -> Unit,
     modifier: Modifier = Modifier,
@@ -88,15 +77,15 @@ private fun CountryPickerForm(
         ) {
             val configuration = LocalConfiguration.current
             if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                CountryPickerHeaderContent(countryPickerState)
+                CountryPickerHeaderContent(availableCountries, storeName)
             }
             LazyColumn {
                 if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
                     item {
-                        CountryPickerHeaderContent(countryPickerState)
+                        CountryPickerHeaderContent(availableCountries, storeName)
                     }
                 }
-                itemsIndexed(countryPickerState.countries) { _, country ->
+                itemsIndexed(availableCountries) { _, country ->
                     CountryItem(
                         country = country,
                         onCountrySelected = onCountrySelected,
@@ -117,23 +106,19 @@ private fun CountryPickerForm(
                 .padding(dimensionResource(id = R.dimen.major_100)),
             onClick = onContinueClicked,
         ) {
-            if (countryPickerState.creatingStoreInProgress) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(size = dimensionResource(id = R.dimen.major_150)),
-                    color = colorResource(id = R.color.color_on_primary_surface),
-                )
-            } else {
-                Text(text = stringResource(id = R.string.continue_button))
-            }
+            Text(text = stringResource(id = R.string.continue_button))
         }
     }
 }
 
 @Composable
-private fun CountryPickerHeaderContent(countryPickerState: CountryPickerState.Contentful) {
+private fun CountryPickerHeaderContent(
+    availableCountries: List<StoreCreationCountry>,
+    storeName: String
+) {
     Column {
         Text(
-            text = countryPickerState.storeName.uppercase(),
+            text = storeName.uppercase(),
             style = MaterialTheme.typography.caption,
             color = colorResource(id = R.color.color_on_surface_medium),
             modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.major_100))
@@ -155,7 +140,7 @@ private fun CountryPickerHeaderContent(countryPickerState: CountryPickerState.Co
             modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.minor_100))
         )
         CountryItem(
-            country = countryPickerState.countries.first { it.isSelected },
+            country = availableCountries.first { it.isSelected },
             onCountrySelected = {},
             modifier = Modifier
                 .fillMaxWidth()
@@ -227,36 +212,33 @@ private fun CountryItem(
 fun CountryPickerPreview() {
     WooThemeWithBackground {
         CountryPickerForm(
-            countryPickerState = CountryPickerState.Contentful(
-                storeName = "White Christmas Tree",
-                countries = listOf(
-                    StoreCreationCountry(
-                        name = "Canada",
-                        code = "CA",
-                        emojiFlag = "\uD83C\uDDE8\uD83C\uDDE6",
-                        isSelected = false
-                    ),
-                    StoreCreationCountry(
-                        name = "Spain",
-                        code = "ES",
-                        emojiFlag = "\uD83C\uDDEA\uD83C\uDDF8",
-                        isSelected = false
-                    ),
-                    StoreCreationCountry(
-                        name = "United States",
-                        code = "US",
-                        emojiFlag = "\uD83C\uDDFA\uD83C\uDDF8",
-                        isSelected = false
-                    ),
-                    StoreCreationCountry(
-                        name = "Italy",
-                        code = "IT",
-                        emojiFlag = "\uD83C\uDDEE\uD83C\uDDF9",
-                        isSelected = false
-                    )
+            availableCountries = listOf(
+                StoreCreationCountry(
+                    name = "Canada",
+                    code = "CA",
+                    emojiFlag = "\uD83C\uDDE8\uD83C\uDDE6",
+                    isSelected = false
                 ),
-                creatingStoreInProgress = false
+                StoreCreationCountry(
+                    name = "Spain",
+                    code = "ES",
+                    emojiFlag = "\uD83C\uDDEA\uD83C\uDDF8",
+                    isSelected = false
+                ),
+                StoreCreationCountry(
+                    name = "United States",
+                    code = "US",
+                    emojiFlag = "\uD83C\uDDFA\uD83C\uDDF8",
+                    isSelected = false
+                ),
+                StoreCreationCountry(
+                    name = "Italy",
+                    code = "IT",
+                    emojiFlag = "\uD83C\uDDEE\uD83C\uDDF9",
+                    isSelected = false
+                )
             ),
+            storeName = "Store name",
             onContinueClicked = {},
             onCountrySelected = {},
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
@@ -33,7 +33,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.CountryPickerState
 import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.StoreCreationCountry
 
 @Composable
@@ -59,7 +58,7 @@ fun CountryPickerScreen(viewModel: CountryPickerViewModel) {
 
 @Composable
 private fun CountryPickerForm(
-    state: CountryPickerState.Contentful,
+    state: CountryPickerViewModel.ViewState,
     onContinueClicked: () -> Unit,
     onCountrySelected: (StoreCreationCountry) -> Unit,
     modifier: Modifier = Modifier,
@@ -211,7 +210,7 @@ private fun CountryItem(
 fun CountryPickerPreview() {
     WooThemeWithBackground {
         CountryPickerForm(
-            state = CountryPickerState.Contentful(
+            state = CountryPickerViewModel.ViewState(
                 countries = listOf(
                     StoreCreationCountry(
                         name = "Canada",
@@ -238,8 +237,7 @@ fun CountryPickerPreview() {
                         isSelected = false
                     )
                 ),
-                storeName = "Store name",
-                creatingStoreInProgress = false
+                storeName = "Store name"
             ),
             onContinueClicked = {},
             onCountrySelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.CountryPickerState
 import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.StoreCreationCountry
 
 @Composable
@@ -58,7 +59,7 @@ fun CountryPickerScreen(viewModel: CountryPickerViewModel) {
 
 @Composable
 private fun CountryPickerForm(
-    state: CountryPickerViewModel.ViewState,
+    state: CountryPickerState,
     onContinueClicked: () -> Unit,
     onCountrySelected: (StoreCreationCountry) -> Unit,
     modifier: Modifier = Modifier,
@@ -210,7 +211,7 @@ private fun CountryItem(
 fun CountryPickerPreview() {
     WooThemeWithBackground {
         CountryPickerForm(
-            state = CountryPickerViewModel.ViewState(
+            state = CountryPickerState(
                 countries = listOf(
                     StoreCreationCountry(
                         name = "Canada",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -13,11 +13,11 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.Locale
 import javax.inject.Inject
-import kotlinx.coroutines.flow.map
 
 @HiltViewModel
 class CountryPickerViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.login.storecreation.NewStore
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
 import com.woocommerce.android.util.EmojiUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -35,16 +34,8 @@ class CountryPickerViewModel @Inject constructor(
     private val availableCountries = MutableStateFlow(emptyList<StoreCreationCountry>())
 
     val countryPickerState = availableCountries
-        .map { countries ->
-            CountryPickerState.Contentful(
-                storeName = storeName,
-                countries = countries,
-                creatingStoreInProgress = false
-            )
-        }.asLiveData()
-
-    val storeName
-        get() = newStore.data.name.orEmpty()
+        .map { countries -> ViewState(newStore.data.name.orEmpty(), countries) }
+        .asLiveData()
 
     init {
         analyticsTrackerWrapper.track(
@@ -107,16 +98,6 @@ class CountryPickerViewModel @Inject constructor(
         newStore.update(country = country.toNewStoreCountry())
     }
 
-    sealed class CountryPickerState {
-        data class Contentful(
-            val storeName: String,
-            val countries: List<StoreCreationCountry>,
-            val creatingStoreInProgress: Boolean,
-        ) : CountryPickerState()
-
-        data class Error(val errorType: StoreCreationErrorType) : CountryPickerState()
-    }
-
     private fun StoreCreationCountry.toNewStoreCountry() =
         NewStore.Country(
             name = name,
@@ -125,6 +106,11 @@ class CountryPickerViewModel @Inject constructor(
 
     object NavigateToDomainPickerStep : MultiLiveEvent.Event()
     object NavigateToSummaryStep : MultiLiveEvent.Event()
+
+    data class ViewState(
+        val storeName: String,
+        val countries: List<StoreCreationCountry>
+    )
 
     data class StoreCreationCountry(
         val name: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.login.storecreation.NewStore
-import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
 import com.woocommerce.android.util.EmojiUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -36,7 +35,6 @@ class CountryPickerViewModel @Inject constructor(
 
     val storeName
         get() = newStore.data.name.orEmpty()
-
 
     init {
         analyticsTrackerWrapper.track(
@@ -111,16 +109,6 @@ class CountryPickerViewModel @Inject constructor(
 
     object NavigateToDomainPickerStep : MultiLiveEvent.Event()
     object NavigateToSummaryStep : MultiLiveEvent.Event()
-
-    sealed class CountryPickerState {
-        data class Contentful(
-            val storeName: String,
-            val countries: List<StoreCreationCountry>,
-            val creatingStoreInProgress: Boolean,
-        ) : CountryPickerState()
-
-        data class Error(val errorType: StoreCreationErrorType) : CountryPickerState()
-    }
 
     data class StoreCreationCountry(
         val name: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -34,7 +34,7 @@ class CountryPickerViewModel @Inject constructor(
     private val availableCountries = MutableStateFlow(emptyList<StoreCreationCountry>())
 
     val countryPickerState = availableCountries
-        .map { countries -> ViewState(newStore.data.name.orEmpty(), countries) }
+        .map { CountryPickerState(newStore.data.name.orEmpty(), it) }
         .asLiveData()
 
     init {
@@ -107,7 +107,7 @@ class CountryPickerViewModel @Inject constructor(
     object NavigateToDomainPickerStep : MultiLiveEvent.Event()
     object NavigateToSummaryStep : MultiLiveEvent.Event()
 
-    data class ViewState(
+    data class CountryPickerState(
         val storeName: String,
         val countries: List<StoreCreationCountry>
     )


### PR DESCRIPTION
Fix issue #8781 

Summary
==========
After introducing the Free Trial Summary, we should worry about creating the Free Trial store only from there. This PR aims to remove all the complexity related to the store creation feature from the `Store country picker` fragment, compose view, and View Model.

How to Test
==========
1. Enable the `STORE_CREATION_PROFILER` feature flag and verify that the store creation flow works the same as before.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.