### PR TITLE
[TTP] Add successful refund notification after TTP test payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
@@ -108,7 +108,7 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                 is NavigateToTapTooPaySummaryScreen -> {
                     findNavController().navigate(
                         CardReaderHubFragmentDirections.actionCardReaderHubFragmentToTapToPaySummaryFragment(
-                            TapToPaySummaryFragment.TestTapToPayFlow.Initial
+                            TapToPaySummaryFragment.TestTapToPayFlow.BeforePayment
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.payments.cardreader.hub.CardReaderHubViewModel
 import com.woocommerce.android.ui.payments.cardreader.hub.CardReaderHubViewModel.CardReaderHubEvents.NavigateToTapTooPaySurveyScreen
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams
+import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
 import dagger.hilt.android.AndroidEntryPoint
@@ -106,7 +107,9 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                 }
                 is NavigateToTapTooPaySummaryScreen -> {
                     findNavController().navigate(
-                        CardReaderHubFragmentDirections.actionCardReaderHubFragmentToTapToPaySummaryFragment()
+                        CardReaderHubFragmentDirections.actionCardReaderHubFragmentToTapToPaySummaryFragment(
+                            TapToPaySummaryFragment.TestTapToPayFlow.Initial
+                        )
                     )
                 }
                 is NavigateToTapTooPaySurveyScreen -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectD
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentDialogFragment
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewState.Loading
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewState.Success
+import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
@@ -192,10 +193,14 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                         )
                     findNavController().navigateSafely(action)
                 }
-                is NavigateToTapToPaySummary -> {
+                is NavigateToTapToPaySummaryOrderRefunded -> {
                     findNavController().navigateSafely(
                         SelectPaymentMethodFragmentDirections
-                            .actionSelectPaymentMethodFragmentToTapToPaySummaryFragment()
+                            .actionSelectPaymentMethodFragmentToTapToPaySummaryFragment(
+                                TapToPaySummaryFragment.TestTapToPayFlow.OrderRefunded(
+                                    orderId = event.orderId
+                                )
+                            )
                     )
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -193,12 +193,12 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                         )
                     findNavController().navigateSafely(action)
                 }
