### PR TITLE
View plan details upon request if plan expired

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/domain/SitePlan.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/domain/SitePlan.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import java.time.ZonedDateTime
 
 data class SitePlan(
+    val subscriptionId: String?,
     val name: String,
     val expirationDate: ZonedDateTime,
     val type: Type,
@@ -24,7 +25,7 @@ data class SitePlan(
     }
 
     companion object {
-        val EMPTY = SitePlan("", ZonedDateTime.now(), Type.OTHER)
+        val EMPTY = SitePlan("", "", ZonedDateTime.now(), Type.OTHER)
         const val WP_PREFIX = "WordPress.com"
         const val WOO_EXPRESS_PREFIX = "Woo Express:"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/networking/SitePlanRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/networking/SitePlanRestClient.kt
@@ -58,6 +58,7 @@ class SitePlanRestClient @Inject constructor(
                                     null
                                 } else {
                                     SitePlan(
+                                        subscriptionId = sitePlanDto.id,
                                         name = sitePlanDto.name,
                                         expirationDate = parseDateOrNull(sitePlanDto.expirationDate),
                                         type = determineSitePlanType(id)
@@ -92,6 +93,7 @@ class SitePlanRestClient @Inject constructor(
                                     null
                                 } else {
                                     SitePlan(
+                                        subscriptionId = sitePlanDto.id,
                                         name = sitePlanDto.name,
                                         expirationDate = parseDateOrNull(sitePlanDto.expirationDate),
                                         type = determineSitePlanType(id)
@@ -169,6 +171,7 @@ class SitePlanRestClient @Inject constructor(
     }
 
     data class SitePlanDto(
+        @SerializedName("id") val id: String?,
         @SerializedName("product_name") val name: String,
         @SerializedName("expiry") val expirationDate: String?,
         @SerializedName("current_plan") val currentPlan: Boolean?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
@@ -16,6 +17,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment
 import com.woocommerce.android.ui.login.storecreation.dispatcher.PlanUpgradeStartFragment.Companion.PLAN_UPGRADE_SUCCEED
 import com.woocommerce.android.ui.plans.di.StartUpgradeFlowFactory
+import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesEvent.OpenPlanDetails
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesEvent.OpenSubscribeNow
 import com.woocommerce.android.ui.upgrades.UpgradesViewModel.UpgradesEvent.OpenSupportRequestForm
 import dagger.hilt.android.AndroidEntryPoint
@@ -56,6 +58,13 @@ class UpgradesFragment : BaseFragment() {
                     )
                 }
                 is OpenSupportRequestForm -> startSupportRequestFormActivity(event)
+                is OpenPlanDetails -> {
+                    findNavController().navigate(
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                            urlToLoad = event.planDetailsUrl
+                        )
+                    )
+                }
             }
         }
         handleNotice(PLAN_UPGRADE_SUCCEED) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/upgrades/UpgradesScreen.kt
@@ -43,6 +43,7 @@ fun UpgradesScreen(viewModel: UpgradesViewModel) {
         state = upgradesState,
         onUpgradeNowClicked = viewModel::onSubscribeNowClicked,
         onReportSubscriptionIssueClicked = viewModel::onReportSubscriptionIssueClicked,
+        onViewPlanClicked = viewModel::onViewPlanClicked,
     )
 }
 
@@ -50,6 +51,7 @@ fun UpgradesScreen(viewModel: UpgradesViewModel) {
 fun UpgradesScreen(
     state: UpgradesViewState,
     onUpgradeNowClicked: () -> Unit,
+    onViewPlanClicked: () -> Unit,
     onReportSubscriptionIssueClicked: () -> Unit
 ) {
     Scaffold { paddingValues ->
@@ -85,7 +87,15 @@ fun UpgradesScreen(
                             Text(stringResource(R.string.upgrades_upgrade_now))
                         }
                     }
-
+                    if (state is PlanEnded) {
+                        Divider()
+                        WCOutlinedButton(
+                            onClick = onViewPlanClicked,
+                            modifier = Modifier.padding(vertical = 8.dp),
+                        ) {
+                            Text(stringResource(R.string.upgrades_view_plan))
+                        }
+                    }
                     if (state is Loading) {
                         SkeletonView(width = 132.dp, height = 24.dp)
                     } else if (state is Error) {
@@ -159,7 +169,7 @@ private fun TrialInProgress() {
         UpgradesScreen(
             state =
             TrialInProgress("Free Trial", Period.ofDays(14), "6 days"),
-            {}, {}
+            {}, {}, {}
         )
     }
 }
@@ -171,7 +181,7 @@ private fun TrialInProgress() {
 private fun TrialEnded() {
     WooThemeWithBackground {
         UpgradesScreen(
-            state = TrialEnded("Trial ended"), {}, {}
+            state = TrialEnded("Trial ended"), {}, {}, {}
         )
     }
 }
@@ -185,7 +195,7 @@ private fun NonUpgradeable() {
         UpgradesScreen(
             state =
             NonUpgradeable("eCommerce", "March 2, 2023"),
-            {}, {}
+            {}, {}, {}
         )
     }
 }
@@ -196,7 +206,7 @@ private fun NonUpgradeable() {
 @Composable
 private fun PlanEnded() {
     WooThemeWithBackground {
-        UpgradesScreen(state = PlanEnded("eCommerce ended"), {}, {})
+        UpgradesScreen(state = PlanEnded("eCommerce ended", "123"), {}, {}, {})
     }
 }
 
@@ -206,7 +216,7 @@ private fun PlanEnded() {
 @Composable
 private fun Loading() {
     WooThemeWithBackground {
-        UpgradesScreen(state = Loading, {}, {})
+        UpgradesScreen(state = Loading, {}, {}, {})
     }
 }
 
@@ -216,6 +226,6 @@ private fun Loading() {
 @Composable
 private fun Error() {
     WooThemeWithBackground {
-        UpgradesScreen(state = Error, {}, {})
+        UpgradesScreen(state = Error, {}, {}, {})
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3120,6 +3120,7 @@
     <string name="upgrades_current_plan_ended_caption">Your subscription has ended, and you have limited access to all the features.</string>
     <string name="upgrades_error_fetching_data">Error while fetching plan details</string>
     <string name="upgrades_plan_ended_name">%s ended</string>
+    <string name="upgrades_view_plan">View plan</string>
     <!--
     Subscription
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -54,6 +54,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
 
     private val planRepository: SitePlanRepository = mock {
         onBlocking { fetchCurrentPlanDetails(any()) } doReturn SitePlan(
+            subscriptionId = "",
             name = "",
             expirationDate = ZonedDateTime.now(),
             type = SitePlan.Type.FREE_TRIAL
@@ -200,6 +201,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         setup {
             whenever(planRepository.fetchCurrentPlanDetails(any())).thenReturn(
                 SitePlan(
+                    subscriptionId = "123",
                     name = "Test Plan",
                     expirationDate = ZonedDateTime.now(),
                     type = SitePlan.Type.FREE_TRIAL
@@ -220,6 +222,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         setup {
             whenever(planRepository.fetchCurrentPlanDetails(any())).thenReturn(
                 SitePlan(
+                    subscriptionId = "123",
                     name = "Test Plan",
                     expirationDate = ZonedDateTime.now(),
                     type = SitePlan.Type.OTHER
@@ -240,6 +243,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         setup {
             whenever(planRepository.fetchCurrentPlanDetails(any())).thenReturn(
                 SitePlan(
+                    subscriptionId = "123",
                     name = "WordPress.com Test Plan",
                     expirationDate = ZonedDateTime.now(),
                     type = SitePlan.Type.OTHER
@@ -260,6 +264,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         setup {
             whenever(planRepository.fetchCurrentPlanDetails(any())).thenReturn(
                 SitePlan(
+                    subscriptionId = "123",
                     name = "Woo Express: Test Plan",
                     expirationDate = ZonedDateTime.now(),
                     type = SitePlan.Type.OTHER

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
@@ -270,6 +270,32 @@ class UpgradesViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given current plan has ended, when user taps on view plan, navigate them to plan details`() = testBlocking {
+        // given
+        resourceProvider = mock {
+            on { getString(any(), any()) } doReturn ""
+        }
+        val siteModel = SiteModel().apply { siteId = 456 }
+        createSut(
+            siteModel,
+            type = SitePlan.Type.OTHER,
+            remainingTrialPeriod = Period.ZERO
+        )
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        sut.event.observeForever {
+            events.add(it)
+        }
+
+        // when
+        sut.onViewPlanClicked()
+
+        // then
+        assertThat(events).containsExactly(
+            UpgradesEvent.OpenPlanDetails("https://wordpress.com/purchases/subscriptions/456/123")
+        )
+    }
+
     private fun createSut(
         siteModel: SiteModel = SiteModel(),
         type: SitePlan.Type = SitePlan.Type.FREE_TRIAL,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/upgrades/UpgradesViewModelTest.kt
@@ -180,6 +180,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
             assertThat(viewModelState).isNotNull
             assertThat(viewModelState).isEqualTo(
                 PlanEnded(
+                    subscriptionId = "123",
                     name = "$TEST_SITE_NAME ended",
                 )
             )
@@ -275,6 +276,7 @@ class UpgradesViewModelTest : BaseUnitTest() {
         remainingTrialPeriod: Period = Period.ofDays(10)
     ) {
         val sitePlan = SitePlan(
+            subscriptionId = "123",
             name = "WordPress.com $TEST_SITE_NAME",
             expirationDate = SITE_PLAN_EXPIRATION_DATE,
             type = type


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8869
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds behaviour of opening WPCOM plan details is user has plan that expired and they tappen "view plan" button.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5845095/233673102-4c35b276-3eb0-4eda-9c8e-b180062d073f.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
