### PR TITLE
Hide popular and Last Sold sections when filter is enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -158,7 +158,7 @@ class ProductSelectorViewModel @Inject constructor(
         productsList: List<Product>,
         selectedIds: List<SelectedItem>
     ): List<ProductListItem> {
-        if (searchQuery.value.isNotNullOrEmpty()) {
+        if (searchQuery.value.isNotNullOrEmpty() || !filterState.value.filterOptions.isNullOrEmpty()) {
             return emptyList()
         }
         return productsList.map { it.toUiModel(selectedIds) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -144,17 +144,17 @@ class ProductSelectorViewModel @Inject constructor(
         popularProducts: List<Product>,
         selectedIds: List<SelectedItem>
     ): List<ProductListItem> {
-        return getProductItemsIfSearchQueryIsNotEmpty(popularProducts, selectedIds)
+        return getProductItemsIfSearchQueryEmptyOrNoFilter(popularProducts, selectedIds)
     }
 
     private fun getRecentProductsToDisplay(
         recentProducts: List<Product>,
         selectedIds: List<SelectedItem>
     ): List<ProductListItem> {
-        return getProductItemsIfSearchQueryIsNotEmpty(recentProducts, selectedIds)
+        return getProductItemsIfSearchQueryEmptyOrNoFilter(recentProducts, selectedIds)
     }
 
-    private fun getProductItemsIfSearchQueryIsNotEmpty(
+    private fun getProductItemsIfSearchQueryEmptyOrNoFilter(
         productsList: List<Product>,
         selectedIds: List<SelectedItem>
     ): List<ProductListItem> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -560,6 +560,36 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `given last sold products, when filter is applied, then hide the last sold products section`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+            val ordersList = generateTestOrders()
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(ordersList)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(ProductTestUtils.generateProductList())
+
+            val sut = createViewModel(navArgs)
+            sut.onFiltersChanged(
+                stockStatus = "In stock",
+                productCategory = null,
+                productStatus = null,
+                productType = null,
+                productCategoryName = null
+            )
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+
+            assertThat(viewState?.recentProducts)?.isEmpty()
+        }
+    }
+
     //endregion
 
     // region sort by popularity and recently sold, analytics

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -492,6 +492,36 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `given popular products, when filter is applied, then hide the popular products section`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+            val ordersList = generateTestOrders() + generatePopularOrders()
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(ordersList)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(ProductTestUtils.generateProductList())
+
+            val sut = createViewModel(navArgs)
+            sut.onFiltersChanged(
+                stockStatus = "In stock",
+                productCategory = null,
+                productStatus = null,
+                productType = null,
+                productCategoryName = null
+            )
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+
+            assertThat(viewState?.popularProducts)?.isEmpty()
+        }
+    }
+
     //endregion
 
     // region sort by popularity and recently sold, analytics

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -522,6 +522,44 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `given popular products, when filter is cleared, then show the popular products section`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+            val ordersList = generateTestOrders() + generatePopularOrders()
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(ordersList)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(ProductTestUtils.generateProductList())
+
+            val sut = createViewModel(navArgs)
+            sut.onFiltersChanged(
+                stockStatus = "In stock",
+                productCategory = null,
+                productStatus = null,
+                productType = null,
+                productCategoryName = null
+            )
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+
+            assertThat(viewState?.popularProducts)?.isEmpty()
+            sut.onFiltersChanged(
+                stockStatus = null,
+                productCategory = null,
+                productStatus = null,
+                productType = null,
+                productCategoryName = null
+            )
+            assertThat(viewState?.popularProducts)?.isNotEmpty
+        }
+    }
+
     //endregion
 
     // region sort by popularity and recently sold, analytics

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -590,6 +590,45 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `given last sold products, when filter is cleared, then show the last sold products section`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+            val ordersList = generateTestOrders()
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(ordersList)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(ProductTestUtils.generateProductList())
+
+            val sut = createViewModel(navArgs)
+            sut.onFiltersChanged(
+                stockStatus = "In stock",
+                productCategory = null,
+                productStatus = null,
+                productType = null,
+                productCategoryName = null
+            )
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+
+            assertThat(viewState?.recentProducts)?.isEmpty()
+            sut.onFiltersChanged(
+                stockStatus = null,
+                productCategory = null,
+                productStatus = null,
+                productType = null,
+                productCategoryName = null
+            )
+            assertThat(viewState?.recentProducts)?.isNotEmpty
+        }
+    }
+
+
     //endregion
 
     // region sort by popularity and recently sold, analytics

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -627,8 +627,6 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             assertThat(viewState?.recentProducts)?.isNotEmpty
         }
     }
-
-
     //endregion
 
     // region sort by popularity and recently sold, analytics


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8778 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR hides the Popular and Last Sold sections when the filter is applied in the product selector screen. 

The reason being 
1. The Popular and Last Sold sections sit on top of the filtered products section and this might be a source of confusion for some merchants.
2. If the merchant is applying a filter in the product selector screen, this is mostly because they haven't found the product without the filters applied. This means, when the filter is applied, the Popular and Last Sold section becomes a noise.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Popular and Last Sold sections must be hidden when the filter is applied
1. Navigate to the product selector screen (orders -> + -> Add products)
2. Apply any filter
3. Ensure the popular and last sold sections are not shown

#### Popular and Last Sold sections must be shown when the filter is not applied
1. Navigate to the product selector screen (orders -> + -> Add products)
2. Make sure you see the popular and last sold sections
3. Apply any filter
4. Ensure the popular and last sold sections are not shown
5. Clear the filter
6. Ensure the popular and last sold sections are shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[hide_sections_filter.webm](https://user-images.githubusercontent.com/1331230/231134765-2ce029c3-3cb7-458c-8011-45fa052d9531.webm)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
