### PR TITLE
[Signup] Set minimum password length to 6

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpCredentialsValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpCredentialsValidator.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 
 class SignUpCredentialsValidator @Inject constructor() {
     private companion object {
-        const val PASSWORD_MIN_LENGTH = 7
+        const val PASSWORD_MIN_LENGTH = 6
     }
 
     fun isEmailValid(email: String): Boolean = StringUtils.isValidEmail(email)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8602
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Quick bug fix to set minimum password length to 6, instead of the current value of 7. This matches the behavior on web:

<img src="https://user-images.githubusercontent.com/266376/234862779-22fd5d2f-7f5b-4e13-856a-ccb42c6de260.png" />

See also conversation on issue #8602 for more details.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Be logged out
2. Tap "Get started"
3. Enter an email and a 6-char password and submit. Ensure it is accepted and no error is shown,
