### PR TITLE
Show variation picker in case of variable subscription

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 13.2
 -----
-
+- [**] Fix adding variable subscription products to an order [https://github.com/woocommerce/woocommerce-android/pull/8798]
 
 13.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -204,7 +204,7 @@ class ProductSelectorViewModel @Inject constructor(
 
     private fun Product.toUiModel(selectedItems: Collection<SelectedItem>): ProductListItem {
         fun getProductSelection(): SelectionState {
-            return if (productType == VARIABLE && numVariations > 0) {
+            return if ((productType == VARIABLE || productType == VARIABLE_SUBSCRIPTION) && numVariations > 0) {
                 val intersection = variationIds.intersect(selectedItems.variationIds.toSet())
                 when {
                     intersection.isEmpty() -> UNSELECTED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.products.ProductStockStatus.InStock
 import com.woocommerce.android.ui.products.ProductStockStatus.NotAvailable
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.APPENDING
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.IDLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.LOADING
@@ -280,7 +281,7 @@ class ProductSelectorViewModel @Inject constructor(
 
     fun onProductClick(item: ProductListItem, productSourceForTracking: ProductSourceForTracking) {
         val productSource = updateProductSourceIfSearchIsEnabled(productSourceForTracking)
-        if (item.type == VARIABLE && item.numVariations > 0) {
+        if ((item.type == VARIABLE || item.type == VARIABLE_SUBSCRIPTION) && item.numVariations > 0) {
             triggerEvent(
                 NavigateToVariationSelector(
                     item.id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -204,7 +204,7 @@ class ProductSelectorViewModel @Inject constructor(
 
     private fun Product.toUiModel(selectedItems: Collection<SelectedItem>): ProductListItem {
         fun getProductSelection(): SelectionState {
-            return if ((productType == VARIABLE || productType == VARIABLE_SUBSCRIPTION) && numVariations > 0) {
+            return if (isVariable() && numVariations > 0) {
                 val intersection = variationIds.intersect(selectedItems.variationIds.toSet())
                 when {
                     intersection.isEmpty() -> UNSELECTED
@@ -219,8 +219,11 @@ class ProductSelectorViewModel @Inject constructor(
 
         val stockStatus = when (stockStatus) {
             InStock -> {
-                if (productType == VARIABLE) {
-                    resourceProvider.getString(string.product_stock_status_instock_with_variations, numVariations)
+                if (isVariable()) {
+                    resourceProvider.getString(
+                        string.product_stock_status_instock_with_variations,
+                        numVariations
+                    )
                 } else {
                     getStockStatusLabel()
                 }
@@ -290,7 +293,7 @@ class ProductSelectorViewModel @Inject constructor(
                     productSource
                 )
             )
-        } else if (item.type != VARIABLE) {
+        } else if (item.type != VARIABLE && item.type != VARIABLE_SUBSCRIPTION) {
             selectedItems.update { items ->
                 val selectedProductItems = items.filter {
                     it is SelectedItem.ProductOrVariation || it is SelectedItem.Product
@@ -514,7 +517,7 @@ class ProductSelectorViewModel @Inject constructor(
         @Parcelize
         object NoVariableProductsWithNoVariations : ProductSelectorRestriction() {
             override fun invoke(product: Product): Boolean {
-                return !(product.productType == VARIABLE && product.numVariations == 0)
+                return !(product.isVariable() && product.numVariations == 0)
             }
         }
     }
@@ -523,6 +526,8 @@ class ProductSelectorViewModel @Inject constructor(
         OrderCreation, CouponEdition, Undefined
     }
 }
+
+private fun Product.isVariable() = productType == VARIABLE || productType == VARIABLE_SUBSCRIPTION
 
 val Collection<ProductSelectorViewModel.SelectedItem>.variationIds: List<Long>
     get() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -20,13 +20,14 @@ object ProductTestUtils {
         isPurchasable: Boolean = true,
         customStatus: String? = null,
         variationIds: String = if (isVariable) "[123]" else "[]",
+        productType: String? = null,
     ): Product {
         return WCProductModel(2).apply {
             dateCreated = "2018-01-05T05:14:30Z"
             localSiteId = 1
             remoteProductId = productId
             status = customStatus ?: "publish"
-            type = if (isVariable) "variable" else "simple"
+            type = productType ?: if (isVariable) "variable" else "simple"
             stockStatus = "instock"
             price = "20.00"
             salePrice = "10.00"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.selector
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_CONFIRM_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_COUNT
@@ -24,6 +25,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -33,6 +35,8 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.OrderEntity
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCSettingsModel
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 
@@ -46,13 +50,32 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             isVariable = true,
             variationIds = "[]",
         )
+        private val VARIABLE_SUBSCRIPTION_PRODUCT = ProductTestUtils.generateProduct(
+            productId = 4L,
+            isVariable = true,
+            productType = "variable-subscription",
+            variationIds = "[1,2]",
+        )
+        private val VARIABLE_PRODUCT = ProductTestUtils.generateProduct(
+            productId = 5L,
+            isVariable = true,
+            variationIds = "[1,2]",
+        )
     }
 
     private val currencyFormatter: CurrencyFormatter = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
     private val selectedSite: SelectedSite = mock()
     private val listHandler: ProductListHandler = mock {
-        on { productsFlow } doReturn flowOf(listOf(VALID_PRODUCT, DRAFT_PRODUCT, VARIABLE_PRODUCT_WITH_NO_VARIATIONS))
+        on { productsFlow } doReturn flowOf(
+            listOf(
+                VALID_PRODUCT,
+                DRAFT_PRODUCT,
+                VARIABLE_PRODUCT_WITH_NO_VARIATIONS,
+                VARIABLE_SUBSCRIPTION_PRODUCT,
+                VARIABLE_PRODUCT
+            )
+        )
     }
     private val variationSelectorRepository: VariationSelectorRepository = mock()
     private val resourceProvider: ResourceProvider = mock()
@@ -60,6 +83,16 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     private val productSelectorTracker: ProductSelectorTracker = ProductSelectorTracker(tracker)
     private val orderStore: WCOrderStore = mock()
     private val productsMapper: ProductsMapper = mock()
+    private val siteSettings: WCSettingsModel = mock()
+
+    @Before
+    fun setup() {
+        whenever(resourceProvider.getString(R.string.product_stock_status_instock)).thenReturn("In stock")
+        val site: SiteModel = mock()
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(siteSettings.currencyCode).thenReturn("USD")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+    }
 
     @Test
     fun `given published products restriction, when view model created, should not show draft products`() {
@@ -90,7 +123,10 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         sut.viewState.observeForever { state ->
             assertThat(state.products).isNotEmpty
             assertThat(
-                state.products.filter { (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) && it.numVariations == 0 }
+                state.products.filter {
+                    (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) &&
+                        it.numVariations == 0
+                }
             ).isEmpty()
         }
     }
@@ -108,9 +144,80 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         sut.viewState.observeForever { state ->
             assertThat(state.products).isNotEmpty
             assertThat(
-                state.products.filter { (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) && it.numVariations == 0 }
+                state.products.filter {
+                    (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) &&
+                        it.numVariations == 0
+                }
             ).isEmpty()
             assertThat(state.products.filter { it.id == DRAFT_PRODUCT.remoteId }).isEmpty()
+        }
+    }
+
+    @Test
+    fun `given variable product, when view model created, should generate correct item subtitle`() {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = arrayOf(NoVariableProductsWithNoVariations),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+        ).initSavedStateHandle()
+
+        whenever(currencyFormatter.formatCurrency(VARIABLE_PRODUCT.price!!, "USD"))
+            .thenReturn("$${VARIABLE_PRODUCT.price}")
+
+        val sut = createViewModel(navArgs)
+
+        sut.viewState.observeForever { state ->
+            assertThat(state.products).isNotEmpty
+            state.products.firstOrNull { it.id == VARIABLE_PRODUCT.remoteId }.apply {
+                assertThat(this).isNotNull
+                this!!
+                assertThat(stockAndPrice).isEqualTo("In stock • %d variations • $${VARIABLE_PRODUCT.price}")
+            }
+        }
+    }
+
+    @Test
+    fun `given variable subscription product, when view model created, should generate correct item subtitle`() {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = arrayOf(NoVariableProductsWithNoVariations),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+        ).initSavedStateHandle()
+
+        whenever(currencyFormatter.formatCurrency(VARIABLE_SUBSCRIPTION_PRODUCT.price!!, "USD"))
+            .thenReturn("$${VARIABLE_SUBSCRIPTION_PRODUCT.price}")
+
+        val sut = createViewModel(navArgs)
+
+        sut.viewState.observeForever { state ->
+            assertThat(state.products).isNotEmpty
+            state.products.firstOrNull { it.id == VARIABLE_SUBSCRIPTION_PRODUCT.remoteId }.apply {
+                assertThat(this).isNotNull
+                this!!
+                assertThat(stockAndPrice).isEqualTo("In stock • $${VARIABLE_SUBSCRIPTION_PRODUCT.price}")
+            }
+        }
+    }
+
+    @Test
+    fun `given non-variable product, when view model created, should generate correct item subtitle`() {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = arrayOf(NoVariableProductsWithNoVariations),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+        ).initSavedStateHandle()
+
+        whenever(currencyFormatter.formatCurrency(VALID_PRODUCT.price!!, "USD")).thenReturn("$${VALID_PRODUCT.price}")
+
+        val sut = createViewModel(navArgs)
+
+        sut.viewState.observeForever { state ->
+            assertThat(state.products).isNotEmpty
+            state.products.firstOrNull { it.id == VALID_PRODUCT.remoteId }.apply {
+                assertThat(this).isNotNull
+                this!!
+                assertThat(stockAndPrice).isEqualTo("In stock • $${VALID_PRODUCT.price}")
+            }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -90,7 +90,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         sut.viewState.observeForever { state ->
             assertThat(state.products).isNotEmpty
             assertThat(
-                state.products.filter { it.type == ProductType.VARIABLE && it.numVariations == 0 }
+                state.products.filter { (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) && it.numVariations == 0 }
             ).isEmpty()
         }
     }
@@ -108,7 +108,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         sut.viewState.observeForever { state ->
             assertThat(state.products).isNotEmpty
             assertThat(
-                state.products.filter { it.type == ProductType.VARIABLE && it.numVariations == 0 }
+                state.products.filter { (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) && it.numVariations == 0 }
             ).isEmpty()
             assertThat(state.products.filter { it.id == DRAFT_PRODUCT.remoteId }).isEmpty()
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductListItem
@@ -235,6 +236,62 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         verify(tracker).track(
             AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_CLEAR_SELECTION_BUTTON_TAPPED,
             mapOf("source" to "product_selector")
+        )
+    }
+
+    @Test
+    fun `when variable product is tapped, should redirect to variation picker`() = testBlocking {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = emptyArray(),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+        ).initSavedStateHandle()
+        val popularOrdersList = generatePopularOrders()
+        val ordersList = generateTestOrders()
+        val totalOrders = ordersList + popularOrdersList
+        whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
+
+        val sut = createViewModel(navArgs)
+        sut.onProductClick(
+            item = ProductListItem(1, "", ProductType.VARIABLE, numVariations = 2),
+            productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
+        )
+
+        assertThat(sut.event.value).isEqualTo(
+            ProductNavigationTarget.NavigateToVariationSelector(
+                productId = 1,
+                selectedVariationIds = emptySet(),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+                productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
+            )
+        )
+    }
+
+    @Test
+    fun `when variable subscription is tapped, should redirect to variation picker`() = testBlocking {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = emptyArray(),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+        ).initSavedStateHandle()
+        val popularOrdersList = generatePopularOrders()
+        val ordersList = generateTestOrders()
+        val totalOrders = ordersList + popularOrdersList
+        whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
+
+        val sut = createViewModel(navArgs)
+        sut.onProductClick(
+            item = ProductListItem(23, "", ProductType.VARIABLE_SUBSCRIPTION, numVariations = 2),
+            productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
+        )
+
+        assertThat(sut.event.value).isEqualTo(
+            ProductNavigationTarget.NavigateToVariationSelector(
+                productId = 23,
+                selectedVariationIds = emptySet(),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+                productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
+            )
         )
     }
 


### PR DESCRIPTION
## Bug fix: Adding variable subscription to an order

Closes: #8730
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
**Before**: In case of tapping on the variable subscription product the variation picker was not shown. 
As a result, it was impossible to add a subscription variation to an order.

**After**: In case of tapping on the variable subscription product the variation picker is shown now. It's possible to add subscription variation to an order.

### Testing instructions
1. Create product of type: `variable subscription`. Ensure it has at least one variation available (otherwise it's not displayed on the product list).
2. Create new order and tap "+ Add products".
3. Verify variable subscription product is displayed and tapping on it redirects to the variation picker.
4. Select a variation, go back and confirm selection.
5. Verify the subscription variation is added to the order.

### Visual changes
<!-- Include before and after images or gifs when appropriate. -->
| Before  | After |
| ------------- | ------------- |
| <video src=https://user-images.githubusercontent.com/4527432/231437083-1982bc81-bb62-4d44-b3a2-cab35c2b72d6.mp4/>  | <video src=https://user-images.githubusercontent.com/4527432/231436602-56c00508-c863-4361-b5db-3aeb25c25e03.mp4/>  |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
