### PR TITLE
[UI Tests] Update `Reviews` UI test to account for redesigned Hub Menu.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
 import com.woocommerce.android.e2e.screens.mystore.settings.SettingsScreen
@@ -18,7 +19,9 @@ class MoreMenuScreen : Screen(MORE_MENU_VIEW) {
     fun openReviewsListScreen(composeTestRule: ComposeTestRule): ReviewsListScreen {
         composeTestRule.onNodeWithText(
             getTranslatedString(R.string.more_menu_button_reviews)
-        ).performClick()
+        )
+            .performScrollTo()
+            .performClick()
         return ReviewsListScreen()
     }
 


### PR DESCRIPTION
### Description
This test adds a `scrollTo` before tapping `Reviews` menu item. This is needed after recent hub redesign menu (e.g. #8808). After the redesign, `e2eReviewListShowsAllReviews` started failing because `Reviews` menu item was not visible on screen:

<img width="467" alt="Screenshot 2023-04-17 at 11 38 13" src="https://user-images.githubusercontent.com/73365754/232432490-38838f51-ae25-4ecd-b947-07e48934be39.png">


### Testing instructions
- All tests pass on CI.