### PR TITLE
Fix quantity rules detected issues

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_product_quantity_rules.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_quantity_rules.xml
@@ -30,7 +30,7 @@
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/min_quantity_title"
                         style="@style/Woo.Card.Title"
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:focusable="false"
                         android:text="@string/min_quantity"
@@ -39,7 +39,7 @@
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/min_quantity_value"
                         style="@style/Woo.Card.Body"
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/minor_100"
                         tools:text="2"
@@ -63,7 +63,7 @@
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/max_quantity_title"
                         style="@style/Woo.Card.Title"
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:focusable="false"
                         android:text="@string/max_quantity"
@@ -72,7 +72,7 @@
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/max_quantity_value"
                         style="@style/Woo.Card.Body"
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/minor_100"
                         android:focusable="false"
@@ -96,7 +96,7 @@
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/group_of_title"
                         style="@style/Woo.Card.Title"
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:focusable="false"
                         android:text="@string/group_of"
@@ -105,7 +105,7 @@
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/group_of_value"
                         style="@style/Woo.Card.Body"
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/minor_100"
                         android:focusable="false"

--- a/WooCommerce/src/main/res/layout/fragment_product_quantity_rules.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_quantity_rules.xml
@@ -17,68 +17,100 @@
             <androidx.appcompat.widget.LinearLayoutCompat
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:paddingBottom="@dimen/major_100">
+                android:orientation="vertical">
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/min_quantity_title"
-                    style="@style/Woo.Card.Title"
+                <androidx.appcompat.widget.LinearLayoutCompat
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/min_quantity"
-                    android:textStyle="bold" />
+                    android:focusable="true"
+                    android:orientation="vertical"
+                    android:screenReaderFocusable="true"
+                    tools:ignore="UnusedAttribute">
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/min_quantity_value"
-                    style="@style/Woo.Card.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    tools:text="2"
-                    tools:visibility="visible" />
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/min_quantity_title"
+                        style="@style/Woo.Card.Title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="false"
+                        android:text="@string/min_quantity"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/min_quantity_value"
+                        style="@style/Woo.Card.Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        tools:text="2"
+                        tools:visibility="visible" />
+                </androidx.appcompat.widget.LinearLayoutCompat>
 
                 <com.google.android.material.divider.MaterialDivider
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
                     android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginTop="@dimen/minor_100"
                     android:layout_marginEnd="@dimen/major_100" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/max_quantity_title"
-                    style="@style/Woo.Card.Title"
+                <androidx.appcompat.widget.LinearLayoutCompat
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/max_quantity"
-                    android:textStyle="bold" />
+                    android:focusable="true"
+                    android:orientation="vertical"
+                    android:screenReaderFocusable="true"
+                    tools:ignore="UnusedAttribute">
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/max_quantity_value"
-                    style="@style/Woo.Card.Body"
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/max_quantity_title"
+                        style="@style/Woo.Card.Title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="false"
+                        android:text="@string/max_quantity"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/max_quantity_value"
+                        style="@style/Woo.Card.Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:focusable="false"
+                        tools:text="24" />
+
+                    <com.google.android.material.divider.MaterialDivider
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginStart="@dimen/major_100"
+                        android:layout_marginEnd="@dimen/major_100" />
+                </androidx.appcompat.widget.LinearLayoutCompat>
+
+                <androidx.appcompat.widget.LinearLayoutCompat
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:text="24" />
+                    android:focusable="true"
+                    android:orientation="vertical"
+                    android:screenReaderFocusable="true"
+                    tools:ignore="UnusedAttribute">
 
-                <com.google.android.material.divider.MaterialDivider
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginTop="@dimen/minor_100"
-                    android:layout_marginEnd="@dimen/major_100" />
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/group_of_title"
+                        style="@style/Woo.Card.Title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="false"
+                        android:text="@string/group_of"
+                        android:textStyle="bold" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/group_of_title"
-                    style="@style/Woo.Card.Title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/group_of"
-                    android:textStyle="bold" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/group_of_value"
-                    style="@style/Woo.Card.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    tools:text="2" />
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/group_of_value"
+                        style="@style/Woo.Card.Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:focusable="false"
+                        tools:text="2" />
+                </androidx.appcompat.widget.LinearLayoutCompat>
             </androidx.appcompat.widget.LinearLayoutCompat>
 
         </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
Closes: #8856

### Description
This PR solves different issues detected while running the [Min/Max Quantity: Test Plan](pe5pgL-2Fj-p2):

1. Enhance the Talkback experience by grouping setting's title and value:

| Before | After |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/18119390/233209725-2811f6a2-16dc-41ee-ada7-884546d5a918.png" />  | <img width="300" src="https://user-images.githubusercontent.com/18119390/233218204-9ff7eeac-7a26-4966-a61d-fef2efa56677.png" />  |

Fixed in 231fc07a56565d6b86686c7ce9765851e0815825

2. Forcing RTL text don't align titles to the right

| Before | After |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/18119390/233212051-7bb9c725-091b-46bd-aaaa-ecaab348307a.png" />  | <img width="300" src="https://user-images.githubusercontent.com/18119390/233218467-5ce9b479-2f97-49b4-a299-1d97c89ce24d.png" />  |

Fixed in a686134a6460c3b228ce198eb2a362d35e50261e

### Testing instructions
TC1
1. Go to the device settings
2. Enable TalkBack
3. Get back to the Woo app
4. Open the products tab
5. Select a product containing quantity rules
6. Tap on the Quantity Rules row
7. Tap on one of the quantity rules settings
8. Check that the whole row is selected and that the setting's title and value are read together

TC2
TC1
1. Go to the device settings
2. Enable Force RTL layout direction
3. Get back to the Woo app
4. Open the products tab
5. Select a product containing quantity rules
6. Tap on the Quantity Rules row
7. Check that all the text in the screen is aligned to right
