### PR TITLE
Track when a store is out of sync or times out

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -778,6 +778,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_CREATION_IAP_PURCHASE_ERROR(siteless = true),
     SITE_CREATION_PROFILER_DATA(siteless = true),
     SITE_CREATION_TRY_FOR_FREE_TAPPED(siteless = true),
+    SITE_CREATION_TIMED_OUT(siteless = true),
 
     // Domain change
     CUSTOM_DOMAINS_STEP,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -779,6 +779,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_CREATION_PROFILER_DATA(siteless = true),
     SITE_CREATION_TRY_FOR_FREE_TAPPED(siteless = true),
     SITE_CREATION_TIMED_OUT(siteless = true),
+    SITE_CREATION_PROPERTIES_OUT_OF_SYNC(siteless = true),
 
     // Domain change
     CUSTOM_DOMAINS_STEP,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
@@ -90,6 +90,12 @@ class InstallationViewModel @Inject constructor(
                 )
                 installationTransactionLauncher.onStoreInstalled(properties)
 
+                selectedSite.get().let {
+                    if (!it.isWpComStore && !it.hasWooCommerce && it.name != newStore.data.name) {
+                        analyticsTrackerWrapper.track(AnalyticsEvent.SITE_CREATION_PROPERTIES_OUT_OF_SYNC)
+                    }
+                }
+
                 _viewState.update { SuccessState(newStoreWpAdminUrl) }
             } else {
                 installationTransactionLauncher.onStoreInstallationFailed()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationViewModel.kt
@@ -122,6 +122,9 @@ class InstallationViewModel @Inject constructor(
                     (result as Failure).type == STORE_LOADING_FAILED || // permanent error
                     retries == STORE_LOAD_RETRIES_LIMIT // site found but is not ready & retry limit reached
                 ) {
+                    if (retries == STORE_LOAD_RETRIES_LIMIT) {
+                        analyticsTrackerWrapper.track(AnalyticsEvent.SITE_CREATION_TIMED_OUT)
+                    }
                     processStoreCreationResult(result)
                     break
                 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/InstallationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/InstallationViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.login.storecreation
 import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
@@ -112,6 +113,7 @@ class InstallationViewModelTest : BaseUnitTest() {
         val expectedState = ErrorState(STORE_NOT_READY)
 
         assertEquals(expectedState, observedState)
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.SITE_CREATION_TIMED_OUT)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/InstallationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/InstallationViewModelTest.kt
@@ -180,4 +180,24 @@ class InstallationViewModelTest : BaseUnitTest() {
         // then
         verify(installationTransactionLauncher).onStoreInstallationFailed()
     }
+
+    @Test
+    fun `when a Woo site is found after installation, but has out-of-sync properties, report a tracks event`() = testBlocking {
+        whenever(repository.fetchSiteAfterCreation(newStore.data.siteId!!)).thenReturn(Success(Unit))
+        whenever(selectedSite.get()).thenReturn(
+            SiteModel().apply {
+                setIsWpComStore(false)
+                hasWooCommerce = false
+                name = "different than provided by user"
+                url = newStore.data.domain
+            }
+        )
+
+        whenViewModelIsCreated()
+
+        viewModel.viewState.observeForever(observer)
+        advanceUntilIdle()
+
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.SITE_CREATION_PROPERTIES_OUT_OF_SYNC)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8742
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

iOS counterpart: https://github.com/woocommerce/woocommerce-ios/pull/9417

This PR adds tracking for 2 scenarios:
- store creation (or rather: installation) has timed out
- store has been created but the properties are out of sync

For the first scenario, we already were sending a Tracks event (`site_creation_failed`) but as iOS wasn't, they've added a seperate event. As we want to assert the same behaviour on 2 platforms, I've decided to add this event to match iOS. More context: https://github.com/woocommerce/woocommerce-ios/pull/9417#issuecomment-1503273303 . Next steps: do not send `site_creation_failed` when store creation times out.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I couldn't reproduce "out of sync" behavior even once. I also don't see a reason to mock "out of sync" behavior as I covered sending the event with unit tests.

So my only suggestion is to try create a few Free Trial sites (like 5-10) and if you're spot that site is out of sync, then check if Tracks received the `site_creation_properties_out_of_sync` event.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
