### PR TITLE
[TTP] Specific tap to pay trial payment customer note

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -67,7 +67,10 @@ class OrderCreateEditRepository @Inject constructor(
         }
     }
 
-    suspend fun createSimplePaymentOrder(currentPrice: BigDecimal): Result<Order> {
+    suspend fun createSimplePaymentOrder(
+        currentPrice: BigDecimal,
+        customerNote: String? = null,
+    ): Result<Order> {
         val status = if (isAutoDraftSupported()) {
             WCOrderStatusModel(statusKey = AUTO_DRAFT)
         } else {
@@ -78,7 +81,8 @@ class OrderCreateEditRepository @Inject constructor(
             site = selectedSite.get(),
             amount = currentPrice.toString(),
             isTaxable = true,
-            status = status
+            status = status,
+            customerNote = customerNote
         )
 
         return when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragmentViewModel.kt
@@ -71,13 +71,15 @@ class SimplePaymentsFragmentViewModel @Inject constructor(
                 chargeTaxes = true,
                 orderSubtotal = feeLineTotal,
                 orderTaxes = order.taxLines,
-                orderTotal = order.total
+                orderTotal = order.total,
+                customerNote = order.customerNote,
             )
         } else {
             viewState.copy(
                 chargeTaxes = false,
                 orderSubtotal = feeLineTotal,
-                orderTotal = feeLineTotal
+                orderTotal = feeLineTotal,
+                customerNote = order.customerNote,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -21,6 +22,7 @@ import javax.inject.Inject
 class TapToPaySummaryViewModel @Inject constructor(
     private val orderCreateEditRepository: OrderCreateEditRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val resourceProvider: ResourceProvider,
     savedStateHandle: SavedStateHandle,
 ) : ScopedViewModel(savedStateHandle) {
     private val _viewState = MutableLiveData(UiState())
@@ -34,7 +36,10 @@ class TapToPaySummaryViewModel @Inject constructor(
         analyticsTrackerWrapper.track(AnalyticsEvent.TAP_TO_PAY_SUMMARY_TRY_PAYMENT_TAPPED)
         launch {
             _viewState.value = UiState(isProgressVisible = true)
-            val result = orderCreateEditRepository.createSimplePaymentOrder(TEST_ORDER_AMOUNT)
+            val result = orderCreateEditRepository.createSimplePaymentOrder(
+                TEST_ORDER_AMOUNT,
+                customerNote = resourceProvider.getString(R.string.card_reader_tap_to_pay_test_payment_note)
+            )
             result.fold(
                 onSuccess = {
                     triggerEvent(StartTryPaymentFlow(it))

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1176,6 +1176,7 @@
     <string name="card_reader_tap_to_pay_explanation_test_payment_error">Something went wrong. Please try again later.</string>
     <string name="card_reader_tap_to_pay_beta_features_heading">Tap To Pay</string>
     <string name="card_reader_tap_to_pay_beta_features_subheading">Test out Tap To Pay in the app</string>
+    <string name="card_reader_tap_to_pay_test_payment_note">Tap To Pay Test Payment</string>
 
     <!--
             Card Reader Type Selection

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -53,7 +53,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
 
         orderUpdateStore = mock {
             onBlocking {
-                createSimplePayment(eq(defaultSiteModel), eq("1"), eq(true), eq(null))
+                createSimplePayment(eq(defaultSiteModel), eq("1"), eq(true), eq(null), eq(null))
             } doReturn WooResult(
                 WooError(WooErrorType.API_ERROR, BaseRequest.GenericErrorType.NETWORK_ERROR, DEFAULT_ERROR_MESSAGE)
             )
@@ -82,6 +82,26 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_AMOUNT,
                 AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FLOW
             )
+        )
+    }
+
+    @Test
+    fun `given simple payment order with note, when created, then note is passed`() = testBlocking {
+        // GIVEN
+        val note = "note"
+        whenever(
+            orderUpdateStore.createSimplePayment(
+                eq(defaultSiteModel), eq("1"), eq(true), eq(null), eq(note)
+            )
+        )
+            .thenReturn(WooResult(OrderTestUtils.generateOrder()))
+
+        // WHEN
+        sut.createSimplePaymentOrder(BigDecimal.ONE, note)
+
+        // THEN
+        verify(orderUpdateStore).createSimplePayment(
+            eq(defaultSiteModel), eq("1"), eq(true), eq(null), eq(note)
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -24,17 +25,26 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
 
     private val orderCreateEditRepository: OrderCreateEditRepository = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(R.string.card_reader_tap_to_pay_test_payment_note) }.thenReturn("Test payment")
+    }
 
     private val viewModel = TapToPaySummaryViewModel(
         orderCreateEditRepository,
         analyticsTrackerWrapper,
+        resourceProvider,
         savedStateHandle
     )
 
     @Test
     fun `give order creation error, when onTryPaymentClicked, then show snackbar`() = testBlocking {
         // GIVEN
-        whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
+        whenever(
+            orderCreateEditRepository.createSimplePaymentOrder(
+                BigDecimal.valueOf(0.5),
+                customerNote = "Test payment"
+            )
+        ).thenReturn(
             Result.failure(Exception())
         )
 
@@ -52,7 +62,12 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             val order = mock<Order>()
-            whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
+            whenever(
+                orderCreateEditRepository.createSimplePaymentOrder(
+                    BigDecimal.valueOf(0.5),
+                    customerNote = "Test payment"
+                )
+            ).thenReturn(
                 Result.success(order)
             )
 
@@ -66,7 +81,12 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
     @Test
     fun `when onTryPaymentClicked, then progress is shown and then hidden`() = testBlocking {
         // GIVEN
-        whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
+        whenever(
+            orderCreateEditRepository.createSimplePaymentOrder(
+                BigDecimal.valueOf(0.5),
+                customerNote = "Test payment"
+            )
+        ).thenReturn(
             Result.failure(Exception())
         )
 
@@ -84,7 +104,12 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
     @Test
     fun `when onTryPaymentClicked, then ttp try payment tracked`() = testBlocking {
         // GIVEN
-        whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
+        whenever(
+            orderCreateEditRepository.createSimplePaymentOrder(
+                BigDecimal.valueOf(0.5),
+                customerNote = "Test payment"
+            )
+        ).thenReturn(
             Result.failure(Exception())
         )
 
@@ -100,7 +125,12 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
     @Test
     fun `given error creating order, when onTryPaymentClicked, then card reader failed tracked`() = testBlocking {
         // GIVEN
-        whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
+        whenever(
+            orderCreateEditRepository.createSimplePaymentOrder(
+                BigDecimal.valueOf(0.5),
+                customerNote = "Test payment"
+            )
+        ).thenReturn(
             Result.failure(Exception())
         )
 

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2717-2e0be3475aa17a62447e55185d8faf817e07c69f'
+    fluxCVersion = 'trunk-0d8e5bcb71b6baa81847b98cafb54fc09b82d9be'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.25.0'
+    fluxCVersion = '2717-2e0be3475aa17a62447e55185d8faf817e07c69f'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8497 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To make orders that are created as test TTP payments recognisable, we add a customer note that states it

Do not merge before https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2717 is merged and the hash is changed

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Go to payments (don't forget to enable beta TTP feature before
* Click "test your TPP"
* Notice a customer not

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/232765530-b4df5ba1-dab2-4c0a-b5c9-8ecfa97a3412.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
