### PR TITLE
Free Trial: Adjust store creation use case

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -7,12 +7,10 @@ import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SIT
 import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_LANGUAGE_ID
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_THEME
-import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.flow
 import java.util.TimeZone
 import javax.inject.Inject
 
-@ViewModelScoped
 class CreateFreeTrialStore @Inject constructor(
     private val repository: StoreCreationRepository
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -20,9 +20,9 @@ class CreateFreeTrialStore @Inject constructor(
      * Triggers the creation of a new free trial site given a domain and a name.
      * If the site already exists, it will try to retrieve the site ID from the API.
      *
-     *  @return a [flow] that will emit the Store ID if the creation is successful, null otherwise
+     *  @return a [flow] that will emit the store creation state steps:
      *
-     *  To observe the creation progress, use [state]
+     *  [Loading] -> [Finished] or [Failed]
      */
     suspend operator fun invoke(
         storeDomain: String?,
@@ -55,7 +55,6 @@ class CreateFreeTrialStore @Inject constructor(
         ?: this
 
     sealed class StoreCreationState {
-        object Idle : StoreCreationState()
         object Loading : StoreCreationState()
         data class Finished(val siteId: Long) : StoreCreationState()
         data class Failed(val type: StoreCreationErrorType) : StoreCreationState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -5,6 +5,8 @@ import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.Store
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS
 import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.SiteCreationData
+import com.woocommerce.android.ui.login.storecreation.StoreCreationResult.Failure
+import com.woocommerce.android.ui.login.storecreation.StoreCreationResult.Success
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_LANGUAGE_ID
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_THEME
 import kotlinx.coroutines.flow.flow
@@ -35,21 +37,17 @@ class CreateFreeTrialStore @Inject constructor(
         ).recoverIfSiteExists(storeDomain)
 
         when (result) {
-            is StoreCreationResult.Success -> {
-                emit(Finished(result.data))
-            }
-            is StoreCreationResult.Failure -> {
-                emit(Failed(result.type))
-            }
+            is Success -> emit(Finished(result.data))
+            is Failure -> emit(Failed(result.type))
         }
     }
 
     private suspend fun StoreCreationResult<Long>.recoverIfSiteExists(
         storeDomain: String?
-    ) = run { this as? StoreCreationResult.Failure<Long> }
+    ) = run { this as? Failure<Long> }
         ?.takeIf { it.type == SITE_ADDRESS_ALREADY_EXISTS }
         ?.let { repository.getSiteByUrl(storeDomain) }
-        ?.let { StoreCreationResult.Success(it.siteId) }
+        ?.let { Success(it.siteId) }
         ?: this
 
     sealed class StoreCreationState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -11,9 +11,9 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlinx.coroutines.flow.update
 
 @HiltViewModel
 class StoreCreationSummaryViewModel @Inject constructor(
@@ -25,7 +25,7 @@ class StoreCreationSummaryViewModel @Inject constructor(
     val isLoading = _isLoading.asLiveData()
 
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
-    
+
     fun onTryForFreeButtonPressed() {
         launch {
             createStore(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -3,14 +3,17 @@ package com.woocommerce.android.ui.login.storecreation.summary
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
+import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Finished
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Loading
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.flow.update
 
 @HiltViewModel
 class StoreCreationSummaryViewModel @Inject constructor(
@@ -18,21 +21,26 @@ class StoreCreationSummaryViewModel @Inject constructor(
     private val newStore: NewStore,
     private val createStore: CreateFreeTrialStore
 ) : ScopedViewModel(savedStateHandle) {
-    val isLoading = createStore.state
-        .map { it is Loading }
-        .asLiveData()
+    private val _isLoading = savedStateHandle.getStateFlow(scope = this, initialValue = false)
+    val isLoading = _isLoading.asLiveData()
 
     fun onCancelPressed() { triggerEvent(OnCancelPressed) }
+    
     fun onTryForFreeButtonPressed() {
         launch {
             createStore(
                 storeDomain = newStore.data.domain,
                 storeName = newStore.data.name,
-            ).collect { siteId ->
-                siteId?.let {
-                    newStore.update(siteId = it)
-                    triggerEvent(OnStoreCreationSuccess)
-                } ?: triggerEvent(OnStoreCreationFailure)
+            ).collect { creationState ->
+                _isLoading.update { creationState is Loading }
+                when (creationState) {
+                    is Finished -> {
+                        newStore.update(siteId = creationState.siteId)
+                        triggerEvent(OnStoreCreationSuccess)
+                    }
+                    is Failed -> triggerEvent(OnStoreCreationFailure)
+                    else -> { /* no op */ }
+                }
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -24,12 +24,12 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
     private lateinit var sut: CreateFreeTrialStore
     private lateinit var storeCreationRepository: StoreCreationRepository
 
+    private val expectedSiteId = 123L
+
     @Test
     fun `when createFreeTrialSite is called correctly, then free trial store creation starts`() = testBlocking {
         // Given
-        val jobs = mutableListOf<Job>()
         var lastCreationState: StoreCreationState? = null
-        var receivedSiteID: Long? = null
 
         val siteDomain = "test domain"
         val siteTitle = "test title"
@@ -41,16 +41,11 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
             segmentId = null
         )
         createSut(siteDomain, siteTitle, expectedCreationResult)
-        sut.state
-            .onEach { lastCreationState = it }
-            .launchIn(this)
-            .also { jobs.add(it) }
 
         // When
-        sut(siteDomain, siteTitle)
-            .onEach { receivedSiteID = it }
+        val job = sut(siteDomain, siteTitle)
+            .onEach { lastCreationState = it }
             .launchIn(this)
-            .also { jobs.add(it) }
 
         advanceUntilIdle()
 
@@ -60,18 +55,15 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
             eq(PlansViewModel.NEW_SITE_LANGUAGE_ID),
             any()
         )
-        assertThat(lastCreationState).isEqualTo(StoreCreationState.Finished)
-        assertThat(receivedSiteID).isEqualTo(123L)
+        assertThat(lastCreationState).isEqualTo(StoreCreationState.Finished(expectedSiteId))
 
-        jobs.forEach { it.cancel() }
+        job.cancel()
     }
 
     @Test
     fun `when createFreeTrialSite fails, then the error is returned`() = testBlocking {
         // Given
-        val jobs = mutableListOf<Job>()
         var lastCreationState: StoreCreationState? = null
-        var receivedSiteID: Long? = null
 
         val siteDomain = "test domain"
         val siteTitle = "test title"
@@ -86,16 +78,11 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
         )
 
         createSut(siteDomain, siteTitle, expectedCreationResult)
-        sut.state
-            .onEach { lastCreationState = it }
-            .launchIn(this)
-            .also { jobs.add(it) }
 
         // When
-        sut(siteDomain, siteTitle)
-            .onEach { receivedSiteID = it }
+        val job = sut(siteDomain, siteTitle)
+            .onEach { lastCreationState = it }
             .launchIn(this)
-            .also { jobs.add(it) }
 
         advanceUntilIdle()
 
@@ -108,17 +95,14 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
         assertThat(lastCreationState).isEqualTo(
             Failed(StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED)
         )
-        assertThat(receivedSiteID).isNull()
 
-        jobs.forEach { it.cancel() }
+        job.cancel()
     }
 
     @Test
     fun `when createFreeTrialSite fails with SITE_ADDRESS_ALREADY_EXISTS, then the site is retrieved`() = testBlocking {
         // Given
-        val jobs = mutableListOf<Job>()
         var lastCreationState: StoreCreationState? = null
-        var receivedSiteID: Long? = null
 
         val siteDomain = "test existent domain"
         val siteTitle = "test existent title"
@@ -137,13 +121,11 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
         sut.state
             .onEach { lastCreationState = it }
             .launchIn(this)
-            .also { jobs.add(it) }
 
         // When
-        sut(siteDomain, siteTitle)
-            .onEach { receivedSiteID = it }
+        val job = sut(siteDomain, siteTitle)
+            .onEach { lastCreationState = it }
             .launchIn(this)
-            .also { jobs.add(it) }
 
         advanceUntilIdle()
 
@@ -154,10 +136,9 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
             any()
         )
         verify(storeCreationRepository).getSiteByUrl(siteDomain)
-        assertThat(lastCreationState).isEqualTo(StoreCreationState.Finished)
-        assertThat(receivedSiteID).isEqualTo(123L)
+        assertThat(lastCreationState).isEqualTo(StoreCreationState.Finished(expectedSiteId))
 
-        jobs.forEach { it.cancel() }
+        job.cancel()
     }
 
     private fun createSut(
@@ -172,7 +153,7 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
             segmentId = null
         )
 
-        val siteModel = SiteModel().apply { siteId = 123 }
+        val siteModel = SiteModel().apply { siteId = expectedSiteId }
 
         storeCreationRepository = mock {
             onBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.Si
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -118,9 +117,6 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
             siteTitle,
             StoreCreationResult.Failure(StoreCreationErrorType.SITE_ADDRESS_ALREADY_EXISTS)
         )
-        sut.state
-            .onEach { lastCreationState = it }
-            .launchIn(this)
 
         // When
         val job = sut(siteDomain, siteTitle)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -31,7 +31,7 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
         // Given
         val expectedDomain = "test domain"
         val expectedTitle = "test title"
-        createSut(expectedDomain, expectedTitle, StoreCreationState.Idle)
+        createSut(expectedDomain, expectedTitle, StoreCreationState.Finished(123L))
 
         // When
         sut.onTryForFreeButtonPressed()
@@ -94,7 +94,7 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
         // Given
         val expectedDomain = "test domain"
         val expectedTitle = "test title"
-        createSut(expectedDomain, expectedTitle, StoreCreationState.Idle)
+        createSut(expectedDomain, expectedTitle, StoreCreationState.Finished(123L))
 
         var isLoading: Boolean? = null
         sut.isLoading.observeForever { isLoading = it }
@@ -162,7 +162,7 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
         // Given
         val expectedDomain = "test domain"
         val expectedTitle = "test title"
-        createSut(expectedDomain, expectedTitle, StoreCreationState.Idle)
+        createSut(expectedDomain, expectedTitle, StoreCreationState.Finished(123L))
 
         var lastReceivedEvent: MultiLiveEvent.Event? = null
         sut.event.observeForever { lastReceivedEvent = it }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -46,7 +46,7 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
     @Test
     fun `when onTryForFreeButtonPressed is called, then track expected event`() = testBlocking {
         // Given
-        createSut("", "", StoreCreationState.Idle)
+        createSut("", "", StoreCreationState.Loading)
 
         // When
         sut.onTryForFreeButtonPressed()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSumma
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.doAnswer
@@ -111,7 +111,7 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
         // Given
         val expectedDomain = "test domain"
         val expectedTitle = "test title"
-        createSut(expectedDomain, expectedTitle, StoreCreationState.Loading)
+        createSut(expectedDomain, expectedTitle)
 
         var isLoading: Boolean? = null
         sut.isLoading.observeForever { isLoading = it }
@@ -177,7 +177,7 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
     private fun createSut(
         expectedDomain: String,
         expectedTitle: String,
-        expectedCreationState: StoreCreationState
+        expectedCreationState: StoreCreationState? = null
     ) {
         newStore = mock {
             on { data } doReturn NewStore.NewStoreData(
@@ -190,7 +190,10 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
             onBlocking {
                 invoke(newStore.data.domain, newStore.data.name)
             } doAnswer {
-                flowOf(expectedCreationState)
+                flow {
+                    emit(StoreCreationState.Loading)
+                    expectedCreationState?.let { emit(it) }
+                }
             }
         }
 


### PR DESCRIPTION
Fix issue #8781 

Summary
==========
Takes advantage of the code removal in https://github.com/woocommerce/woocommerce-android/pull/8775 and https://github.com/woocommerce/woocommerce-android/pull/8776 and simplifies how the `CreateFreeTrialStore` use case works.

How to Test
==========
1. Simply test the Free Trial store creation scenario and make sure it works as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.