### PR TITLE
Configure Dependabot to ignore AGP plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       # The Android Gradle Plugin is a dependency we'd like to have in sync with other
       # in-house libraries due to compatibility with composite build.
       - dependency-name: "com.android.tools.build:gradle"
+      - dependency-name: "com.android.application"
+      - dependency-name: "com.android.library"
       # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
       # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968
       - dependency-name: "com.github.tomakehurst:wiremock"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR disables Dependabot alerts for AGP plugins as, cited from code comment,

```
# The Android Gradle Plugin is a dependency we'd like to have in sync with other
# in-house libraries due to compatibility with composite build. 
```

Dependabot recently created this PR: https://github.com/woocommerce/woocommerce-android/pull/8905

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
You can check that in this [list of PRs on fork](https://github.com/wzieba/woocommerce-android/pulls?page=1&q=is%3Apr+is%3Aopen) with [this Dependabot configuration,](https://github.com/wzieba/woocommerce-android/blob/trunk/.github/dependabot.yml) a PR for updating AGP was not created.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
