### PR TITLE
[REST API] Remove the need for cookie+nonce authentication for Jetpack activation process in REST API login flow.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -30,7 +30,7 @@ class FetchJetpackStatus @Inject constructor(
         SUCCESS, NOT_FOUND, FORBIDDEN
     }
     suspend operator fun invoke(): Result<Pair<JetpackStatus, JetpackStatusFetchResponse>> {
-        return jetpackStore.fetchJetpackUser(selectedSite.get()).let { result ->
+        return jetpackStore.fetchJetpackUser(selectedSite.get(), useApplicationPasswords = true).let { result ->
             when {
                 result.error?.errorCode == NOT_FOUND_STATUS_CODE -> {
                     Result.success(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -38,9 +38,15 @@ class JetpackActivationRepository @Inject constructor(
         SiteUtils.getSiteByMatchingUrl(siteStore, url)
     }
 
-    suspend fun fetchJetpackConnectionUrl(site: SiteModel): Result<String> = runWithRetry {
+    suspend fun fetchJetpackConnectionUrl(
+        site: SiteModel,
+        useApplicationPasswords: Boolean = false
+    ): Result<String> = runWithRetry {
         WooLog.d(WooLog.T.LOGIN, "Fetching Jetpack Connection URL")
-        val result = jetpackStore.fetchJetpackConnectionUrl(site, autoRegisterSiteIfNeeded = true)
+        val result = jetpackStore.fetchJetpackConnectionUrl(
+            site,
+            autoRegisterSiteIfNeeded = true,
+            useApplicationPasswords = useApplicationPasswords)
         return@runWithRetry when {
             result.isError -> {
                 WooLog.w(WooLog.T.LOGIN, "Fetching Jetpack Connection URL failed: ${result.error.message}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -46,7 +46,8 @@ class JetpackActivationRepository @Inject constructor(
         val result = jetpackStore.fetchJetpackConnectionUrl(
             site,
             autoRegisterSiteIfNeeded = true,
-            useApplicationPasswords = useApplicationPasswords)
+            useApplicationPasswords = useApplicationPasswords
+        )
         return@runWithRetry when {
             result.isError -> {
                 WooLog.w(WooLog.T.LOGIN, "Fetching Jetpack Connection URL failed: ${result.error.message}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
@@ -128,7 +128,8 @@ class JetpackActivationMainFragment : BaseFragment() {
                 urlToLoad = event.url,
                 urlsToTriggerExit = event.connectionValidationUrls.toTypedArray(),
                 title = getString(R.string.login_jetpack_installation_approve_connection),
-                displayMode = DisplayMode.MODAL
+                displayMode = DisplayMode.MODAL,
+                urlComparisonMode = event.urlComparisonMode
             ),
             navOptions = NavOptions.Builder()
                 .setEnterAnim(R.anim.slide_up)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -415,23 +415,22 @@ class JetpackActivationMainViewModel @Inject constructor(
                 }
 
                 if (useApplicationPasswords) {
-                    // Depending on whether the site has site-connection or not, we should pass different URL to the
-                    // webview.
-                    //
-                    // If the site already has Jetpack site-connection, we can use the URL given by the API as-is.
-                    // We can tell that this is the case if the URL given by API starts with
-                    // JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX.
-                    //
-                    // If the site has no site-connection, the URL given by the API will be in the format of
-                    // https://{site_url}/wp-admin/admin.php?page=jetpack&action=register&_wpnonce={nonce}
-                    //
-                    // With application passwords login where we don't want to use cookie-nonce authentication,
-                    // the URL above is unusable to connect the site to Jetpack. See:
-                    // https://github.com/woocommerce/woocommerce-android/issues/7525
-                    //
-                    // As a workaround, we use a special URL that will let merchants to connect the site without
-                    // the app needing to do cookie-nonce authentication.
-                    // Reference: pe5sF9-1le-p2#comment-1942
+                    // Depending on the site's connection status, we should provide different URLs to the webview.
+                    // If the site already has a Jetpack site-connection, we can use the API-given URL as-is. We
+                    // know this is the case if the URL starts with JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX.
+
+                    // If the site lacks a connection, the API-provided URL will be in the format of
+                    // https://{site_url}/wp-admin/admin.php?page=jetpack&action=register&_wpnonce={nonce}.
+                    // For application password login, where we don't want to use cookie-nonce authentication, the URL
+                    // above cannot be used to connect the site to Jetpack.
+                    // See: https://github.com/woocommerce/woocommerce-android/issues/7525
+
+                    // As a workaround, we use a special URL that enables site connection without the app needing
+                    // cookie-nonce authentication. The format looks like below:
+                    // https://wordpress.com/jetpack/connect?url=<site_url>
+                    //  &mobile_redirect=woocommerce://jetpack-connected&from=mobile
+                    // See: pe5sF9-1le-p2#comment-1942
+
                     val chosenUrl =
                         if (connectionUrl.startsWith(JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX)) {
                             connectionUrl
@@ -441,9 +440,9 @@ class JetpackActivationMainViewModel @Inject constructor(
                                 "&from=mobile"
                         }
 
-                    // In the case of using the special URL, the validation URL will be MOBILE_REDIRECT, so we need
-                    // to set the comparison mode to be EQUALITY to make sure the webview exits only
-                    // when the redirect is happening.
+                    // In the special URL case, the validation URL must match the MOBILE_REDIRECT value. Therefore,
+                    // we set the comparison mode to EQUALITY to ensure the webview returns to the app only when the
+                    // redirect takes place.
                     val comparisonMode =
                         if (connectionUrl.startsWith(JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX)) {
                             UrlComparisonMode.PARTIAL

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -52,7 +52,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackConnectionUrlError
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackUserError
 import org.wordpress.android.util.UrlUtils
-import java.net.URI
 import javax.inject.Inject
 
 @HiltViewModel
@@ -402,6 +401,7 @@ class JetpackActivationMainViewModel @Inject constructor(
         }
     }
 
+    @Suppress("LongMethod")
     private suspend fun startJetpackConnection() {
         WooLog.d(WooLog.T.LOGIN, "Jetpack Activation: start Jetpack Connection")
         val currentSite = site.await()
@@ -454,7 +454,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                         ShowJetpackConnectionWebView(
                             url = chosenUrl,
                             connectionValidationUrls = listOf(MOBILE_REDIRECT),
-                            urlComparisonMode = UrlComparisonMode.EQUALITY
+                            urlComparisonMode = comparisonMode
                         )
                     )
                 } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -14,11 +14,14 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.support.help.HelpOrigin.JETPACK_INSTALLATION
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.common.PluginRepository
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginActivated
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginActivationFailed
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginInstallFailed
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginInstalled
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.UrlComparisonMode
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
@@ -49,6 +52,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackConnectionUrlError
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackUserError
 import org.wordpress.android.util.UrlUtils
+import java.net.URI
 import javax.inject.Inject
 
 @HiltViewModel
@@ -64,6 +68,8 @@ class JetpackActivationMainViewModel @Inject constructor(
         private const val JETPACK_SLUG = "jetpack"
         private const val JETPACK_NAME = "jetpack/jetpack"
         private const val JETPACK_PLANS_URL = "wordpress.com/jetpack/connect/plans"
+        private const val JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX = "https://jetpack.wordpress.com/jetpack.authorize"
+        private const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
         private const val DELAY_AFTER_CONNECTION_MS = 500L
         private const val DELAY_BEFORE_SHOWING_ERROR_STATE_MS = 1000L
         private const val CONNECTED_EMAIL_KEY = "connected-email"
@@ -398,7 +404,9 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     private suspend fun startJetpackConnection() {
         WooLog.d(WooLog.T.LOGIN, "Jetpack Activation: start Jetpack Connection")
-        jetpackActivationRepository.fetchJetpackConnectionUrl(site.await()).fold(
+        val currentSite = site.await()
+        val useApplicationPasswords = currentSite.connectionType == SiteConnectionType.ApplicationPasswords
+        jetpackActivationRepository.fetchJetpackConnectionUrl(currentSite, useApplicationPasswords).fold(
             onSuccess = { connectionUrl ->
                 if (!isFromBanner) {
                     analyticsTrackerWrapper.track(
@@ -406,12 +414,57 @@ class JetpackActivationMainViewModel @Inject constructor(
                     )
                 }
 
-                triggerEvent(
-                    ShowJetpackConnectionWebView(
-                        url = connectionUrl,
-                        connectionValidationUrls = listOf(JETPACK_PLANS_URL, navArgs.siteUrl)
+                if (useApplicationPasswords) {
+                    // Depending on whether the site has site-connection or not, we should pass different URL to the
+                    // webview.
+                    //
+                    // If the site already has Jetpack site-connection, we can use the URL given by the API as-is.
+                    // We can tell that this is the case if the URL given by API starts with
+                    // JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX.
+                    //
+                    // If the site has no site-connection, the URL given by the API will be in the format of
+                    // https://{site_url}/wp-admin/admin.php?page=jetpack&action=register&_wpnonce={nonce}
+                    //
+                    // With application passwords login where we don't want to use cookie-nonce authentication,
+                    // the URL above is unusable to connect the site to Jetpack. See:
+                    // https://github.com/woocommerce/woocommerce-android/issues/7525
+                    //
+                    // As a workaround, we use a special URL that will let merchants to connect the site without
+                    // the app needing to do cookie-nonce authentication.
+                    // Reference: pe5sF9-1le-p2#comment-1942
+                    val chosenUrl =
+                        if (connectionUrl.startsWith(JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX)) {
+                            connectionUrl
+                        } else {
+                            "https://wordpress.com/jetpack/connect?url=" + navArgs.siteUrl +
+                                "&mobile_redirect=" + MOBILE_REDIRECT +
+                                "&from=mobile"
+                        }
+
+                    // In the case of using the special URL, the validation URL will be MOBILE_REDIRECT, so we need
+                    // to set the comparison mode to be EQUALITY to make sure the webview exits only
+                    // when the redirect is happening.
+                    val comparisonMode =
+                        if (connectionUrl.startsWith(JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX)) {
+                            UrlComparisonMode.PARTIAL
+                        } else {
+                            UrlComparisonMode.EQUALITY
+                        }
+                    triggerEvent(
+                        ShowJetpackConnectionWebView(
+                            url = chosenUrl,
+                            connectionValidationUrls = listOf(MOBILE_REDIRECT),
+                            urlComparisonMode = UrlComparisonMode.EQUALITY
+                        )
                     )
-                )
+                } else {
+                    triggerEvent(
+                        ShowJetpackConnectionWebView(
+                            url = connectionUrl,
+                            connectionValidationUrls = listOf(JETPACK_PLANS_URL, navArgs.siteUrl)
+                        )
+                    )
+                }
             },
             onFailure = {
                 val error = (it as? OnChangedException)?.error as? JetpackConnectionUrlError
@@ -565,7 +618,8 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     data class ShowJetpackConnectionWebView(
         val url: String,
-        val connectionValidationUrls: List<String>
+        val connectionValidationUrls: List<String>,
+        val urlComparisonMode: UrlComparisonMode = UrlComparisonMode.PARTIAL
     ) : MultiLiveEvent.Event()
 
     data class GoToPasswordScreen(val email: String) : MultiLiveEvent.Event()

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-8c3bc0c99238481571e20f6f59e519e6693a66c3'
+    fluxCVersion = '2707-273f78bbae0a4ea0a2e002c023360dce26f0b504'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8749 

> **Warning**
>  Please do not merge before the FluxC PR wordpress-mobile/WordPress-FluxC-Android#2707 is merged, and the FluxC version here is updated to match.


> **Note**
>  This is targeting `release/13.1` as the initial plan is to include it into beta (but might change depending on review pace)

---

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After adding the REST API login flow, we are exploring the possibility of exclusively using webview to generate application passwords for logging in, without any native login components that we currently use. In this scenario, the app no longer receives site credentials, so we cannot make API calls requiring cookie+nonce authentication.

This PR does two things to achieve that:

#### 1. Change Jetpack-related API calls that previously used cookie+nonce, to use application pasword.

At present, the Jetpack activation feature in the REST API login flow contains some functions involving cookie+nonce API calls:
1. Fetching the Jetpack connection URL,
2. Fetching the Jetpack user (through Jetpack connection data).

This PR, along with FluxC PR [wordpress-mobile/WordPress-FluxC-Android#2707](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2707), ensures that these two calls use application passwords instead. 

> **Note**
> Please note that the removal of cookie+nonce is only needed for REST API login flow. Fetching that uses cookie+nonce is still possible, to make sure [Jetpack installation in WPCom login flow](https://github.com/woocommerce/woocommerce-android/pull/7889) is still supported.

#### 2. Update the Jetpack Connection phase using an alternative solution that doesn't require cookie+nonce authentication.

The Jetpack Connection phase is updated in this PR to account for the removal of cookie+nonce authentication usage.

<details><summary>Read more for technical details.</summary>

For more context, the Jetpack activation flow consists of several hybrid steps:
1. Installation (native) ->
2. Activation (native) ->
3. Connection (webview, as native support is unavailable).

The Jetpack Connection phase is completed on a webview using the URL retrieved from the fetch Jetpack connection URL call. Previously, as explained in [this issue](https://github.com/woocommerce/woocommerce-android/issues/7525) and in [this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2538), the mechanism was done differently depending on whether the site already had Jetpack with site-connection, or whether Jetpack had not yet been installed. In the former case, the retrieved URL can be used as-is, while in the latter case, the app would first register the site to Jetpack behind the scene (using cookie+nonce authentication) to obtain a usable Jetpack connection URL.

In this PR, since we no longer want to use cookie+nonce authentication, we handle the case where Jetpack is not yet installed differently. Rather than registering first (no longer possible), we use an alternative URL in the format: `https://wordpress.com/jetpack/connect?url=<site_url>&mobile_redirect=woocommerce://jetpack-connected&from=mobile`. This URL can be used without cookie+nonce authentication to support connection until completion. It does so by doing a "mobile redirect" after connection is completed, and the webview can capture it and return the result back to the app for further action. This alternative method is discussed internally in pe5sF9-1le-p2#comment-1942

</details> 

---

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Have a test .org site with WooCommerce, but no Jetpack installed,
2. Start app, login using site address,
3. Once logged in, on the My Store screen, tap the Jetpack benefits banner at the bottom,
4. On the Jetpack benefits screen, tap the "Log In to Continue" screen,
5. Ensure the WordPress.com email login screen is shown, enter email,
6. Ensure the password field is shown, enter the password there,
7. Ensure that the Jetpack Activation screen is shown, with the "Installing Jetpack" heading at the top,
8. Wait and ensure "Installing Jetpack" step completes,
9. Wait and ensure "Activating" step completes,
10. Wait and ensure "Connect store to Jetpack" opens a webview,
11. Follow the steps on the webview until connection is completed,
12. Ensure that the webview automatically closes,
13. Ensure that "Connect store to Jetpack" now says "Validating", wait until it completes,
14. Ensure that "All done" is checked afterward.
15. Ensure "Go to Store" button shows up,
16. Tap the button, ensure that you're now logged back in to the app. Now the app should be in the Jetpack/WordPress.com login state, so all functionalities should be available and the Jetpack banner on My Store is not shown anymore.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
