### PR TITLE
EU-bound Shipping Notice: Add EU shipping notice to `Customs` view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -310,7 +310,6 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                 isVisible = true
                 setDismissClickListener { collapse() }
             }
-
         }
 
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -12,12 +12,14 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentShippingCustomsBinding
+import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -77,6 +79,13 @@ class ShippingCustomsFragment :
             itemAnimator = DefaultItemAnimator().apply {
                 // Disable change animations to avoid duplicating viewholders
                 supportsChangeAnimations = false
+            }
+        }
+
+        if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()) {
+            with(binding.shippingNoticeBanner) {
+                isVisible = true
+                setDismissClickListener { collapse() }
             }
         }
 

--- a/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
@@ -4,12 +4,26 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/packages_list"
+    <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:itemCount="2"
-        tools:listitem="@layout/shipping_customs_list_item" />
+        android:orientation="vertical">
+
+        <com.woocommerce.android.ui.orders.shippinglabels.creation.banner.ShippingNoticeCard
+            android:id="@+id/shipping_notice_banner"
+            style="@style/Woo.Card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="visible"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/packages_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:itemCount="2"
+            tools:listitem="@layout/shipping_customs_list_item" />
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
     <ProgressBar
         android:id="@+id/progress_view"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
@@ -14,7 +14,7 @@
             style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="visible"/>
+            android:visibility="gone"/>
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/packages_list"


### PR DESCRIPTION
Summary
==========
Fix issue #8888 by adding the banner introduced in https://github.com/woocommerce/woocommerce-android/pull/8895 to the `Shipping Customs` view.

Screen capture
==========

https://user-images.githubusercontent.com/5920403/235270896-22d4e812-f117-4100-a0af-f8b10ccf3237.mp4



How to Test
==========
### Scenario 1
1. Open the app with a site containing the Shipping Labels plugin configured
2. Open the order details of an order with the `processing` status
3. Hit the `Create Shipping Label` button
4. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
5. Verify that the Banner is correctly displayed inside the view
6. Verify that hitting the dismiss button works and dismiss the banner with a collapse animation

### Scenario 2
1. Disable the `EU_SHIPPING_NOTIFICATION` flag inside the `FeatureFlag` class
2. Open the app with a site containing the Shipping Labels plugin configured
3. Open the order details of an order with the `processing` status
4. Hit the `Create Shipping Label` button
5. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
6. Verify that the Banner DOES NOT show up inside the view

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.