### PR TITLE
Order creation: Remove product status filter option

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.products.ProductStockStatus.Companion.fromString
 import com.woocommerce.android.ui.products.ProductType.OTHER
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorRestriction.OnlyPublishedProducts
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -248,7 +249,8 @@ class ProductFilterListViewModel @Inject constructor(
     }
 
     private fun buildFilterListItemUiModel(): List<FilterListItemUiModel> {
-        val filterListItems = mutableListOf(
+        val filterListItems = mutableListOf<FilterListItemUiModel>()
+        filterListItems.add(
             FilterListItemUiModel(
                 STOCK_STATUS,
                 resourceProvider.getString(string.product_stock_status),
@@ -262,32 +264,37 @@ class ProductFilterListViewModel @Inject constructor(
                     }.toMutableList(),
                     productFilterOptions[STOCK_STATUS].isNullOrEmpty()
                 )
-            ),
-            FilterListItemUiModel(
-                STATUS,
-                resourceProvider.getString(string.product_status),
-                addDefaultFilterOption(
-                    ProductStatus.values().map {
-                        FilterListOptionItemUiModel(
-                            resourceProvider.getString(it.stringResource),
-                            filterOptionItemValue = it.value,
-                            isSelected = productFilterOptions[STATUS] == it.value
-                        )
-                    }.toMutableList(),
-                    productFilterOptions[STATUS].isNullOrEmpty()
+            )
+        )
+        if (arguments.restrictions?.contains(OnlyPublishedProducts) == false) {
+            filterListItems.add(
+                FilterListItemUiModel(
+                    STATUS,
+                    resourceProvider.getString(string.product_status),
+                    addDefaultFilterOption(
+                        ProductStatus.values().map {
+                            FilterListOptionItemUiModel(
+                                resourceProvider.getString(it.stringResource),
+                                filterOptionItemValue = it.value,
+                                isSelected = productFilterOptions[STATUS] == it.value
+                            )
+                        }.toMutableList(),
+                        productFilterOptions[STATUS].isNullOrEmpty()
+                    )
                 )
-            ),
-            FilterListItemUiModel(
-                TYPE,
-                resourceProvider.getString(string.product_type),
-                addDefaultFilterOption(
-                    ProductType.values().filterNot { it == OTHER }.map {
-                        FilterListOptionItemUiModel(
-                            resourceProvider.getString(it.stringResource),
-                            filterOptionItemValue = it.value,
-                            isSelected = productFilterOptions[TYPE] == it.value
-                        )
-                    }.toMutableList(),
+            )
+        }
+        filterListItems.add(FilterListItemUiModel(
+            TYPE,
+            resourceProvider.getString(string.product_type),
+            addDefaultFilterOption(
+                ProductType.values().filterNot { it == OTHER }.map {
+                    FilterListOptionItemUiModel(
+                        resourceProvider.getString(it.stringResource),
+                        filterOptionItemValue = it.value,
+                        isSelected = productFilterOptions[TYPE] == it.value
+                    )
+                }.toMutableList(),
                     productFilterOptions[TYPE].isNullOrEmpty()
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -284,17 +284,18 @@ class ProductFilterListViewModel @Inject constructor(
                 )
             )
         }
-        filterListItems.add(FilterListItemUiModel(
-            TYPE,
-            resourceProvider.getString(string.product_type),
-            addDefaultFilterOption(
-                ProductType.values().filterNot { it == OTHER }.map {
-                    FilterListOptionItemUiModel(
-                        resourceProvider.getString(it.stringResource),
-                        filterOptionItemValue = it.value,
-                        isSelected = productFilterOptions[TYPE] == it.value
-                    )
-                }.toMutableList(),
+        filterListItems.add(
+            FilterListItemUiModel(
+                TYPE,
+                resourceProvider.getString(string.product_type),
+                addDefaultFilterOption(
+                    ProductType.values().filterNot { it == OTHER }.map {
+                        FilterListOptionItemUiModel(
+                            resourceProvider.getString(it.stringResource),
+                            filterOptionItemValue = it.value,
+                            isSelected = productFilterOptions[TYPE] == it.value
+                        )
+                    }.toMutableList(),
                     productFilterOptions[TYPE].isNullOrEmpty()
                 )
             )
@@ -411,7 +412,8 @@ class ProductFilterListViewModel @Inject constructor(
         var margin: Int = DEFAULT_FILTER_OPTION_MARGIN
     ) : Parcelable {
         companion object {
-            @DimenRes const val DEFAULT_FILTER_OPTION_MARGIN = 0
+            @DimenRes
+            const val DEFAULT_FILTER_OPTION_MARGIN = 0
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.models.QuantityRules
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorRestriction
 import com.woocommerce.android.ui.products.selector.ProductSourceForTracking
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility
 import com.woocommerce.android.ui.products.settings.ProductVisibility
@@ -128,7 +129,8 @@ sealed class ProductNavigationTarget : Event() {
         val productType: String?,
         val productStatus: String?,
         val productCategory: String?,
-        val productCategoryName: String?
+        val productCategoryName: String?,
+        val restrictions: List<ProductSelectorRestriction>
     ) : ProductNavigationTarget()
 
     data class ViewProductSubscription(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -381,7 +381,8 @@ class ProductNavigator @Inject constructor() {
                         target.productType,
                         target.productStatus,
                         target.productCategory,
-                        target.productCategoryName
+                        target.productCategoryName,
+                        target.restrictions.toTypedArray(),
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -159,7 +159,7 @@ class ProductSelectorViewModel @Inject constructor(
         productsList: List<Product>,
         selectedIds: List<SelectedItem>
     ): List<ProductListItem> {
-        if (searchQuery.value.isNotNullOrEmpty() || !filterState.value.filterOptions.isNullOrEmpty()) {
+        if (searchQuery.value.isNotNullOrEmpty() || filterState.value.filterOptions.isNotEmpty()) {
             return emptyList()
         }
         return productsList.map { it.toUiModel(selectedIds) }
@@ -335,7 +335,7 @@ class ProductSelectorViewModel @Inject constructor(
         triggerEvent(ExitWithResult(selectedItems.value))
     }
 
-    private fun isFilterActive() = !filterState.value.filterOptions.isNullOrEmpty()
+    private fun isFilterActive() = filterState.value.filterOptions.isNotEmpty()
 
     fun onSearchQueryChanged(query: String) {
         searchQuery.value = query

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -277,7 +277,8 @@ class ProductSelectorViewModel @Inject constructor(
                 filterState.value.filterOptions[ProductFilterOption.TYPE],
                 filterState.value.filterOptions[ProductFilterOption.STATUS],
                 filterState.value.filterOptions[ProductFilterOption.CATEGORY],
-                filterState.value.productCategoryName
+                filterState.value.productCategoryName,
+                productsRestrictions.toList()
             )
         )
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_filters.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_filters.xml
@@ -28,15 +28,19 @@
             android:name="selectedProductCategoryName"
             app:nullable="true"
             app:argType="string" />
-        <action
-            android:id="@+id/action_productFilterListFragment_to_productFilterOptionListFragment"
-            app:destination="@id/productFilterOptionListFragment">
-            <argument
-                android:name="selectedFilterItemPosition"
-                app:nullable="false"
-                app:argType="integer" />
-        </action>
+        <argument
+            android:name="restrictions"
+            app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$ProductSelectorRestriction[]"
+            app:nullable="true" />
     </fragment>
+    <action
+        android:id="@+id/action_productFilterListFragment_to_productFilterOptionListFragment"
+        app:destination="@id/productFilterOptionListFragment">
+        <argument
+            android:name="selectedFilterItemPosition"
+            app:nullable="false"
+            app:argType="integer" />
+    </action>
     <fragment
         android:id="@+id/productFilterOptionListFragment"
         android:name="com.woocommerce.android.ui.products.ProductFilterOptionListFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
@@ -60,6 +60,11 @@
                 android:name="selectedProductCategoryName"
                 app:argType="string"
                 app:nullable="true" />
+            <argument
+                android:name="restrictions"
+                app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$ProductSelectorRestriction[]"
+                app:nullable="true"
+                android:defaultValue="@null" />
         </action>
     </fragment>
     <include app:graph="@navigation/nav_graph_product_filters" />


### PR DESCRIPTION
Fixes #8683. The order creation flow has a restriction on the available products (`PUBLISHED` only), so it doesn't make sense to show the product status filter in the product selector.

![image](https://user-images.githubusercontent.com/1522856/234578620-02346397-a51c-461f-9dd6-f500146b7106.png)

**To test:**
1. Log in
2. Go to Orders
3. Tap on the + button to create a new order
4. Tap on the Add products button
5. Tap on Filters
6. Notice the Status option is gone