### PR TITLE
Remove AD_ID permission from merged Manifest

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.ACTION_OPEN_DOCUMENT" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 
     <application
         android:name=".WooCommerce"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### This PR fixes issue with `com.google.android.gms.permission.ad_ID` being added to the merged `Manifest.XML`. 

The permission comes from the following dependencies:
<img width="555" alt="Screenshot 2023-04-25 at 18 28 06" src="https://user-images.githubusercontent.com/4527432/234343991-7491b207-915b-4cdb-9a50-e5bf9993ca21.png">

Context: p1682438964455599-slack-C6H8C3G23

### Testing instructions
Verify that the merged manifest doesn't contain the `ad_ID` permission.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->