### PR TITLE
EU-bound Shipping Notice: Create EU shipping banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCreateShippingLabelBinding
 import com.woocommerce.android.databinding.ViewShippingLabelOrderPackagePriceBinding
 import com.woocommerce.android.databinding.ViewShippingLabelOrderSummaryBinding
+import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.isNotEqualTo
@@ -304,7 +305,14 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
     }
 
     private fun initializeViews(binding: FragmentCreateShippingLabelBinding) {
-        binding.shippingNoticeBanner.isVisible = FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()
+        if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()) {
+            with(binding.shippingNoticeBanner) {
+                isVisible = true
+                setDismissClickListener { collapse() }
+            }
+
+        }
+
 
         binding.originStep.continueButtonClickListener = {
             viewModel.onContinueButtonTapped(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -19,7 +19,12 @@ import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.model.*
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.CustomsPackage
+import com.woocommerce.android.model.PaymentMethod
+import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.model.ShippingRate
+import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.WooDialog
@@ -311,7 +316,6 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                 setDismissClickListener { collapse() }
             }
         }
-
 
         binding.originStep.continueButtonClickListener = {
             viewModel.onContinueButtonTapped(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -56,6 +56,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAd
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SUGGESTED_ADDRESS_DISCARDED
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
@@ -303,6 +304,8 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
     }
 
     private fun initializeViews(binding: FragmentCreateShippingLabelBinding) {
+        binding.shippingNoticeBanner.isVisible = FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()
+
         binding.originStep.continueButtonClickListener = {
             viewModel.onContinueButtonTapped(
                 ORIGIN_ADDRESS

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -310,7 +310,6 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                 isVisible = true
                 setDismissClickListener { collapse() }
             }
-
         }
 
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -21,6 +21,6 @@ class ShippingNoticeCard @JvmOverloads constructor(
 
     init {
         binding.dismissButton.setOnClickListener(onDismissClicked)
-        binding.ctaButton.setOnClickListener(onLearnMoreClicked)
+        binding.learnMoreButton.setOnClickListener(onLearnMoreClicked)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -1,0 +1,4 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
+
+class ShippingNoticeCard {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -1,4 +1,26 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 
-class ShippingNoticeCard {
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.databinding.ShippingNoticeBannerBinding
+
+class ShippingNoticeCard @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(context, attrs, defStyleAttr) {
+    private val binding = ShippingNoticeBannerBinding.inflate(
+        LayoutInflater.from(context), this, true
+    )
+
+    var onLearnMoreClicked: (View) -> Unit = {}
+    var onDismissClicked: (View) -> Unit = {}
+
+    init {
+        binding.dismissButton.setOnClickListener(onDismissClicked)
+        binding.ctaButton.setOnClickListener(onLearnMoreClicked)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -16,11 +16,11 @@ class ShippingNoticeCard @JvmOverloads constructor(
         LayoutInflater.from(context), this, true
     )
 
-    var onLearnMoreClicked: (View) -> Unit = {}
-    var onDismissClicked: (View) -> Unit = {}
+    fun setLearnMoreClickListener(action: (View) -> Unit) {
+        binding.learnMoreButton.setOnClickListener(action)
+    }
 
-    init {
-        binding.dismissButton.setOnClickListener(onDismissClicked)
-        binding.learnMoreButton.setOnClickListener(onLearnMoreClicked)
+    fun setDismissClickListener(action: (View) -> Unit) {
+        binding.dismissButton.setOnClickListener(action)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -55,7 +55,7 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             IPP_TAP_TO_PAY,
-            EU_SHIPPING_NOTIFICATION-> PackageUtils.isDebugBuild()
+            EU_SHIPPING_NOTIFICATION -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -26,7 +26,8 @@ enum class FeatureFlag {
     QUANTITY_RULES_READ_ONLY_SUPPORT,
     BUNDLED_PRODUCTS_READ_ONLY_SUPPORT,
     COMPOSITE_PRODUCTS_READ_ONLY_SUPPORT,
-    STORE_CREATION_PROFILER;
+    STORE_CREATION_PROFILER,
+    EU_SHIPPING_NOTIFICATION;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -53,7 +54,8 @@ enum class FeatureFlag {
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            IPP_TAP_TO_PAY -> PackageUtils.isDebugBuild()
+            IPP_TAP_TO_PAY,
+            EU_SHIPPING_NOTIFICATION-> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }

--- a/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
@@ -24,7 +24,8 @@
             android:id="@+id/shipping_notice_banner"
             style="@style/Woo.Card"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:visibility="gone"/>
 
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:id="@+id/steps_layout"

--- a/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
@@ -20,6 +20,11 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.woocommerce.android.ui.orders.shippinglabels.creation.banner.ShippingNoticeCard
+            style="@style/Woo.Card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:id="@+id/steps_layout"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
@@ -21,9 +21,10 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <com.woocommerce.android.ui.orders.shippinglabels.creation.banner.ShippingNoticeCard
+            android:id="@+id/shipping_notice_banner"
             style="@style/Woo.Card"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content" />
 
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:id="@+id/steps_layout"
@@ -105,6 +106,6 @@
             layout="@layout/view_shipping_label_order_summary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/major_100"/>
+            android:layout_marginBottom="@dimen/major_100" />
     </LinearLayout>
 </ScrollView>

--- a/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
+++ b/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
@@ -30,12 +30,12 @@
         android:textColor="@color/material_on_surface_emphasis_high_type"
         android:textSize="@dimen/text_minor_130"
         app:layout_constraintLeft_toRightOf="@+id/icon"
-        app:layout_constraintRight_toLeftOf="@+id/dismiss_button"
+        app:layout_constraintRight_toLeftOf="@+id/close_button"
         app:layout_constraintTop_toTopOf="@+id/icon"
         tools:text="@string/feedback_banner_ipp_title_beginner" />
 
     <androidx.appcompat.widget.AppCompatImageButton
-        android:id="@+id/dismiss_button"
+        android:id="@+id/close_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/major_75"
@@ -56,10 +56,10 @@
         android:textColor="@color/material_on_surface_emphasis_high_type"
         android:textSize="@dimen/text_minor_125"
         app:layout_constraintLeft_toRightOf="@+id/icon"
-        app:layout_constraintRight_toLeftOf="@+id/dismiss_button"
+        app:layout_constraintRight_toLeftOf="@+id/close_button"
         app:layout_constraintTop_toBottomOf="@+id/title"
         tools:ignore="RtlHardcoded"
-        tools:text="@string/feedback_banner_ipp_message_beginner" />
+        tools:text="@string/shipping_notice_banner_content" />
 
     <com.google.android.material.divider.MaterialDivider
         android:id="@+id/divider"
@@ -67,13 +67,31 @@
         android:layout_width="match_parent"
         app:layout_constraintTop_toBottomOf="@+id/message" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/cta_button"
-        style="@style/Woo.Card.Button"
+    <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/minor_00"
-        android:text="@string/feedback_banner_ipp_cta_button"
-        app:layout_constraintTop_toBottomOf="@+id/divider" />
+        android:orientation="horizontal"
+        android:layout_marginHorizontal="@dimen/major_100"
+        app:layout_constraintTop_toBottomOf="@+id/divider">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/learn_more_button"
+            style="@style/Woo.Card.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginTop="@dimen/minor_00"
+            android:text="@string/shipping_notice_learn_more" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/dismiss_button"
+            style="@style/Woo.Card.Button"
+            android:layout_weight="1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_00"
+            android:text="@string/shipping_notice_dismiss" />
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
+++ b/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
@@ -14,50 +14,27 @@
         android:id="@+id/icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_125"
-        android:paddingLeft="@dimen/minor_00"
-        android:paddingRight="@dimen/major_125"
-        android:src="@drawable/ic_feedback_banner_logo"
-        app:tint="@color/color_on_surface"
+        android:layout_marginTop="@dimen/major_125"
+        android:paddingHorizontal="@dimen/minor_100"
+        android:paddingTop="@dimen/minor_25"
+        android:src="@drawable/ic_tintable_info_outline_24dp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:tint="@color/color_secondary"
         tools:ignore="RtlHardcoded" />
-
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/title"
-        android:layout_width="@dimen/minor_00"
-        android:layout_height="wrap_content"
-        android:textColor="@color/material_on_surface_emphasis_high_type"
-        android:textSize="@dimen/text_minor_130"
-        app:layout_constraintLeft_toRightOf="@+id/icon"
-        app:layout_constraintRight_toLeftOf="@+id/close_button"
-        app:layout_constraintTop_toTopOf="@+id/icon"
-        tools:text="@string/feedback_banner_ipp_title_beginner" />
-
-    <androidx.appcompat.widget.AppCompatImageButton
-        android:id="@+id/close_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_75"
-        android:background="?selectableItemBackgroundBorderless"
-        android:padding="@dimen/minor_100"
-        android:src="@drawable/ic_feedback_banner_dismiss"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/message"
         android:layout_width="@dimen/minor_00"
         android:layout_height="wrap_content"
         android:paddingLeft="@dimen/minor_00"
-        android:paddingTop="@dimen/minor_100"
         android:paddingRight="@dimen/major_125"
         android:paddingBottom="@dimen/major_100"
         android:textColor="@color/material_on_surface_emphasis_high_type"
         android:textSize="@dimen/text_minor_125"
-        app:layout_constraintLeft_toRightOf="@+id/icon"
-        app:layout_constraintRight_toLeftOf="@+id/close_button"
-        app:layout_constraintTop_toBottomOf="@+id/title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/icon"
+        app:layout_constraintTop_toTopOf="@id/icon"
         tools:ignore="RtlHardcoded"
         tools:text="@string/shipping_notice_banner_content" />
 
@@ -70,8 +47,8 @@
     <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_marginHorizontal="@dimen/major_100"
+        android:orientation="horizontal"
         app:layout_constraintTop_toBottomOf="@+id/divider">
 
         <com.google.android.material.button.MaterialButton
@@ -79,18 +56,20 @@
             style="@style/Woo.Card.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:layout_marginTop="@dimen/minor_00"
-            android:text="@string/shipping_notice_learn_more" />
+            android:layout_weight="1"
+            android:text="@string/shipping_notice_learn_more"
+            android:textColor="@color/color_secondary" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/dismiss_button"
             style="@style/Woo.Card.Button"
-            android:layout_weight="1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/minor_00"
-            android:text="@string/shipping_notice_dismiss" />
+            android:layout_weight="1"
+            android:text="@string/shipping_notice_dismiss"
+            android:textColor="@color/color_secondary" />
 
     </androidx.appcompat.widget.LinearLayoutCompat>
 

--- a/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
+++ b/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
@@ -30,13 +30,13 @@
         android:paddingLeft="@dimen/minor_00"
         android:paddingRight="@dimen/major_125"
         android:paddingBottom="@dimen/major_100"
+        android:text="@string/shipping_notice_banner_content"
         android:textColor="@color/material_on_surface_emphasis_high_type"
         android:textSize="@dimen/text_minor_125"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/icon"
         app:layout_constraintTop_toTopOf="@id/icon"
-        tools:ignore="RtlHardcoded"
-        tools:text="@string/shipping_notice_banner_content" />
+        tools:ignore="RtlHardcoded" />
 
     <com.google.android.material.divider.MaterialDivider
         android:id="@+id/divider"

--- a/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
+++ b/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.divider.MaterialDivider
+        style="@style/Woo.Divider"
+        android:layout_width="match_parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_125"
+        android:paddingLeft="@dimen/minor_00"
+        android:paddingRight="@dimen/major_125"
+        android:src="@drawable/ic_feedback_banner_logo"
+        app:tint="@color/color_on_surface"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="RtlHardcoded" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/title"
+        android:layout_width="@dimen/minor_00"
+        android:layout_height="wrap_content"
+        android:textColor="@color/material_on_surface_emphasis_high_type"
+        android:textSize="@dimen/text_minor_130"
+        app:layout_constraintLeft_toRightOf="@+id/icon"
+        app:layout_constraintRight_toLeftOf="@+id/dismiss_button"
+        app:layout_constraintTop_toTopOf="@+id/icon"
+        tools:text="@string/feedback_banner_ipp_title_beginner" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/dismiss_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_75"
+        android:background="?selectableItemBackgroundBorderless"
+        android:padding="@dimen/minor_100"
+        android:src="@drawable/ic_feedback_banner_dismiss"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/message"
+        android:layout_width="@dimen/minor_00"
+        android:layout_height="wrap_content"
+        android:paddingLeft="@dimen/minor_00"
+        android:paddingTop="@dimen/minor_100"
+        android:paddingRight="@dimen/major_125"
+        android:paddingBottom="@dimen/major_100"
+        android:textColor="@color/material_on_surface_emphasis_high_type"
+        android:textSize="@dimen/text_minor_125"
+        app:layout_constraintLeft_toRightOf="@+id/icon"
+        app:layout_constraintRight_toLeftOf="@+id/dismiss_button"
+        app:layout_constraintTop_toBottomOf="@+id/title"
+        tools:ignore="RtlHardcoded"
+        tools:text="@string/feedback_banner_ipp_message_beginner" />
+
+    <com.google.android.material.divider.MaterialDivider
+        android:id="@+id/divider"
+        style="@style/Woo.Divider"
+        android:layout_width="match_parent"
+        app:layout_constraintTop_toBottomOf="@+id/message" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/cta_button"
+        style="@style/Woo.Card.Button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_00"
+        android:text="@string/feedback_banner_ipp_cta_button"
+        app:layout_constraintTop_toBottomOf="@+id/divider" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
+++ b/WooCommerce/src/main/res/layout/shipping_notice_banner.xml
@@ -27,8 +27,8 @@
         android:id="@+id/message"
         android:layout_width="@dimen/minor_00"
         android:layout_height="wrap_content"
-        android:paddingLeft="@dimen/minor_00"
-        android:paddingRight="@dimen/major_125"
+        android:paddingStart="@dimen/minor_00"
+        android:paddingEnd="@dimen/major_75"
         android:paddingBottom="@dimen/major_100"
         android:text="@string/shipping_notice_banner_content"
         android:textColor="@color/material_on_surface_emphasis_high_type"
@@ -38,36 +38,29 @@
         app:layout_constraintTop_toTopOf="@id/icon"
         tools:ignore="RtlHardcoded" />
 
-    <com.google.android.material.divider.MaterialDivider
-        android:id="@+id/divider"
-        style="@style/Woo.Divider"
-        android:layout_width="match_parent"
-        app:layout_constraintTop_toBottomOf="@+id/message" />
-
     <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
+        android:gravity="end"
         android:orientation="horizontal"
-        app:layout_constraintTop_toBottomOf="@+id/divider">
+        app:layout_constraintTop_toBottomOf="@+id/message">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/learn_more_button"
-            style="@style/Woo.Card.Button"
+            style="@style/Woo.Button.TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/minor_00"
-            android:layout_weight="1"
             android:text="@string/shipping_notice_learn_more"
             android:textColor="@color/color_secondary" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/dismiss_button"
-            style="@style/Woo.Card.Button"
+            style="@style/Woo.Button.TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/minor_00"
-            android:layout_weight="1"
+            android:layout_marginEnd="@dimen/major_75"
             android:text="@string/shipping_notice_dismiss"
             android:textColor="@color/color_secondary" />
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3246,7 +3246,7 @@
     <!--
     Eu-Bound Shipping notice banner
     -->
-    <string name="shipping_notice_banner_content">From now on, shipping to countries that follow European Union (EU) customs rules, you must provide a clear and specific description of every item. Otherwise, shipments may be delayed or interrupted at customs.</string>
+    <string name="shipping_notice_banner_content">When shipping to countries that follow European Union (EU) customs rules, you must provide a clear, specific description of every item. Otherwise, shipments may be delayed or interrupted at customs.</string>
     <string name="shipping_notice_learn_more">Learn More</string>
     <string name="shipping_notice_dismiss">Dismiss</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3242,4 +3242,11 @@
     <string name="component_default_option">Default option</string>
     <string name="component_type_products">Products</string>
     <string name="component_type_categories">Categories</string>
+
+    <!--
+    Eu-Bound Shipping notice banner
+    -->
+    <string name="shipping_notice_banner_content">From now on, shipping to countries that follow European Union (EU) customs rules, you must provide a clear and specific description of every item. Otherwise, shipments may be delayed or interrupted at customs.</string>
+    <string name="shipping_notice_learn_more">Learn More</string>
+    <string name="shipping_notice_dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
Summary
==========
Fix issues #8893 and #8887 by introducing the `EU_SHIPPING_NOTIFICATION` Feature Flag and the EU-bound shipping notice banner UI for usage in all shipping-related views. It also introduces the Banner to the `CreateShippingLabelFragment` view.

Since this PR only addresses the UI part, the `dismiss` button state is not persisted, the banner is always visible, and the `learn more` button does nothing. Those changes are available in https://github.com/woocommerce/woocommerce-android/pull/8918.

:warning: There's a difference between the design text and the actual one. Please refer to pecCkj-rP#comment-269 for more context.

Screenshots
==========
| Figma | Actual |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/5920403/234532466-dae23abe-3599-4cad-a2d1-fc184ef7a98c.png" width="270" height="570" /> | <img src="https://user-images.githubusercontent.com/5920403/235009656-2ad46276-3dde-46b8-bbea-e34118dc8f83.png" width="270" height="570" /> |


How to Test
==========
### Scenario 1
1. Open the app with a site containing the Shipping Labels plugin configured
2. Open the order details of an order with the `processing` status
3. Hit the `Create Shipping Label` button
4. Verify that the Banner is correctly displayed inside the view
5. Verify that hitting the dismiss button works and dismiss the banner with a collapse animation

### Scenario 2
1. Disable the `EU_SHIPPING_NOTIFICATION` flag inside the `FeatureFlag` class
2. Open the app with a site containing the Shipping Labels plugin configured
3. Open the order details of an order with the `processing` status
4. Hit the `Create Shipping Label` button
5. Verify that the Banner DOES NOT show up inside the view

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.