### PR TITLE
Allow Site Credentials login form on Account Mismatch Error Screen to be scrollable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -142,7 +142,8 @@ private fun SiteCredentialsScreen(
         Column(
             modifier = Modifier
                 .weight(1f)
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
         ) {
             Text(text = stringResource(id = R.string.enter_credentials_for_site, viewState.siteUrl))
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -130,7 +130,7 @@ fun AccountMismatchErrorScreen(viewModel: AccountMismatchErrorViewModel) {
 @Composable
 private fun SiteCredentialsScreen(
     viewState: ViewState.SiteCredentialsViewState,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
@@ -406,6 +406,26 @@ private fun AccountMismatchPreview() {
                 inlineButtonAction = {},
                 showJetpackTermsConsent = true,
                 showNavigationIcon = true,
+                onBackPressed = {}
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SiteCredentialsScreenPreview() {
+    WooThemeWithBackground {
+        SiteCredentialsScreen(
+            viewState = ViewState.SiteCredentialsViewState(
+                siteUrl = "woocommerce.com",
+                username = "username",
+                password = "password",
+                errorMessage = null,
+                onUsernameChanged = {},
+                onPasswordChanged = {},
+                onContinueClick = {},
+                onLoginWithAnotherAccountClick = {},
                 onBackPressed = {}
             )
         )


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR allows the login form on Account mismatch error Screen to be scrollable, making it usable on smaller/shorter device screens.

Also adds a preview to the compose screen for the login form.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Have two WordPress.com test accounts: A and B,
2. Test using a small device with short vertical screen (I'm using Nexus S in emulator),
3. Have a .org test site that is already connected to Jetpack with WordPress.com account A,
4. Start app, login with site address of the test site,
5. Continue logging in using WordPress.com account B's credentials,
6. Make sure the account mismatch error screen is shown,
7. Tap the "Connect Jetpack to your account" button,
8. Make sure the site credentials login screen is shown,
9. Tap the "Username" field to make the keyboard appear,
10. Try to scroll vertically above the keyboard and make sure the screen can scroll.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

(Relevant demo only until about 0:20, please ignore the rest)

[Scrolling demo](https://user-images.githubusercontent.com/266376/235606826-979e0030-351c-4f66-b34f-8ac08494095f.webm)
