### PR TITLE
[JITM] Add support for SVG for JITMs + dark mode

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -375,6 +375,7 @@ dependencies {
     implementation "com.google.accompanist:accompanist-swiperefresh:$composeAccompanistVersion"
     implementation "com.google.accompanist:accompanist-systemuicontroller:$composeAccompanistVersion"
     implementation "io.coil-kt:coil-compose:$coilVersion"
+    implementation "io.coil-kt:coil-svg:$coilVersion"
 
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.3.2'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmModal.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmModal.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.jitm
 
 import android.content.res.Configuration
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -58,7 +59,10 @@ fun JitmModal(state: JitmState.Modal) {
                 ) {
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
-                            .data(state.backgroundImageUrl)
+                            .data(
+                                if (isSystemInDarkTheme()) state.backgroundDarkImageUrl
+                                else state.backgroundLightImageUrl
+                            )
                             .fallback(R.drawable.img_woo_generic_error)
                             .error(R.drawable.img_woo_generic_error)
                             .decoderFactory(SvgDecoder.Factory())
@@ -129,7 +133,8 @@ fun JitmDialogPreview() {
                 title = UiString.UiStringRes(R.string.card_reader_upsell_card_reader_banner_title),
                 description = UiString.UiStringRes(R.string.card_reader_upsell_card_reader_banner_description),
                 primaryActionLabel = UiString.UiStringRes(R.string.card_reader_upsell_card_reader_banner_cta),
-                backgroundImageUrl = "",
+                backgroundLightImageUrl = "",
+                backgroundDarkImageUrl = ""
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmModal.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmModal.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil.compose.AsyncImage
+import coil.decode.SvgDecoder
 import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
@@ -60,6 +61,7 @@ fun JitmModal(state: JitmState.Modal) {
                             .data(state.backgroundImageUrl)
                             .fallback(R.drawable.img_woo_generic_error)
                             .error(R.drawable.img_woo_generic_error)
+                            .decoderFactory(SvgDecoder.Factory())
                             .build(),
                         contentDescription = null,
                         contentScale = ContentScale.Crop,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmState.kt
@@ -15,12 +15,18 @@ sealed interface JitmState {
     ) : JitmState {
         sealed class LocalOrRemoteImage {
             data class Local(@DrawableRes val drawableId: Int) : LocalOrRemoteImage()
-            data class Remote(val url: String) : LocalOrRemoteImage()
+            data class Remote(
+                val urlLightMode: String,
+                val urlDarkMode: String,
+            ) : LocalOrRemoteImage()
         }
 
         sealed class LabelOrRemoteIcon {
             data class Label(val label: UiString) : LabelOrRemoteIcon()
-            data class Remote(val url: String) : LabelOrRemoteIcon()
+            data class Remote(
+                val urlLightMode: String,
+                val urlDarkMode: String,
+            ) : LabelOrRemoteIcon()
         }
     }
 
@@ -30,7 +36,8 @@ sealed interface JitmState {
         val title: UiString,
         val description: UiString,
         val primaryActionLabel: UiString,
-        val backgroundImageUrl: String?,
+        val backgroundLightImageUrl: String?,
+        val backgroundDarkImageUrl: String?,
     ) : JitmState
 
     object Hidden : JitmState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmViewModel.kt
@@ -77,8 +77,11 @@ class JitmViewModel @Inject constructor(
                     title = UiString.UiStringText(model.content.message),
                     description = UiString.UiStringText(model.content.description),
                     primaryActionLabel = UiString.UiStringText(model.cta.message),
-                    backgroundImageUrl = model.assets?.get(JITM_ASSETS_BACKGROUND_IMAGE_KEY),
+                    backgroundLightImageUrl = model.assets?.get(JITM_ASSETS_BACKGROUND_IMAGE_LIGHT_THEME_KEY),
+                    backgroundDarkImageUrl = model.assets?.get(JITM_ASSETS_BACKGROUND_IMAGE_DARK_THEME_KEY)
+                        ?: model.assets?.get(JITM_ASSETS_BACKGROUND_IMAGE_LIGHT_THEME_KEY),
                 )
+
                 else -> JitmState.Banner(
                     onPrimaryActionClicked = { onJitmCtaClicked(model) },
                     onDismissClicked = { onJitmDismissClicked(model) },
@@ -127,6 +130,7 @@ class JitmViewModel @Inject constructor(
                             model.featureClass
                         )
                     }
+
                     else -> jitmTracker.trackJitmDismissFailure(
                         MyStoreViewModel.UTM_SOURCE,
                         model.id,
@@ -140,11 +144,20 @@ class JitmViewModel @Inject constructor(
     }
 
     private fun Assets.getBackgroundImage() =
-        this?.get(JITM_ASSETS_BACKGROUND_IMAGE_KEY)?.let { JitmState.Banner.LocalOrRemoteImage.Remote(it) }
-            ?: JitmState.Banner.LocalOrRemoteImage.Local(R.drawable.ic_banner_upsell_card_reader_illustration)
+        this?.get(JITM_ASSETS_BACKGROUND_IMAGE_LIGHT_THEME_KEY)?.let {
+            JitmState.Banner.LocalOrRemoteImage.Remote(
+                urlLightMode = it,
+                urlDarkMode = this[JITM_ASSETS_BACKGROUND_IMAGE_DARK_THEME_KEY] ?: it
+            )
+        } ?: JitmState.Banner.LocalOrRemoteImage.Local(R.drawable.ic_banner_upsell_card_reader_illustration)
 
     private fun Assets.getBadgeIcon() =
-        this?.get(JITM_ASSETS_BADGE_IMAGE_KEY)?.let { JitmState.Banner.LabelOrRemoteIcon.Remote(it) }
+        this?.get(JITM_ASSETS_BADGE_IMAGE_LIGHT_THEME_KEY)?.let {
+            JitmState.Banner.LabelOrRemoteIcon.Remote(
+                urlLightMode = it,
+                urlDarkMode = this[JITM_ASSETS_BADGE_IMAGE_DARK_THEME_KEY] ?: it
+            )
+        }
             ?: JitmState.Banner.LabelOrRemoteIcon.Label(
                 UiString.UiStringRes(R.string.card_reader_upsell_card_reader_banner_new)
             )
@@ -153,8 +166,12 @@ class JitmViewModel @Inject constructor(
 
     companion object {
         const val JITM_MESSAGE_PATH_KEY = "jitm_message_path_key"
-        private const val JITM_ASSETS_BACKGROUND_IMAGE_KEY = "background_image_url"
-        private const val JITM_ASSETS_BADGE_IMAGE_KEY = "badge_image_url"
+
+        private const val JITM_ASSETS_BACKGROUND_IMAGE_LIGHT_THEME_KEY = "background_image_url"
+        private const val JITM_ASSETS_BACKGROUND_IMAGE_DARK_THEME_KEY = "background_image_dark_url"
+
+        private const val JITM_ASSETS_BADGE_IMAGE_LIGHT_THEME_KEY = "badge_image_url"
+        private const val JITM_ASSETS_BADGE_IMAGE_DARK_THEME_KEY = "badge_image_dark_url"
 
         private const val JITM_TEMPLATE_MODAL = "modal"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import coil.decode.SvgDecoder
 import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
@@ -135,6 +136,7 @@ private fun BackgroundImage(bannerState: JitmState.Banner) {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(icon.url)
+                    .decoderFactory(SvgDecoder.Factory())
                     .build(),
                 contentDescription = null,
                 modifier = Modifier.width(154.dp)
@@ -170,6 +172,7 @@ private fun BadgeIcon(bannerState: JitmState.Banner) {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(icon.url)
+                    .decoderFactory(SvgDecoder.Factory())
                     .build(),
                 contentDescription = null,
                 modifier = Modifier.height(26.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.payments.banner
 
 import android.content.res.Configuration
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -135,7 +136,10 @@ private fun BackgroundImage(bannerState: JitmState.Banner) {
         is JitmState.Banner.LocalOrRemoteImage.Remote -> {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data(icon.url)
+                    .data(
+                        if (isSystemInDarkTheme()) icon.urlDarkMode
+                        else icon.urlLightMode
+                    )
                     .decoderFactory(SvgDecoder.Factory())
                     .build(),
                 contentDescription = null,
@@ -171,7 +175,10 @@ private fun BadgeIcon(bannerState: JitmState.Banner) {
         is JitmState.Banner.LabelOrRemoteIcon.Remote -> {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data(icon.url)
+                    .data(
+                        if (isSystemInDarkTheme()) icon.urlDarkMode
+                        else icon.urlLightMode
+                    )
                     .decoderFactory(SvgDecoder.Factory())
                     .build(),
                 contentDescription = null,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8916
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds
* SVG support for remote assets
* Images for dark theme for remote assets 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The easiest way to test would be to change the code of `JitmViewModel`. 
For instance you can use this snippets:

```
backgroundLightImageUrl = "https://svgur.com/i/sfL.svg",
backgroundDarkImageUrl = "https://svgur.com/i/sdP.svg",
```

and

```
backgroundImage = JitmState.Banner.LocalOrRemoteImage.Remote(
 "https://svgur.com/i/sfL.svg",
  "https://svgur.com/i/sdP.svg",
),
```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="292" alt="Screenshot 2023-05-01 at 15 27 23" src="https://user-images.githubusercontent.com/4923871/235447459-c9392980-1102-438c-b296-40ecc48202be.png">
<img width="294" alt="Screenshot 2023-05-01 at 15 27 08" src="https://user-images.githubusercontent.com/4923871/235447468-3593e8b6-1146-4426-872b-ac062f69bc00.png">
<img width="297" alt="Screenshot 2023-05-01 at 15 23 24" src="https://user-images.githubusercontent.com/4923871/235447471-063f6450-15f6-4e2e-99fa-bc08a2218fa1.png">
<img width="295" alt="Screenshot 2023-05-01 at 14 51 54" src="https://user-images.githubusercontent.com/4923871/235447475-0faa73f0-c27d-4181-b05a-d9a8acd4a5ce.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
