### PR TITLE
EU-bound Shipping Notice: Introduce EU customs rule check

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -257,7 +257,7 @@ object AppPrefs {
         set(option) = setString(UPDATE_SIMULATED_READER_OPTION, option)
 
     var isEUShippingNoticeDismissed: Boolean
-        get() = getBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, false)
+        get() = false // getBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, false)
         set(value) = setBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -257,7 +257,7 @@ object AppPrefs {
         set(option) = setString(UPDATE_SIMULATED_READER_OPTION, option)
 
     var isEUShippingNoticeDismissed: Boolean
-        get() = false // getBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, false)
+        get() = getBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, false)
         set(value) = setBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -50,7 +50,8 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
         val originCountryCode: String,
         val destinationCountryCode: String,
         val shippingPackages: List<ShippingLabelPackage>,
-        val customsPackages: List<CustomsPackage>
+        val customsPackages: List<CustomsPackage>,
+        val isEUShippingScenario: Boolean
     ) : CreateShippingLabelEvent()
 
     data class ShowShippingRates(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -313,7 +313,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
     }
 
     private fun initializeViews(binding: FragmentCreateShippingLabelBinding) {
-        if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()) {
+        if (viewModel.isEUShippingScenario) {
             with(binding.shippingNoticeBanner) {
                 isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
                 setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -282,7 +282,8 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                             originCountryCode = event.originCountryCode,
                             destinationCountryCode = event.destinationCountryCode,
                             shippingPackages = event.shippingPackages.toTypedArray(),
-                            customsPackages = event.customsPackages.toTypedArray()
+                            customsPackages = event.customsPackages.toTypedArray(),
+                            isEUShippingScenario = event.isEUShippingScenario
                         )
                     findNavController().navigateSafely(action)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -206,7 +206,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         }
 
         viewModel.isEUShippingScenario.observe(viewLifecycleOwner) {
-            if (it) return@observe
+            if (it.not()) return@observe
 
             with(binding.shippingNoticeBanner) {
                 isVisible = AppPrefs.isEUShippingNoticeDismissed.not()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -205,7 +205,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
             }
         }
 
-        viewModel.isEUShippingScenario.observe(viewLifecycleOwner) {
+        viewModel.shouldDisplayShippingNotice.observe(viewLifecycleOwner) {
             if (it.not()) return@observe
 
             with(binding.shippingNoticeBanner) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -64,7 +64,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAd
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SUGGESTED_ADDRESS_DISCARDED
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
@@ -206,6 +205,15 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
             }
         }
 
+        viewModel.isEUShippingScenario.observe(viewLifecycleOwner) {
+            if (it) return@observe
+
+            with(binding.shippingNoticeBanner) {
+                isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
+                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
+            }
+        }
+
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
@@ -313,12 +321,6 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
     }
 
     private fun initializeViews(binding: FragmentCreateShippingLabelBinding) {
-        if (viewModel.isEUShippingScenario) {
-            with(binding.shippingNoticeBanner) {
-                isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
-                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
-            }
-        }
 
         binding.originStep.continueButtonClickListener = {
             viewModel.onContinueButtonTapped(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -170,7 +170,7 @@ class CreateShippingLabelViewModel @Inject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    val isEUShippingScenario = checkEUShippingScenario(
+    val shouldDisplayShippingNotice = checkEUShippingScenario(
         stateMachine.transitions
     ).asLiveData()
 
@@ -370,7 +370,7 @@ class CreateShippingLabelViewModel @Inject constructor(
                 destinationCountryCode = destinationCountryCode,
                 shippingPackages = shippingPackages,
                 customsPackages = customsPackages,
-                isEUShippingScenario = isEUShippingScenario.value ?: false
+                isEUShippingScenario = shouldDisplayShippingNotice.value ?: false
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -110,6 +110,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.NOT_READY
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepsState
+import com.woocommerce.android.ui.orders.shippinglabels.creation.banner.CheckEUShippingScenario
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CurrencyFormatter
@@ -151,7 +152,8 @@ class CreateShippingLabelViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter,
     private val getLocations: GetLocations,
-    private val appPrefs: AppPrefsWrapper
+    private val appPrefs: AppPrefsWrapper,
+    private val checkEUShippingScenario: CheckEUShippingScenario
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val STATE_KEY = KEY_STATE
@@ -166,6 +168,9 @@ class CreateShippingLabelViewModel @Inject constructor(
 
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
+
+    val isEUShippingScenario
+        get() = checkEUShippingScenario()
 
     init {
         initializeStateMachine()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -367,7 +367,8 @@ class CreateShippingLabelViewModel @Inject constructor(
                 originCountryCode = originCountryCode,
                 destinationCountryCode = destinationCountryCode,
                 shippingPackages = shippingPackages,
-                customsPackages = customsPackages
+                customsPackages = customsPackages,
+                isEUShippingScenario = isEUShippingScenario.value ?: false
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -143,6 +143,7 @@ import kotlin.system.measureTimeMillis
 class CreateShippingLabelViewModel @Inject constructor(
     savedState: SavedStateHandle,
     parameterRepository: ParameterRepository,
+    checkEUShippingScenario: CheckEUShippingScenario,
     private val orderDetailRepository: OrderDetailRepository,
     private val shippingLabelRepository: ShippingLabelRepository,
     private val stateMachine: ShippingLabelsStateMachine,
@@ -169,7 +170,9 @@ class CreateShippingLabelViewModel @Inject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    val isEUShippingScenario = CheckEUShippingScenario().invoke(stateMachine).asLiveData()
+    val isEUShippingScenario = checkEUShippingScenario(
+        stateMachine.transitions
+    ).asLiveData()
 
     init {
         initializeStateMachine()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -153,8 +153,7 @@ class CreateShippingLabelViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter,
     private val getLocations: GetLocations,
-    private val appPrefs: AppPrefsWrapper,
-    private val checkEUShippingScenario: CheckEUShippingScenario
+    private val appPrefs: AppPrefsWrapper
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val STATE_KEY = KEY_STATE
@@ -170,7 +169,7 @@ class CreateShippingLabelViewModel @Inject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    val isEUShippingScenario = checkEUShippingScenario().asLiveData()
+    val isEUShippingScenario = CheckEUShippingScenario().invoke(stateMachine).asLiveData()
 
     init {
         initializeStateMachine()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -169,8 +170,7 @@ class CreateShippingLabelViewModel @Inject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    val isEUShippingScenario
-        get() = checkEUShippingScenario()
+    val isEUShippingScenario = checkEUShippingScenario().asLiveData()
 
     init {
         initializeStateMachine()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -105,7 +105,7 @@ class ShippingCustomsFragment :
         }
 
         viewModel.isEUShippingScenario.observe(viewLifecycleOwner) {
-            if (it) return@observe
+            if (it.not()) return@observe
 
             with(binding.shippingNoticeBanner) {
                 isVisible = AppPrefs.isEUShippingNoticeDismissed.not()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -83,6 +83,13 @@ class ShippingCustomsFragment :
             }
         }
 
+        if (viewModel.isEUShippingScenario) {
+            with(binding.shippingNoticeBanner) {
+                isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
+                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
+            }
+        }
+
         setupObservers(binding)
     }
 
@@ -101,15 +108,6 @@ class ShippingCustomsFragment :
             new.isProgressViewShown.takeIfNotEqualTo(old?.isProgressViewShown) { show ->
                 binding.progressView.isVisible = show
                 binding.packagesList.isVisible = !show
-            }
-        }
-
-        viewModel.isEUShippingScenario.observe(viewLifecycleOwner) {
-            if (it.not()) return@observe
-
-            with(binding.shippingNoticeBanner) {
-                isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
-                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsViewModel.OpenShippingInstructions
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -84,7 +83,7 @@ class ShippingCustomsFragment :
             }
         }
 
-        if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()) {
+        if (viewModel.isEUShippingScenario) {
             with(binding.shippingNoticeBanner) {
                 isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
                 setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -83,13 +83,6 @@ class ShippingCustomsFragment :
             }
         }
 
-        if (viewModel.isEUShippingScenario) {
-            with(binding.shippingNoticeBanner) {
-                isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
-                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
-            }
-        }
-
         setupObservers(binding)
     }
 
@@ -110,6 +103,16 @@ class ShippingCustomsFragment :
                 binding.packagesList.isVisible = !show
             }
         }
+
+        viewModel.isEUShippingScenario.observe(viewLifecycleOwner) {
+            if (it) return@observe
+
+            with(binding.shippingNoticeBanner) {
+                isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
+                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
+            }
+        }
+
         viewModel.event.observe(
             viewLifecycleOwner
         ) { event ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.model.ContentsType
@@ -71,8 +72,7 @@ class ShippingCustomsViewModel @Inject constructor(
     val countries: List<Location>
         get() = dataStore.getCountries().map { it.toAppModel() }
 
-    val isEUShippingScenario
-        get() = checkEUShippingScenario()
+    val isEUShippingScenario = checkEUShippingScenario().asLiveData()
 
     init {
         loadData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.model.RestrictionType
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsViewModel.LineValidationState
+import com.woocommerce.android.ui.orders.shippinglabels.creation.banner.CheckEUShippingScenario
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -48,7 +49,8 @@ class ShippingCustomsViewModel @Inject constructor(
     private val selectedSide: SelectedSite,
     parameterRepository: ParameterRepository,
     private val dataStore: WCDataStore,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val checkEUShippingScenario: CheckEUShippingScenario
 ) : ScopedViewModel(savedStateHandle), ShippingCustomsFormListener {
     companion object {
         private const val KEY_PARAMETERS = "key_parameters"
@@ -68,6 +70,9 @@ class ShippingCustomsViewModel @Inject constructor(
 
     val countries: List<Location>
         get() = dataStore.getCountries().map { it.toAppModel() }
+
+    val isEUShippingScenario
+        get() = checkEUShippingScenario()
 
     init {
         loadData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.model.ContentsType
@@ -13,7 +12,6 @@ import com.woocommerce.android.model.RestrictionType
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsViewModel.LineValidationState
-import com.woocommerce.android.ui.orders.shippinglabels.creation.banner.CheckEUShippingScenario
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -50,8 +48,7 @@ class ShippingCustomsViewModel @Inject constructor(
     private val selectedSide: SelectedSite,
     parameterRepository: ParameterRepository,
     private val dataStore: WCDataStore,
-    private val resourceProvider: ResourceProvider,
-    private val checkEUShippingScenario: CheckEUShippingScenario
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedStateHandle), ShippingCustomsFormListener {
     companion object {
         private const val KEY_PARAMETERS = "key_parameters"
@@ -72,7 +69,8 @@ class ShippingCustomsViewModel @Inject constructor(
     val countries: List<Location>
         get() = dataStore.getCountries().map { it.toAppModel() }
 
-    val isEUShippingScenario = checkEUShippingScenario().asLiveData()
+    val isEUShippingScenario
+        get() = args.isEUShippingScenario
 
     init {
         loadData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -64,42 +64,5 @@ class CheckEUShippingScenario @Inject constructor() {
             "SE", "SWE",
             "CH", "CHE"
         )
-        EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES.any { countryIsoCode ->
-            countryIsoCode.first == code || countryIsoCode.second == code
-        }
-
-    companion object {
-        const val US_COUNTRY_CODE = "US"
-        val EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES = listOf(
-            Pair("AT", "AUT"),
-            Pair("BE", "BEL"),
-            Pair("BG", "BGR"),
-            Pair("HR", "HRV"),
-            Pair("CY", "CYP"),
-            Pair("CZ", "CZE"),
-            Pair("DK", "DNK"),
-            Pair("EE", "EST"),
-            Pair("FI", "FIN"),
-            Pair("FR", "FRA"),
-            Pair("DE", "DEU"),
-            Pair("GR", "GRC"),
-            Pair("HU", "HUN"),
-            Pair("IE", "IRL"),
-            Pair("IT", "ITA"),
-            Pair("LV", "LVA"),
-            Pair("LT", "LTU"),
-            Pair("LU", "LUX"),
-            Pair("MT", "MLT"),
-            Pair("NL", "NLD"),
-            Pair("NO", "NOR"),
-            Pair("PL", "POL"),
-            Pair("PT", "PRT"),
-            Pair("RO", "ROU"),
-            Pair("SK", "SVK"),
-            Pair("SI", "SVN"),
-            Pair("ES", "ESP"),
-            Pair("SE", "SWE"),
-            Pair("CH", "CHE")
-        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
+
+class CheckEUShippingScenario {
+    operator fun invoke(): Boolean {
+        return false
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -1,9 +1,14 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine
 import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+import kotlinx.coroutines.flow.flow
 
-class CheckEUShippingScenario {
-    operator fun invoke(): Boolean {
-        return FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()
+class CheckEUShippingScenario @Inject constructor(
+    private val stateMachine: ShippingLabelsStateMachine
+) {
+    operator fun invoke() = flow {
+        emit(FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -29,7 +29,41 @@ class CheckEUShippingScenario @Inject constructor() {
             destinationCountry.isEUCountryFollowingNewCustomRules()
     }
 
-    private fun Location.isEUCountryFollowingNewCustomRules() =
+    private fun Location.isEUCountryFollowingNewCustomRules() = code in EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES
+
+    companion object {
+        const val US_COUNTRY_CODE = "US"
+        val EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES = setOf(
+            "AT", "AUT",
+            "BE", "BEL",
+            "BG", "BGR",
+            "HR", "HRV",
+            "CY", "CYP",
+            "CZ", "CZE",
+            "DK", "DNK",
+            "EE", "EST",
+            "FI", "FIN",
+            "FR", "FRA",
+            "DE", "DEU",
+            "GR", "GRC",
+            "HU", "HUN",
+            "IE", "IRL",
+            "IT", "ITA",
+            "LV", "LVA",
+            "LT", "LTU",
+            "LU", "LUX",
+            "MT", "MLT",
+            "NL", "NLD",
+            "NO", "NOR",
+            "PL", "POL",
+            "PT", "PRT",
+            "RO", "ROU",
+            "SK", "SVK",
+            "SI", "SVN",
+            "ES", "ESP",
+            "SE", "SWE",
+            "CH", "CHE"
+        )
         EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES.any { countryIsoCode ->
             countryIsoCode.first == code || countryIsoCode.second == code
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 
-import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
@@ -26,11 +25,8 @@ class CheckEUShippingScenario @Inject constructor() {
         val destinationCountry = stepsState.shippingAddressStep.data.country
 
         return originCountry.code == US_COUNTRY_CODE &&
-            destinationCountry.isFollowingNewEUCustomRules
+            destinationCountry.code in EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES
     }
-
-    private val Location.isFollowingNewEUCustomRules
-        get() = code in EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES
 
     companion object {
         const val US_COUNTRY_CODE = "US"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -15,7 +15,6 @@ class CheckEUShippingScenario {
             when (it.state) {
                 is WaitingForInput -> emit(it.state.data.isEUShippingConditionMet())
                 else -> emit(false)
-
             }
         }
     }
@@ -33,9 +32,8 @@ class CheckEUShippingScenario {
             countryIsoCode.first == code || countryIsoCode.second == code
         }
 
-
     companion object {
-        val US_COUNTRY_CODE = "US"
+        const val US_COUNTRY_CODE = "US"
         val EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES = listOf(
             Pair("AT", "AUT"),
             Pair("BE", "BEL"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -1,17 +1,19 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 
 import com.woocommerce.android.model.Location
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 
-class CheckEUShippingScenario {
-    operator fun invoke(stateMachine: ShippingLabelsStateMachine) = flow {
+class CheckEUShippingScenario @Inject constructor() {
+    operator fun invoke(shippingStateTransitions: StateFlow<Transition>) = flow {
         if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled().not()) emit(false)
 
-        stateMachine.transitions.collect {
+        shippingStateTransitions.collect {
             when (it.state) {
                 is WaitingForInput -> emit(it.state.data.isEUShippingConditionMet())
                 else -> emit(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -26,10 +26,11 @@ class CheckEUShippingScenario @Inject constructor() {
         val destinationCountry = stepsState.shippingAddressStep.data.country
 
         return originCountry.code == US_COUNTRY_CODE &&
-            destinationCountry.isEUCountryFollowingNewCustomRules()
+            destinationCountry.isFollowingNewEUCustomRules
     }
 
-    private fun Location.isEUCountryFollowingNewCustomRules() = code in EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES
+    private val Location.isFollowingNewEUCustomRules
+        get() = code in EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES
 
     companion object {
         const val US_COUNTRY_CODE = "US"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 
+import com.woocommerce.android.util.FeatureFlag
+
 class CheckEUShippingScenario {
     operator fun invoke(): Boolean {
-        return false
+        return FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
 import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 import kotlinx.coroutines.flow.flow
@@ -9,6 +10,21 @@ class CheckEUShippingScenario @Inject constructor(
     private val stateMachine: ShippingLabelsStateMachine
 ) {
     operator fun invoke() = flow {
-        emit(FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled())
+        if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled().not()) emit(false)
+
+        stateMachine.transitions.collect {
+            when (it.state) {
+                is WaitingForInput -> emit(it.state.isEUShippingConditionMet())
+                else -> emit(false)
+
+            }
+        }
+    }
+
+    private fun WaitingForInput.isEUShippingConditionMet(): Boolean {
+        val originCountry = data.stepsState.originAddressStep.data.country
+        val destinationCountry = data.stepsState.shippingAddressStep.data.country
+
+        return originCountry.code == "US" && destinationCountry.code == "UK"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -5,13 +5,10 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.util.FeatureFlag
-import javax.inject.Inject
 import kotlinx.coroutines.flow.flow
 
-class CheckEUShippingScenario @Inject constructor(
-    private val stateMachine: ShippingLabelsStateMachine
-) {
-    operator fun invoke() = flow {
+class CheckEUShippingScenario {
+    operator fun invoke(stateMachine: ShippingLabelsStateMachine) = flow {
         if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled().not()) emit(false)
 
         stateMachine.transitions.collect {
@@ -22,8 +19,6 @@ class CheckEUShippingScenario @Inject constructor(
             }
         }
     }
-
-    operator fun invoke(data: StateMachineData) = data.isEUShippingConditionMet()
 
     private fun StateMachineData.isEUShippingConditionMet(): Boolean {
         val originCountry = stepsState.originAddressStep.data.country

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 
+import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
 import com.woocommerce.android.util.FeatureFlag
@@ -25,8 +26,14 @@ class CheckEUShippingScenario @Inject constructor(
         val originCountry = data.stepsState.originAddressStep.data.country
         val destinationCountry = data.stepsState.shippingAddressStep.data.country
 
-        return originCountry.code == US_COUNTRY_CODE && destinationCountry.code == "UK"
+        return originCountry.code == US_COUNTRY_CODE &&
+            destinationCountry.isEUCountryFollowingNewCustomRules()
     }
+
+    private fun Location.isEUCountryFollowingNewCustomRules() =
+        EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES.any { countryIsoCode ->
+            countryIsoCode.first == code || countryIsoCode.second == code
+        }
 
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -25,6 +25,42 @@ class CheckEUShippingScenario @Inject constructor(
         val originCountry = data.stepsState.originAddressStep.data.country
         val destinationCountry = data.stepsState.shippingAddressStep.data.country
 
-        return originCountry.code == "US" && destinationCountry.code == "UK"
+        return originCountry.code == US_COUNTRY_CODE && destinationCountry.code == "UK"
+    }
+
+
+    companion object {
+        val US_COUNTRY_CODE = "US"
+        val EU_COUNTRIES_FOLLOWING_CUSTOMS_RULES = listOf(
+            Pair("AT", "AUT"),
+            Pair("BE", "BEL"),
+            Pair("BG", "BGR"),
+            Pair("HR", "HRV"),
+            Pair("CY", "CYP"),
+            Pair("CZ", "CZE"),
+            Pair("DK", "DNK"),
+            Pair("EE", "EST"),
+            Pair("FI", "FIN"),
+            Pair("FR", "FRA"),
+            Pair("DE", "DEU"),
+            Pair("GR", "GRC"),
+            Pair("HU", "HUN"),
+            Pair("IE", "IRL"),
+            Pair("IT", "ITA"),
+            Pair("LV", "LVA"),
+            Pair("LT", "LTU"),
+            Pair("LU", "LUX"),
+            Pair("MT", "MLT"),
+            Pair("NL", "NLD"),
+            Pair("NO", "NOR"),
+            Pair("PL", "POL"),
+            Pair("PT", "PRT"),
+            Pair("RO", "ROU"),
+            Pair("SK", "SVK"),
+            Pair("SI", "SVN"),
+            Pair("ES", "ESP"),
+            Pair("SE", "SWE"),
+            Pair("CH", "CHE")
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 import kotlinx.coroutines.flow.flow
@@ -15,16 +16,18 @@ class CheckEUShippingScenario @Inject constructor(
 
         stateMachine.transitions.collect {
             when (it.state) {
-                is WaitingForInput -> emit(it.state.isEUShippingConditionMet())
+                is WaitingForInput -> emit(it.state.data.isEUShippingConditionMet())
                 else -> emit(false)
 
             }
         }
     }
 
-    private fun WaitingForInput.isEUShippingConditionMet(): Boolean {
-        val originCountry = data.stepsState.originAddressStep.data.country
-        val destinationCountry = data.stepsState.shippingAddressStep.data.country
+    operator fun invoke(data: StateMachineData) = data.isEUShippingConditionMet()
+
+    private fun StateMachineData.isEUShippingConditionMet(): Boolean {
+        val originCountry = stepsState.originAddressStep.data.country
+        val destinationCountry = stepsState.shippingAddressStep.data.country
 
         return originCountry.code == US_COUNTRY_CODE &&
             destinationCountry.isEUCountryFollowingNewCustomRules()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -5,9 +5,9 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.util.FeatureFlag
-import javax.inject.Inject
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
 
 class CheckEUShippingScenario @Inject constructor() {
     operator fun invoke(shippingStateTransitions: StateFlow<Transition>) = flow {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -5,12 +5,12 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.util.FeatureFlag
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 class CheckEUShippingScenario @Inject constructor() {
-    operator fun invoke(shippingStateTransitions: StateFlow<Transition>) = flow {
+    operator fun invoke(shippingStateTransitions: Flow<Transition>) = flow {
         if (FeatureFlag.EU_SHIPPING_NOTIFICATION.isEnabled().not()) emit(false)
 
         shippingStateTransitions.collect {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenario.kt
@@ -5,9 +5,9 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.util.FeatureFlag
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
-import kotlinx.coroutines.flow.Flow
 
 class CheckEUShippingScenario @Inject constructor() {
     operator fun invoke(shippingStateTransitions: Flow<Transition>) = flow {

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -480,6 +480,9 @@
         <argument
             android:name="customsPackages"
             app:argType="com.woocommerce.android.model.CustomsPackage[]" />
+        <argument
+            android:name="isEUShippingScenario"
+            app:argType="boolean" />
     </fragment>
     <dialog
         android:id="@+id/moveShippingItemDialog"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -197,6 +197,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             CreateShippingLabelViewModel(
                 savedState,
                 parameterRepository,
+                mock(),
                 orderDetailRepository,
                 shippingLabelRepository,
                 stateMachine,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepsState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
+import com.woocommerce.android.ui.orders.shippinglabels.creation.banner.CheckEUShippingScenario
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -93,6 +94,9 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             on { invoke(any(), any()) } doReturn (Location.EMPTY to AmbiguousLocation.EMPTY)
         }
     )
+    private val checkEUShippingScenario: CheckEUShippingScenario = mock {
+        on { invoke(any()) } doReturn flow { emit(false) }
+    }
 
     private val data = StateMachineData(
         order = orderMapper.toAppModel(order),
@@ -197,7 +201,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             CreateShippingLabelViewModel(
                 savedState,
                 parameterRepository,
-                mock(),
+                checkEUShippingScenario,
                 orderDetailRepository,
                 shippingLabelRepository,
                 stateMachine,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -50,6 +50,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -95,7 +96,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
         }
     )
     private val checkEUShippingScenario: CheckEUShippingScenario = mock {
-        on { invoke(any()) } doReturn flow { emit(false) }
+        on { invoke(any()) } doReturn flowOf(false)
     }
 
     private val data = StateMachineData(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModelTest.kt
@@ -58,7 +58,8 @@ class ShippingCustomsViewModelTest : BaseUnitTest() {
         shippingPackages = emptyArray(),
         originCountryCode = "US",
         destinationCountryCode = "CA",
-        customsPackages = arrayOf(CreateShippingLabelTestUtils.generateCustomsPackage())
+        customsPackages = arrayOf(CreateShippingLabelTestUtils.generateCustomsPackage()),
+        isEUShippingScenario = false
     )
 
     fun setup(navArgs: ShippingCustomsFragmentArgs = defaultNavArgs) {
@@ -91,7 +92,8 @@ class ShippingCustomsViewModelTest : BaseUnitTest() {
                 shippingPackages = arrayOf(shippingPackage),
                 originCountryCode = originCountryCode,
                 destinationCountryCode = "CA",
-                customsPackages = emptyArray()
+                customsPackages = emptyArray(),
+                isEUShippingScenario = false
             )
         )
 
@@ -115,7 +117,8 @@ class ShippingCustomsViewModelTest : BaseUnitTest() {
                 shippingPackages = emptyArray(),
                 originCountryCode = "US",
                 destinationCountryCode = "CA",
-                customsPackages = arrayOf(customsPackage)
+                customsPackages = arrayOf(customsPackage),
+                isEUShippingScenario = false
             )
         )
 
@@ -134,7 +137,8 @@ class ShippingCustomsViewModelTest : BaseUnitTest() {
                 shippingPackages = emptyArray(),
                 originCountryCode = "US",
                 destinationCountryCode = "CA",
-                customsPackages = arrayOf(customsPackage)
+                customsPackages = arrayOf(customsPackage),
+                isEUShippingScenario = false
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
@@ -32,6 +32,26 @@ internal class CheckEUShippingScenarioTest: BaseUnitTest() {
     }
 
     @Test
+    fun `when origin country is NOT US, then emit true`() = testBlocking {
+        // Given
+        val transitions = generateExpectedTransitions(
+            originCountryCode = "DE",
+            destinationCountryCodePair = Pair("AT", "AUT")
+        )
+        val results = mutableListOf<Boolean>()
+
+        // When
+        sut.invoke(transitions)
+            .onEach { results.add(it) }
+            .launchIn(this)
+
+        // Then
+        assertThat(results).hasSize(2)
+        assertThat(results[0]).isFalse
+        assertThat(results[1]).isFalse
+    }
+
+    @Test
     fun `when origin country is US and destination country is AT then emit true`() = testBlocking {
         // Given
         val transitions = generateExpectedTransitions(
@@ -47,6 +67,8 @@ internal class CheckEUShippingScenarioTest: BaseUnitTest() {
 
         // Then
         assertThat(results).hasSize(2)
+        assertThat(results[0]).isTrue
+        assertThat(results[1]).isTrue
     }
 
     private fun generateExpectedTransitions(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
@@ -23,7 +23,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class CheckEUShippingScenarioTest: BaseUnitTest() {
+internal class CheckEUShippingScenarioTest : BaseUnitTest() {
     lateinit var sut: CheckEUShippingScenario
 
     @Before
@@ -83,20 +83,20 @@ internal class CheckEUShippingScenarioTest: BaseUnitTest() {
         originCountryCode: String,
         destinationCountryCode: String
     ) = WaitingForInput(
-            data = StateMachineData(
-                order = Order.EMPTY,
-                stepsState = emptyStepState.copy(
-                    originAddressStep = OriginAddressStep(
-                        StepStatus.READY,
-                        Address.EMPTY.copy(country = Location.EMPTY.copy(code = originCountryCode))
-                    ),
-                    shippingAddressStep = ShippingAddressStep(
-                        StepStatus.READY,
-                        Address.EMPTY.copy(country = Location.EMPTY.copy(code = destinationCountryCode))
-                    )
+        data = StateMachineData(
+            order = Order.EMPTY,
+            stepsState = emptyStepState.copy(
+                originAddressStep = OriginAddressStep(
+                    StepStatus.READY,
+                    Address.EMPTY.copy(country = Location.EMPTY.copy(code = originCountryCode))
+                ),
+                shippingAddressStep = ShippingAddressStep(
+                    StepStatus.READY,
+                    Address.EMPTY.copy(country = Location.EMPTY.copy(code = destinationCountryCode))
                 )
             )
-        ).let { ShippingLabelsStateMachine.Transition(it, null) }
+        )
+    ).let { ShippingLabelsStateMachine.Transition(it, null) }
 
     private val emptyStepState = ShippingLabelsStateMachine.StepsState(
         originAddressStep = OriginAddressStep(StepStatus.NOT_READY, Address.EMPTY),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.Idle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CarrierStep
@@ -70,6 +71,21 @@ internal class CheckEUShippingScenarioTest : BaseUnitTest() {
         assertThat(results).hasSize(2)
         assertThat(results[0]).isFalse
         assertThat(results[1]).isFalse
+    }
+
+    @Test
+    fun `when transition state is not WaitingForInput, then emit false`() = testBlocking {
+        // Given
+        val results = mutableListOf<Boolean>()
+
+        // When
+        sut.invoke(flowOf(ShippingLabelsStateMachine.Transition(Idle, null)))
+            .onEach { results.add(it) }
+            .launchIn(this)
+
+        // Then
+        assertThat(results).hasSize(1)
+        assertThat(results[0]).isFalse
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.TestScope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -52,11 +53,45 @@ internal class CheckEUShippingScenarioTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when origin country is US and destination country is AT then emit true`() = testBlocking {
+    fun `when origin country is US and destination country is every EU country following customs rules then emit true`() = testBlocking {
+        assertCheckSucceedsFor(Pair("AT", "AUT"))
+        assertCheckSucceedsFor(Pair("BE", "BEL"))
+        assertCheckSucceedsFor(Pair("BG", "BGR"))
+        assertCheckSucceedsFor(Pair("HR", "HRV"))
+        assertCheckSucceedsFor(Pair("CY", "CYP"))
+        assertCheckSucceedsFor(Pair("CZ", "CZE"))
+        assertCheckSucceedsFor(Pair("DK", "DNK"))
+        assertCheckSucceedsFor(Pair("EE", "EST"))
+        assertCheckSucceedsFor(Pair("FI", "FIN"))
+        assertCheckSucceedsFor(Pair("FR", "FRA"))
+        assertCheckSucceedsFor(Pair("DE", "DEU"))
+        assertCheckSucceedsFor(Pair("GR", "GRC"))
+        assertCheckSucceedsFor(Pair("HU", "HUN"))
+        assertCheckSucceedsFor(Pair("IE", "IRL"))
+        assertCheckSucceedsFor(Pair("IT", "ITA"))
+        assertCheckSucceedsFor(Pair("LV", "LVA"))
+        assertCheckSucceedsFor(Pair("LT", "LTU"))
+        assertCheckSucceedsFor(Pair("LU", "LUX"))
+        assertCheckSucceedsFor(Pair("MT", "MLT"))
+        assertCheckSucceedsFor(Pair("NL", "NLD"))
+        assertCheckSucceedsFor(Pair("NO", "NOR"))
+        assertCheckSucceedsFor(Pair("PL", "POL"))
+        assertCheckSucceedsFor(Pair("PT", "PRT"))
+        assertCheckSucceedsFor(Pair("RO", "ROU"))
+        assertCheckSucceedsFor(Pair("SK", "SVK"))
+        assertCheckSucceedsFor(Pair("SI", "SVN"))
+        assertCheckSucceedsFor(Pair("ES", "ESP"))
+        assertCheckSucceedsFor(Pair("SE", "SWE"))
+        assertCheckSucceedsFor(Pair("CH", "CHE"))
+    }
+
+    private fun TestScope.assertCheckSucceedsFor(
+        countryCodes: Pair<String, String>
+    ) {
         // Given
         val transitions = generateExpectedTransitions(
             originCountryCode = "US",
-            destinationCountryCodePair = Pair("AT", "AUT")
+            destinationCountryCodePair = countryCodes
         )
         val results = mutableListOf<Boolean>()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
@@ -53,35 +53,147 @@ internal class CheckEUShippingScenarioTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when origin country is US and destination country is every EU country following customs rules then emit true`() = testBlocking {
+    fun `when origin country is US and destination country is AT-AUT then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("AT", "AUT"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is BE-BEL then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("BE", "BEL"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is BG-BGR then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("BG", "BGR"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is HR-HRV then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("HR", "HRV"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is CY-CYP then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("CY", "CYP"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is CZ-CZE then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("CZ", "CZE"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is DK-DNK then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("DK", "DNK"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is EE-EST then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("EE", "EST"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is FI-FIN then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("FI", "FIN"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is FR-FRA then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("FR", "FRA"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is DE-DEU then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("DE", "DEU"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is GR-GRC then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("GR", "GRC"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is HU-HUN then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("HU", "HUN"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is IE-IRL then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("IE", "IRL"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is IT-ITA then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("IT", "ITA"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is LV-LVA then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("LV", "LVA"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is LT-LTU then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("LT", "LTU"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is LU-LUX then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("LU", "LUX"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is MT-MLT then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("MT", "MLT"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is NL-NLD then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("NL", "NLD"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is NO-NOR then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("NO", "NOR"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is PL-POL then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("PL", "POL"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is PT-PRT then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("PT", "PRT"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is RO-ROU then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("RO", "ROU"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is SK-SVK then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("SK", "SVK"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is SI-SVN then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("SI", "SVN"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is ES-ESP then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("ES", "ESP"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is SE-SWE then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("SE", "SWE"))
+    }
+
+    @Test
+    fun `when origin country is US and destination country is CH-CHE then emit true`() = testBlocking {
         assertCheckSucceedsFor(Pair("CH", "CHE"))
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation.banner
+
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.Location
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CarrierStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CustomsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.OriginAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PackagingStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PaymentsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.ShippingAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.single
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class CheckEUShippingScenarioTest: BaseUnitTest() {
+    lateinit var sut: CheckEUShippingScenario
+
+    @Before
+    fun setUp() {
+        sut = CheckEUShippingScenario()
+    }
+
+    @Test
+    fun `when origin country is US and destination country is EU then emit true`() = testBlocking {
+        // Given
+        val originCountry = "US"
+        val destinationCountry = "AT"
+        val state = ShippingLabelsStateMachine.State.WaitingForInput(
+            data = ShippingLabelsStateMachine.StateMachineData(
+                order = Order.EMPTY,
+                stepsState = emptyStepState.copy(
+                    originAddressStep = OriginAddressStep(
+                        StepStatus.READY,
+                        Address.EMPTY.copy(country = Location.EMPTY.copy(code = originCountry))
+                    ),
+                    shippingAddressStep = ShippingAddressStep(
+                        StepStatus.READY,
+                        Address.EMPTY.copy(country = Location.EMPTY.copy(code = destinationCountry))
+                    )
+                )
+            )
+        )
+
+        // When
+        val result = sut.invoke(
+            flowOf(ShippingLabelsStateMachine.Transition(state, null))
+        ).single()
+
+        // Then
+        assert(result)
+    }
+
+    private val emptyStepState = ShippingLabelsStateMachine.StepsState(
+        originAddressStep = OriginAddressStep(StepStatus.NOT_READY, Address.EMPTY),
+        shippingAddressStep = ShippingAddressStep(StepStatus.NOT_READY, Address.EMPTY),
+        packagingStep = PackagingStep(StepStatus.NOT_READY, emptyList()),
+        customsStep = CustomsStep(StepStatus.NOT_READY, false, null),
+        carrierStep = CarrierStep(StepStatus.NOT_READY, emptyList()),
+        paymentsStep = PaymentsStep(StepStatus.NOT_READY, null)
+    )
+
+    private val expectedIncludedCountries = listOf(
+        Pair("AT", "AUT"),
+        Pair("BE", "BEL"),
+        Pair("BG", "BGR"),
+        Pair("HR", "HRV"),
+        Pair("CY", "CYP"),
+        Pair("CZ", "CZE"),
+        Pair("DK", "DNK"),
+        Pair("EE", "EST"),
+        Pair("FI", "FIN"),
+        Pair("FR", "FRA"),
+        Pair("DE", "DEU"),
+        Pair("GR", "GRC"),
+        Pair("HU", "HUN"),
+        Pair("IE", "IRL"),
+        Pair("IT", "ITA"),
+        Pair("LV", "LVA"),
+        Pair("LT", "LTU"),
+        Pair("LU", "LUX"),
+        Pair("MT", "MLT"),
+        Pair("NL", "NLD"),
+        Pair("NO", "NOR"),
+        Pair("PL", "POL"),
+        Pair("PT", "PRT"),
+        Pair("RO", "ROU"),
+        Pair("SK", "SVK"),
+        Pair("SI", "SVN"),
+        Pair("ES", "ESP"),
+        Pair("SE", "SWE"),
+        Pair("CH", "CHE")
+    )
+
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
@@ -33,11 +33,31 @@ internal class CheckEUShippingScenarioTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when origin country is NOT US, then emit true`() = testBlocking {
+    fun `when origin country is NOT US, then emit false`() = testBlocking {
         // Given
         val transitions = generateExpectedTransitions(
             originCountryCode = "DE",
             destinationCountryCodePair = Pair("AT", "AUT")
+        )
+        val results = mutableListOf<Boolean>()
+
+        // When
+        sut.invoke(transitions)
+            .onEach { results.add(it) }
+            .launchIn(this)
+
+        // Then
+        assertThat(results).hasSize(2)
+        assertThat(results[0]).isFalse
+        assertThat(results[1]).isFalse
+    }
+
+    @Test
+    fun `when origin country is US and destination country is not in EU new custom rules, then emit false`() = testBlocking {
+        // Given
+        val transitions = generateExpectedTransitions(
+            originCountryCode = "DE",
+            destinationCountryCodePair = Pair("BR", "BRA")
         )
         val results = mutableListOf<Boolean>()
 


### PR DESCRIPTION
Summary
==========
Fix issue #8889 and #8890 by introducing the expected scenario of when the EU notice should be presented. Following the USPS instructions, the notice will be triggered when the origin address is from the US and the destination address is one of the following countries:

<img width="697" alt="image" src="https://user-images.githubusercontent.com/5920403/235547782-54e2b1de-879a-4c8e-9568-1e9e2fa8d03d.png">

Screen Capture
==========
https://user-images.githubusercontent.com/5920403/235547826-5cd451ee-2236-49b1-90e4-72b01bdc4734.mp4

How to Test
==========
For better testing the scenarios introduced here, I recommend setting the `AppPrefs.isEUShippingNoticeDismissed` always to return `false`.

1. Open the app using a store with the `Shipping Labels` plugin activated
2. Open the Order Details of an order with the `Processing` status
3. Hit the `Create Shipping Label` button
4. Verify that the Banner only appears when the Origin country is `US` and the Destination country is one of the EU countries listed above.
5. Verify that the `Customs` view also follows the exact same visibility configuration from the `Create Shipping Label` view

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.