### PR TITLE
Fix product list refreshing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onEmpty
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
@@ -129,7 +130,11 @@ class ProductSelectorViewModel @Inject constructor(
             filterState = filterState,
             searchQuery = searchQuery
         )
-    }.asLiveData()
+    }
+        .onEmpty {
+            fetchProducts(forceRefresh = true)
+        }
+        .asLiveData()
 
     init {
         monitorSearchQuery()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -96,7 +96,10 @@ class ProductSelectorViewModel @Inject constructor(
         products.filter { product ->
             productsRestrictions.map { restriction -> restriction(product) }.fold(true) { acc, result -> acc && result }
         }
+    }.onEmpty {
+        fetchProducts(forceRefresh = true)
     }
+
     private val popularProducts: MutableStateFlow<List<Product>> = MutableStateFlow(emptyList())
     private val recentProducts: MutableStateFlow<List<Product>> = MutableStateFlow(emptyList())
 
@@ -130,11 +133,7 @@ class ProductSelectorViewModel @Inject constructor(
             filterState = filterState,
             searchQuery = searchQuery
         )
-    }
-        .onEmpty {
-            fetchProducts(forceRefresh = true)
-        }
-        .asLiveData()
+    }.asLiveData()
 
     init {
         monitorSearchQuery()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -402,31 +402,6 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         )
     }
 
-    @Test
-    fun `given no published products in cache, when view model created, then should fetch products`() = testBlocking {
-        // given
-        val navArgs = ProductSelectorFragmentArgs(
-            selectedItems = emptyArray(),
-            restrictions = emptyArray(),
-            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-        ).initSavedStateHandle()
-        val popularOrdersList = generatePopularOrders()
-        val ordersList = generateTestOrders()
-        val totalOrders = ordersList + popularOrdersList
-        whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
-        whenever(listHandler.productsFlow).thenReturn(flowOf(emptyList()))
-
-        createViewModel(navArgs)
-
-        val argCaptor = argumentCaptor<Boolean>()
-        verify(listHandler).loadFromCacheAndFetch(
-            searchQuery = any(),
-            forceRefresh = argCaptor.capture(),
-            filters = any(),
-        )
-        assertThat(argCaptor.firstValue).isTrue()
-    }
-
     // region Sort by popularity and recently sold products
 
     @Test
@@ -1309,5 +1284,11 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             )
         }
         return ordersList
+    }
+
+    // private fun generateDraftProducts() generating list of products having draft status for testing
+
+    private fun generateDraftProducts(number: Int) = (0..number).map {
+        ProductTestUtils.generateProduct(customStatus = "draft")
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -402,6 +402,31 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given no published products in cache, when view model created, then should fetch products`() = testBlocking {
+        // given
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = emptyArray(),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+        ).initSavedStateHandle()
+        val popularOrdersList = generatePopularOrders()
+        val ordersList = generateTestOrders()
+        val totalOrders = ordersList + popularOrdersList
+        whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
+        whenever(listHandler.productsFlow).thenReturn(flowOf(emptyList()))
+
+        createViewModel(navArgs)
+
+        val argCaptor = argumentCaptor<Boolean>()
+        verify(listHandler).loadFromCacheAndFetch(
+            searchQuery = any(),
+            forceRefresh = argCaptor.capture(),
+            filters = any(),
+        )
+        assertThat(argCaptor.firstValue).isTrue()
+    }
+
     // region Sort by popularity and recently sold products
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Fix product list refreshing

**Closes**: #8833 
<!-- Id number of the GitHub issue this PR addresses. -->
**Problem**: In case there are many draft products (20+), e.g. when setting up a new store, and we fetch them into the local database - for example by opening the product selector screen, when we add a published product it's not visible immediately.

### Description
Re-fetching products in case no products are found in local storage.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Update all the products in the store to `status: draft` and open the product selector. Observe that no products are displayed.
2. Update the status of one product to `published`. Observe it gets fetched and displayed in the product selector.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
