### PR TITLE
Mark "Launch Store" onboarding task as complete when site is public

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
 import com.woocommerce.android.e2e.screens.mystore.settings.SettingsScreen
@@ -18,7 +19,9 @@ class MoreMenuScreen : Screen(MORE_MENU_VIEW) {
     fun openReviewsListScreen(composeTestRule: ComposeTestRule): ReviewsListScreen {
         composeTestRule.onNodeWithText(
             getTranslatedString(R.string.more_menu_button_reviews)
-        ).performClick()
+        )
+            .performScrollTo()
+            .performClick()
         return ReviewsListScreen()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -38,6 +38,7 @@ class StoreOnboardingRepository @Inject constructor(
         return when {
             result.isError ->
                 WooLog.i(WooLog.T.ONBOARDING, "Error fetching onboarding tasks: ${result.error}")
+
             else -> {
                 WooLog.d(WooLog.T.ONBOARDING, "Success fetching onboarding tasks")
                 val mobileSupportedTasks = result.model?.map { it.toOnboardingTask() }
@@ -57,6 +58,10 @@ class StoreOnboardingRepository @Inject constructor(
                                 )
                             )
                         }
+                    }
+                    ?.map {
+                        if (shouldMarkLaunchStoreAsCompleted(it)) it.copy(isComplete = true)
+                        else it
                     }
                     ?.sortedBy { it.type.order }
                     ?: emptyList()
@@ -80,6 +85,9 @@ class StoreOnboardingRepository @Inject constructor(
         }
     }
 
+    private fun shouldMarkLaunchStoreAsCompleted(task: OnboardingTask) =
+        task.type == LAUNCH_YOUR_STORE && selectedSite.get().isVisible && !selectedSite.get().isFreeTrial
+
     fun isOnboardingCompleted(): Boolean =
         appPrefsWrapper.isOnboardingCompleted(selectedSite.getSelectedSiteId())
 
@@ -98,6 +106,7 @@ class StoreOnboardingRepository @Inject constructor(
                     }
                 )
             }
+
             else -> {
                 WooLog.d(WooLog.T.ONBOARDING, "Site launched successfully")
                 Success


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Workaround for backend issue #8846
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Full context of the problem provided in the [issue description](https://github.com/woocommerce/woocommerce-android/issues/8846)

The workaround consists of overriding the returned value `isCompleted` when fetching onboarding tasks for "Launch your store" task if the following conditions are satisfied: 
- Site's visibility is set to `true` for the field `"visible": true,` 
- Site is not free trial. Free trial sites have `"visible": true,` from the moment they are created, but we know for a fact that they are not launched. So if the sites are on free trial we will not override the `isCompleted` 


### Testing instructions

**Scenario 1 Simple site already public.**

1. Create a site `public`. To do that trigger a POST request to https://public-api.wordpress.com/rest/v1.1/sites/new endpoint setting the field "public": 1, (1 = public). If you have any trouble with this step I can invite you to a site that is already experiencing the inconsistent state. 
2. Upgrade the site to the eCommerce plan
3. Check the "Launch store" task is displayed as completed in the onboarding list. 

<img width="300"  src="https://user-images.githubusercontent.com/2663464/232797599-6036ee0f-7aa4-4db9-9c45-a95dcea092b4.png"> 

**Scenario 2 Brand new free trial site**

1. Create a free trial site from the mobile app by following store creation flow.
2. Check "Launch Store" task is pending. 

<img width="300"  src="https://user-images.githubusercontent.com/2663464/232797531-7f120717-db70-4f11-86b5-9d6af79bc5e0.png"> 


