### PR TITLE
Merge 13.2 code freeze into trunk

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+13.3
+-----
+
+
 13.2
 -----
 - [**] Fix adding variable subscription products to an order [https://github.com/woocommerce/woocommerce-android/pull/8798]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,9 +74,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "13.1"
+            versionName "13.2-rc-1"
         }
-        versionCode 403
+        versionCode 404
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_132"
+msgid ""
+"13.2:\n"
+"This release includes some bug fixes, visual & accessibility enhancements to the orders and products sections of the app. Keep your feedback rolling in; it helps us figure out what to work on next.\n"
+msgstr ""
+
 msgctxt "release_note_131"
 msgid ""
 "13.1:\n"
 "More love for In-Person Payments and orders this time around, including the option to select your most popular products when creating an order.\n"
-msgstr ""
-
-msgctxt "release_note_130"
-msgid ""
-"13.0:\n"
-"Great news for folks that are using WooCommerce Subscriptions extension. We have added read only support for the WooCommerce Subsciptions extension in the order detail and product detail screens. More features coming soon!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,7 +1,1 @@
-- [**] Fix adding variable subscription products to an order [https://github.com/woocommerce/woocommerce-android/pull/8798]
-- [*] Added RTL languages support in search fields [https://github.com/woocommerce/woocommerce-android/pull/8770]
-- [*][internal] Visual improvements to the Payments Hub Screen [https://github.com/woocommerce/woocommerce-android/pull/8768]
-- [*] Orders: Adds read-only support for the Gift cards extension in the Order details. [https://github.com/woocommerce/woocommerce-android/pull/8684]
-- [*] Products: Adds read-only support for the Max/min quantity rules extension in the Products details. [https://github.com/woocommerce/woocommerce-android/pull/8715]
-- [*] Products: Adds read-only support for the Bundled Products extension in the Products details. [https://github.com/woocommerce/woocommerce-android/pull/8806]
-
+This release includes some bug fixes, visual & accessibility enhancements to the orders and products sections of the app. Keep your feedback rolling in; it helps us figure out what to work on next.

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,7 @@
-More love for In-Person Payments and orders this time around, including the option to select your most popular products when creating an order.
+- [**] Fix adding variable subscription products to an order [https://github.com/woocommerce/woocommerce-android/pull/8798]
+- [*] Added RTL languages support in search fields [https://github.com/woocommerce/woocommerce-android/pull/8770]
+- [*][internal] Visual improvements to the Payments Hub Screen [https://github.com/woocommerce/woocommerce-android/pull/8768]
+- [*] Orders: Adds read-only support for the Gift cards extension in the Order details. [https://github.com/woocommerce/woocommerce-android/pull/8684]
+- [*] Products: Adds read-only support for the Max/min quantity rules extension in the Products details. [https://github.com/woocommerce/woocommerce-android/pull/8715]
+- [*] Products: Adds read-only support for the Bundled Products extension in the Products details. [https://github.com/woocommerce/woocommerce-android/pull/8806]
+

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -564,7 +564,7 @@
     <string name="domains_free_with_credits">Free for the first year</string>
     <string name="domains_purchase_successful_heading">Congratulations on your purchase</string>
     <string name="domains_purchase_successful_delay_notice">Your site address is being set up. It may take up 30 minutes for your domain to start working.</string>
-    <string name="domains_purchase_successful_settings_notice">You can find the domain settings in Settings -> Domains</string>
+    <string name="domains_purchase_successful_settings_notice">You can find the domain settings in Settings -&gt; Domains</string>
     <string name="domain_registration_privacy_protection_title">Privacy Protection</string>
     <string name="domain_registration_privacy_protection_description">Domain owners have to share contact information in a public database of all domains.
         With Privacy Protection, we publish our own information instead of yours and privately forward any communication to you.</string>
@@ -1171,7 +1171,7 @@
     <string name="card_reader_tap_to_pay_explanation_title">Collect card payments\nwith your phone</string>
     <string name="card_reader_tap_to_pay_explanation_ready">Your phone is ready for Tap to Pay.\nYour customer can tap their card\non your phone to pay.</string>
     <string name="card_reader_tap_to_pay_explanation_try_and_refund">Try a payment using your card and\nrefund it when you’re done.</string>
-    <string name="card_reader_tap_to_pay_explanation_where_to_find"> You can find Tap to Pay on Android in\nMenu > Payments, or Collect Payment and\nchoose Tap to Pay.</string>
+    <string name="card_reader_tap_to_pay_explanation_where_to_find"> You can find Tap to Pay on Android in\nMenu &gt; Payments, or Collect Payment and\nchoose Tap to Pay.</string>
     <string name="card_reader_tap_to_pay_explanation_try_payment">Try a payment</string>
     <string name="card_reader_tap_to_pay_explanation_test_payment_error">Something went wrong. Please try again later.</string>
     <string name="card_reader_tap_to_pay_beta_features_heading">Tap To Pay</string>
@@ -3259,7 +3259,7 @@
     <string name="subscription_total" translatable="false">%1$s /\n%2$s</string>
     <string name="subscription_period_interval_single">Every %1$s</string>
     <string name="subscription_period_interval_multiple">Every %1$d %2$s</string>
-    <string name="subscription_end_date" translatable="false">&#160;- %1$s</string>
+    <string name="subscription_end_date" translatable="false"> - %1$s</string>
     <string name="product_subscription_description">%1$s every %2$s %3$s</string>
     <string name="subscription_period" translatable="false">%1$s %2$s</string>
     <string name="subscription_never_expire">Never expire</string>

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-c4f88d5272c51d59cb7763681699b5925d76dace'
+    fluxCVersion = '2.25.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -95,17 +95,6 @@
     <string name="product_bulk_update_status">Update status</string>
     <string name="product_bulk_update_status_updated">Status updated!</string>
     <string name="review_notifications">Reviews</string>
-    <string name="more_menu">Menu</string>
-    <string name="more_menu_button_woo_admin">WooCommerce Admin</string>
-    <string name="more_menu_button_wс_admin">WC Admin</string>
-    <string name="more_menu_button_payments">Payments</string>
-    <string name="more_menu_button_analytics">Analytics</string>
-    <string name="more_menu_button_inbox">Inbox</string>
-    <string name="more_menu_button_store">View Store</string>
-    <string name="more_menu_button_coupons">Coupons</string>
-    <string name="more_menu_button_reviews">Reviews</string>
-    <string name="more_menu_button_upgrades">Upgrades</string>
-    <string name="more_menu_avatar">User profile picture</string>
     <string name="version_with_name_param">Version %s</string>
     <string name="share_store_button">Share your store</string>
     <string name="share_store_dialog_title">Share your store\'s URL</string>
@@ -2200,6 +2189,7 @@
     <string name="product_type_virtual">Virtual</string>
     <string name="product_type_downloadable">Downloadable</string>
     <string name="product_type_subscription">Subscription</string>
+    <string name="product_type_bundle">Bundle</string>
 
     <!-- Product type bottom sheets -->
     <string name="product_type_list_header">Select a product type</string>
@@ -3241,6 +3231,9 @@
     <string name="free_trial_feature_auto_updates_backups">Auto updates &amp; backups</string>
     <string name="free_trial_feature_site_security">Site security</string>
     <string name="free_trial_feature_fast_to_launch">Fast to launch</string>
+    <string name="free_trial_summary_store_creation_error_title">Something went wrong</string>
+    <string name="free_trial_summary_store_creation_error_message">Sorry, we cannot create your store right now, please try again later.</string>
+    <string name="free_trial_summary_store_creation_error_dialog_action">Got It!</string>
 
 
     <!--
@@ -3319,5 +3312,53 @@
     <string name="max_quantity">Maximum quantity</string>
     <string name="group_of">Group of</string>
     <string name="quantity_rules_info_notice">You can edit product\'s quantity rules in the web dashboard.</string>
+
+    <string name="empty_min_quantity">No minimum</string>
+    <string name="empty_max_quantity">No maximum</string>
+    <string name="empty_group_of">Not grouped</string>
+
+    <!--
+    Bundled products
+    -->
+    <string name="product_bundle">Bundled products</string>
+    <string name="product_bundle_single_count">1 product</string>
+    <string name="product_bundle_multiple_count">%d products</string>
+    <string name="bundled_products_info_notice">You can edit bundled products in the web dashboard.</string>
+
+
+    <!--
+    More Menu
+    -->
+    <string name="more_menu">Menu</string>
+    <string name="more_menu_button_woo_admin">WooCommerce Admin</string>
+    <string name="more_menu_avatar">User profile picture</string>
+    <string name="more_menu_button_analytics">Analytics</string>
+
+    <string name="more_menu_settings_section_title">Settings</string>
+    <string name="more_menu_general_section_title">General</string>
+
+    <string name="more_menu_button_wс_admin">WC Admin</string>
+    <string name="more_menu_button_wc_admin_description">Manage more on admin</string>
+
+    <string name="more_menu_button_payments">Payments</string>
+    <string name="more_menu_button_payments_description">Join the mobile payments</string>
+
+    <string name="more_menu_button_inbox">Inbox</string>
+    <string name="more_menu_button_inbox_description">Stay up-to-date</string>
+
+    <string name="more_menu_button_store">View Store</string>
+    <string name="more_menu_button_store_description">View your store</string>
+
+    <string name="more_menu_button_coupons">Coupons</string>
+    <string name="more_menu_button_coupons_description">Boost sales with special offers</string>
+
+    <string name="more_menu_button_reviews">Reviews</string>
+    <string name="more_menu_button_reviews_description">Capture reviews for your store</string>
+
+    <string name="more_menu_button_upgrades">Upgrades</string>
+    <string name="more_menu_button_upgrades_description">Manage your plans</string>
+
+    <string name="more_menu_button_settings">Settings</string>
+    <string name="more_menu_button_settings_description">Update your preferences</string>
 
 </resources>


### PR DESCRIPTION
This PR merges the changes from the 13.2 code freeze into `trunk`. Includes: 
- Version bump
- Updated release notes
- Frozen app strings
- Bumped FluxC from a `trunk` hash to the stable `2.25.0`