### PR TITLE
feat: remove WooExpress prefix from upgrades

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModel.kt
@@ -135,6 +135,7 @@ class UpgradesViewModel @Inject constructor(
 
     private val SitePlan.prettifiedName
         get() = name.removePrefix("WordPress.com ")
+            .removePrefix("Woo Express: ")
 
     sealed interface UpgradesViewState {
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8838
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes "Woo Express" prefix from the Upgrades screen plan name.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not needed

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | Now |
|--------|--------|
| <img width="566" alt="Screenshot 2023-04-18 at 18 14 34" src="https://user-images.githubusercontent.com/5845095/232845176-68fbf652-6b29-4ac8-b5ea-97c0570a4a07.png"> | <img width="566" alt="Screenshot 2023-04-18 at 18 36 37" src="https://user-images.githubusercontent.com/5845095/232845217-50e6e03f-c2ce-4a57-870a-76ab1738198b.png"> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
