### PR TITLE
Release composite products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 -----
 - [*] [Internal] Removed IPP upsell banner from the Payment Method Selection Screen. [https://github.com/woocommerce/woocommerce-android/pull/8815]
 - [*] Improves loading experience while users wait for their new store to be ready [https://github.com/woocommerce/woocommerce-android/pull/8799]
+- [*] Products: Adds read-only support for the Composite Products extension in the Products details. [https://github.com/woocommerce/woocommerce-android/pull/8818]
 
 13.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -47,12 +47,12 @@ enum class FeatureFlag {
             QUANTITY_RULES_READ_ONLY_SUPPORT,
             BUNDLED_PRODUCTS_READ_ONLY_SUPPORT,
             IPP_UK,
-            ANALYTICS_HUB_FEEDBACK_BANNER -> true
+            ANALYTICS_HUB_FEEDBACK_BANNER,
+            COMPOSITE_PRODUCTS_READ_ONLY_SUPPORT -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            IPP_TAP_TO_PAY,
-            COMPOSITE_PRODUCTS_READ_ONLY_SUPPORT -> PackageUtils.isDebugBuild()
+            IPP_TAP_TO_PAY -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION,
             STORE_CREATION_PROFILER -> false


### PR DESCRIPTION
### Description
This small PR enables the feature flag for composite products and updates the release notes.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
