### PR TITLE
[UI Tests] Make search and filter related waits consistent between Orders and Products tests.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -375,7 +375,7 @@ open class Screen {
         SupplierIdler(supplier).idleUntilReady(false)
     }
 
-    private fun waitForAtLeastOneElementToBeDisplayed(elementId: Int) {
+    fun waitForAtLeastOneElementToBeDisplayed(elementId: Int) {
         waitForConditionToBeTrue(
             Supplier {
                 atLeastOneElementIsDisplayed(elementId)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/OrderListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/OrderListScreen.kt
@@ -35,8 +35,6 @@ class OrderListScreen : Screen {
 
     fun enterSearchTerm(term: String): OrderListScreen {
         typeTextInto(androidx.appcompat.R.id.search_src_text, term)
-        // Sleep to let the previous results disappear
-        Thread.sleep(2000)
         // If we expect for results, we wait for the list header
         waitForElementToBeDisplayed(R.id.orderListHeader)
         return this
@@ -44,8 +42,6 @@ class OrderListScreen : Screen {
 
     fun enterAbsentSearchTerm(term: String): OrderListScreen {
         typeTextInto(androidx.appcompat.R.id.search_src_text, term)
-        // Sleep to let the previous results disappear
-        Thread.sleep(2000)
         // If we don't expect for results, we wait for "no results" situation
         waitForElementToBeDisplayed(R.id.empty_view_title)
         return this

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/OrderListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/OrderListScreen.kt
@@ -35,6 +35,8 @@ class OrderListScreen : Screen {
 
     fun enterSearchTerm(term: String): OrderListScreen {
         typeTextInto(androidx.appcompat.R.id.search_src_text, term)
+        // Sleep to let the previous results disappear
+        Thread.sleep(2000)
         // If we expect for results, we wait for the list header
         waitForElementToBeDisplayed(R.id.orderListHeader)
         return this
@@ -42,6 +44,8 @@ class OrderListScreen : Screen {
 
     fun enterAbsentSearchTerm(term: String): OrderListScreen {
         typeTextInto(androidx.appcompat.R.id.search_src_text, term)
+        // Sleep to let the previous results disappear
+        Thread.sleep(2000)
         // If we don't expect for results, we wait for "no results" situation
         waitForElementToBeDisplayed(R.id.empty_view_title)
         return this

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
@@ -61,7 +61,18 @@ class ProductListScreen : Screen {
 
     fun enterSearchTerm(term: String): ProductListScreen {
         typeTextInto(androidx.appcompat.R.id.search_src_text, term)
+        // Sleep to let the previous results disappear
         Thread.sleep(2000)
+        waitForAtLeastOneElementToBeDisplayed(R.id.productInfoContainer)
+        return this
+    }
+
+    fun enterAbsentSearchTerm(term: String): ProductListScreen {
+        typeTextInto(androidx.appcompat.R.id.search_src_text, term)
+        // Sleep to let the previous results disappear
+        Thread.sleep(2000)
+        // If we don't expect for results, we wait for "no results" situation
+        waitForElementToBeDisplayed(R.id.empty_view_title)
         return this
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
@@ -61,16 +61,12 @@ class ProductListScreen : Screen {
 
     fun enterSearchTerm(term: String): ProductListScreen {
         typeTextInto(androidx.appcompat.R.id.search_src_text, term)
-        // Sleep to let the previous results disappear
-        Thread.sleep(2000)
         waitForAtLeastOneElementToBeDisplayed(R.id.productInfoContainer)
         return this
     }
 
     fun enterAbsentSearchTerm(term: String): ProductListScreen {
         typeTextInto(androidx.appcompat.R.id.search_src_text, term)
-        // Sleep to let the previous results disappear
-        Thread.sleep(2000)
         // If we don't expect for results, we wait for "no results" situation
         waitForElementToBeDisplayed(R.id.empty_view_title)
         return this

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/shared/FilterScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/shared/FilterScreen.kt
@@ -51,8 +51,6 @@ class FilterScreen : Screen {
         )
 
         clickOn(showProductButton)
-        // Sleep to let the previous results disappear
-        Thread.sleep(2000)
 
         if (expectResults) {
             waitForAtLeastOneElementToBeDisplayed(R.id.productInfoContainer)
@@ -65,8 +63,6 @@ class FilterScreen : Screen {
 
     fun tapShowOrders(expectResults: Boolean): OrderListScreen {
         clickOn(R.id.showOrdersButton)
-        // Sleep to let the previous results disappear
-        Thread.sleep(2000)
 
         if (expectResults) {
             waitForElementToBeDisplayed(R.id.orderListHeader)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/shared/FilterScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/shared/FilterScreen.kt
@@ -39,7 +39,7 @@ class FilterScreen : Screen {
         return this
     }
 
-    fun tapShowProducts(expectResults: Boolean): ProductListScreen {
+    fun showProducts(expectResults: Boolean): ProductListScreen {
         val showProductButton = Espresso.onView(
             Matchers.allOf(
                 Matchers.anyOf(
@@ -61,7 +61,7 @@ class FilterScreen : Screen {
         return ProductListScreen()
     }
 
-    fun tapShowOrders(expectResults: Boolean): OrderListScreen {
+    fun showOrders(expectResults: Boolean): OrderListScreen {
         clickOn(R.id.showOrdersButton)
 
         if (expectResults) {
@@ -75,7 +75,7 @@ class FilterScreen : Screen {
 
     fun leaveFilterScreenToProducts(): ProductListScreen {
         if (isElementDisplayed(R.id.filterList) || isElementDisplayed(R.id.filterOptionList)) {
-            tapShowProducts(false)
+            showProducts(false)
         }
 
         return ProductListScreen()
@@ -83,7 +83,7 @@ class FilterScreen : Screen {
 
     fun leaveFilterScreenToOrders(): OrderListScreen {
         if (isElementDisplayed(R.id.filterList)) {
-            tapShowOrders(false)
+            showOrders(false)
         }
 
         return OrderListScreen()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/shared/FilterScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/shared/FilterScreen.kt
@@ -39,7 +39,7 @@ class FilterScreen : Screen {
         return this
     }
 
-    fun tapShowProducts(): ProductListScreen {
+    fun tapShowProducts(expectResults: Boolean): ProductListScreen {
         val showProductButton = Espresso.onView(
             Matchers.allOf(
                 Matchers.anyOf(
@@ -51,17 +51,35 @@ class FilterScreen : Screen {
         )
 
         clickOn(showProductButton)
+        // Sleep to let the previous results disappear
+        Thread.sleep(2000)
+
+        if (expectResults) {
+            waitForAtLeastOneElementToBeDisplayed(R.id.productInfoContainer)
+        } else {
+            waitForElementToBeDisplayedWithoutFailure(R.id.empty_view_title)
+        }
+
         return ProductListScreen()
     }
 
-    fun tapShowOrders(): OrderListScreen {
+    fun tapShowOrders(expectResults: Boolean): OrderListScreen {
         clickOn(R.id.showOrdersButton)
+        // Sleep to let the previous results disappear
+        Thread.sleep(2000)
+
+        if (expectResults) {
+            waitForElementToBeDisplayed(R.id.orderListHeader)
+        } else {
+            waitForElementToBeDisplayedWithoutFailure(R.id.empty_view_title)
+        }
+
         return OrderListScreen()
     }
 
     fun leaveFilterScreenToProducts(): ProductListScreen {
         if (isElementDisplayed(R.id.filterList) || isElementDisplayed(R.id.filterOptionList)) {
-            tapShowProducts()
+            tapShowProducts(false)
         }
 
         return ProductListScreen()
@@ -69,7 +87,7 @@ class FilterScreen : Screen {
 
     fun leaveFilterScreenToOrders(): OrderListScreen {
         if (isElementDisplayed(R.id.filterList)) {
-            tapShowOrders()
+            tapShowOrders(false)
         }
 
         return OrderListScreen()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
@@ -96,13 +96,13 @@ class OrdersRealAPI : TestBase() {
             // Filter by "Order Status" = "Completed"
             .tapFilters()
             .filterByPropertyAndValue("Order Status", "Completed")
-            .tapShowOrders(true)
+            .showOrders(true)
             .assertOrderCard(order41)
             .assertOrdersCount(1)
             // Check that "Clear" button works
             .tapFilters()
             .clearFilters()
-            .tapShowOrders(true)
+            .showOrders(true)
             .assertOrderCard(order40)
             .assertOrderCard(order41)
             .assertOrdersCount(2)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
@@ -96,13 +96,13 @@ class OrdersRealAPI : TestBase() {
             // Filter by "Order Status" = "Completed"
             .tapFilters()
             .filterByPropertyAndValue("Order Status", "Completed")
-            .tapShowOrders()
+            .tapShowOrders(true)
             .assertOrderCard(order41)
             .assertOrdersCount(1)
             // Check that "Clear" button works
             .tapFilters()
             .clearFilters()
-            .tapShowOrders()
+            .tapShowOrders(true)
             .assertOrderCard(order40)
             .assertOrderCard(order41)
             .assertOrdersCount(2)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
@@ -99,7 +99,7 @@ class OrdersRealAPI : TestBase() {
             .tapShowOrders()
             .assertOrderCard(order41)
             .assertOrdersCount(1)
-            // Check that "Clear" button works
+            // Check if "Clear" button works
             .tapFilters()
             .clearFilters()
             .tapShowOrders()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
@@ -99,7 +99,7 @@ class OrdersRealAPI : TestBase() {
             .tapShowOrders()
             .assertOrderCard(order41)
             .assertOrdersCount(1)
-            // Check if "Clear" button works
+            // Check that "Clear" button works
             .tapFilters()
             .clearFilters()
             .tapShowOrders()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
@@ -120,7 +120,9 @@ class OrdersRealAPI : TestBase() {
             .enterSearchTerm(order40.customerName)
             .assertOrderCard(order40)
             .assertOrdersCount(1)
+            .leaveSearchMode()
             // Search for non-existing order
+            .openSearchPane()
             .enterAbsentSearchTerm("Absent Order")
             .assertSearchResultsAbsent("Absent Order")
             // Leave search and make sure all orders are listed

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
@@ -119,11 +119,15 @@ class ProductsRealAPI : TestBase() {
             .enterSearchTerm(productCappuccino.name)
             .assertProductCard(productCappuccino)
             .assertProductsCount(1)
+            .leaveSearchMode()
             // Search for 'productSalad'
+            .openSearchPane()
             .enterSearchTerm(productSalad.name)
             .assertProductCard(productSalad)
             .assertProductsCount(1)
+            .leaveSearchMode()
             // Search for non-existing product
+            .openSearchPane()
             .enterAbsentSearchTerm("Unexisting Product")
             .assertProductsCount(0)
             // Leave search and make sure all products are listed
@@ -136,18 +140,24 @@ class ProductsRealAPI : TestBase() {
     @Test
     fun e2eRealApiProductsSearchBySKU() {
         ProductListScreen()
+            // Search for a simple product SKU
             .openSearchPane()
             .tapSearchSKU()
-            // Search for a simple product SKU
             .enterSearchTerm(productSalad.sku)
             .assertProductCard(productSalad)
             .assertProductsCount(1)
+            .leaveSearchMode()
             // Search for variations sharing a part of SKU
+            .openSearchPane()
+            .tapSearchSKU()
             .enterSearchTerm(productCappuccino.sku + "-ALM")
             .assertProductCard(productCappuccinoAlmondMedium)
             .assertProductCard(productCappuccinoAlmondLarge)
             .assertProductsCount(2)
+            .leaveSearchMode()
             // Search for exact variation SKU
+            .openSearchPane()
+            .tapSearchSKU()
             .enterSearchTerm(productCappuccinoAlmondLarge.sku)
             .assertProductCard(productCappuccinoAlmondLarge)
             .assertProductsCount(1)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
@@ -124,7 +124,7 @@ class ProductsRealAPI : TestBase() {
             .assertProductCard(productSalad)
             .assertProductsCount(1)
             // Search for non-existing product
-            .enterSearchTerm("Unexisting Product")
+            .enterAbsentSearchTerm("Unexisting Product")
             .assertProductsCount(0)
             // Leave search and make sure all products are listed
             .leaveSearchMode()
@@ -160,20 +160,20 @@ class ProductsRealAPI : TestBase() {
             // Filter by "Product type" = "Simple"
             .tapFilters()
             .filterByPropertyAndValue("Product type", "Simple")
-            .tapShowProducts()
+            .tapShowProducts(true)
             .assertProductCard(productSalad)
             .assertProductsCount(1)
             // Check that "Clear" button works
             .tapFilters()
             .clearFilters()
-            .tapShowProducts()
+            .tapShowProducts(true)
             .assertProductCard(productSalad)
             .assertProductCard(productCappuccino)
             .assertProductsCount(2)
             // Filter by "Stock status" = "Out of Stock" and expect to see zero products
             .tapFilters()
             .filterByPropertyAndValue("Stock status", "Out of stock")
-            .tapShowProducts()
+            .tapShowProducts(false)
             .assertProductsCount(0)
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
@@ -170,20 +170,20 @@ class ProductsRealAPI : TestBase() {
             // Filter by "Product type" = "Simple"
             .tapFilters()
             .filterByPropertyAndValue("Product type", "Simple")
-            .tapShowProducts(true)
+            .showProducts(true)
             .assertProductCard(productSalad)
             .assertProductsCount(1)
             // Check that "Clear" button works
             .tapFilters()
             .clearFilters()
-            .tapShowProducts(true)
+            .showProducts(true)
             .assertProductCard(productSalad)
             .assertProductCard(productCappuccino)
             .assertProductsCount(2)
             // Filter by "Stock status" = "Out of Stock" and expect to see zero products
             .tapFilters()
             .filterByPropertyAndValue("Stock status", "Out of stock")
-            .tapShowProducts(false)
+            .showProducts(false)
             .assertProductsCount(0)
     }
 


### PR DESCRIPTION
### Why
The Search and Filter tests for Products and Orders Lists that I recently added were inconsistent in the following ways:

- When searching for existing item, Orders tests waited for results table header to be shown, while Products tests did not wait for any particular element to appear, they just slept for 2 sec.
- When searching for non-existing item, Orders tests waited for empty results view using a dedicated method, while for Products the same 2 sec sleep was used
- When using Filter, none of the tests waited for results or their absence.

### Description
This PR brings consistency to this area, by doing the following:
- For both Orders and Products, when we search for **existing** item, we wait for certain element (depends on the screen) to appear.
- For both Orders and Products, when we search for a **non-existing** item, we wait for `R.id.empty_view_title` to appear.
- When we use Filter, we define if we expect to see the results in the same ways as above.
- [**The most controversial**] after hitting `Search` or `Filter`, and before waiting for elements mentioned above, the methods also wait for 2 seconds for the old results to go away - when not done, this causes problems on CI ([here](https://buildkite.com/automattic/woocommerce-android/builds/11672#0187c35d-0b09-4466-9ee6-2b6ddf553a25) and [here](https://buildkite.com/automattic/woocommerce-android/builds/11672#0187c41c-1ac6-44f1-8715-f689b39623fa)).

### Testing instructions
- CI is green.
