### PR TITLE
Update bottom nav selected tab color to primary color

### DIFF
--- a/WooCommerce/src/main/res/color/button_toggle_fg_selector.xml
+++ b/WooCommerce/src/main/res/color/button_toggle_fg_selector.xml
@@ -7,7 +7,7 @@
     <item
         android:state_checked="true"
         android:alpha="@dimen/alpha_emphasis_high"
-        android:color="@color/color_on_surface"/>
+        android:color="@color/color_primary"/>
     <item
         android:alpha="@dimen/alpha_emphasis_medium"
         android:color="@color/color_on_surface"/>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8898 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Updating the bottom nav color for selected tab. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Just log into the app and switch between light and dark mode.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
`woo_purple_60` for light mode

![Screenshot 2023-04-26 at 17 45 54](https://user-images.githubusercontent.com/2663464/234630167-c6bb8536-9026-44ff-9baf-ad17188ef054.png)


`woo_purple_30` for dark mode
![Screenshot 2023-04-26 at 17 46 06](https://user-images.githubusercontent.com/2663464/234630163-7e3603a5-18c3-4c5a-a0d9-e10440d187cd.png)

