### PR TITLE
Bundled products analytics

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -808,6 +808,6 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     PRODUCT_DETAIL_VIEW_QUANTITY_RULES_TAPPED,
     PRODUCT_VARIATION_VIEW_QUANTITY_RULES_TAPPED,
 
-    //Bundled products
+    // Bundled products
     PRODUCT_DETAIL_VIEW_BUNDLED_PRODUCTS_TAPPED
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -806,5 +806,8 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
 
     // Quantity rules (Min/Max extension)
     PRODUCT_DETAIL_VIEW_QUANTITY_RULES_TAPPED,
-    PRODUCT_VARIATION_VIEW_QUANTITY_RULES_TAPPED
+    PRODUCT_VARIATION_VIEW_QUANTITY_RULES_TAPPED,
+
+    //Bundled products
+    PRODUCT_DETAIL_VIEW_BUNDLED_PRODUCTS_TAPPED
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -810,7 +810,8 @@ class ProductDetailCardBuilder(
                 drawable.ic_widgets
             ) {
                 viewModel.onEditProductCardClicked(
-                    ProductNavigationTarget.ViewBundleProducts(this.remoteId)
+                    ProductNavigationTarget.ViewBundleProducts(this.remoteId),
+                    AnalyticsEvent.PRODUCT_DETAIL_VIEW_BUNDLED_PRODUCTS_TAPPED
                 )
             }
         } else null


### PR DESCRIPTION
⚠️ This PR needs [this PR](https://github.com/woocommerce/woocommerce-android/pull/8806) to be merge first

Closes: #8610

### Description
This adds an analytics event when the Bundled products row is tapped in product details (for Product Bundles):

* `product_detail_view_bundled_products_tapped ` (Event [registration](https://github.com/Automattic/tracks-events-registration/pull/1556))

### Testing instructions

#### Prerequisites

1. Install and activate the [Product Bundles extension](https://woocommerce.com/document/bundles/) on your store.
2. Create at least one product with the Product bundle type, with at least one bundled product.

#### To test

1. Build and run the app.
2. Open the Products tab and select a product bundle.
3. Tap the Bundled products row in the product details. Confirm the new event is triggered.

### Images/gif
```
🔵 Tracked: product_detail_view_bundled_products_tapped, Properties: {"blog_id":214253715,"is_wpcom_store":true,"is_debug":true}
```
