### PR TITLE
Update Kotlin Version

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -380,6 +380,8 @@ fun MoreMenuBadge(badgeState: BadgeState?) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Spacer(modifier = Modifier.weight(1f))
+
+            @Suppress("RememberReturnType")
             val visible = remember {
                 MutableTransitionState(badgeState.animateAppearance.not()).apply { targetState = true }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -290,6 +290,7 @@ private fun PreviewProductCategorySelector() {
         )
     }
 
+    @Suppress("RememberReturnType")
     val categories = remember {
         (1L..10L).map {
             generateCategory(it, childrenDepth = it.coerceAtMost(4).toInt())

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
 
     // Compose and its module versions need to be consistent with each other (for example 'compose-theme-adapter')
     composeBOMVersion = "2022.12.00"
-    composeCompilerVersion = "1.3.2"
+    composeCompilerVersion = "1.4.4"
     composeAccompanistVersion = "0.23.1"
     composeThemeAdapterVersion = "1.1.17"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,8 @@
 pluginManagement {
     gradle.ext.agpVersion = '7.2.1'
-    gradle.ext.daggerVersion = '2.42'
+    gradle.ext.daggerVersion = '2.45'
     gradle.ext.detektVersion = '1.19.0'
-    gradle.ext.kotlinVersion = '1.7.20'
+    gradle.ext.kotlinVersion = '1.8.10'
     gradle.ext.navigationVersion = '2.5.3'
 
     repositories {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The latest version of Stripe requires kotlin 1.8.10. This PR brings this update so we can slightly reduce risk by updating it transitively

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
A general smoke test is required. It updates compose, so more attention to compose screens is nessasery

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
