### PR TITLE
Store installation performance tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -777,7 +777,6 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_CREATION_IAP_PURCHASE_SUCCESS(siteless = true),
     SITE_CREATION_IAP_PURCHASE_ERROR(siteless = true),
     SITE_CREATION_PROFILER_DATA(siteless = true),
-    SITE_CREATION_WAITING_TIME,
 
     // Domain change
     CUSTOM_DOMAINS_STEP,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -777,6 +777,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_CREATION_IAP_PURCHASE_SUCCESS(siteless = true),
     SITE_CREATION_IAP_PURCHASE_ERROR(siteless = true),
     SITE_CREATION_PROFILER_DATA(siteless = true),
+    SITE_CREATION_WAITING_TIME,
 
     // Domain change
     CUSTOM_DOMAINS_STEP,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/WaitingTimeTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/WaitingTimeTracker.kt
@@ -13,13 +13,14 @@ class WaitingTimeTracker(
         waitingStartedTimestamp = currentTimeInMillis()
     }
 
-    fun end() = waitingStartedTimestamp?.elapsedWaitingTime?.let {
-        AnalyticsTracker.track(
-            trackEvent,
-            mapOf(AnalyticsTracker.KEY_WAITING_TIME to it)
-        )
-        waitingStartedTimestamp = null
-    }
+    fun end(additionalProperties: Map<String, *> = emptyMap<String, String>()) =
+        waitingStartedTimestamp?.elapsedWaitingTime?.let {
+            AnalyticsTracker.track(
+                trackEvent,
+                additionalProperties + mapOf(AnalyticsTracker.KEY_WAITING_TIME to it)
+            )
+            waitingStartedTimestamp = null
+        }
 
     fun abort() {
         waitingStartedTimestamp = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationFragment.kt
@@ -31,6 +31,11 @@ class InstallationFragment : BaseFragment() {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        lifecycle.addObserver(viewModel.performanceObserver)
+        super.onCreate(savedInstanceState)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationTransactionLauncher.kt
@@ -7,50 +7,21 @@ import com.automattic.android.tracks.crashlogging.performance.PerformanceTransac
 import com.automattic.android.tracks.crashlogging.performance.TransactionId
 import com.automattic.android.tracks.crashlogging.performance.TransactionOperation
 import com.automattic.android.tracks.crashlogging.performance.TransactionStatus
-import com.woocommerce.android.analytics.AnalyticsEvent.SITE_CREATION_WAITING_TIME
+import com.woocommerce.android.analytics.AnalyticsEvent.LOGIN_WOOCOMMERCE_SITE_CREATED
 import com.woocommerce.android.analytics.WaitingTimeTracker
-import com.woocommerce.android.util.CoroutineDispatchers
 import dagger.hilt.android.scopes.ViewModelScoped
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ViewModelScoped
 class InstallationTransactionLauncher @Inject constructor(
     private val performanceTransactionRepository: PerformanceTransactionRepository,
-    dispatchers: CoroutineDispatchers,
 ) : LifecycleEventObserver {
     private companion object {
         const val TRANSACTION_NAME = "SiteInstallation"
     }
 
     private var performanceTransactionId: TransactionId? = null
-    private val conditionsToSatisfy = MutableStateFlow(Conditions.values().toList())
-    private val validatorScope = CoroutineScope(dispatchers.main + Job())
-    private val waitingTimeTracker = WaitingTimeTracker(SITE_CREATION_WAITING_TIME)
-
-    init {
-        validatorScope.launch {
-            conditionsToSatisfy.collect { toSatisfy ->
-                if (toSatisfy.isEmpty()) {
-                    performanceTransactionId?.let {
-                        performanceTransactionRepository.finishTransaction(
-                            it,
-                            TransactionStatus.SUCCESSFUL
-                        )
-                    }
-                    waitingTimeTracker.end()
-                }
-            }
-        }
-    }
-
-    private enum class Conditions {
-        STORE_INSTALLED,
-    }
+    private val waitingTimeTracker = WaitingTimeTracker(LOGIN_WOOCOMMERCE_SITE_CREATED)
 
     fun onStoreInstallationRequested() {
         performanceTransactionId =
@@ -61,13 +32,21 @@ class InstallationTransactionLauncher @Inject constructor(
         waitingTimeTracker.start()
     }
 
-    fun onStoreInstalled() = satisfyCondition(Conditions.STORE_INSTALLED)
-
-    fun onStoreInstallationFailed() {
-        abortTracking()
+    fun onStoreInstalled(parameters: Map<String, *>) {
+        performanceTransactionId?.let {
+            performanceTransactionRepository.finishTransaction(
+                it,
+                TransactionStatus.SUCCESSFUL
+            )
+        }
+        waitingTimeTracker.end(parameters)
     }
 
-    private fun abortTracking() {
+    fun onStoreInstallationFailed() {
+        abortMeasurement()
+    }
+
+    private fun abortMeasurement() {
         performanceTransactionId?.let {
             performanceTransactionRepository.finishTransaction(
                 it,
@@ -78,18 +57,10 @@ class InstallationTransactionLauncher @Inject constructor(
         waitingTimeTracker.abort()
     }
 
-    fun clear() {
-        validatorScope.cancel()
-    }
-
-    private fun satisfyCondition(condition: Conditions) {
-        conditionsToSatisfy.value = (conditionsToSatisfy.value - condition)
-    }
-
     override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
         when (event) {
             Lifecycle.Event.ON_DESTROY -> {
-                abortTracking()
+                abortMeasurement()
             }
 
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationTransactionLauncher.kt
@@ -1,0 +1,100 @@
+package com.woocommerce.android.ui.login.storecreation.installation
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.automattic.android.tracks.crashlogging.performance.PerformanceTransactionRepository
+import com.automattic.android.tracks.crashlogging.performance.TransactionId
+import com.automattic.android.tracks.crashlogging.performance.TransactionOperation
+import com.automattic.android.tracks.crashlogging.performance.TransactionStatus
+import com.woocommerce.android.analytics.AnalyticsEvent.SITE_CREATION_WAITING_TIME
+import com.woocommerce.android.analytics.WaitingTimeTracker
+import com.woocommerce.android.util.CoroutineDispatchers
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ViewModelScoped
+class InstallationTransactionLauncher @Inject constructor(
+    private val performanceTransactionRepository: PerformanceTransactionRepository,
+    dispatchers: CoroutineDispatchers,
+) : LifecycleEventObserver {
+    private companion object {
+        const val TRANSACTION_NAME = "SiteInstallation"
+    }
+
+    private var performanceTransactionId: TransactionId? = null
+    private val conditionsToSatisfy = MutableStateFlow(Conditions.values().toList())
+    private val validatorScope = CoroutineScope(dispatchers.main + Job())
+    private val waitingTimeTracker = WaitingTimeTracker(SITE_CREATION_WAITING_TIME)
+
+    init {
+        validatorScope.launch {
+            conditionsToSatisfy.collect { toSatisfy ->
+                if (toSatisfy.isEmpty()) {
+                    performanceTransactionId?.let {
+                        performanceTransactionRepository.finishTransaction(
+                            it,
+                            TransactionStatus.SUCCESSFUL
+                        )
+                    }
+                    waitingTimeTracker.end()
+                }
+            }
+        }
+    }
+
+    private enum class Conditions {
+        STORE_INSTALLED,
+    }
+
+    fun onStoreInstallationRequested() {
+        performanceTransactionId =
+            performanceTransactionRepository.startTransaction(
+                TRANSACTION_NAME,
+                TransactionOperation.UI_LOAD
+            )
+        waitingTimeTracker.start()
+    }
+
+    fun onStoreInstalled() = satisfyCondition(Conditions.STORE_INSTALLED)
+
+    fun onStoreInstallationFailed() {
+        abortTracking()
+    }
+
+    private fun abortTracking() {
+        performanceTransactionId?.let {
+            performanceTransactionRepository.finishTransaction(
+                it,
+                TransactionStatus.ABORTED
+            )
+        }
+        performanceTransactionId = null
+        waitingTimeTracker.abort()
+    }
+
+    fun clear() {
+        validatorScope.cancel()
+    }
+
+    private fun satisfyCondition(condition: Conditions) {
+        conditionsToSatisfy.value = (conditionsToSatisfy.value - condition)
+    }
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        when (event) {
+            Lifecycle.Event.ON_DESTROY -> {
+                abortTracking()
+            }
+
+            else -> {
+                // no-op
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
@@ -80,7 +80,6 @@ class InstallationViewModel @Inject constructor(
     private fun loadNewStore() {
         suspend fun processStoreCreationResult(result: StoreCreationResult<Unit>) {
             if (result is Success) {
-                installationTransactionLauncher.onStoreInstalled()
                 repository.selectSite(newStore.data.siteId!!)
 
                 val properties = mapOf(
@@ -89,7 +88,7 @@ class InstallationViewModel @Inject constructor(
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_NATIVE,
                     AnalyticsTracker.KEY_IS_FREE_TRIAL to FeatureFlag.FREE_TRIAL_M2.isEnabled()
                 )
-                analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_WOOCOMMERCE_SITE_CREATED, properties)
+                installationTransactionLauncher.onStoreInstalled(properties)
 
                 _viewState.update { SuccessState(newStoreWpAdminUrl) }
             } else {
@@ -156,10 +155,6 @@ class InstallationViewModel @Inject constructor(
     fun onRetryButtonClicked() {
         analyticsTrackerWrapper.track(AnalyticsEvent.SITE_CREATION_SITE_LOADING_RETRIED)
         loadNewStore()
-    }
-
-    override fun onCleared() {
-        installationTransactionLauncher.clear()
     }
 
     sealed interface ViewState : Parcelable {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/InstallationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/InstallationViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.login.storecreation
 import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.STORE_LOADING_FAILED
@@ -14,6 +15,7 @@ import com.woocommerce.android.ui.login.storecreation.installation.InstallationV
 import com.woocommerce.android.ui.login.storecreation.installation.InstallationViewModel.ViewState
 import com.woocommerce.android.ui.login.storecreation.installation.InstallationViewModel.ViewState.ErrorState
 import com.woocommerce.android.ui.login.storecreation.installation.InstallationViewModel.ViewState.SuccessState
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -153,7 +155,14 @@ class InstallationViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         // then
-        verify(installationTransactionLauncher).onStoreInstalled()
+        verify(installationTransactionLauncher).onStoreInstalled(
+            mapOf(
+                AnalyticsTracker.KEY_SOURCE to null,
+                AnalyticsTracker.KEY_URL to newStore.data.domain,
+                AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_NATIVE,
+                AnalyticsTracker.KEY_IS_FREE_TRIAL to FeatureFlag.FREE_TRIAL_M2.isEnabled()
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8787
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds support for tracking performance of the "store installation" process via Sentry Performance Monitoring and Tracks.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Create a store in the app and see if:
- there's a new transaction in Sentry (`StoreInstallation`)
- there's an event in Tracks: `woocommerceandroid_login_woocommerce_site_created` and it has `waiting_time` property

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/5845095/231141670-01cabf2d-f3b6-4ff3-aad2-7d20d71a0e7a.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
