### PR TITLE
Pop the back-stack before opening an order detail

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -1019,6 +1019,7 @@ class MainActivity :
         if (launchedFromNotification) {
             binding.bottomNav.currentPosition = ORDERS
             binding.bottomNav.active(ORDERS.position)
+            navController.popBackStack(R.id.orders, false)
         }
 
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderDetailFragment(orderId, remoteNoteId)


### PR DESCRIPTION
Fixes #7483. Previously, tapping on a new order notification didn't do anything if a user was already on the order detail screen. Now it shows the tapped order.

**To test**
1. Open details of any order
2. Create a new order in the store
3. Click on the received notification
4. See that detail of the new order is opened