### PR TITLE
Free Trial: Add store creation error dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
@@ -59,9 +59,9 @@ class StoreCreationSummaryFragment : BaseFragment() {
     private fun displayStoreCreationErrorDialog() {
         WooDialog.showDialog(
             activity = requireActivity(),
-            titleId = R.string.support_request_error_title,
-            messageId = R.string.support_request_error_message,
-            positiveButtonId = R.string.support_request_dialog_action
+            titleId = R.string.free_trial_summary_store_creation_error_title,
+            messageId = R.string.free_trial_summary_store_creation_error_message,
+            positiveButtonId = R.string.free_trial_summary_store_creation_error_dialog_action
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
@@ -11,6 +11,9 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnCancelPressed
+import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationFailure
+import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationSuccess
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -42,11 +45,16 @@ class StoreCreationSummaryFragment : BaseFragment() {
     private fun setupEventObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is StoreCreationSummaryViewModel.OnCancelPressed -> findNavController().popBackStack()
-                is StoreCreationSummaryViewModel.OnStoreCreationSuccess -> findNavController().navigateSafely(
+                is OnCancelPressed -> findNavController().popBackStack()
+                is OnStoreCreationSuccess -> findNavController().navigateSafely(
                     StoreCreationSummaryFragmentDirections.actionSummaryFragmentToInstallationFragment()
                 )
+                is OnStoreCreationFailure -> displayStoreCreationErrorDialog()
             }
         }
+    }
+
+    private fun displayStoreCreationErrorDialog() {
+        TODO("Not yet implemented")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
@@ -8,9 +8,11 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnCancelPressed
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationFailure
 import com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryViewModel.OnStoreCreationSuccess
@@ -55,6 +57,11 @@ class StoreCreationSummaryFragment : BaseFragment() {
     }
 
     private fun displayStoreCreationErrorDialog() {
-        TODO("Not yet implemented")
+        WooDialog.showDialog(
+            activity = requireActivity(),
+            titleId = R.string.support_request_error_title,
+            messageId = R.string.support_request_error_message,
+            positiveButtonId = R.string.support_request_dialog_action
+        )
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3241,6 +3241,9 @@
     <string name="free_trial_feature_auto_updates_backups">Auto updates &amp; backups</string>
     <string name="free_trial_feature_site_security">Site security</string>
     <string name="free_trial_feature_fast_to_launch">Fast to launch</string>
+    <string name="free_trial_summary_store_creation_error_title">Something went wrong</string>
+    <string name="free_trial_summary_store_creation_error_message">Sorry, we cannot create your store right now, please try again later.</string>
+    <string name="free_trial_summary_store_creation_error_dialog_action">Got It!</string>
 
 
     <!--


### PR DESCRIPTION
Summary
==========
Fix issue #8783 by implementing a simple dialog to notify the user that something went wrong. Previously there was no error handling, risking a confusing experience for our users.


How to Test
==========
1. Modify the `CreateFreeTrialStore` use case to forcefully emit a `Failed` state to replicate the error scenario easily.
2. Start a free trial store creation and verify that the error is displayed as expected in the Summary view.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.