### PR TITLE
Track onboarding completed only if it was shown at least once

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.UPDATE_SIMULATED_READER_OPTION
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.ONBOARDING_CAROUSEL_DISPLAYED
+import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_ONBOARDING_SHOWN_AT_LEAST_ONCE
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_ONBOARDING_TASKS_COMPLETED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.orNullIfEmpty
@@ -175,6 +176,9 @@ object AppPrefs {
 
         // Whether onboarding tasks have been completed or not for a given site
         STORE_ONBOARDING_TASKS_COMPLETED,
+
+        // Was store onboarding shown at least once
+        STORE_ONBOARDING_SHOWN_AT_LEAST_ONCE,
 
         // Time when the last successful payment was made with a card reader
         CARD_READER_LAST_SUCCESSFUL_PAYMENT_TIME,
@@ -904,15 +908,28 @@ object AppPrefs {
         default = false
     )
 
+    private fun getStoreOnboardingKeyFor(siteId: Int) =
+        PrefKeyString("$STORE_ONBOARDING_TASKS_COMPLETED:$siteId")
+
+    fun setStoreOnboardingShown(siteId: Int) {
+        setBoolean(
+            key = PrefKeyString("$STORE_ONBOARDING_SHOWN_AT_LEAST_ONCE:$siteId"),
+            value = true
+        )
+    }
+
+    fun getStoreOnboardingShown(siteId: Int): Boolean =
+        getBoolean(
+            key = PrefKeyString("$STORE_ONBOARDING_SHOWN_AT_LEAST_ONCE:$siteId"),
+            default = false
+        )
+
     fun getCardReaderLastSuccessfulPaymentTime() =
         getLong(UndeletablePrefKey.CARD_READER_LAST_SUCCESSFUL_PAYMENT_TIME, 0L)
 
     fun setCardReaderSuccessfulPaymentTime() {
         setLong(UndeletablePrefKey.CARD_READER_LAST_SUCCESSFUL_PAYMENT_TIME, System.currentTimeMillis())
     }
-
-    private fun getStoreOnboardingKeyFor(siteId: Int) =
-        PrefKeyString("$STORE_ONBOARDING_TASKS_COMPLETED:$siteId")
 
     /**
      * Remove all user and site-related preferences.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -326,4 +326,10 @@ class AppPrefsWrapper @Inject constructor() {
     }
 
     fun isOnboardingCompleted(siteId: Int): Boolean = AppPrefs.areOnboardingTaskCompletedFor(siteId)
+
+    fun setStoreOnboardingShown(siteId: Int) {
+        AppPrefs.setStoreOnboardingShown(siteId)
+    }
+
+    fun getStoreOnboardingShown(siteId: Int): Boolean = AppPrefs.getStoreOnboardingShown(siteId)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -67,8 +67,14 @@ class StoreOnboardingRepository @Inject constructor(
                         "All onboarding tasks are completed for siteId: ${selectedSite.getSelectedSiteId()}"
                     )
                     appPrefsWrapper.markAllOnboardingTasksCompleted(selectedSite.getSelectedSiteId())
-                    analyticsTrackerWrapper.track(stat = STORE_ONBOARDING_COMPLETED)
+                    if (appPrefsWrapper.getStoreOnboardingShown(selectedSite.getSelectedSiteId())) {
+                        analyticsTrackerWrapper.track(stat = STORE_ONBOARDING_COMPLETED)
+                    }
                 }
+                if (mobileSupportedTasks.any { !it.isComplete }) {
+                    appPrefsWrapper.setStoreOnboardingShown(selectedSite.getSelectedSiteId())
+                }
+
                 onboardingTasksCacheFlow.emit(mobileSupportedTasks)
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes tracking issue
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
`STORE_ONBOARDING_COMPLETED` event should be only tracked once for those sites where the onboarding list was displayed at least once. With the previous implementation, we would fetch the onboarding tasks list from the API and if all tasks were completed, then track `STORE_ONBOARDING_COMPLETED` regardless of the onboarding list being shown at least one time. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create a jurassic ninja site. 
2. Complete all 3 onboarding tasks 
3. Check `store_onboarding_completed` event is tracked and onboarding list is gone. You can verify the tracked event in the logcat, searching for: `Tracked: store_onboarding_completed, Properties: {"blog_id":0,"is_wpcom_store":false,"is_debug":true}`
4. Clear app data
5. Log in again into the jurassic ninja site 
6. Check `store_onboarding_completed` is not tracked since all the onboarding tasks are already completed and the onboarding list was never shown to the user. 

