### PR TITLE
Fix a product filter crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -266,7 +266,7 @@ class ProductFilterListViewModel @Inject constructor(
                 )
             )
         )
-        if (arguments.restrictions?.contains(OnlyPublishedProducts) == false) {
+        if (arguments.restrictions?.contains(OnlyPublishedProducts) != true) {
             filterListItems.add(
                 FilterListItemUiModel(
                     STATUS,

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -138,6 +138,11 @@
                 android:name="selectedProductCategoryName"
                 app:argType="string"
                 app:nullable="true" />
+            <argument
+                android:name="restrictions"
+                app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$ProductSelectorRestriction[]"
+                app:nullable="true"
+                android:defaultValue="@null" />
         </action>
         <action
             android:id="@+id/action_productListFragment_to_productTypesBottomSheet"


### PR DESCRIPTION
~copilot:summary~ 🤷 

Fixes a crash when user taps on the Filter button in Products.

**To test:**
1. Go to Product list
2. Tap on Filters
3. Notice the app opens the product filter options, which includes the `Status`