### PR TITLE
feat: animate show/hide of the Free Trial banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -91,6 +91,7 @@ import com.woocommerce.android.ui.products.ProductListFragmentDirections
 import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
+import com.woocommerce.android.util.WooAnimUtils.animateBottomBar
 import com.woocommerce.android.widgets.AppRatingDialog
 import com.woocommerce.android.widgets.DisabledAppBarLayoutBehavior
 import dagger.hilt.android.AndroidEntryPoint
@@ -742,14 +743,14 @@ class MainActivity :
         viewModel.trialStatusBarState.observe(this) { trialStatusBarState ->
             when (trialStatusBarState) {
                 TrialStatusBarState.Hidden ->
-                    binding.trialBar.visibility = View.GONE
+                    animateBottomBar(binding.trialBar, show = false)
                 is TrialStatusBarState.Visible -> {
                     binding.trialBar.text = trialStatusBarFormatterFactory.create(
                         context = this,
                         startUpgradeFlowFactory = startUpgradeFlowFactory.create(navController)
                     ).format(trialStatusBarState.daysLeft)
                     binding.trialBar.movementMethod = LinkMovementMethod.getInstance()
-                    binding.trialBar.visibility = View.VISIBLE
+                    animateBottomBar(binding.trialBar, show = true)
                 }
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8558
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds animation (the same as for "offline banner") of showing/hiding the Free Trial banner.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not needed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5845095/233113585-35a90f3f-a2d8-45e6-ad0e-826f725167f5.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
