### PR TITLE
Feature/8791 sitepicker navigation improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import kotlinx.coroutines.delay
 
 @Composable
 fun StoreNamePickerScreen(viewModel: StoreNamePickerViewModel) {
@@ -121,7 +122,11 @@ private fun NamePickerForm(
         }
     }
     // Request focus on store name field when entering screen
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    LaunchedEffect(Unit) {
+        @Suppress("MagicNumber")
+        delay(timeMillis = 800)
+        focusRequester.requestFocus()
+    }
 }
 
 @ExperimentalFoundationApi

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import kotlinx.coroutines.delay
 
 @Composable
 fun StoreNamePickerScreen(viewModel: StoreNamePickerViewModel) {
@@ -122,11 +121,7 @@ private fun NamePickerForm(
         }
     }
     // Request focus on store name field when entering screen
-    LaunchedEffect(Unit) {
-        @Suppress("MagicNumber")
-        delay(timeMillis = 800)
-        focusRequester.requestFocus()
-    }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
 }
 
 @ExperimentalFoundationApi

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -135,16 +135,15 @@ class SitePickerViewModel @Inject constructor(
             if (sitesInDb.isNotEmpty()) {
                 displaySites(sitesInDb)
             }
-            fetchSitesFromApi(sitesInDb.isEmpty() || !loginSiteAddress.isNullOrEmpty())
+            fetchSitesFromApi(showSkeleton = sitesInDb.isEmpty() || !loginSiteAddress.isNullOrEmpty())
         }
     }
 
