### PR TITLE
Free Trial: Fix More menu drop down arrow visibility issue

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -125,7 +125,8 @@ private fun MoreMenuHeader(
                 userAvatarUrl = state.userAvatarUrl,
                 siteName = state.siteName,
                 planName = state.sitePlan,
-                siteUrl = state.siteUrl
+                siteUrl = state.siteUrl,
+                modifier = Modifier.weight(1f, false)
             )
 
             if (state.isStoreSwitcherEnabled) {
@@ -180,12 +181,13 @@ private fun HeaderButton(
 
 @Composable
 private fun HeaderContent(
+    modifier: Modifier,
     userAvatarUrl: String,
     siteName: String,
     planName: String,
     siteUrl: String
 ) {
-    Row {
+    Row(modifier) {
         HeaderAvatar(
             modifier = Modifier.align(Alignment.CenterVertically),
             avatarUrl = userAvatarUrl


### PR DESCRIPTION
Summary
==========
Hotfix for the drop down arrow icon inside the More Menu header. Sometimes the arrow can become hidden if the header content is too large. This PR sets a weight for the header content to address this.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20230421_173022](https://user-images.githubusercontent.com/5920403/233730117-0b3c759d-f77b-4432-aaf0-51683c68b7a4.png) | ![Screenshot_20230421_172729](https://user-images.githubusercontent.com/5920403/233730126-3112f27c-a5b8-49c8-9c89-c1cc867c8bee.png) |

How to Test
==========
1. Forcefully set a long Store site name, absolute URL and site plan inside the `MoreMenuViewState`. Verify that for any text length, the drop down arrow is still visible.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
