### PR TITLE
Check for allow combinations setting on variation quantity rules

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -60,6 +60,7 @@ class ProductDetailRepository @Inject constructor(
     private val taxStore: WCTaxStore,
     private val coroutineDispatchers: CoroutineDispatchers,
     private val quantityRulesMapper: QuantityRulesMapper,
+    private val gson: Gson
 ) {
     private var continuationUpdateProduct: Continuation<Boolean>? = null
     private var continuationFetchProductPassword = ContinuationWrapper<String?>(PRODUCTS)
@@ -71,8 +72,6 @@ class ProductDetailRepository @Inject constructor(
 
     private var isFetchingTaxClassList = false
     private var remoteProductId: Long = 0L
-
-    private val gson by lazy { Gson() }
 
     var lastFetchProductErrorType: ProductErrorType? = null
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products
 
+import com.google.gson.Gson
 import com.woocommerce.android.AppConstants
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_UPDATE_ERROR
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_UPDATE_SUCCESS
@@ -36,6 +37,7 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_S
 import org.wordpress.android.fluxc.action.WCProductAction.UPDATED_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_PASSWORD
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.model.WCMetaData
 import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload
@@ -69,6 +71,8 @@ class ProductDetailRepository @Inject constructor(
 
     private var isFetchingTaxClassList = false
     private var remoteProductId: Long = 0L
+
+    private val gson by lazy { Gson() }
 
     var lastFetchProductErrorType: ProductErrorType? = null
 
@@ -283,6 +287,15 @@ class ProductDetailRepository @Inject constructor(
     fun getQuantityRules(remoteProductId: Long): QuantityRules? {
         return getCachedWCProductModel(remoteProductId)?.metadata
             ?.let { quantityRulesMapper.toAppModelFromProductMetadata(it) }
+    }
+
+    fun getProductMetadata(remoteProductId: Long): Map<String, Any>? {
+        val metadata = getCachedWCProductModel(remoteProductId)?.metadata ?: return null
+        val metadataArray = gson.fromJson(metadata, Array<WCMetaData>::class.java)
+
+        return metadataArray
+            .filter { metadataItem -> metadataItem.key.isNullOrEmpty().not() }
+            .associate { metadataItem -> metadataItem.key!! to metadataItem.value }
     }
 
     @SuppressWarnings("unused")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/GetProductVariationQuantityRulesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/GetProductVariationQuantityRulesTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.variations
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.models.QuantityRules
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -13,6 +14,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 
@@ -24,6 +26,7 @@ class GetProductVariationQuantityRulesTest : BaseUnitTest() {
     }
     private val wooCommerceStore: WooCommerceStore = mock()
     private val variationDetailRepository: VariationDetailRepository = mock()
+    private val productDetailRepository: ProductDetailRepository = mock()
 
     private lateinit var sut: GetProductVariationQuantityRules
 
@@ -33,7 +36,8 @@ class GetProductVariationQuantityRulesTest : BaseUnitTest() {
             selectedSite = selectedSite,
             wooCommerceStore = wooCommerceStore,
             variationDetailRepository = variationDetailRepository,
-            dispatchers = coroutinesTestRule.testDispatchers
+            dispatchers = coroutinesTestRule.testDispatchers,
+            productDetailRepository = productDetailRepository
         )
     }
 
@@ -56,27 +60,7 @@ class GetProductVariationQuantityRulesTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when min max extension is installed and active then get quantity rules`() = testBlocking {
-        val productId = 1L
-        val variationId = 1L
-        val plugin = SitePluginModel().apply { setIsActive(true) }
-        val quantityRules = QuantityRules(2, 20, 2)
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                any(),
-                eq(WooCommerceStore.WooPlugin.WOO_MIN_MAX_QUANTITIES)
-            )
-        )
-            .doReturn(plugin)
-        whenever(variationDetailRepository.getQuantityRules(productId, variationId)).doReturn(quantityRules)
-
-        val result = sut.invoke(productId, variationId)
-
-        Assertions.assertThat(result).isEqualTo(quantityRules)
-    }
-
-    @Test
-    fun `when min max extension is installed and NOT active then return null quantity rules`() = testBlocking {
+    fun `when min max extension is NOT active then return null quantity rules`() = testBlocking {
         val productId = 1L
         val variationId = 1L
         val plugin = SitePluginModel().apply { setIsActive(false) }
@@ -92,4 +76,71 @@ class GetProductVariationQuantityRulesTest : BaseUnitTest() {
 
         Assertions.assertThat(result).isNull()
     }
+
+    @Test
+    fun `when min max extension active and allow combinations is enabled then return null`() =
+        testBlocking {
+            val productId = 1L
+            val variationId = 1L
+            val plugin = SitePluginModel().apply { setIsActive(true) }
+            val metadata: Map<String, Any> = mapOf(WCProductModel.QuantityRulesMetadataKeys.ALLOW_COMBINATION to "yes")
+            whenever(
+                wooCommerceStore.getSitePlugin(
+                    any(),
+                    eq(WooCommerceStore.WooPlugin.WOO_MIN_MAX_QUANTITIES)
+                )
+            )
+                .doReturn(plugin)
+            whenever(productDetailRepository.getProductMetadata(productId)).doReturn(metadata)
+
+            val result = sut.invoke(productId, variationId)
+
+            Assertions.assertThat(result).isNull()
+        }
+
+    @Test
+    fun `when min max extension is active and allow combinations is disabled then get quantity rules`() =
+        testBlocking {
+            val productId = 1L
+            val variationId = 1L
+            val plugin = SitePluginModel().apply { setIsActive(true) }
+            val metadata: Map<String, Any> = mapOf(WCProductModel.QuantityRulesMetadataKeys.ALLOW_COMBINATION to "no")
+            val quantityRules = QuantityRules(2, 20, 2)
+            whenever(
+                wooCommerceStore.getSitePlugin(
+                    any(),
+                    eq(WooCommerceStore.WooPlugin.WOO_MIN_MAX_QUANTITIES)
+                )
+            )
+                .doReturn(plugin)
+            whenever(variationDetailRepository.getQuantityRules(productId, variationId)).doReturn(quantityRules)
+            whenever(productDetailRepository.getProductMetadata(productId)).doReturn(metadata)
+
+            val result = sut.invoke(productId, variationId)
+
+            Assertions.assertThat(result).isEqualTo(quantityRules)
+        }
+
+    @Test
+    fun `when min max extension is active and allow combinations is not in metadata then get quantity rules`() =
+        testBlocking {
+            val productId = 1L
+            val variationId = 1L
+            val plugin = SitePluginModel().apply { setIsActive(true) }
+            val metadata: Map<String, Any> = mapOf(WCProductModel.QuantityRulesMetadataKeys.ALLOW_COMBINATION to "no")
+            val quantityRules = QuantityRules(2, 20, 2)
+            whenever(
+                wooCommerceStore.getSitePlugin(
+                    any(),
+                    eq(WooCommerceStore.WooPlugin.WOO_MIN_MAX_QUANTITIES)
+                )
+            )
+                .doReturn(plugin)
+            whenever(variationDetailRepository.getQuantityRules(productId, variationId)).doReturn(quantityRules)
+            whenever(productDetailRepository.getProductMetadata(productId)).doReturn(metadata)
+
+            val result = sut.invoke(productId, variationId)
+
+            Assertions.assertThat(result).isEqualTo(quantityRules)
+        }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2705-088cc1c6e2f904dd4be51402b12431defc99b21d'
+    fluxCVersion = 'trunk-dca1ac8c04bd083c14f55b67f02d6fe5d04bfad2'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-dac8dbbe35fc9f95b5c96da624ed93e8406339d9'
+    fluxCVersion = '2705-088cc1c6e2f904dd4be51402b12431defc99b21d'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ This PR depends on [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2705)

Closes: #8773

### Why
We are adding Min / Max Quantities read-only support to the Woo App. The allow combination is a setting that enables combining different variations purchased to match the quantities rules. When this setting is enabled we should hide the per-variation quantity rules to match wp-admin behavior.

### Description
This PR updates the GetProductVariationQuantityRules behavior to display variations quantity rules only when the combine variations setting is disabled on `wp-admin`.

### Testing instructions

TC1
#### On `wp-admin`
1. Create a variable product with variations.
2. Add quantity rules to one/all of the variations of the variable product
3. Check that the combine variations setting is unchecked on the `wp-admin`

#### On the app
1. Open the products tab
2. Tap on the variable product created
3. Tap on Variations
4. Tap on the variation with the quantities rules
5. Check that the Quantity rules card is shown
6. Tap on the Quantity rules card
7. Check that the Quantity rules information is shown

TC2
#### On `wp-admin`
3. Enabled the combine variations setting 

#### On the app
1. Open the products tab
2. Tap on the variable product created
3. Tap on Variations
4. Tap on the variation with the quantities rules
5. Check that the Quantity rules card is NOT shown

### Images/gif

https://user-images.githubusercontent.com/18119390/230685629-08e249e9-80c4-4ed8-b39d-31be4c91bd06.mp4

