### PR TITLE
Handle the case that a site might not be found

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -97,10 +97,14 @@ class WPApiSiteRepository @Inject constructor(
                 }
 
                 else -> {
-                    WooLog.d(WooLog.T.LOGIN, "Site $url fetch succeeded")
-                    getSiteByUrl(url)?.let { site ->
+                    val site = getSiteByUrl(url)
+                    if (site != null) {
+                        WooLog.d(WooLog.T.LOGIN, "Site $url fetch succeeded")
                         Result.success(site)
-                    } ?: Result.failure(IllegalArgumentException("Site not found: $url"))
+                    } else {
+                        WooLog.e(WooLog.T.LOGIN, "Site fetched but not found in DB: $url")
+                        Result.failure(IllegalArgumentException("Site fetched but not found in DB: $url"))
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -98,8 +98,9 @@ class WPApiSiteRepository @Inject constructor(
 
                 else -> {
                     WooLog.d(WooLog.T.LOGIN, "Site $url fetch succeeded")
-                    val site = getSiteByUrl(url)!!
-                    Result.success(site)
+                    getSiteByUrl(url)?.let { site ->
+                        Result.success(site)
+                    } ?: Result.failure(IllegalArgumentException("Site not found: $url"))
                 }
             }
         }


### PR DESCRIPTION
Fixes #8765, by null-checking the return value of `getSiteByUrl()` function. The exception then bubbles up and results in a failed login, but at least the app won't crash.