### PR TITLE
Remove remote config for performance monitoring

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -19,7 +19,6 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     private val remoteConfig: FirebaseRemoteConfig
 ) : RemoteConfigRepository {
     companion object {
-        private const val PERFORMANCE_MONITORING_SAMPLE_RATE_KEY = "wc_android_performance_monitoring_sample_rate"
         private const val DEBUG_INTERVAL = 10L
         private const val RELEASE_INTERVAL = 31200L
     }
@@ -65,9 +64,6 @@ class FirebaseRemoteConfigRepository @Inject constructor(
                 WooLog.e(T.UTILS, it)
             }
     }
-
-    override fun getPerformanceMonitoringSampleRate(): Double =
-        remoteConfig.getDouble(PERFORMANCE_MONITORING_SAMPLE_RATE_KEY)
 
     @VisibleForTesting
     fun observeStringRemoteValue(key: String) = changesTrigger

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.flow.Flow
 interface RemoteConfigRepository {
     val fetchStatus: Flow<RemoteConfigFetchStatus>
     fun fetchRemoteConfig()
-    fun getPerformanceMonitoringSampleRate(): Double
 }
 
 enum class RemoteConfigFetchStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt
@@ -2,20 +2,31 @@ package com.woocommerce.android.util.crashlogging
 
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.config.RemoteConfigRepository
+import com.woocommerce.android.util.BuildConfigWrapper
 import javax.inject.Inject
 
 class SpecifyPerformanceMonitoringConfig @Inject constructor(
-    private val remoteConfigRepository: RemoteConfigRepository,
+    private val buildConfig: BuildConfigWrapper,
     private val analyticsWrapper: AnalyticsTrackerWrapper
 ) {
+
+    private companion object {
+        const val RELEASE_PERFORMANCE_MONITORING_SAMPLE_RATE = 0.1
+        const val DEBUG_PERFORMANCE_MONITORING_SAMPLE_RATE = 1.0
+    }
+
     operator fun invoke(): PerformanceMonitoringConfig {
-        val sampleRate = remoteConfigRepository.getPerformanceMonitoringSampleRate()
+        val sampleRate = if (buildConfig.debug) {
+            DEBUG_PERFORMANCE_MONITORING_SAMPLE_RATE
+        } else {
+            RELEASE_PERFORMANCE_MONITORING_SAMPLE_RATE
+        }
         val userEnabled = analyticsWrapper.sendUsageStats
 
-        return when {
-            !userEnabled || sampleRate <= 0.0 || sampleRate > 1.0 -> PerformanceMonitoringConfig.Disabled
-            else -> PerformanceMonitoringConfig.Enabled(sampleRate)
+        return if (!userEnabled) {
+            PerformanceMonitoringConfig.Disabled
+        } else {
+            PerformanceMonitoringConfig.Enabled(sampleRate)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfig.kt
@@ -11,22 +11,16 @@ class SpecifyPerformanceMonitoringConfig @Inject constructor(
 ) {
 
     private companion object {
-        const val RELEASE_PERFORMANCE_MONITORING_SAMPLE_RATE = 0.1
-        const val DEBUG_PERFORMANCE_MONITORING_SAMPLE_RATE = 1.0
+        const val PERFORMANCE_MONITORING_SAMPLE_RATE = 0.01
     }
 
     operator fun invoke(): PerformanceMonitoringConfig {
-        val sampleRate = if (buildConfig.debug) {
-            DEBUG_PERFORMANCE_MONITORING_SAMPLE_RATE
-        } else {
-            RELEASE_PERFORMANCE_MONITORING_SAMPLE_RATE
-        }
         val userEnabled = analyticsWrapper.sendUsageStats
 
-        return if (!userEnabled) {
+        return if (!userEnabled || buildConfig.debug) {
             PerformanceMonitoringConfig.Disabled
         } else {
-            PerformanceMonitoringConfig.Enabled(sampleRate)
+            PerformanceMonitoringConfig.Enabled(PERFORMANCE_MONITORING_SAMPLE_RATE)
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfigTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/SpecifyPerformanceMonitoringConfigTest.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.util.crashlogging
 
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.config.RemoteConfigRepository
+import com.woocommerce.android.util.BuildConfigWrapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.doReturn
@@ -10,17 +10,13 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class SpecifyPerformanceMonitoringConfigTest {
-    private val remoteConfig: RemoteConfigRepository = mock {
-        on { getPerformanceMonitoringSampleRate() } doReturn 0.5
-    }
-    private val analytics: AnalyticsTrackerWrapper = mock {
-        on { sendUsageStats } doReturn true
-    }
+    private val buildConfig: BuildConfigWrapper = mock()
+    private val analytics: AnalyticsTrackerWrapper = mock()
 
-    private val sut = SpecifyPerformanceMonitoringConfig(remoteConfig, analytics)
+    private val sut = SpecifyPerformanceMonitoringConfig(buildConfig, analytics)
 
     @Test
-    fun `if user disabled tracking, disable performance monitoring`() {
+    fun `given the user disabled tracking, disable performance monitoring`() {
         whenever(analytics.sendUsageStats).thenReturn(false)
 
         val result = sut.invoke()
@@ -29,8 +25,8 @@ class SpecifyPerformanceMonitoringConfigTest {
     }
 
     @Test
-    fun `if monitoring sample rate is zero, disable performance monitoring`() {
-        whenever(remoteConfig.getPerformanceMonitoringSampleRate()).doReturn(0.0)
+    fun `given the debug app, disable performance monitoring`() {
+        whenever(buildConfig.debug).doReturn(true)
 
         val result = sut.invoke()
 
@@ -38,30 +34,12 @@ class SpecifyPerformanceMonitoringConfigTest {
     }
 
     @Test
-    fun `if monitoring sample rate is above 1, disable performance monitoring`() {
-        whenever(remoteConfig.getPerformanceMonitoringSampleRate()).doReturn(1.2)
-
-        val result = sut.invoke()
-
-        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Disabled)
-    }
-
-    @Test
-    fun `if monitoring sample rate is below 0, disable performance monitoring`() {
-        whenever(remoteConfig.getPerformanceMonitoringSampleRate()).doReturn(-123.0)
-
-        val result = sut.invoke()
-
-        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Disabled)
-    }
-
-    @Test
-    fun `if monitoring sample rate is between 0 and 1 and user enabled tracking, enable performance monitoring`() {
+    fun `given the app is not debug and user did not disabled tracking, enable performance monitoring`() {
         whenever(analytics.sendUsageStats).thenReturn(true)
-        whenever(remoteConfig.getPerformanceMonitoringSampleRate()).doReturn(0.7)
+        whenever(buildConfig.debug).doReturn(false)
 
         val result = sut.invoke()
 
-        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Enabled(0.7))
+        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Enabled(0.01))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8908
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes remote config usage for setting the sampling rate for performance monitoring.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The logic is covered with unit tests, there's no need for manual testing.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
