### PR TITLE
[TTP] Add new badge to TTP row

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewHolder.kt
@@ -27,6 +27,10 @@ abstract class CardReaderHubViewHolder(val parent: ViewGroup, @LayoutRes layout:
             binding.cardReaderHubListItemLabelTv.text = UiHelpers.getTextOfUiString(itemView.context, uiState.label)
             UiHelpers.setTextOrHide(binding.cardReaderHubListItemDescriptionTv, uiState.description)
             binding.cardReaderMenuIcon.setImageResource(uiState.icon)
+            UiHelpers.setDrawableOrHide(
+                binding.cardReaderHubBadgeIcon,
+                uiState.iconBadge?.let { AppCompatResources.getDrawable(parent.context, it) }
+            )
 
             if (uiState.isEnabled) {
                 binding.root.setOnClickListener { uiState.onClick.invoke() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -191,6 +191,7 @@ class CardReaderHubViewModel @Inject constructor(
                     index = 5,
                     onClick = ::onTapToPayClicked,
                     shortDivider = shouldShowTTPFeedbackRequest,
+                    iconBadge = R.drawable.ic_badge_new,
                 )
             )
             if (shouldShowTTPFeedbackRequest) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewState.kt
@@ -23,6 +23,7 @@ data class CardReaderHubViewState(
             override val index: Int,
             override val onClick: () -> Unit,
             val shortDivider: Boolean = false,
+            @DrawableRes val iconBadge: Int? = null,
         ) : ListItem()
 
         data class ToggleableListItem(

--- a/WooCommerce/src/main/res/drawable/ic_badge_new.xml
+++ b/WooCommerce/src/main/res/drawable/ic_badge_new.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="42dp"
-    android:height="24dp"
+    android:width="28dp"
+    android:height="16dp"
     android:viewportWidth="42"
     android:viewportHeight="24">
   <path

--- a/WooCommerce/src/main/res/drawable/ic_badge_new.xml
+++ b/WooCommerce/src/main/res/drawable/ic_badge_new.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="42dp"
+    android:height="24dp"
+    android:viewportWidth="42"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M8,0L34,0A8,8 0,0 1,42 8L42,16A8,8 0,0 1,34 24L8,24A8,8 0,0 1,0 16L0,8A8,8 0,0 1,8 0z"
+      android:fillColor="#F7EDF7"/>
+  <path
+      android:pathData="M7.025,16H8.719V10.592H8.813L12.727,16H14.191V7.545H12.498V12.93H12.404L8.502,7.545H7.025V16ZM16.648,16H22.25V14.541H18.418V12.402H22.033V11.043H18.418V9.004H22.25V7.545H16.648V16ZM26.241,16H27.911L29.493,10.305H29.587L31.187,16H32.845L35.089,7.545H33.261L31.954,13.586H31.861L30.29,7.545H28.796L27.255,13.586H27.161L25.843,7.545H24.003L26.241,16Z"
+      android:fillColor="#674399"/>
+</vector>

--- a/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
@@ -45,7 +45,7 @@
         android:layout_marginBottom="@dimen/major_100"
         android:textColor="@color/color_surface_variant"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@id/cardReaderHubListItemLabelTv"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/cardReaderHubListItemLabelTv"
         app:layout_constraintTop_toBottomOf="@id/cardReaderHubListItemLabelTv"
         tools:text="Use your phone to accept card payments" />

--- a/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
@@ -29,7 +29,7 @@
         android:layout_marginTop="@dimen/major_100"
         android:layout_marginEnd="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@id/cardReaderHubListItemDescriptionTv"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/cardReaderHubBadgeIcon"
         app:layout_constraintStart_toEndOf="@id/cardReaderMenuIcon"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
@@ -50,6 +50,17 @@
         app:layout_constraintStart_toStartOf="@id/cardReaderHubListItemLabelTv"
         app:layout_constraintTop_toBottomOf="@id/cardReaderHubListItemLabelTv"
         tools:text="Use your phone to accept card payments" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/cardReaderHubBadgeIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_10"
+        android:padding="@dimen/minor_100"
+        app:layout_constraintBottom_toBottomOf="@id/cardReaderHubListItemLabelTv"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:srcCompat="@drawable/ic_badge_new" />
 
     <com.google.android.material.divider.MaterialDivider
         android:id="@+id/cardReaderHubListItemDivider"

--- a/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
@@ -29,7 +29,6 @@
         android:layout_marginTop="@dimen/major_100"
         android:layout_marginEnd="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@id/cardReaderHubListItemDescriptionTv"
-        app:layout_constraintEnd_toStartOf="@id/cardReaderHubBadgeIcon"
         app:layout_constraintStart_toEndOf="@id/cardReaderMenuIcon"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
@@ -57,8 +56,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/minor_10"
         android:padding="@dimen/minor_100"
-        app:layout_constraintBottom_toBottomOf="@id/cardReaderHubListItemLabelTv"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/cardReaderHubListItemLabelTv"
         app:layout_constraintTop_toTopOf="parent"
         tools:srcCompat="@drawable/ic_badge_new" />
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -1287,7 +1287,8 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
                     it.icon == R.drawable.ic_baseline_contactless &&
                     it.label == UiStringRes(R.string.card_reader_test_tap_to_pay) &&
                     it.description == UiStringRes(R.string.card_reader_tap_to_pay_description) &&
-                    it.index == 5
+                    it.index == 5 &&
+                    it.iconBadge == R.drawable.ic_badge_new
             }
         }
 
@@ -1313,7 +1314,8 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
                     it.icon == R.drawable.ic_feedback_banner_logo &&
                     it.label == UiStringRes(R.string.card_reader_tap_to_pay_share_feedback) &&
                     it.description == null &&
-                    it.index == 6
+                    it.index == 6 &&
+                    it.iconBadge == null
             }
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8902
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To bring more attention we add a "new" badge to the TTP row

So far it's shown all the time. We may consider showing it just once, although I don't think that it's any intrusive so we can just keep it there for a couple of versions. @joshheald wdyt? Also, UI looks ok for you?

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Have beta TTP flag enabled
* Open Payments screen
* Notice new badge

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="240" alt="image" src="https://user-images.githubusercontent.com/4923871/234827072-3e18f0cb-d505-4a9b-8786-8284b0018527.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