-    private suspend fun fetchSitesFromApi(showSkeleton: Boolean, delayTime: Long = 0) {
+    private suspend fun fetchSitesFromApi(showSkeleton: Boolean) {
         sitePickerViewState = sitePickerViewState.copy(
             isSkeletonViewVisible = showSkeleton
         )
 
-        delay(delayTime)
         val startTime = System.currentTimeMillis()
         val result = repository.fetchWooCommerceSites()
         val duration = System.currentTimeMillis() - startTime

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -254,7 +254,7 @@ class SitePickerViewModel @Inject constructor(
         }
         if (navArgs.openedFromLogin && wooSites.size == 1) {
             onSiteSelected(wooSites.first())
-            onContinueButtonClick(true)
+            onContinueButtonClick(isAutoLogin = true)
         }
     }
 
@@ -642,7 +642,7 @@ class SitePickerViewModel @Inject constructor(
     }
 
     private fun startStoreCreationFlow() {
-        appPrefsWrapper.markAsNewSignUp(false)
+        appPrefsWrapper.markAsNewSignUp(newSignUp = false)
         triggerEvent(NavigateToStoreCreationEvent)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -96,7 +96,7 @@ class SitePickerViewModel @Inject constructor(
         updateSiteViewDetails()
         loadAndDisplayUserInfo()
         loadAndDisplaySites()
-        if (appPrefsWrapper.getIsNewSignUp()) startStoreCreationWebFlow()
+        if (appPrefsWrapper.getIsNewSignUp()) startStoreCreationFlow()
         if (selectedSiteId.value == null && selectedSite.exists()) {
             selectedSiteId.value = selectedSite.getSelectedSiteId()
         }
@@ -623,7 +623,7 @@ class SitePickerViewModel @Inject constructor(
         fetchSitesFromApi(showSkeleton = true)
     }
 
-    private fun startStoreCreationWebFlow() {
+    private fun startStoreCreationFlow() {
         appPrefsWrapper.markAsNewSignUp(false)
         triggerEvent(NavigateToStoreCreationEvent)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -437,8 +437,11 @@ class SitePickerViewModel @Inject constructor(
 
     fun onRefreshButtonClick() {
         analyticsTrackerWrapper.track(AnalyticsEvent.SITE_PICKER_NOT_CONNECTED_JETPACK_REFRESH_APP_LINK_TAPPED)
-        sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = true)
-        launch { fetchSitesFromApi(showSkeleton = false) }
+        launch {
+            sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = true)
+            fetchSitesFromApi(showSkeleton = false)
+            sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
+        }
     }
 
     fun onNewToWooClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -435,15 +435,6 @@ class SitePickerViewModel @Inject constructor(
         triggerEvent(SitePickerEvent.NavigateToEmailHelpDialogEvent)
     }
 
-    fun onRefreshButtonClick() {
-        analyticsTrackerWrapper.track(AnalyticsEvent.SITE_PICKER_NOT_CONNECTED_JETPACK_REFRESH_APP_LINK_TAPPED)
-        launch {
-            sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = true)
-            fetchSitesFromApi(showSkeleton = false)
-            sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
-        }
-    }
-
     fun onNewToWooClick() {
         analyticsTrackerWrapper.track(AnalyticsEvent.SITE_PICKER_NEW_TO_WOO_TAPPED)
         triggerEvent(SitePickerEvent.NavigateToNewToWooEvent)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -201,7 +201,12 @@ class SitePickerViewModel @Inject constructor(
         }
 
         if (filteredSites.isEmpty()) {
-            loginSiteAddress?.let { showAccountMismatchScreen(it) } ?: loadNoStoreView()
+            if (loginSiteAddress != null) {
+                showAccountMismatchScreen(loginSiteAddress!!)
+            } else {
+                if (navArgs.openedFromLogin) startStoreCreationFlow()
+                loadNoStoreView()
+            }
             return
         }
 
@@ -261,13 +266,16 @@ class SitePickerViewModel @Inject constructor(
                 // The url doesn't match any sites for this account.
                 showAccountMismatchScreen(url)
             }
+
             site.isSimpleWPComSite -> {
                 loadSimpleWPComView(site)
             }
+
             !site.hasWooCommerce -> {
                 // Show not woo store message view.
                 loadWooNotFoundView(site)
             }
+
             else -> {
                 // We have a pre-validation woo store. Attempt to just
                 // login with this store directly.
@@ -498,6 +506,7 @@ class SitePickerViewModel @Inject constructor(
                                 }
                             )
                         }
+
                         else -> {
                             sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
                             triggerEvent(SitePickerEvent.ShowWooUpgradeDialogEvent)
@@ -519,6 +528,7 @@ class SitePickerViewModel @Inject constructor(
                 )
                 getJetpackTimeoutDialogEvent()
             }
+
             else -> ShowSnackbar(
                 message = string.login_verifying_site_error,
                 args = arrayOf(it.site.getSiteName())
@@ -571,11 +581,13 @@ class SitePickerViewModel @Inject constructor(
                     )
                     fetchSite(site, retries = retries + 1)
                 }
+
                 !updatedSite.hasWooCommerce -> {
                     // Force a retry if the woocommerce_is_active is not updated yet
                     WooLog.d(WooLog.T.SITE_PICKER, "Fetched site has woocommerce_is_active false, retry")
                     fetchSite(site, retries = retries + 1)
                 }
+
                 else -> {
                     WooLog.d(WooLog.T.SITE_PICKER, "Site fetched successfully")
                     result

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -248,7 +248,14 @@ class SitePickerViewModel @Inject constructor(
             isNoStoresViewVisible = false,
             currentSitePickerState = SitePickerState.StoreListState
         )
-        loginSiteAddress?.let { processLoginSiteAddress(it) }
+        loginSiteAddress?.let {
+            processLoginSiteAddress(it)
+            return
+        }
+        if (navArgs.openedFromLogin && wooSites.size == 1) {
+            onSiteSelected(wooSites.first())
+            onContinueButtonClick(true)
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -140,9 +140,7 @@ class SitePickerViewModel @Inject constructor(
     }
 
     private suspend fun fetchSitesFromApi(showSkeleton: Boolean) {
-        sitePickerViewState = sitePickerViewState.copy(
-            isSkeletonViewVisible = showSkeleton
-        )
+        sitePickerViewState = sitePickerViewState.copy(isSkeletonViewVisible = showSkeleton)
 
         val startTime = System.currentTimeMillis()
         val result = repository.fetchWooCommerceSites()
@@ -160,10 +158,7 @@ class SitePickerViewModel @Inject constructor(
                 onSitesLoaded(repository.getSites())
             }
         }
-        sitePickerViewState = sitePickerViewState.copy(
-            isSkeletonViewVisible = false,
-            isProgressDiaLogVisible = false
-        )
+        sitePickerViewState = sitePickerViewState.copy(isSkeletonViewVisible = false)
     }
 
     private suspend fun getSitesFromDb(): List<SiteModel> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -569,27 +569,6 @@ class SitePickerViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given user is logging in, when refresh button is clicked, refresh the screen`() =
-        testBlocking {
-            givenTheScreenIsFromLogin(true)
-            whenSitesAreFetched()
-            whenViewModelIsCreated()
-
-            val isProgressShown = ArrayList<Boolean>()
-            viewModel.sitePickerViewStateData.observeForever { old, new ->
-                new.isProgressDiaLogVisible.takeIfNotEqualTo(old?.isProgressDiaLogVisible) { isProgressShown.add(it) }
-            }
-
-            viewModel.onRefreshButtonClick()
-
-            verify(analyticsTrackerWrapper, times(1)).track(
-                AnalyticsEvent.SITE_PICKER_NOT_CONNECTED_JETPACK_REFRESH_APP_LINK_TAPPED
-            )
-            verify(repository, atLeastOnce()).fetchWooCommerceSites()
-            assertThat(isProgressShown).containsExactly(false, true, false)
-        }
-
-    @Test
     fun `given user is logging in, when new to woo clicked, then open browser with the docs`() = testBlocking {
         givenTheScreenIsFromLogin(true)
         whenViewModelIsCreated()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -273,6 +273,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
             )
             whenSitesAreFetched(returnsEmpty = true)
             whenViewModelIsCreated()
+            advanceUntilIdle()
 
             var sitePickerData: SitePickerViewModel.SitePickerViewState? = null
             viewModel.sitePickerViewStateData.observeForever { _, new -> sitePickerData = new }
@@ -347,10 +348,12 @@ class SitePickerViewModelTest : BaseUnitTest() {
             givenTheScreenIsFromLogin(calledFromLogin = true)
             givenThatSiteVerificationIsCompleted()
             whenSitesAreFetched(sitesFromDb = emptyList(), sitesFromApi = emptyList())
+            whenever(appPrefsWrapper.getIsNewSignUp()).thenReturn(false)
 
             whenViewModelIsCreated()
-            val sitePickerState = viewModel.sitePickerViewStateData.liveData.captureValues().last()
+            advanceUntilIdle()
             val event = viewModel.event.captureValues().last()
+            val sitePickerState = viewModel.sitePickerViewStateData.liveData.captureValues().last()
 
             assertThat(event).isEqualTo(NavigateToStoreCreationEvent)
             assertThat(sitePickerState.currentSitePickerState).isEqualTo(NoStoreState)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8791 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds small (but tricky) improvements to log in experience. Upon login with WordPress email: 
- If the user doesn't have any available store then trigger store creation flow right away
- If the user has only one store available then automatically select the available store and navigate to my store tab


Additionally it adds some smaller improvements I'll describe in the code changes. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create a new account clicking in "Get Started" button
2. Check store creation flow is triggered automatically
3. Kill the app
4. Re launch and check that store creation is launched again as you don't have any available stores yet. 
5. Navigate back
6. Click on "Log in with another account" 
10. Log in using WordPress email with an account that has just one store. 
11. Check that you are automatically taken to my store tab after log in. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
**New account**

https://user-images.githubusercontent.com/2663464/234593750-a7d61f68-6a84-4ce3-a647-b8fb3cfee3e3.mp4

**Account with no stores**

https://user-images.githubusercontent.com/2663464/234595211-415ab7ea-3b71-4fe2-854b-c0b68bac1cbb.mp4


**Account with a single store**

https://user-images.githubusercontent.com/2663464/234595252-673bb09f-5ea6-44e6-90ec-2c07e07e9a3b.mp4

