### PR TITLE
Enable hiding and showing onboarding list on demand

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 13.4
 - [*] [Internal] Adds partial height chrome tab in a few places. [https://github.com/woocommerce/woocommerce-android/pull/8502]
 - [*] [Internal] Better payments error tracking [https://github.com/woocommerce/woocommerce-android/pull/8875]
+- [**] Allow users to show or hide onboarding list [https://github.com/woocommerce/woocommerce-android/pull/8907]
 
 13.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.UPDATE_SIMULATED_READER_OPTION
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.ONBOARDING_CAROUSEL_DISPLAYED
+import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_ONBOARDING_SETTING_VISIBILITY
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_ONBOARDING_SHOWN_AT_LEAST_ONCE
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_ONBOARDING_TASKS_COMPLETED
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_PHONE_NUMBER
@@ -181,6 +182,9 @@ object AppPrefs {
 
         // Was store onboarding shown at least once
         STORE_ONBOARDING_SHOWN_AT_LEAST_ONCE,
+
+        // User preference in regards to show store onboarding or not
+        STORE_ONBOARDING_SETTING_VISIBILITY,
 
         // Time when the last successful payment was made with a card reader
         CARD_READER_LAST_SUCCESSFUL_PAYMENT_TIME,
@@ -934,6 +938,19 @@ object AppPrefs {
             key = PrefKeyString("$STORE_ONBOARDING_SHOWN_AT_LEAST_ONCE:$siteId"),
             default = false
         )
+
+    fun getOnboardingSettingVisibility(siteId: Int): Boolean =
+        getBoolean(
+            key = PrefKeyString("$STORE_ONBOARDING_SETTING_VISIBILITY:$siteId"),
+            default = true
+        )
+
+    fun setOnboardingSettingVisibility(siteId: Int, visible: Boolean) {
+        setBoolean(
+            key = PrefKeyString("$STORE_ONBOARDING_SETTING_VISIBILITY:$siteId"),
+            value = visible
+        )
+    }
 
     fun getCardReaderLastSuccessfulPaymentTime() =
         getLong(UndeletablePrefKey.CARD_READER_LAST_SUCCESSFUL_PAYMENT_TIME, 0L)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -333,6 +333,12 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getStoreOnboardingShown(siteId: Int): Boolean = AppPrefs.getStoreOnboardingShown(siteId)
 
+    fun getOnboardingSettingVisibility(siteId: Int): Boolean = AppPrefs.getOnboardingSettingVisibility(siteId)
+
+    fun setOnboardingSettingVisibility(siteId: Int, show: Boolean) {
+        AppPrefs.setOnboardingSettingVisibility(siteId, show)
+    }
+
     fun setStorePhoneNumber(siteId: Int, phoneNumber: String) = AppPrefs.setStorePhoneNumber(siteId, phoneNumber)
 
     fun getStorePhoneNumber(siteId: Int): String = AppPrefs.getStorePhoneNumber(siteId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -807,6 +807,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     STORE_ONBOARDING_TASK_TAPPED,
     STORE_ONBOARDING_TASK_COMPLETED,
     STORE_ONBOARDING_COMPLETED,
+    STORE_ONBOARDING_HIDE_LIST,
 
     // Quantity rules (Min/Max extension)
     PRODUCT_DETAIL_VIEW_QUANTITY_RULES_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -502,6 +502,9 @@ class AnalyticsTracker private constructor(private val context: Context) {
 
         // -- Store Onboarding
         const val ONBOARDING_TASK_KEY = "task"
+        const val KEY_HIDE_ONBOARDING_SOURCE = "source"
+        const val KEY_ONBOARDING_PENDING_TASKS = "pending_tasks"
+        const val KEY_HIDE_ONBOARDING_LIST_VALUE = "hide"
         const val VALUE_STORE_DETAILS = "store_details"
         const val VALUE_PRODUCTS = "products"
         const val VALUE_ADD_DOMAIN = "add_domain"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
@@ -28,7 +28,7 @@ class ShouldShowOnboarding @Inject constructor(
         } else false
 
         return if (!areAllTaskCompleted
-            && appPrefsWrapper.getOnboardingSettingVisibility(siteId)
+            && isOnboardingListSettingVisible()
             && FeatureFlag.STORE_CREATION_ONBOARDING.isEnabled()
         ) {
             appPrefsWrapper.setStoreOnboardingShown(siteId)
@@ -42,4 +42,7 @@ class ShouldShowOnboarding @Inject constructor(
     fun updateOnboardingVisibilitySetting(show: Boolean) {
         appPrefsWrapper.setOnboardingSettingVisibility(selectedSite.getSelectedSiteId(), show)
     }
+
+    fun isOnboardingListSettingVisible() =
+        appPrefsWrapper.getOnboardingSettingVisibility(selectedSite.getSelectedSiteId())
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
@@ -27,7 +27,10 @@ class ShouldShowOnboarding @Inject constructor(
             true
         } else false
 
-        return if (!areAllTaskCompleted && FeatureFlag.STORE_CREATION_ONBOARDING.isEnabled()) {
+        return if (!areAllTaskCompleted
+            && appPrefsWrapper.getOnboardingSettingVisibility(siteId)
+            && FeatureFlag.STORE_CREATION_ONBOARDING.isEnabled()
+        ) {
             appPrefsWrapper.setStoreOnboardingShown(siteId)
             true
         } else false
@@ -35,4 +38,8 @@ class ShouldShowOnboarding @Inject constructor(
 
     fun isOnboardingMarkedAsCompleted(): Boolean =
         appPrefsWrapper.isOnboardingCompleted(selectedSite.getSelectedSiteId())
+
+    fun updateOnboardingVisibilitySetting(show: Boolean) {
+        appPrefsWrapper.setOnboardingSettingVisibility(selectedSite.getSelectedSiteId(), show)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
@@ -2,20 +2,36 @@ package com.woocommerce.android.ui.login.storecreation.onboarding
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent.STORE_ONBOARDING_COMPLETED
+import com.woocommerce.android.analytics.AnalyticsEvent.STORE_ONBOARDING_HIDE_LIST
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTask
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ABOUT_YOUR_STORE
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ADD_FIRST_PRODUCT
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.CUSTOMIZE_DOMAIN
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.PAYMENTS
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.WC_PAYMENTS
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton // Needed to keep track of the pending tasks when tracking
 class ShouldShowOnboarding @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val selectedSite: SelectedSite,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
+    private var pendingTasks: List<OnboardingTask> = emptyList()
+
     operator fun invoke(tasks: List<OnboardingTask>): Boolean {
         if (tasks.isEmpty()) return false
+
+        pendingTasks = tasks.filter { !it.isComplete }
 
         val siteId = selectedSite.getSelectedSiteId()
         val areAllTaskCompleted = if (tasks.all { it.isComplete }) {
@@ -39,10 +55,36 @@ class ShouldShowOnboarding @Inject constructor(
     fun isOnboardingMarkedAsCompleted(): Boolean =
         appPrefsWrapper.isOnboardingCompleted(selectedSite.getSelectedSiteId())
 
-    fun updateOnboardingVisibilitySetting(show: Boolean) {
+    fun updateOnboardingVisibilitySetting(show: Boolean, source: Source) {
+        analyticsTrackerWrapper.track(
+            stat = STORE_ONBOARDING_HIDE_LIST,
+            properties = mapOf(
+                AnalyticsTracker.KEY_HIDE_ONBOARDING_SOURCE to source.name.lowercase(),
+                AnalyticsTracker.KEY_HIDE_ONBOARDING_LIST_VALUE to !show,
+                AnalyticsTracker.KEY_ONBOARDING_PENDING_TASKS to pendingTasks
+                    .map { getTaskTrackingKey(it.type) }.joinToString()
+            )
+        )
         appPrefsWrapper.setOnboardingSettingVisibility(selectedSite.getSelectedSiteId(), show)
     }
 
     fun isOnboardingListSettingVisible() =
         appPrefsWrapper.getOnboardingSettingVisibility(selectedSite.getSelectedSiteId())
+
+    private fun getTaskTrackingKey(type: OnboardingTaskType) =
+        when (type) {
+            ABOUT_YOUR_STORE -> AnalyticsTracker.VALUE_STORE_DETAILS
+            ADD_FIRST_PRODUCT -> AnalyticsTracker.VALUE_PRODUCTS
+            LAUNCH_YOUR_STORE -> AnalyticsTracker.VALUE_LAUNCH_SITE
+            CUSTOMIZE_DOMAIN -> AnalyticsTracker.VALUE_ADD_DOMAIN
+            WC_PAYMENTS,
+            PAYMENTS -> AnalyticsTracker.VALUE_PAYMENTS
+
+            MOBILE_UNSUPPORTED -> null
+        }
+
+    enum class Source {
+        ONBOARDING_LIST,
+        SETTINGS
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.ui.login.storecreation.onboarding
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsEvent.STORE_ONBOARDING_COMPLETED
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTask
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.WooLog
+import javax.inject.Inject
+
+class ShouldShowOnboarding @Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val selectedSite: SelectedSite,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+) {
+    operator fun invoke(tasks: List<OnboardingTask>): Boolean {
+        if (tasks.isEmpty()) return false
+
+        val siteId = selectedSite.getSelectedSiteId()
+        val areAllTaskCompleted = if (tasks.all { it.isComplete }) {
+            WooLog.d(WooLog.T.ONBOARDING, "All onboarding tasks are completed for siteId: $siteId")
+            appPrefsWrapper.markAllOnboardingTasksCompleted(siteId)
+            if (appPrefsWrapper.getStoreOnboardingShown(siteId)) {
+                analyticsTrackerWrapper.track(stat = STORE_ONBOARDING_COMPLETED)
+            }
+            true
+        } else false
+
+        return if (!areAllTaskCompleted && FeatureFlag.STORE_CREATION_ONBOARDING.isEnabled()) {
+            appPrefsWrapper.setStoreOnboardingShown(siteId)
+            true
+        } else false
+    }
+
+    fun isOnboardingMarkedAsCompleted(): Boolean =
+        appPrefsWrapper.isOnboardingCompleted(selectedSite.getSelectedSiteId())
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
@@ -27,9 +27,9 @@ class ShouldShowOnboarding @Inject constructor(
             true
         } else false
 
-        return if (!areAllTaskCompleted
-            && isOnboardingListSettingVisible()
-            && FeatureFlag.STORE_CREATION_ONBOARDING.isEnabled()
+        return if (!areAllTaskCompleted &&
+            isOnboardingListSettingVisible() &&
+            FeatureFlag.STORE_CREATION_ONBOARDING.isEnabled()
         ) {
             appPrefsWrapper.setStoreOnboardingShown(siteId)
             true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -6,7 +6,8 @@ import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.values
 import com.woocommerce.android.util.WooLog
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.TaskDto
 import org.wordpress.android.fluxc.store.OnboardingStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -23,14 +24,14 @@ class StoreOnboardingRepository @Inject constructor(
     private val siteStore: SiteStore
 ) {
 
-    private val onboardingTasksCacheFlow: MutableStateFlow<List<OnboardingTask>> = MutableStateFlow(emptyList())
+    private val onboardingTasksCacheFlow: MutableSharedFlow<List<OnboardingTask>> = MutableSharedFlow()
 
-    fun observeOnboardingTasks() = onboardingTasksCacheFlow
+    fun observeOnboardingTasks(): SharedFlow<List<OnboardingTask>> = onboardingTasksCacheFlow
 
     suspend fun fetchOnboardingTasks() {
         WooLog.d(WooLog.T.ONBOARDING, "Fetching onboarding tasks")
         val result = onboardingStore.fetchOnboardingTasks(selectedSite.get())
-        return when {
+        when {
             result.isError ->
                 WooLog.i(WooLog.T.ONBOARDING, "Error fetching onboarding tasks: ${result.error}")
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -1,8 +1,5 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding
 
-import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.analytics.AnalyticsEvent.STORE_ONBOARDING_COMPLETED
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
@@ -23,9 +20,7 @@ import javax.inject.Singleton
 class StoreOnboardingRepository @Inject constructor(
     private val onboardingStore: OnboardingStore,
     private val selectedSite: SelectedSite,
-    private val siteStore: SiteStore,
-    private val appPrefsWrapper: AppPrefsWrapper,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val siteStore: SiteStore
 ) {
 
     private val onboardingTasksCacheFlow: MutableStateFlow<List<OnboardingTask>> = MutableStateFlow(emptyList())
@@ -66,20 +61,6 @@ class StoreOnboardingRepository @Inject constructor(
                     ?.sortedBy { it.type.order }
                     ?: emptyList()
 
-                if (mobileSupportedTasks.all { it.isComplete }) {
-                    WooLog.d(
-                        WooLog.T.ONBOARDING,
-                        "All onboarding tasks are completed for siteId: ${selectedSite.getSelectedSiteId()}"
-                    )
-                    appPrefsWrapper.markAllOnboardingTasksCompleted(selectedSite.getSelectedSiteId())
-                    if (appPrefsWrapper.getStoreOnboardingShown(selectedSite.getSelectedSiteId())) {
-                        analyticsTrackerWrapper.track(stat = STORE_ONBOARDING_COMPLETED)
-                    }
-                }
-                if (mobileSupportedTasks.any { !it.isComplete }) {
-                    appPrefsWrapper.setStoreOnboardingShown(selectedSite.getSelectedSiteId())
-                }
-
                 onboardingTasksCacheFlow.emit(mobileSupportedTasks)
             }
         }
@@ -87,9 +68,6 @@ class StoreOnboardingRepository @Inject constructor(
 
     private fun shouldMarkLaunchStoreAsCompleted(task: OnboardingTask) =
         task.type == LAUNCH_YOUR_STORE && selectedSite.get().isVisible && !selectedSite.get().isFreeTrial
-
-    fun isOnboardingCompleted(): Boolean =
-        appPrefsWrapper.isOnboardingCompleted(selectedSite.getSelectedSiteId())
 
     suspend fun launchStore(): LaunchStoreResult {
         WooLog.d(WooLog.T.ONBOARDING, "Launching store")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -208,7 +208,6 @@ private fun OnboardingMoreMenu(
     }
 }
 
-
 @Composable
 fun OnboardingTaskList(
     tasks: List<OnboardingTaskUi>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -100,6 +101,7 @@ fun StoreOnboardingCollapsed(
     onShareFeedbackClicked: () -> Unit,
     onTaskClicked: (OnboardingTaskUi) -> Unit,
     modifier: Modifier = Modifier,
+    onHideOnboardingClicked: () -> Unit,
     numberOfItemsToShowInCollapsedMode: Int = NUMBER_ITEMS_IN_COLLAPSED_MODE,
 ) {
     Box(modifier = modifier.fillMaxWidth()) {
@@ -162,6 +164,14 @@ fun StoreOnboardingCollapsed(
                     onClick = { onShareFeedbackClicked() }
                 ) {
                     Text(stringResource(id = R.string.store_onboarding_menu_share_feedback))
+                }
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                DropdownMenuItem(
+                    modifier = Modifier
+                        .height(dimensionResource(id = R.dimen.major_175)),
+                    onClick = { onHideOnboardingClicked() }
+                ) {
+                    Text(stringResource(id = R.string.store_onboarding_menu_hide_store_setup))
                 }
             }
         }
@@ -364,6 +374,7 @@ private fun OnboardingPreview() {
         ),
         onViewAllClicked = {},
         onShareFeedbackClicked = {},
+        onHideOnboardingClicked = {},
         onTaskClicked = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProgressIndicatorDefaults
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.Icons.Outlined
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -52,6 +52,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.WcTag
@@ -157,47 +159,55 @@ fun StoreOnboardingCollapsed(
                 .align(Alignment.TopEnd)
                 .padding(top = dimensionResource(id = R.dimen.minor_100))
         ) {
-            OverflowMenu {
-                DropdownMenuItem(
-                    modifier = Modifier
-                        .height(dimensionResource(id = R.dimen.major_175)),
-                    onClick = { onShareFeedbackClicked() }
-                ) {
-                    Text(stringResource(id = R.string.store_onboarding_menu_share_feedback))
-                }
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
-                DropdownMenuItem(
-                    modifier = Modifier
-                        .height(dimensionResource(id = R.dimen.major_175)),
-                    onClick = { onHideOnboardingClicked() }
-                ) {
-                    Text(stringResource(id = R.string.store_onboarding_menu_hide_store_setup))
-                }
-            }
+            OnboardingMoreMenu(onShareFeedbackClicked, onHideOnboardingClicked)
         }
     }
 }
 
 @Composable
-fun OverflowMenu(content: @Composable () -> Unit) {
+private fun OnboardingMoreMenu(
+    onShareFeedbackClicked: () -> Unit,
+    onHideOnboardingClicked: () -> Unit
+) {
     var showMenu by remember { mutableStateOf(false) }
     IconButton(onClick = { showMenu = !showMenu }) {
         Icon(
-            imageVector = Icons.Outlined.MoreVert,
-            contentDescription = stringResource(R.string.more_menu),
+            imageVector = Outlined.MoreVert,
+            contentDescription = stringResource(string.more_menu),
         )
     }
     DropdownMenu(
         offset = DpOffset(
-            x = dimensionResource(id = R.dimen.major_100),
+            x = dimensionResource(id = dimen.major_100),
             y = 0.dp
         ),
         expanded = showMenu,
         onDismissRequest = { showMenu = false }
     ) {
-        content()
+        DropdownMenuItem(
+            modifier = Modifier
+                .height(dimensionResource(id = dimen.major_175)),
+            onClick = {
+                showMenu = false
+                onShareFeedbackClicked()
+            }
+        ) {
+            Text(stringResource(id = string.store_onboarding_menu_share_feedback))
+        }
+        Spacer(modifier = Modifier.height(dimensionResource(id = dimen.minor_100)))
+        DropdownMenuItem(
+            modifier = Modifier
+                .height(dimensionResource(id = dimen.major_175)),
+            onClick = {
+                showMenu = false
+                onHideOnboardingClicked()
+            }
+        ) {
+            Text(stringResource(id = string.store_onboarding_menu_hide_store_setup))
+        }
     }
 }
+
 
 @Composable
 fun OnboardingTaskList(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -69,6 +69,7 @@ class StoreOnboardingViewModel @Inject constructor(
             CUSTOMIZE_DOMAIN -> OnboardingTaskUi(CustomizeDomainTaskRes, isCompleted = task.isComplete)
             WC_PAYMENTS,
             PAYMENTS -> OnboardingTaskUi(SetupPaymentsTaskRes, isCompleted = task.isComplete)
+
             MOBILE_UNSUPPORTED -> error("Unknown task type is not allowed in UI layer")
         }
 
@@ -82,6 +83,10 @@ class StoreOnboardingViewModel @Inject constructor(
 
     fun onShareFeedbackClicked() {
         triggerEvent(NavigateToSurvey)
+    }
+
+    fun onHideOnboardingClicked() {
+
     }
 
     fun onTaskClicked(task: OnboardingTaskUi) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -87,7 +87,7 @@ class StoreOnboardingViewModel @Inject constructor(
 
     fun onHideOnboardingClicked() {
         _viewState.value = _viewState.value?.copy(show = false)
-
+        shouldShowOnboarding.updateOnboardingVisibilitySetting(show = false)
     }
 
     fun onTaskClicked(task: OnboardingTaskUi) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PAYMEN
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCTS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STORE_DETAILS
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding.Source.ONBOARDING_LIST
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTask
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ABOUT_YOUR_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ADD_FIRST_PRODUCT
@@ -93,7 +94,10 @@ class StoreOnboardingViewModel @Inject constructor(
                 positiveButtonId = R.string.remove,
                 positiveBtnAction = { dialog, _ ->
                     _viewState.value = _viewState.value?.copy(show = false)
-                    shouldShowOnboarding.updateOnboardingVisibilitySetting(show = false)
+                    shouldShowOnboarding.updateOnboardingVisibilitySetting(
+                        show = false,
+                        source = ONBOARDING_LIST
+                    )
                     dialog.dismiss()
                 },
                 negativeBtnAction = { dialog, _ -> dialog.dismiss() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -42,7 +42,13 @@ class StoreOnboardingViewModel @Inject constructor(
         const val NUMBER_ITEMS_IN_COLLAPSED_MODE = 3
     }
 
-    private val _viewState = MutableLiveData<OnboardingState>()
+    private val _viewState = MutableLiveData(
+        OnboardingState(
+            show = false,
+            title = R.string.store_onboarding_title,
+            tasks = emptyList(),
+        )
+    )
     val viewState = _viewState
 
     init {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -86,8 +86,20 @@ class StoreOnboardingViewModel @Inject constructor(
     }
 
     fun onHideOnboardingClicked() {
-        _viewState.value = _viewState.value?.copy(show = false)
-        shouldShowOnboarding.updateOnboardingVisibilitySetting(show = false)
+        triggerEvent(
+            MultiLiveEvent.Event.ShowDialog(
+                titleId = R.string.store_onboarding_dialog_title,
+                messageId = R.string.store_onboarding_dialog_description,
+                positiveButtonId = R.string.remove,
+                positiveBtnAction = { dialog, _ ->
+                    _viewState.value = _viewState.value?.copy(show = false)
+                    shouldShowOnboarding.updateOnboardingVisibilitySetting(show = false)
+                    dialog.dismiss()
+                },
+                negativeBtnAction = { dialog, _ -> dialog.dismiss() },
+                negativeButtonId = R.string.cancel,
+            )
+        )
     }
 
     fun onTaskClicked(task: OnboardingTaskUi) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -206,7 +206,8 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                                     onboardingState = state,
                                     onViewAllClicked = storeOnboardingViewModel::viewAllClicked,
                                     onShareFeedbackClicked = storeOnboardingViewModel::onShareFeedbackClicked,
-                                    onTaskClicked = storeOnboardingViewModel::onTaskClicked
+                                    onTaskClicked = storeOnboardingViewModel::onTaskClicked,
+                                    onHideOnboardingClicked = storeOnboardingViewModel::onHideOnboardingClicked
                                 )
                             }
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -57,6 +57,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
@@ -235,14 +236,18 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
                     findNavController().navigateSafely(
                         directions = MyStoreFragmentDirections.actionMyStoreToProductTypesBottomSheet()
                     )
+
                 is StoreOnboardingViewModel.NavigateToSetupPayments ->
                     findNavController().navigateSafely(
                         directions = MyStoreFragmentDirections.actionMyStoreToGetPaidFragment()
                     )
+
                 is StoreOnboardingViewModel.NavigateToAboutYourStore ->
                     findNavController().navigateSafely(
                         MyStoreFragmentDirections.actionMyStoreToAboutYourStoreFragment()
                     )
+
+                is ShowDialog -> event.showDialog()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -13,6 +13,8 @@ interface MainSettingsContract {
         fun setupJetpackInstallOption()
         fun setupApplicationPasswordsSettings()
 
+        fun setupOnboardingListVisibilitySetting()
+
         val isDomainOptionVisible: Boolean
     }
 
@@ -21,5 +23,6 @@ interface MainSettingsContract {
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
         fun handleJetpackInstallOption(supportsJetpackInstallation: Boolean)
         fun handleApplicationPasswordsSettings()
+        fun handleStoreSetupListSetting(enabled: Boolean, onToggleChange: (Boolean) -> Unit)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -220,6 +220,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         presenter.setupAnnouncementOption()
         presenter.setupJetpackInstallOption()
         presenter.setupApplicationPasswordsSettings()
+        presenter.setupOnboardingListVisibilitySetting()
     }
 
     private fun showDomainDashboard() {
@@ -255,16 +256,12 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
     override fun handleJetpackInstallOption(supportsJetpackInstallation: Boolean) {
         if (supportsJetpackInstallation) {
-            binding.storeSettingsContainer.visibility = View.VISIBLE
             binding.optionInstallJetpack.visibility = View.VISIBLE
             binding.optionInstallJetpack.setOnClickListener {
                 findNavController().navigateSafely(
                     MainSettingsFragmentDirections.actionMainSettingsFragmentToNavGraphJetpackInstall()
                 )
             }
-        } else {
-            // Hide the whole container because jetpack is the only option there
-            binding.storeSettingsContainer.visibility = View.GONE
         }
     }
 
@@ -290,6 +287,14 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
     override fun handleApplicationPasswordsSettings() {
         binding.optionNotifications.hide()
+    }
+
+    override fun handleStoreSetupListSetting(enabled: Boolean, onToggleChange: (Boolean) -> Unit) {
+        binding.optionStoreOnboardingListVisibility.show()
+        binding.optionStoreOnboardingListVisibility.isChecked = enabled
+        binding.optionStoreOnboardingListVisibility.setOnCheckedChangeListener { _, isChecked ->
+            onToggleChange(isChecked)
+        }
     }
 
     private fun updateStoreSettings() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -210,7 +210,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
 
         lifecycleScope.launch {
-            binding.domainGroup.isVisible = presenter.isDomainOptionVisible
+            binding.optionDomain.isVisible = presenter.isDomainOptionVisible
             binding.optionDomain.setOnClickListener {
                 AnalyticsTracker.track(SETTINGS_DOMAINS_TAPPED)
                 showDomainDashboard()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -221,6 +221,9 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         presenter.setupJetpackInstallOption()
         presenter.setupApplicationPasswordsSettings()
         presenter.setupOnboardingListVisibilitySetting()
+
+        binding.storeSettingsContainer.isVisible = binding.optionInstallJetpack.isVisible ||
+            binding.optionDomain.isVisible || binding.optionStoreOnboardingListVisibility.isVisible
     }
 
     private fun showDomainDashboard() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.prefs
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding
+import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding.Source.SETTINGS
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.FeatureFlag
@@ -85,7 +86,10 @@ class MainSettingsPresenter @Inject constructor(
             appSettingsFragmentView?.handleStoreSetupListSetting(
                 enabled = shouldShowOnboarding.isOnboardingListSettingVisible(),
                 onToggleChange = { isChecked ->
-                    shouldShowOnboarding.updateOnboardingVisibilitySetting(isChecked)
+                    shouldShowOnboarding.updateOnboardingVisibilitySetting(
+                        show = isChecked,
+                        source = SETTINGS
+                    )
                 }
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.prefs
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.FeatureFlag
@@ -20,6 +21,7 @@ class MainSettingsPresenter @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val featureAnnouncementRepository: FeatureAnnouncementRepository,
     private val buildConfigWrapper: BuildConfigWrapper,
+    private val shouldShowOnboarding: ShouldShowOnboarding
 ) : MainSettingsContract.Presenter {
     private var appSettingsFragmentView: MainSettingsContract.View? = null
 
@@ -75,6 +77,17 @@ class MainSettingsPresenter @Inject constructor(
     override fun setupApplicationPasswordsSettings() {
         if (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords) {
             appSettingsFragmentView?.handleApplicationPasswordsSettings()
+        }
+    }
+
+    override fun setupOnboardingListVisibilitySetting() {
+        if (!shouldShowOnboarding.isOnboardingMarkedAsCompleted()) {
+            appSettingsFragmentView?.handleStoreSetupListSetting(
+                enabled = shouldShowOnboarding.isOnboardingListSettingVisible(),
+                onToggleChange = { isChecked ->
+                    shouldShowOnboarding.updateOnboardingVisibilitySetting(isChecked)
+                }
+            )
         }
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -39,7 +39,7 @@
             <View style="@style/Woo.Divider" />
             <!--
                     Store Settings
-                -->
+            -->
             <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -57,6 +57,15 @@
                 tools:visibility="visible" />
 
             <!--
+                Domain configuration
+            -->
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/option_domain"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:optionTitle="@string/domain" />
+
+            <!--
                 Store onboarding list visibility
             -->
             <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
@@ -69,8 +78,6 @@
             <View style="@style/Woo.Divider" />
 
         </LinearLayout>
-
-        <View style="@style/Woo.Divider" />
 
         <!--
             Notifications (pre- API 26)
@@ -108,6 +115,7 @@
                 app:toggleOptionDesc="@string/settings_notifs_reviews_detail"
                 app:toggleOptionTitle="@string/settings_notifs_reviews" />
 
+            <View style="@style/Woo.Divider" />
         </LinearLayout>
 
         <!--
@@ -141,19 +149,17 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:optionTitle="@string/settings_app_theme_title"
-            app:optionValue="@string/settings_app_theme_option_default">
-
-            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-                android:id="@+id/option_image_optimization"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:toggleOptionDesc="@string/settings_image_optimization_message"
-                app:toggleOptionTitle="@string/settings_image_optimization_title" />
-        </com.woocommerce.android.ui.prefs.WCSettingsOptionValueView>
+            app:optionValue="@string/settings_app_theme_option_default" />
 
         <!--
             Image Optimization
         -->
+        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+            android:id="@+id/option_image_optimization"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:toggleOptionDesc="@string/settings_image_optimization_message"
+            app:toggleOptionTitle="@string/settings_image_optimization_title" />
 
         <!--
             Privacy
@@ -186,31 +192,6 @@
             app:optionTitle="@string/send_feedback" />
 
         <View style="@style/Woo.Divider" />
-
-        <!--
-            Store settings
-        -->
-        <LinearLayout
-            android:id="@+id/domain_group"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
-                android:id="@+id/category_store_settings"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/settings_store" />
-
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/option_domain"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/domain" />
-
-            <View android:id="@+id/domain_divider" style="@style/Woo.Divider" />
-
-        </LinearLayout>
 
         <!--
             About

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -73,7 +73,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:toggleOptionDesc="@string/store_onboarding_setting_description"
-                app:toggleOptionTitle="@string/store_onboarding_setting_title" />
+                app:toggleOptionTitle="@string/store_onboarding_setting_title"
+                android:visibility="gone" />
 
             <View style="@style/Woo.Divider" />
 

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -30,13 +30,14 @@
             android:layout_height="wrap_content"
             app:optionTitle="@string/dev_options" />
 
+        <View style="@style/Woo.Divider" />
+
         <LinearLayout
             android:id="@+id/store_settings_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <View style="@style/Woo.Divider" />
             <!--
                     Store Settings
             -->

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout xmlns:tools="http://schemas.android.com/tools"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorSurface"
@@ -55,6 +56,18 @@
                 app:optionTitle="@string/settings_install_jetpack"
                 tools:visibility="visible" />
 
+            <!--
+                Store onboarding list visibility
+            -->
+            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+                android:id="@+id/option_store_onboarding_list_visibility"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:toggleOptionDesc="@string/store_onboarding_setting_description"
+                app:toggleOptionTitle="@string/store_onboarding_setting_title" />
+
+            <View style="@style/Woo.Divider" />
+
         </LinearLayout>
 
         <View style="@style/Woo.Divider" />
@@ -95,7 +108,6 @@
                 app:toggleOptionDesc="@string/settings_notifs_reviews_detail"
                 app:toggleOptionTitle="@string/settings_notifs_reviews" />
 
-            <View style="@style/Woo.Divider" />
         </LinearLayout>
 
         <!--
@@ -129,17 +141,19 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:optionTitle="@string/settings_app_theme_title"
-            app:optionValue="@string/settings_app_theme_option_default" />
+            app:optionValue="@string/settings_app_theme_option_default">
+
+            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+                android:id="@+id/option_image_optimization"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:toggleOptionDesc="@string/settings_image_optimization_message"
+                app:toggleOptionTitle="@string/settings_image_optimization_title" />
+        </com.woocommerce.android.ui.prefs.WCSettingsOptionValueView>
 
         <!--
             Image Optimization
         -->
-        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-            android:id="@+id/option_image_optimization"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:toggleOptionDesc="@string/settings_image_optimization_message"
-            app:toggleOptionTitle="@string/settings_image_optimization_title" />
 
         <!--
             Privacy

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3036,6 +3036,8 @@
     <string name="store_onboarding_collapsed_transition_name">Onboarding collapsed list</string>
     <string name="store_onboarding_menu_share_feedback">Share feedback</string>
     <string name="store_onboarding_menu_hide_store_setup">Hide store setup list</string>
+    <string name="store_onboarding_dialog_title">Hide store setup list</string>
+    <string name="store_onboarding_dialog_description">You can restore it back when you need it from Menu > Settings > Store</string>
     <string name="store_onboarding_upgrade_plan_to_launch_store_banner_text">To launch your store, you need to upgrade to our plan. &lt;u&gt;Upgrade&lt;/u&gt;</string>
     <string name="store_onboarding_launch_store_button">Publish my store</string>
     <string name="store_onboarding_launch_store_share_url_button">Share URL</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3054,7 +3054,7 @@
     <string name="store_onboarding_get_paid_title">Payments Setup</string>
     <string name="store_onboarding_get_paid_loading_label">Loading…</string>
     <string name="store_onboarding_setting_title">Store Setup List</string>
-    <string name="store_onboarding_setting_description">Hide or show store setup list</string>
+    <string name="store_onboarding_setting_description">Show or hide store setup list</string>
 
     <!--
     Support Request

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3035,6 +3035,7 @@
     <string name="store_onboarding_full_screen_transition_name">Onboarding full screen</string>
     <string name="store_onboarding_collapsed_transition_name">Onboarding collapsed list</string>
     <string name="store_onboarding_menu_share_feedback">Share feedback</string>
+    <string name="store_onboarding_menu_hide_store_setup">Hide store setup list</string>
     <string name="store_onboarding_upgrade_plan_to_launch_store_banner_text">To launch your store, you need to upgrade to our plan. &lt;u&gt;Upgrade&lt;/u&gt;</string>
     <string name="store_onboarding_launch_store_button">Publish my store</string>
     <string name="store_onboarding_launch_store_share_url_button">Share URL</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3053,6 +3053,8 @@
     <string name="store_onboarding_launch_store_ok">OK</string>
     <string name="store_onboarding_get_paid_title">Payments Setup</string>
     <string name="store_onboarding_get_paid_loading_label">Loading…</string>
+    <string name="store_onboarding_setting_title">Store Setup List</string>
+    <string name="store_onboarding_setting_description">Hide or show store setup list</string>
 
     <!--
     Support Request

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModelTest.kt
@@ -24,6 +24,26 @@ import org.mockito.kotlin.whenever
 @ExperimentalCoroutinesApi
 class StoreOnboardingViewModelTest : BaseUnitTest() {
     private companion object {
+        val ONBOARDING_TASK_INCOMPLETED_LIST = listOf(
+            OnboardingTask(
+                type = OnboardingTaskType.ABOUT_YOUR_STORE,
+                isComplete = false,
+                isVisible = true,
+                isVisited = false
+            ),
+            OnboardingTask(
+                type = OnboardingTaskType.ADD_FIRST_PRODUCT,
+                isComplete = false,
+                isVisible = true,
+                isVisited = false
+            ),
+            OnboardingTask(
+                type = OnboardingTaskType.CUSTOMIZE_DOMAIN,
+                isComplete = false,
+                isVisible = true,
+                isVisited = false
+            )
+        )
         val ONBOARDING_TASK_COMPLETED_LIST = listOf(
             OnboardingTask(
                 type = OnboardingTaskType.ABOUT_YOUR_STORE,
@@ -65,6 +85,17 @@ class StoreOnboardingViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
 
             Assertions.assertThat(viewModel.viewState.value?.show).isFalse
+        }
+
+    @Test
+    fun `given a list of incomplete tasks , when view model is created, onboarding is shown`() =
+        testBlocking {
+            onboardingTasksCacheFlow.tryEmit(ONBOARDING_TASK_INCOMPLETED_LIST)
+            whenever(shouldShowOnboarding(ONBOARDING_TASK_INCOMPLETED_LIST)).thenReturn(true)
+
+            whenViewModelIsCreated()
+
+            Assertions.assertThat(viewModel.viewState.value?.show).isTrue
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8900 

### Description
Enable users to show or hide the onboarding list on demand: 

- Design details: VyLr7LvKodHE4kINfBE7Lw-fi-4028_120388

![Screenshot 2023-04-26 at 20 37 47](https://user-images.githubusercontent.com/2663464/234671353-f2f659e8-0040-4763-82d0-148c629c228b.png)


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a site that has the onboarding list visible
2. Click on the over flow menu and select "Hide store setup list
3. Notice how the store setup is hidden and the following event is tracked listing all the tasks that are pending and the `source` property with `onboarding_list` value: 
`store_onboarding_hide_list, Properties: {"source":"onboarding_list","hide":true,"pending_tasks":"products, add_domain, payments",`  
4. Navigate to Menu -> Settings -> Store Setup List. Check the "switch" is disabled as the onboarding list is currently hidden
5. Change the "switch" state to re-enable the onboarding list and verify the event is tracked: 
`store_onboarding_hide_list, Properties: {"source":"settings","hide":false,"pending_tasks":"products, add_domain, payments"`
6. Navigate back to my store tab and check onboarding list is displayed again. 
7. Complete all the onboarding tasks and check that the setting to show/hide the onboarding list is not displayed anymore

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2663464/235171737-8af62c67-6e80-43d3-ab75-5bc35c46e00a.mp4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
