### PR TITLE
Release hosted woo read only support

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,9 @@
 - [**] Fix adding variable subscription products to an order [https://github.com/woocommerce/woocommerce-android/pull/8798]
 - [*] Added RTL languages support in search fields [https://github.com/woocommerce/woocommerce-android/pull/8770]
 - [*][internal] Visual improvements to the Payments Hub Screen [https://github.com/woocommerce/woocommerce-android/pull/8768]
+- [*] Orders: Adds read-only support for the Gift cards extension in the Order details. [https://github.com/woocommerce/woocommerce-android/pull/8684]
+- [*] Products: Adds read-only support for the Max/min quantity rules extension in the Products details. [https://github.com/woocommerce/woocommerce-android/pull/8715]
+- [*] Products: Adds read-only support for the Bundled Products extension in the Products details. [https://github.com/woocommerce/woocommerce-android/pull/8806]
 
 13.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -40,15 +40,15 @@ enum class FeatureFlag {
             IPP_FEEDBACK_BANNER,
             FREE_TRIAL_M2,
             STORE_CREATION_ONBOARDING,
-            REST_API_I2 -> true
+            REST_API_I2,
+            GIFT_CARD_READ_ONLY_SUPPORT,
+            QUANTITY_RULES_READ_ONLY_SUPPORT,
+            BUNDLED_PRODUCTS_READ_ONLY_SUPPORT -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             IPP_TAP_TO_PAY,
-            ANALYTICS_HUB_FEEDBACK_BANNER,
-            GIFT_CARD_READ_ONLY_SUPPORT,
-            QUANTITY_RULES_READ_ONLY_SUPPORT,
-            BUNDLED_PRODUCTS_READ_ONLY_SUPPORT -> PackageUtils.isDebugBuild()
+            ANALYTICS_HUB_FEEDBACK_BANNER -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION,
             STORE_CREATION_PROFILER -> false


### PR DESCRIPTION
### Description
This enables the Gift cards, Max/min quantity rules, and Bundled Products feature-flags, to release read-only support for composite products.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
