### PR TITLE
Free Trial: Adjust Summary back button

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -81,8 +81,7 @@
             app:popUpTo="@id/nav_graph_store_creation" />
         <action
             android:id="@+id/action_countryPickerFragment_to_summaryFragment"
-            app:destination="@id/summaryFragment"
-            app:popUpTo="@id/nav_graph_store_creation" />
+            app:destination="@id/summaryFragment" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
Summary
==========
Fix issue #8878 by adjusting the back button behavior of the Free Trial Summary. 

Previously, tapping the back button in the Free Trial Summary view would bring the user back to the Store Picker. Still, since the Store Profiler was enabled back to the Store Creation, this may lead to data loss and an annoying reselection of all creation options.

The fix consists of relying on the store creation flow data retention to return to the previous view and allow the user to choose different Country and store profile options before creating the store without restarting the creation process.

Thanks @JorgeMucientes, for raising the issue!

Capture
==========
https://user-images.githubusercontent.com/5920403/234142351-889433d6-44e2-4e0a-b842-6c33ce898914.mp4


How to Test
==========
1. Start the Free Trial creation process. Select any option until you reach the Free Trial summary
2. Hit the back button and verify that the view returns to the previous one instead of jumping all the way back to the Store Picker

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.