-                is NavigateToTapToPaySummaryOrderRefunded -> {
+                is NavigateToTapToPaySummary -> {
                     findNavController().navigateSafely(
                         SelectPaymentMethodFragmentDirections
                             .actionSelectPaymentMethodFragmentToTapToPaySummaryFragment(
-                                TapToPaySummaryFragment.TestTapToPayFlow.OrderRefunded(
-                                    orderId = event.orderId
+                                TapToPaySummaryFragment.TestTapToPayFlow.AfterPayment(
+                                    order = event.order
                                 )
                             )
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -337,7 +337,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
                     triggerEvent(
                         when (autoRefundIfTestTapToPayPayment()) {
                             TPPTestingPaymentRefundResult.SUCCESS -> {
-                                NavigateToTapToPaySummary
+                                NavigateToTapToPaySummaryOrderRefunded(cardReaderPaymentFlowParam.orderId)
                             }
                             TPPTestingPaymentRefundResult.FAILED -> {
                                 NavigateToOrderDetails(cardReaderPaymentFlowParam.orderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SharePaymentUrl.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SharePaymentUrl.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments.methodselection
 
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -31,8 +32,8 @@ data class NavigateToOrderDetails(
     val orderId: Long
 ) : MultiLiveEvent.Event()
 
-data class NavigateToTapToPaySummaryOrderRefunded(
-    val orderId: Long
+data class NavigateToTapToPaySummary(
+    val order: Order
 ) : MultiLiveEvent.Event()
 
 object NavigateBackToOrderList : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SharePaymentUrl.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SharePaymentUrl.kt
@@ -31,7 +31,9 @@ data class NavigateToOrderDetails(
     val orderId: Long
 ) : MultiLiveEvent.Event()
 
-object NavigateToTapToPaySummary : MultiLiveEvent.Event()
+data class NavigateToTapToPaySummaryOrderRefunded(
+    val orderId: Long
+) : MultiLiveEvent.Event()
 
 object NavigateBackToOrderList : MultiLiveEvent.Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -86,7 +87,7 @@ class TapToPaySummaryFragment : BaseFragment() {
 
     sealed class TestTapToPayFlow : Parcelable {
         @Parcelize
-        data class OrderRefunded(val orderId: Long) : TestTapToPayFlow()
+        data class AfterPayment(val order: Order) : TestTapToPayFlow()
 
         @Parcelize
         object Initial : TestTapToPayFlow()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
@@ -90,6 +90,6 @@ class TapToPaySummaryFragment : BaseFragment() {
         data class AfterPayment(val order: Order) : TestTapToPayFlow()
 
         @Parcelize
-        object Initial : TestTapToPayFlow()
+        object BeforePayment : TestTapToPayFlow()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.payments.taptopay.summary
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,15 +9,20 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType
+import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryViewModel.NavigateToOrderDetails
+import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryViewModel.ShowSuccessfulRefundNotification
 import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryViewModel.StartTryPaymentFlow
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -41,7 +47,6 @@ class TapToPaySummaryFragment : BaseFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-
         setupObservers()
     }
 
@@ -50,6 +55,14 @@ class TapToPaySummaryFragment : BaseFragment() {
             when (event) {
                 is Exit -> findNavController().navigateUp()
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is ShowSuccessfulRefundNotification -> {
+                    Snackbar.make(
+                        requireView(),
+                        getString(event.message),
+                        BaseTransientBottomBar.LENGTH_LONG
+                    ).setAction(getString(event.actionLabel)) { event.action.invoke() }
+                        .show()
+                }
                 is StartTryPaymentFlow -> {
                     findNavController().navigate(
                         TapToPaySummaryFragmentDirections
@@ -59,8 +72,23 @@ class TapToPaySummaryFragment : BaseFragment() {
                             )
                     )
                 }
+                is NavigateToOrderDetails -> {
+                    findNavController().navigate(
+                        TapToPaySummaryFragmentDirections.actionTapToPaySummaryFragmentToOrderDetailFragment(
+                            event.orderId
+                        )
+                    )
+                }
                 else -> event.isHandled = false
             }
         }
+    }
+
+    sealed class TestTapToPayFlow : Parcelable {
+        @Parcelize
+        data class OrderRefunded(val orderId: Long) : TestTapToPayFlow()
+
+        @Parcelize
+        object Initial : TestTapToPayFlow()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -44,7 +44,7 @@ class TapToPaySummaryViewModel @Inject constructor(
 
     private fun handleFlowParam(flow: TapToPaySummaryFragment.TestTapToPayFlow) =
         when (flow) {
-            TapToPaySummaryFragment.TestTapToPayFlow.Initial -> {
+            TapToPaySummaryFragment.TestTapToPayFlow.BeforePayment -> {
                 // no-op
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments.taptopay.summary
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -7,11 +8,13 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
@@ -23,11 +26,22 @@ class TapToPaySummaryViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     savedStateHandle: SavedStateHandle,
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: TapToPaySummaryFragmentArgs by savedState.navArgs()
+
     private val _viewState = MutableLiveData(UiState())
     val viewState: LiveData<UiState> = _viewState
 
     init {
         analyticsTrackerWrapper.track(AnalyticsEvent.TAP_TO_PAY_SUMMARY_SHOWN)
+
+        when (val flow = navArgs.testTapToPayFlow) {
+            TapToPaySummaryFragment.TestTapToPayFlow.Initial -> {
+                // no-op
+            }
+            is TapToPaySummaryFragment.TestTapToPayFlow.OrderRefunded -> {
+                showSuccessfulRefundNotification(flow.orderId)
+            }
+        }.exhaustive
     }
 
     fun onTryPaymentClicked() {
@@ -58,11 +72,31 @@ class TapToPaySummaryViewModel @Inject constructor(
         triggerEvent(Event.Exit)
     }
 
+    private fun showSuccessfulRefundNotification(orderId: Long) {
+        triggerEvent(
+            ShowSuccessfulRefundNotification(
+                message = R.string.card_reader_tap_to_pay_successful_refund_message,
+                actionLabel = R.string.card_reader_tap_to_pay_successful_refund_action_label,
+                action = {
+                    triggerEvent(NavigateToOrderDetails(orderId))
+                }
+            )
+        )
+    }
+
     data class UiState(
         val isProgressVisible: Boolean = false
     )
 
     data class StartTryPaymentFlow(val order: Order) : Event()
+
+    data class NavigateToOrderDetails(val orderId: Long) : Event()
+
+    data class ShowSuccessfulRefundNotification(
+        @StringRes val message: Int,
+        @StringRes val actionLabel: Int,
+        val action: () -> Unit
+    ): Event()
 
     companion object {
         private val TEST_ORDER_AMOUNT = BigDecimal.valueOf(0.5)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -8,15 +8,17 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.WCRefundStore
 import java.math.BigDecimal
 import javax.inject.Inject
 
@@ -24,6 +26,9 @@ import javax.inject.Inject
 class TapToPaySummaryViewModel @Inject constructor(
     private val orderCreateEditRepository: OrderCreateEditRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val refundStore: WCRefundStore,
+    private val resourceProvider: ResourceProvider,
+    private val selectedSite: SelectedSite,
     savedStateHandle: SavedStateHandle,
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: TapToPaySummaryFragmentArgs by savedState.navArgs()
@@ -34,15 +39,25 @@ class TapToPaySummaryViewModel @Inject constructor(
     init {
         analyticsTrackerWrapper.track(AnalyticsEvent.TAP_TO_PAY_SUMMARY_SHOWN)
 
-        when (val flow = navArgs.testTapToPayFlow) {
+        handleFlowParam(navArgs.testTapToPayFlow)
+    }
+
+    private fun handleFlowParam(flow: TapToPaySummaryFragment.TestTapToPayFlow) =
+        when (flow) {
             TapToPaySummaryFragment.TestTapToPayFlow.Initial -> {
                 // no-op
             }
-            is TapToPaySummaryFragment.TestTapToPayFlow.OrderRefunded -> {
-                showSuccessfulRefundNotification(flow.orderId)
+
+            is TapToPaySummaryFragment.TestTapToPayFlow.AfterPayment -> {
+                launch {
+                    _viewState.value = UiState(isProgressVisible = true)
+                    triggerEvent(ShowSnackbar(R.string.card_reader_tap_to_pay_explanation_refunding_payment))
+                    autoRefundTestPayment(flow.order)
+                    _viewState.value = UiState(isProgressVisible = false)
+                }
+                Unit
             }
-        }.exhaustive
-    }
+        }
 
     fun onTryPaymentClicked() {
         analyticsTrackerWrapper.track(AnalyticsEvent.TAP_TO_PAY_SUMMARY_TRY_PAYMENT_TAPPED)
@@ -72,6 +87,23 @@ class TapToPaySummaryViewModel @Inject constructor(
         triggerEvent(Event.Exit)
     }
 
+    private suspend fun autoRefundTestPayment(order: Order) {
+        refundStore.createAmountRefund(
+            selectedSite.get(),
+            order.id,
+            order.total,
+            resourceProvider.getString(R.string.tap_to_pay_refund_reason),
+            true,
+        ).apply {
+            if (!isError) {
+                showSuccessfulRefundNotification(order.id)
+            } else {
+                triggerEvent(ShowSnackbar(R.string.card_reader_tap_to_pay_explanation_refund_failed))
+                triggerEvent(NavigateToOrderDetails(order.id))
+            }
+        }
+    }
+
     private fun showSuccessfulRefundNotification(orderId: Long) {
         triggerEvent(
             ShowSuccessfulRefundNotification(
@@ -96,7 +128,7 @@ class TapToPaySummaryViewModel @Inject constructor(
         @StringRes val message: Int,
         @StringRes val actionLabel: Int,
         val action: () -> Unit
-    ): Event()
+    ) : Event()
 
     companion object {
         private val TEST_ORDER_AMOUNT = BigDecimal.valueOf(0.5)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.payments.taptopay.summary
 
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -42,7 +43,8 @@ class TapToPaySummaryViewModel @Inject constructor(
         handleFlowParam(navArgs.testTapToPayFlow)
     }
 
-    private fun handleFlowParam(flow: TapToPaySummaryFragment.TestTapToPayFlow) =
+    @VisibleForTesting
+    internal fun handleFlowParam(flow: TapToPaySummaryFragment.TestTapToPayFlow) =
         when (flow) {
             TapToPaySummaryFragment.TestTapToPayFlow.BeforePayment -> {
                 // no-op

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -36,17 +36,18 @@
             app:popUpToInclusive="false" />
         <action
             android:id="@+id/action_selectPaymentMethodFragment_to_orderDetailFragment"
+            app:destination="@id/nav_graph_orders"
             app:popUpTo="@+id/tapToPaySummaryFragment"
-            app:popUpToInclusive="true"
-            app:destination="@id/nav_graph_orders">
+            app:popUpToInclusive="true">
             <argument
                 android:name="orderId"
                 app:argType="long" />
         </action>
         <action
             android:id="@+id/action_selectPaymentMethodFragment_to_tapToPaySummaryFragment"
+            app:destination="@id/tapToPaySummaryFragment"
             app:popUpTo="@+id/tapToPaySummaryFragment"
-            app:popUpToInclusive="false" />
+            app:popUpToInclusive="true" />
     </fragment>
 
     <!-- Onboarding flow -->
@@ -318,6 +319,18 @@
         <action
             android:id="@+id/action_tapToPaySummaryFragment_to_simplePaymentsFragment"
             app:destination="@+id/simplePaymentsFragment" />
+        <action
+            android:id="@+id/action_tapToPaySummaryFragment_to_orderDetailFragment"
+            app:destination="@id/nav_graph_orders">
+            <argument
+                android:name="orderId"
+                app:argType="long" />
+        </action>
+
+        <argument
+            android:name="testTapToPayFlow"
+            app:argType="com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryFragment$TestTapToPayFlow"
+            app:nullable="false" />
     </fragment>
 
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1176,6 +1176,8 @@
     <string name="card_reader_tap_to_pay_explanation_test_payment_error">Something went wrong. Please try again later.</string>
     <string name="card_reader_tap_to_pay_beta_features_heading">Tap To Pay</string>
     <string name="card_reader_tap_to_pay_beta_features_subheading">Test out Tap To Pay in the app</string>
+    <string name="card_reader_tap_to_pay_successful_refund_message">Test Tap To Pay payment was successfully refunded</string>
+    <string name="card_reader_tap_to_pay_successful_refund_action_label">View Order</string>
 
     <!--
             Card Reader Type Selection

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1170,7 +1170,7 @@
     <string name="card_reader_tap_to_pay_explanation_screen_title">Tap To Pay</string>
     <string name="card_reader_tap_to_pay_explanation_title">Collect card payments\nwith your phone</string>
     <string name="card_reader_tap_to_pay_explanation_ready">Your phone is ready for Tap to Pay.\nYour customer can tap their card\non your phone to pay.</string>
-    <string name="card_reader_tap_to_pay_explanation_try_and_refund">Try a payment using your card and\nrefund it when you’re done.</string>
+    <string name="card_reader_tap_to_pay_explanation_try_and_refund">Try a payment using your card and\nit will be refunded when you’re done.</string>
     <string name="card_reader_tap_to_pay_explanation_where_to_find"> You can find Tap to Pay on Android in\nMenu &gt; Payments, or Collect Payment and\nchoose Tap to Pay.</string>
     <string name="card_reader_tap_to_pay_explanation_try_payment">Try a payment</string>
     <string name="card_reader_tap_to_pay_explanation_test_payment_error">Something went wrong. Please try again later.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1174,6 +1174,8 @@
     <string name="card_reader_tap_to_pay_explanation_where_to_find"> You can find Tap to Pay on Android in\nMenu &gt; Payments, or Collect Payment and\nchoose Tap to Pay.</string>
     <string name="card_reader_tap_to_pay_explanation_try_payment">Try a payment</string>
     <string name="card_reader_tap_to_pay_explanation_test_payment_error">Something went wrong. Please try again later.</string>
+    <string name="card_reader_tap_to_pay_explanation_refunding_payment">Refunding test payment…</string>
+    <string name="card_reader_tap_to_pay_explanation_refund_failed">The refund failed. Try to refund manually</string>
     <string name="card_reader_tap_to_pay_beta_features_heading">Tap To Pay</string>
     <string name="card_reader_tap_to_pay_beta_features_subheading">Test out Tap To Pay in the app</string>
     <string name="card_reader_tap_to_pay_successful_refund_message">Test Tap To Pay payment was successfully refunded</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -28,7 +28,7 @@ import com.woocommerce.android.ui.payments.methodselection.NavigateToCardReaderH
 import com.woocommerce.android.ui.payments.methodselection.NavigateToCardReaderPaymentFlow
 import com.woocommerce.android.ui.payments.methodselection.NavigateToCardReaderRefundFlow
 import com.woocommerce.android.ui.payments.methodselection.NavigateToOrderDetails
-import com.woocommerce.android.ui.payments.methodselection.NavigateToTapToPaySummaryOrderRefunded
+import com.woocommerce.android.ui.payments.methodselection.NavigateToTapToPaySummary
 import com.woocommerce.android.ui.payments.methodselection.OpenGenericWebView
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodFragmentArgs
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewModel
@@ -642,7 +642,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
 
             // THEN
-            assertThat(viewModel.event.value).isEqualTo(NavigateToTapToPaySummaryOrderRefunded)
+            assertThat(viewModel.event.value).isEqualTo(NavigateToTapToPaySummary)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -28,7 +28,7 @@ import com.woocommerce.android.ui.payments.methodselection.NavigateToCardReaderH
 import com.woocommerce.android.ui.payments.methodselection.NavigateToCardReaderPaymentFlow
 import com.woocommerce.android.ui.payments.methodselection.NavigateToCardReaderRefundFlow
 import com.woocommerce.android.ui.payments.methodselection.NavigateToOrderDetails
-import com.woocommerce.android.ui.payments.methodselection.NavigateToTapToPaySummary
+import com.woocommerce.android.ui.payments.methodselection.NavigateToTapToPaySummaryOrderRefunded
 import com.woocommerce.android.ui.payments.methodselection.OpenGenericWebView
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodFragmentArgs
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewModel
@@ -642,7 +642,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
 
             // THEN
-            assertThat(viewModel.event.value).isEqualTo(NavigateToTapToPaySummary)
+            assertThat(viewModel.event.value).isEqualTo(NavigateToTapToPaySummaryOrderRefunded)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -205,6 +205,28 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given try ttp payment flow and autorefund success, when snack bar action clicked, then NavigateToOrderDetails event emitted`() =
+        testBlocking {
+            // GIVEN
+            whenever(
+                refundStore.createAmountRefund(
+                    selectedSite.get(),
+                    order.id,
+                    order.total,
+                    "Test Tap To Pay payment auto refund",
+                    true,
+                )
+            ).thenReturn(WooResult(mock<WCRefundModel>()))
+
+            // WHEN
+            val viewModel = initViewModel(TapToPaySummaryFragment.TestTapToPayFlow.AfterPayment(order))
+            ((viewModel.event.value as TapToPaySummaryViewModel.ShowSuccessfulRefundNotification).action).invoke()
+
+            // THEN
+            assertThat(viewModel.event.value).isEqualTo(TapToPaySummaryViewModel.NavigateToOrderDetails(1))
+        }
+
+    @Test
     fun `given after payment flow and autorefund fails, when vm created, then exit to order details`() =
         testBlocking {
             // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -1,35 +1,49 @@
 package com.woocommerce.android.ui.payments.taptopay.summary
 
-import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WCRefundStore
 import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TapToPaySummaryViewModelTest : BaseUnitTest() {
-    private val savedStateHandle: SavedStateHandle = SavedStateHandle()
-
+    private val order: Order = mock {
+        on { id }.thenReturn(1L)
+    }
+    private val site: SiteModel = mock {
+        on { name }.thenReturn("siteName")
+    }
     private val orderCreateEditRepository: OrderCreateEditRepository = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
-
-    private val viewModel = TapToPaySummaryViewModel(
-        orderCreateEditRepository,
-        analyticsTrackerWrapper,
-        savedStateHandle
-    )
+    private val refundStore: WCRefundStore = mock()
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(R.string.tap_to_pay_refund_reason) }.thenReturn("Test Tap To Pay payment auto refund")
+    }
+    private val selectedSite: SelectedSite = mock {
+        on { get() }.thenReturn(site)
+    }
 
     @Test
     fun `give order creation error, when onTryPaymentClicked, then show snackbar`() = testBlocking {
@@ -37,6 +51,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
             Result.failure(Exception())
         )
+        val viewModel = initViewModel()
 
         // WHEN
         viewModel.onTryPaymentClicked()
@@ -55,6 +70,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
             whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
                 Result.success(order)
             )
+            val viewModel = initViewModel()
 
             // WHEN
             viewModel.onTryPaymentClicked()
@@ -69,6 +85,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
             Result.failure(Exception())
         )
+        val viewModel = initViewModel()
 
         val states = viewModel.viewState.captureValues()
 
@@ -87,6 +104,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
             Result.failure(Exception())
         )
+        val viewModel = initViewModel()
 
         // WHEN
         viewModel.onTryPaymentClicked()
@@ -103,6 +121,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(orderCreateEditRepository.createSimplePaymentOrder(BigDecimal.valueOf(0.5))).thenReturn(
             Result.failure(Exception())
         )
+        val viewModel = initViewModel()
 
         // WHEN
         viewModel.onTryPaymentClicked()
@@ -119,6 +138,9 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when onBackClicked, then exit emitted`() {
+        // GIVEN
+        val viewModel = initViewModel()
+
         // WHEN
         viewModel.onBackClicked()
 
@@ -128,6 +150,70 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when view model started, then view shown tracked`() {
+        // WHEN
+        initViewModel()
+
+        // THEN
         verify(analyticsTrackerWrapper).track(AnalyticsEvent.TAP_TO_PAY_SUMMARY_SHOWN)
     }
+
+    @Test
+    fun `given try ttp payment flow and autorefund success, when vm created, then show success snack bar`() =
+        testBlocking {
+            // GIVEN
+            whenever(
+                refundStore.createAmountRefund(
+                    selectedSite.get(),
+                    order.id,
+                    order.total,
+                    "Test Tap To Pay payment auto refund",
+                    true,
+                )
+            ).thenReturn(WooResult(mock<WCRefundModel>()))
+
+            // WHEN
+            val viewModel = initViewModel(TapToPaySummaryFragment.TestTapToPayFlow.AfterPayment(order))
+
+            // THEN
+            val event = viewModel.event.value as TapToPaySummaryViewModel.ShowSuccessfulRefundNotification
+            assertThat(event.actionLabel).isEqualTo(R.string.card_reader_tap_to_pay_successful_refund_action_label)
+            assertThat(event.message).isEqualTo(R.string.card_reader_tap_to_pay_successful_refund_message)
+        }
+
+    @Test
+    fun `given after payment flow and autorefund fails, when vm created, then exit to order details`() =
+        testBlocking {
+            // GIVEN
+            whenever(
+                refundStore.createAmountRefund(
+                    selectedSite.get(),
+                    order.id,
+                    order.total,
+                    "Test Tap To Pay payment auto refund",
+                    true,
+                )
+            ).thenReturn(
+                WooResult(
+                    WooError(WooErrorType.API_ERROR, BaseRequest.GenericErrorType.NETWORK_ERROR)
+                )
+            )
+
+            // WHEN
+            val viewModel = initViewModel(TapToPaySummaryFragment.TestTapToPayFlow.AfterPayment(order))
+
+            // THEN
+            assertThat(viewModel.event.value).isEqualTo(TapToPaySummaryViewModel.NavigateToOrderDetails(1))
+        }
+
+    private fun initViewModel(
+        flow: TapToPaySummaryFragment.TestTapToPayFlow = TapToPaySummaryFragment.TestTapToPayFlow.BeforePayment
+    ) =
+        TapToPaySummaryViewModel(
+            orderCreateEditRepository,
+            analyticsTrackerWrapper,
+            refundStore,
+            resourceProvider,
+            selectedSite,
+            TapToPaySummaryFragmentArgs(flow).initSavedStateHandle()
+        )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -32,14 +32,13 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
     private val order: Order = mock {
         on { id }.thenReturn(1L)
     }
-    private val site: SiteModel = mock {
-        on { name }.thenReturn("siteName")
-    }
+    private val site: SiteModel = mock()
     private val orderCreateEditRepository: OrderCreateEditRepository = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val refundStore: WCRefundStore = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(R.string.tap_to_pay_refund_reason) }.thenReturn("Test Tap To Pay payment auto refund")
+        on { getString(R.string.card_reader_tap_to_pay_test_payment_note) }.thenReturn("Test payment")
     }
     private val selectedSite: SelectedSite = mock {
         on { get() }.thenReturn(site)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -205,6 +205,33 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given try ttp payment flow and autorefund success, when vm created, then UIState loading true and then false`() =
+        testBlocking {
+            // GIVEN
+            whenever(
+                refundStore.createAmountRefund(
+                    selectedSite.get(),
+                    order.id,
+                    order.total,
+                    "Test Tap To Pay payment auto refund",
+                    true,
+                )
+            ).thenAnswer {
+                WooResult(mock<WCRefundModel>())
+            }
+
+            // WHEN
+            val viewModel = initViewModel(TapToPaySummaryFragment.TestTapToPayFlow.AfterPayment(order))
+            val states = viewModel.viewState.captureValues()
+            viewModel.handleFlowParam(TapToPaySummaryFragment.TestTapToPayFlow.AfterPayment(order))
+
+            // THEN
+            assertThat(states[0].isProgressVisible).isFalse()
+            assertThat(states[1].isProgressVisible).isTrue()
+            assertThat(states[2].isProgressVisible).isFalse()
+        }
+
+    @Test
     fun `given try ttp payment flow and autorefund success, when snack bar action clicked, then NavigateToOrderDetails event emitted`() =
         testBlocking {
             // GIVEN


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8843
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds a snack bar with an action that indicates that the refund was done automatically.  A user can open the order details screen too

Also, it moves the refund code to the TTP summary screen and adds snack bar that indicates that refund is in progress

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Test the cases:
* Refund successful and navigate to the order details screen via snack bar action
* Refund not successful and then it opens order details automatically and notifies a user with snack bar (you may do this by modifying condition on `TapToPaySummaryViewModel::101`
* Notice that text on the TTP summary screen is changed to indicate that refund will be done automatically


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/233287865-dc7f9ab1-dede-4f8c-9dcc-4e13bca94842.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
