### PR TITLE
Fix product attributes description

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Order.OrderStatus
@@ -123,8 +124,10 @@ data class Order(
         val attributesDescription
             get() = attributesList.filter {
                 it.value.isNotEmpty() && it.key.isNotEmpty()
-            }.joinToString {
-                it.value.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+            }.joinToString { attribute ->
+                attribute.value
+                    .fastStripHtml()
+                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
             }
 
         companion object {


### PR DESCRIPTION
Closes: #8394

### Why
While working on the Hosted Woo Extensions support, we noted that on some item attributes, the $ sign is replaced with its HTML-coded character set in the order item details.

### Description
This small PR fixes the format of attributes that contain html encoded characters.

### Testing instructions
Since we discovered this issue while testing gift cards, I recommend placing an order that contains a gift card and verifying that the attribute description is readable.

### Images/gif
| Before  | After |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/18119390/220964019-a0b98ae9-c433-401d-a82d-de13384afa88.png" />  | <img width="300" src="https://user-images.githubusercontent.com/18119390/234337321-4f0fe7bf-981b-4316-8f71-e8b8d2a3813f.png" />  |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
