### PR TITLE
EU-bound Shipping Notice: Add shipping notice `Learn more` and `Dismiss` behaviors

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -109,6 +109,7 @@ object AppPrefs {
         IS_TAP_TO_PAY_BETA_ENABLED,
         JETPACK_INSTALLATION_FROM_BANNER,
         NOTIFICATIONS_PERMISSION_BAR,
+        IS_EU_SHIPPING_NOTICE_DISMISSED,
     }
 
     /**
@@ -250,6 +251,10 @@ object AppPrefs {
     var updateReaderOptionSelected: String
         get() = getString(UPDATE_SIMULATED_READER_OPTION, UpdateOptions.RANDOM.toString())
         set(option) = setString(UPDATE_SIMULATED_READER_OPTION, option)
+
+    var isEUShippingNoticeDismissed: Boolean
+        get() = getBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, false)
+        set(value) = setBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -86,4 +86,6 @@ object AppUrls {
         LOGIN_SITE_ADDRESS to "$LOGIN_HELP_CENTER#enter-store-address",
         LOGIN_USERNAME_PASSWORD to "$LOGIN_HELP_CENTER#enter-store-credentials",
     )
+
+    const val EU_SHIPPING_CUSTOMS_REQUIREMENTS = "https://www.usps.com/international/new-eu-customs-rules.htm"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -312,7 +312,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
             with(binding.shippingNoticeBanner) {
                 isVisible = true
                 setDismissClickListener { collapse() }
-                setLearnMoreClickListener { viewModel.onShippingNoticeLearnMoreClicked() }
+                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.PACKAGING
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.PAYMENT
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.SHIPPING_ADDRESS
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.OpenShippingInstructions
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.OrderSummaryState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.StepUiState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.Failed
@@ -56,6 +57,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustoms
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SUGGESTED_ADDRESS_DISCARDED
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PriceUtils
@@ -271,6 +273,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                         )
                     findNavController().navigateSafely(action)
                 }
+                is OpenShippingInstructions -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is ShowDialog -> event.showDialog()
                 is Exit -> findNavController().navigateUp()
                 else -> event.isHandled = false
@@ -309,6 +312,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
             with(binding.shippingNoticeBanner) {
                 isVisible = true
                 setDismissClickListener { collapse() }
+                setLearnMoreClickListener { viewModel.onShippingNoticeLearnMoreClicked() }
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -9,11 +9,11 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCreateShippingLabelBinding
 import com.woocommerce.android.databinding.ViewShippingLabelOrderPackagePriceBinding
 import com.woocommerce.android.databinding.ViewShippingLabelOrderSummaryBinding
-import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.isNotEqualTo
@@ -310,8 +310,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
     private fun initializeViews(binding: FragmentCreateShippingLabelBinding) {
         if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()) {
             with(binding.shippingNoticeBanner) {
-                isVisible = true
-                setDismissClickListener { collapse() }
+                isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
                 setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -315,7 +315,6 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
             }
         }
 
-
         binding.originStep.continueButtonClickListener = {
             viewModel.onContinueButtonTapped(
                 ORIGIN_ADDRESS

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -757,8 +756,8 @@ class CreateShippingLabelViewModel @Inject constructor(
         }
     }
 
-    fun onShippingNoticeLearnMoreClicked() {
-        triggerEvent(OpenShippingInstructions(AppUrls.EU_SHIPPING_CUSTOMS_REQUIREMENTS))
+    fun onShippingNoticeLearnMoreClicked(learnMoreUrl: String) {
+        triggerEvent(OpenShippingInstructions(learnMoreUrl))
     }
 
     override fun onCleared() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -116,6 +117,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -755,6 +757,10 @@ class CreateShippingLabelViewModel @Inject constructor(
         }
     }
 
+    fun onShippingNoticeLearnMoreClicked() {
+        triggerEvent(OpenShippingInstructions(AppUrls.EU_SHIPPING_CUSTOMS_REQUIREMENTS))
+    }
+
     override fun onCleared() {
         super.onCleared()
         shippingLabelRepository.clearCache()
@@ -840,4 +846,6 @@ class CreateShippingLabelViewModel @Inject constructor(
     enum class FlowStep {
         ORIGIN_ADDRESS, SHIPPING_ADDRESS, PACKAGING, CUSTOMS, CARRIER, PAYMENT
     }
+
+    data class OpenShippingInstructions(val url: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -10,15 +10,17 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentShippingCustomsBinding
-import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsViewModel.OpenShippingInstructions
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -84,8 +86,8 @@ class ShippingCustomsFragment :
 
         if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()) {
             with(binding.shippingNoticeBanner) {
-                isVisible = true
-                setDismissClickListener { collapse() }
+                isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
+                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
             }
         }
 
@@ -113,6 +115,7 @@ class ShippingCustomsFragment :
             viewLifecycleOwner
         ) { event ->
             when (event) {
+                is OpenShippingInstructions -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is ExitWithResult<*> -> navigateBackWithResult(EDIT_CUSTOMS_RESULT, event.data)
                 is Exit -> navigateBackWithNotice(EDIT_CUSTOMS_CLOSED)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsViewModel.LineValidationState
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -132,6 +133,10 @@ class ShippingCustomsViewModel @Inject constructor(
 
     fun onBackButtonClicked() {
         triggerEvent(Exit)
+    }
+
+    fun onShippingNoticeLearnMoreClicked(learnMoreUrl: String) {
+        triggerEvent(OpenShippingInstructions(learnMoreUrl))
     }
 
     override fun onPackageExpandedChanged(position: Int, isExpanded: Boolean) {
@@ -364,6 +369,8 @@ class ShippingCustomsViewModel @Inject constructor(
             get() = itemDescriptionErrorMessage == null && hsTariffErrorMessage == null &&
                 weightErrorMessage == null && valueErrorMessage == null
     }
+
+    data class OpenShippingInstructions(val url: String) : MultiLiveEvent.Event()
 }
 
 typealias CustomsLineUiState = Pair<CustomsLine, LineValidationState>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
@@ -30,9 +29,5 @@ class ShippingNoticeCard @JvmOverloads constructor(
         binding.learnMoreButton.setOnClickListener {
             action(AppUrls.EU_SHIPPING_CUSTOMS_REQUIREMENTS)
         }
-    }
-
-    fun setDismissClickListener(action: (View) -> Unit) {
-        binding.dismissButton.setOnClickListener(action)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -5,8 +5,10 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.databinding.ShippingNoticeBannerBinding
+import com.woocommerce.android.extensions.collapse
 
 class ShippingNoticeCard @JvmOverloads constructor(
     context: Context,
@@ -16,6 +18,13 @@ class ShippingNoticeCard @JvmOverloads constructor(
     private val binding = ShippingNoticeBannerBinding.inflate(
         LayoutInflater.from(context), this, true
     )
+
+    init {
+        binding.dismissButton.setOnClickListener {
+            AppPrefs.isEUShippingNoticeDismissed = true
+            collapse()
+        }
+    }
 
     fun setLearnMoreClickListener(action: (url: String) -> Unit) {
         binding.learnMoreButton.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.databinding.ShippingNoticeBannerBinding
 
 class ShippingNoticeCard @JvmOverloads constructor(
@@ -16,8 +17,10 @@ class ShippingNoticeCard @JvmOverloads constructor(
         LayoutInflater.from(context), this, true
     )
 
-    fun setLearnMoreClickListener(action: (View) -> Unit) {
-        binding.learnMoreButton.setOnClickListener(action)
+    fun setLearnMoreClickListener(action: (url: String) -> Unit) {
+        binding.learnMoreButton.setOnClickListener {
+            action(AppUrls.EU_SHIPPING_CUSTOMS_REQUIREMENTS)
+        }
     }
 
     fun setDismissClickListener(action: (View) -> Unit) {


### PR DESCRIPTION
Summary
==========
Partially fix issues #8890 and #8889 by configuring the `Learn More` button behavior and the `dismiss` button persistence. 

Screen capture
==========
https://user-images.githubusercontent.com/5920403/235269716-c0d0b293-1a60-457a-8ac2-97956de8d390.mp4

How to Test
==========
Make sure the `EU_SHIPPING_NOTIFICATION` Feature flag is active before testing.

### Scenario 1
1. Open the app using a store with the `Shipping Labels` plugin activated
2. Open the Order Details of an order with the `Processing` status
3. Hit the `Create Shipping Label` button
4. Verify that the Banner is correctly displayed inside the view
5. Verify that hitting the dismiss button works and the Banner no longer appears no matter what

### Scenario 2
1. Open the app using a store with the `Shipping Labels` plugin activated
2. Open the Order Details of an order with the `Processing` status
3. Hit the `Create Shipping Label` button
4. Verify that the Banner is correctly displayed inside the view
5. Hit the `Learn more` button and verify that a web view with the `USPS` page explaining the new Customs rule opens

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.