### PR TITLE
[TTP] Add badges to highlight TTP on more menu button and menu screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -192,6 +192,10 @@ object AppPrefs {
 
         // A phone number associated with the store (used in shipping labels)
         STORE_PHONE_NUMBER,
+
+        USER_SEEN_NEW_FEATURE_MORE_SCREEN,
+
+        USER_CLICKED_ON_PAYMENTS_MORE_SCREEN,
     }
 
     fun init(context: Context) {
@@ -845,6 +849,20 @@ object AppPrefs {
 
     fun hasOnboardingCarouselBeenDisplayed(): Boolean =
         getBoolean(ONBOARDING_CAROUSEL_DISPLAYED, false)
+
+    fun isUserSeenNewFeatureOnMoreScreen(): Boolean =
+        getBoolean(UndeletablePrefKey.USER_SEEN_NEW_FEATURE_MORE_SCREEN, false)
+
+    fun setUserSeenNewFeatureOnMoreScreen() {
+        setBoolean(UndeletablePrefKey.USER_SEEN_NEW_FEATURE_MORE_SCREEN, true)
+    }
+
+    fun isPaymentsIconWasClickedOnMoreScreen(): Boolean =
+        getBoolean(UndeletablePrefKey.USER_CLICKED_ON_PAYMENTS_MORE_SCREEN, false)
+
+    fun setPaymentsIconWasClickedOnMoreScreen() {
+        setBoolean(UndeletablePrefKey.USER_CLICKED_ON_PAYMENTS_MORE_SCREEN, true)
+    }
 
     fun setActiveStatsGranularity(currentSiteId: Int, activeStatsGranularity: String) {
         setString(getActiveStatsGranularityFilterKey(currentSiteId), activeStatsGranularity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -192,6 +192,14 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getLoginEmail() = AppPrefs.getLoginEmail()
 
+    fun isUserSeenNewFeatureOnMoreScreen() = AppPrefs.isUserSeenNewFeatureOnMoreScreen()
+
+    fun setUserSeenNewFeatureOnMoreScreen() = AppPrefs.setUserSeenNewFeatureOnMoreScreen()
+
+    fun isPaymentsIconWasClickedOnMoreScreen() = AppPrefs.isPaymentsIconWasClickedOnMoreScreen()
+
+    fun setPaymentsIconWasClickedOnMoreScreen() = AppPrefs.setPaymentsIconWasClickedOnMoreScreen()
+
     fun setOnboardingCarouselDisplayed(displayed: Boolean) =
         AppPrefs.setOnboardingCarouselDisplayed(displayed)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -70,6 +70,7 @@ import com.woocommerce.android.ui.main.BottomNavigationPosition.ORDERS
 import com.woocommerce.android.ui.main.BottomNavigationPosition.PRODUCTS
 import com.woocommerce.android.ui.main.MainActivityViewModel.BottomBarState
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
 import com.woocommerce.android.ui.main.MainActivityViewModel.RequestNotificationsPermission
 import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForAppLink
@@ -782,6 +783,7 @@ class MainActivity :
         viewModel.moreMenuBadgeState.observe(this) { moreMenuBadgeState ->
             when (moreMenuBadgeState) {
                 is UnseenReviews -> binding.bottomNav.showMoreMenuUnseenReviewsBadge(moreMenuBadgeState.count)
+                NewFeature -> binding.bottomNav.showMoreMenuNewFeatureBadge()
                 Hidden -> binding.bottomNav.hideMoreMenuBadge()
             }.exhaustive
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -23,9 +23,9 @@ import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
-import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
+import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.WooLog
@@ -33,9 +33,8 @@ import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.SiteStore

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -21,8 +21,11 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
 import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.WooLog
@@ -30,6 +33,7 @@ import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
@@ -48,6 +52,7 @@ class MainActivityViewModel @Inject constructor(
     private val prefs: AppPrefs,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val resolveAppLink: ResolveAppLink,
+    moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
     unseenReviewsCountHandler: UnseenReviewsCountHandler,
     determineTrialStatusBarState: DetermineTrialStatusBarState,
 ) : ScopedViewModel(savedState) {
@@ -59,8 +64,11 @@ class MainActivityViewModel @Inject constructor(
 
     val startDestination = if (selectedSite.exists()) R.id.dashboard else R.id.nav_graph_site_picker
 
-    val moreMenuBadgeState = unseenReviewsCountHandler.observeUnseenCount().map { reviewsCount ->
-        determineMenuBadgeState(reviewsCount)
+    val moreMenuBadgeState = combine(
+        unseenReviewsCountHandler.observeUnseenCount(),
+        moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable,
+    ) { reviewsCount, features ->
+        determineMenuBadgeState(reviewsCount, features)
     }.asLiveData()
 
     private val _bottomBarState: MutableStateFlow<BottomBarState> = MutableStateFlow(BottomBarState.Visible)
@@ -183,7 +191,9 @@ class MainActivityViewModel @Inject constructor(
         }
     }
 
-    private fun determineMenuBadgeState(reviews: Int) = if (reviews > 0) UnseenReviews(reviews) else Hidden
+    private fun determineMenuBadgeState(count: Int, features: List<MoreMenuNewFeature>) =
+        if (features.isNotEmpty()) NewFeature
+        else if (count > 0) UnseenReviews(count) else Hidden
 
     fun showFeatureAnnouncementIfNeeded() {
         launch {
@@ -253,6 +263,7 @@ class MainActivityViewModel @Inject constructor(
 
     sealed class MoreMenuBadgeState {
         data class UnseenReviews(val count: Int) : MoreMenuBadgeState()
+        object NewFeature : MoreMenuBadgeState()
         object Hidden : MoreMenuBadgeState()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -114,6 +114,11 @@ class MainBottomNavigationView @JvmOverloads constructor(
         moreMenuBadge.isVisible = true
     }
 
+    fun showMoreMenuNewFeatureBadge() {
+        moreMenuBadge.backgroundColor = ContextCompat.getColor(context, R.color.color_secondary)
+        moreMenuBadge.isVisible = true
+    }
+
     fun hideMoreMenuBadge() {
         moreMenuBadge.isVisible = false
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -70,6 +70,12 @@ class MoreMenuFragment : TopLevelFragment() {
         setupObservers()
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        viewModel.onViewResumed()
+    }
+
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandler.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.moremenu
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature.Payments
+import dagger.Reusable
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import javax.inject.Inject
+
+@Reusable
+class MoreMenuNewFeatureHandler @Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper,
+) {
+    val moreMenuNewFeaturesAvailable = appPrefsWrapper.observePrefs()
+        .onStart { emit(Unit) }
+        .map {
+            if (appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()) {
+                emptyList()
+            } else {
+                listOf(Payments)
+            }
+        }
+
+    val moreMenuPaymentsFeatureWasClicked = appPrefsWrapper.observePrefs()
+        .onStart { emit(Unit) }
+        .map { appPrefsWrapper.isPaymentsIconWasClickedOnMoreScreen() }
+
+    fun markPaymentsIconAsClicked() {
+        appPrefsWrapper.setPaymentsIconWasClickedOnMoreScreen()
+    }
+
+    fun markNewFeatureAsSeen() {
+        appPrefsWrapper.setUserSeenNewFeatureOnMoreScreen()
+    }
+}
+
+enum class MoreMenuNewFeature {
+    Payments
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandler.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.moremenu
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature.Payments
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import dagger.Reusable
 import kotlinx.coroutines.flow.map
@@ -12,14 +12,14 @@ import javax.inject.Inject
 @Reusable
 class MoreMenuNewFeatureHandler @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
-    private val isTapToPayAvailable: IsTapToPayAvailable,
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
 ) {
     val moreMenuNewFeaturesAvailable = appPrefsWrapper.observePrefs()
         .onStart { emit(Unit) }
         .map {
             when {
                 appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen() -> emptyList()
-                isTapToPayAvailable().isAvailable -> listOf(Payments)
+                tapToPayAvailabilityStatus().isAvailable -> listOf(Payments)
                 else -> emptyList()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandler.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.moremenu
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature.Payments
+import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
+import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import dagger.Reusable
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -10,14 +12,15 @@ import javax.inject.Inject
 @Reusable
 class MoreMenuNewFeatureHandler @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
+    private val isTapToPayAvailable: IsTapToPayAvailable,
 ) {
     val moreMenuNewFeaturesAvailable = appPrefsWrapper.observePrefs()
         .onStart { emit(Unit) }
         .map {
-            if (appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()) {
-                emptyList()
-            } else {
-                listOf(Payments)
+            when {
+                appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen() -> emptyList()
+                isTapToPayAvailable().isAvailable -> listOf(Payments)
+                else -> emptyList()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -144,7 +144,7 @@ class MoreMenuViewModel @Inject constructor(
         if (!paymentsFeatureWasClicked && tapToPayAvailabilityStatus().isAvailable) BadgeState(
             badgeSize = R.dimen.major_110,
             backgroundColor = R.color.color_secondary,
-            textColor = R.color.color_surface,
+            textColor = R.color.color_on_surface,
             textState = TextState("", R.dimen.text_minor_80),
             animateAppearance = true,
         ) else null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -21,6 +21,8 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
+import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
+import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -45,6 +47,7 @@ class MoreMenuViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
     private val appPrefsWrapper: AppPrefsWrapper,
+    private val isTapToPayAvailableChecker: IsTapToPayAvailable,
     unseenReviewsCountHandler: UnseenReviewsCountHandler
 ) : ScopedViewModel(savedState) {
     val moreMenuViewState =
@@ -138,7 +141,7 @@ class MoreMenuViewModel @Inject constructor(
     )
 
     private fun buildPaymentsBadgeState(paymentsFeatureWasClicked: Boolean) =
-        if (!paymentsFeatureWasClicked) BadgeState(
+        if (!paymentsFeatureWasClicked && isTapToPayAvailableChecker().isAvailable) BadgeState(
             badgeSize = R.dimen.major_110,
             backgroundColor = R.color.color_secondary,
             textColor = R.color.color_surface,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -21,7 +21,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
@@ -47,7 +47,7 @@ class MoreMenuViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
     private val appPrefsWrapper: AppPrefsWrapper,
-    private val isTapToPayAvailableChecker: IsTapToPayAvailable,
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     unseenReviewsCountHandler: UnseenReviewsCountHandler
 ) : ScopedViewModel(savedState) {
     val moreMenuViewState =
@@ -141,7 +141,7 @@ class MoreMenuViewModel @Inject constructor(
     )
 
     private fun buildPaymentsBadgeState(paymentsFeatureWasClicked: Boolean) =
-        if (!paymentsFeatureWasClicked && isTapToPayAvailableChecker().isAvailable) BadgeState(
+        if (!paymentsFeatureWasClicked && tapToPayAvailabilityStatus().isAvailable) BadgeState(
             badgeSize = R.dimen.major_110,
             backgroundColor = R.color.color_secondary,
             textColor = R.color.color_surface,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTracker.kt
@@ -63,7 +63,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.NotAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable
 import javax.inject.Inject
 
 class CardReaderTracker @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -42,7 +42,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.OnboardingCompleted
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.StripeAccountPendingRequirement
 import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.Available
+import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.util.UtmProvider
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.CARD_READER
@@ -181,7 +181,7 @@ class CardReaderHubViewModel @Inject constructor(
     }
 
     private fun MutableList<ListItem>.addTapToPay() {
-        if (isTTPAvailable) {
+        if (isTapToPayAvailable().isAvailable) {
             add(GapBetweenSections(index = 4))
             add(
                 NonToggleableListItem(
@@ -413,7 +413,7 @@ class CardReaderHubViewModel @Inject constructor(
             is CardReadersHub -> {
                 when (params.openInHub) {
                     TAP_TO_PAY_SUMMARY -> {
-                        if (isTTPAvailable) {
+                        if (isTapToPayAvailable().isAvailable) {
                             triggerEvent(CardReaderHubEvents.NavigateToTapTooPaySummaryScreen)
                         } else {
                             triggerEvent(ShowToast(R.string.card_reader_tap_to_pay_not_available_error))
@@ -450,9 +450,6 @@ class CardReaderHubViewModel @Inject constructor(
             remoteSiteId = selectedSite.get().siteId,
             selfHostedSiteId = selectedSite.get().selfHostedSiteId,
         )
-
-    private val isTTPAvailable
-        get() = storeCountryCode != null && isTapToPayAvailable(storeCountryCode) == Available
 
     private val shouldShowTTPFeedbackRequest: Boolean
         get() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -41,7 +41,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.OnboardingCompleted
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.StripeAccountPendingRequirement
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.util.UtmProvider
 import com.woocommerce.android.util.WooLog
@@ -68,7 +68,7 @@ class CardReaderHubViewModel @Inject constructor(
     cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
     private val cardReaderTracker: CardReaderTracker,
     @Named("payment-menu") private val paymentMenuUtmProvider: UtmProvider,
-    private val isTapToPayAvailable: IsTapToPayAvailable,
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val appPrefs: AppPrefs,
     private val feedbackRepository: FeedbackRepository,
 ) : ScopedViewModel(savedState) {
@@ -181,7 +181,7 @@ class CardReaderHubViewModel @Inject constructor(
     }
 
     private fun MutableList<ListItem>.addTapToPay() {
-        if (isTapToPayAvailable().isAvailable) {
+        if (tapToPayAvailabilityStatus().isAvailable) {
             add(GapBetweenSections(index = 4))
             add(
                 NonToggleableListItem(
@@ -413,7 +413,7 @@ class CardReaderHubViewModel @Inject constructor(
             is CardReadersHub -> {
                 when (params.openInHub) {
                     TAP_TO_PAY_SUMMARY -> {
-                        if (isTapToPayAvailable().isAvailable) {
+                        if (tapToPayAvailabilityStatus().isAvailable) {
                             triggerEvent(CardReaderHubEvents.NavigateToTapTooPaySummaryScreen)
                         } else {
                             triggerEvent(ShowToast(R.string.card_reader_tap_to_pay_not_available_error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -67,7 +67,6 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private val cardPaymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker,
     private val learnMoreUrlProvider: LearnMoreUrlProvider,
     private val cardReaderTracker: CardReaderTracker,
-    private val wooStore: WooCommerceStore,
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val appPrefs: AppPrefs = AppPrefs,
 ) : ScopedViewModel(savedState) {
@@ -131,8 +130,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
     )
 
     private fun isTapToPayAvailable(): Boolean {
-        val countryCode = wooStore.getStoreCountryCode(selectedSite.get()) ?: return false
-        val result = isTapToPayAvailable(countryCode)
+        val result = tapToPayAvailabilityStatus()
         return if (result is NotAvailable) {
             cardReaderTracker.trackTapToPayNotAvailableReason(result)
             false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -36,8 +36,8 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType.
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewState.Loading
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewState.Success
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.NotAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -68,7 +68,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private val learnMoreUrlProvider: LearnMoreUrlProvider,
     private val cardReaderTracker: CardReaderTracker,
     private val wooStore: WooCommerceStore,
-    private val isTapToPayAvailable: IsTapToPayAvailable,
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val appPrefs: AppPrefs = AppPrefs,
 ) : ScopedViewModel(savedState) {
     private val navArgs: SelectPaymentMethodFragmentArgs by savedState.navArgs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailable.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/IsTapToPayAvailable.kt
@@ -4,28 +4,34 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
 import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.SystemVersionUtilsWrapper
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 class IsTapToPayAvailable @Inject constructor(
     private val appPrefs: AppPrefs = AppPrefs,
+    private val selectedSite: SelectedSite,
     private val deviceFeatures: DeviceFeatures,
     private val systemVersionUtilsWrapper: SystemVersionUtilsWrapper,
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
+    private val wooStore: WooCommerceStore,
 ) {
-    operator fun invoke(countryCode: String) =
+    operator fun invoke() =
         when {
             !appPrefs.isTapToPayEnabled -> Result.NotAvailable.TapToPayDisabled
             !systemVersionUtilsWrapper.isAtLeastP() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
             !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
-            !isTppSupportedInCountry(countryCode) -> Result.NotAvailable.CountryNotSupported
+            !isTppSupportedInCountry(wooStore.getStoreCountryCode(selectedSite.get())) ->
+                Result.NotAvailable.CountryNotSupported
+
             else -> Result.Available
         }
 
-    private fun isTppSupportedInCountry(countryCode: String) =
+    private fun isTppSupportedInCountry(countryCode: String?) =
         when (val config = cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode)) {
             is CardReaderConfigForSupportedCountry -> config.supportedReaders.any { it is ReaderType.BuildInReader }
             CardReaderConfigForUnsupportedCountry -> false
@@ -42,3 +48,5 @@ class IsTapToPayAvailable @Inject constructor(
         }
     }
 }
+
+val IsTapToPayAvailable.Result.isAvailable get() = this is IsTapToPayAvailable.Result.Available

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.util.SystemVersionUtilsWrapper
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-class IsTapToPayAvailable @Inject constructor(
+class TapToPayAvailabilityStatus @Inject constructor(
     private val appPrefs: AppPrefs = AppPrefs,
     private val selectedSite: SelectedSite,
     private val deviceFeatures: DeviceFeatures,
@@ -49,4 +49,4 @@ class IsTapToPayAvailable @Inject constructor(
     }
 }
 
-val IsTapToPayAvailable.Result.isAvailable get() = this is IsTapToPayAvailable.Result.Available
+val TapToPayAvailabilityStatus.Result.isAvailable get() = this is TapToPayAvailabilityStatus.Result.Available

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.push.WooNotificationType
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
+import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
 import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForNotification
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenOrderCreation
@@ -28,6 +29,8 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewTapToPay
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewUrlInWebView
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature.Payments
+import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -108,6 +111,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     private val featureAnnouncementRepository: FeatureAnnouncementRepository = mock()
     private val buildConfigWrapper: BuildConfigWrapper = mock()
     private val prefs: AppPrefs = mock()
+    private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler = mock()
     private val unseenReviewsCountHandler: UnseenReviewsCountHandler = mock {
         on { observeUnseenCount() } doReturn MutableStateFlow(1)
     }
@@ -379,10 +383,11 @@ class MainActivityViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given zero unseen reviews, when listening badge state, then hidden returned`() =
+    fun `given zero unseen reviews and no new features, when listening badge state, then hidden returned`() =
         testBlocking {
             // GIVEN
             whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(0))
+            whenever(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable).thenReturn(MutableStateFlow(emptyList()))
             createViewModel()
 
             // WHEN
@@ -393,10 +398,13 @@ class MainActivityViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given unseen reviews, when listening badge state, then unseen reviews returned`() =
+    fun `given unseen reviews and no new features, when listening badge state, then unseen reviews returned`() =
         testBlocking {
             // GIVEN
             whenever(unseenReviewsCountHandler.observeUnseenCount()).thenReturn(flowOf(1))
+            whenever(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable).thenReturn(
+                MutableStateFlow(emptyList())
+            )
             createViewModel()
 
             // WHEN
@@ -526,6 +534,8 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 prefs,
                 analyticsTrackerWrapper,
                 resolveAppLink,
+                mock(),
+                moreMenuNewFeatureHandler,
                 unseenReviewsCountHandler,
                 mock {
                     onBlocking { invoke(any()) } doReturn emptyFlow()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -532,7 +532,6 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 prefs,
                 analyticsTrackerWrapper,
                 resolveAppLink,
-                mock(),
                 moreMenuNewFeatureHandler,
                 unseenReviewsCountHandler,
                 mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.push.WooNotificationType
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
-import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.NewFeature
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
 import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForNotification
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenOrderCreation
@@ -29,7 +28,6 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewTapToPay
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewUrlInWebView
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
-import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature.Payments
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandlerTest.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.ui.moremenu
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class MoreMenuNewFeatureHandlerTest : BaseUnitTest() {
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
+
+    @Test
+    fun `given new feature is not seen, when checking state, then returns not empty list`() = testBlocking {
+        // GIVEN
+        whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
+        whenever(appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()).thenReturn(false)
+        val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper)
+
+        // WHEN && THEN
+        assertThat(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable.first()).isNotEmpty
+    }
+
+    @Test
+    fun `given new feature is seen, when checking state, then returns empty list`() = testBlocking {
+        // GIVEN
+        whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
+        whenever(appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()).thenReturn(true)
+        val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper)
+
+        // WHEN && THEN
+        assertThat(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable.first()).isEmpty()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandlerTest.kt
@@ -17,15 +17,30 @@ class MoreMenuNewFeatureHandlerTest : BaseUnitTest() {
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
 
     @Test
-    fun `given new feature is not seen, when checking state, then returns not empty list`() = testBlocking {
-        // GIVEN
-        whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
-        whenever(appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()).thenReturn(false)
-        val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper, tapToPayAvailabilityStatus)
+    fun `given new feature is not seen and ttp available, when checking state, then returns not empty list`() =
+        testBlocking {
+            // GIVEN
+            whenever(tapToPayAvailabilityStatus()).thenReturn(TapToPayAvailabilityStatus.Result.Available)
+            whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
+            whenever(appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()).thenReturn(false)
+            val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper, tapToPayAvailabilityStatus)
 
-        // WHEN && THEN
-        assertThat(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable.first()).isNotEmpty
-    }
+            // WHEN && THEN
+            assertThat(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable.first()).isNotEmpty
+        }
+
+    @Test
+    fun `given new feature is not seen and ttp not available, when checking state, then returns empty list`() =
+        testBlocking {
+            // GIVEN
+            whenever(tapToPayAvailabilityStatus()).thenReturn(TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable)
+            whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
+            whenever(appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()).thenReturn(false)
+            val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper, tapToPayAvailabilityStatus)
+
+            // WHEN && THEN
+            assertThat(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable.first()).isEmpty()
+        }
 
     @Test
     fun `given new feature is seen, when checking state, then returns empty list`() = testBlocking {
@@ -37,4 +52,28 @@ class MoreMenuNewFeatureHandlerTest : BaseUnitTest() {
         // WHEN && THEN
         assertThat(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable.first()).isEmpty()
     }
+
+    @Test
+    fun `given more menu payments was clicked, when moreMenuPaymentsFeatureWasClicked, then returns true`() =
+        testBlocking {
+            // GIVEN
+            whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
+            whenever(appPrefsWrapper.isPaymentsIconWasClickedOnMoreScreen()).thenReturn(true)
+            val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper, tapToPayAvailabilityStatus)
+
+            // WHEN && THEN
+            assertThat(moreMenuNewFeatureHandler.moreMenuPaymentsFeatureWasClicked.first()).isTrue
+        }
+
+    @Test
+    fun `given more menu payments was not clicked, when moreMenuPaymentsFeatureWasClicked, then returns false`() =
+        testBlocking {
+            // GIVEN
+            whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
+            whenever(appPrefsWrapper.isPaymentsIconWasClickedOnMoreScreen()).thenReturn(false)
+            val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper, tapToPayAvailabilityStatus)
+
+            // WHEN && THEN
+            assertThat(moreMenuNewFeatureHandler.moreMenuPaymentsFeatureWasClicked.first()).isFalse
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandlerTest.kt
@@ -33,7 +33,9 @@ class MoreMenuNewFeatureHandlerTest : BaseUnitTest() {
     fun `given new feature is not seen and ttp not available, when checking state, then returns empty list`() =
         testBlocking {
             // GIVEN
-            whenever(tapToPayAvailabilityStatus()).thenReturn(TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(
+                TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable
+            )
             whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
             whenever(appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()).thenReturn(false)
             val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper, tapToPayAvailabilityStatus)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuNewFeatureHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.moremenu
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,13 +14,14 @@ import org.mockito.kotlin.whenever
 @ExperimentalCoroutinesApi
 class MoreMenuNewFeatureHandlerTest : BaseUnitTest() {
     private val appPrefsWrapper: AppPrefsWrapper = mock()
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
 
     @Test
     fun `given new feature is not seen, when checking state, then returns not empty list`() = testBlocking {
         // GIVEN
         whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
         whenever(appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()).thenReturn(false)
-        val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper)
+        val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper, tapToPayAvailabilityStatus)
 
         // WHEN && THEN
         assertThat(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable.first()).isNotEmpty
@@ -30,7 +32,7 @@ class MoreMenuNewFeatureHandlerTest : BaseUnitTest() {
         // GIVEN
         whenever(appPrefsWrapper.observePrefs()).thenReturn(MutableStateFlow(Unit))
         whenever(appPrefsWrapper.isUserSeenNewFeatureOnMoreScreen()).thenReturn(true)
-        val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper)
+        val moreMenuNewFeatureHandler = MoreMenuNewFeatureHandler(appPrefsWrapper, tapToPayAvailabilityStatus)
 
         // WHEN && THEN
         assertThat(moreMenuNewFeatureHandler.moreMenuNewFeaturesAvailable.first()).isEmpty()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.push.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
 import com.woocommerce.android.util.captureValues
@@ -70,6 +71,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     private val appPrefsWrapper: AppPrefsWrapper = mock()
 
     private lateinit var viewModel: MoreMenuViewModel
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
 
     suspend fun setup(setupMocks: suspend () -> Unit = {}) {
         setupMocks()
@@ -82,6 +84,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             planRepository = planRepository,
             resourceProvider = resourceProvider,
             unseenReviewsCountHandler = unseenReviewsCountHandler,
+            tapToPayAvailabilityStatus = tapToPayAvailabilityStatus,
             appPrefsWrapper = appPrefsWrapper
         )
     }
@@ -101,50 +104,6 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     }
 
     @Test
-    fun `when on view resumed, then new feature handler marks new feature as seen`() = testBlocking {
-        // GIVEN
-        setup { }
-
-        // WHEN
-        viewModel.onViewResumed()
-
-        // THEN
-        verify(moreMenuNewFeatureHandler).markNewFeatureAsSeen()
-    }
-
-    @Test
-    fun `given user never clicked payments, when building state, then badge displayed`() = testBlocking {
-        // GIVEN
-        val prefsChanges = MutableSharedFlow<Boolean>()
-        setup {
-            whenever(moreMenuNewFeatureHandler.moreMenuPaymentsFeatureWasClicked).thenReturn(prefsChanges)
-        }
-
-        // WHEN
-        val states = viewModel.moreMenuViewState.captureValues()
-        prefsChanges.emit(false)
-
-        // THEN
-        assertThat(states.last().moreMenuItems.first().badgeState).isNotNull
-    }
-
-    @Test
-    fun `given user clicked payments, when building state, then badge is not displayed`() = testBlocking {
-        // GIVEN
-        val prefsChanges = MutableSharedFlow<Boolean>()
-        setup {
-            whenever(moreMenuNewFeatureHandler.moreMenuPaymentsFeatureWasClicked).thenReturn(prefsChanges)
-        }
-
-        // WHEN
-        val states = viewModel.moreMenuViewState.captureValues()
-        prefsChanges.emit(true)
-
-        // THEN
-        assertThat(states.last().moreMenuItems.first().badgeState).isNull()
-    }
-
-    @Test
     fun `when building state, then payments icon displayed`() = testBlocking {
         // GIVEN
         val prefsChanges = MutableSharedFlow<Boolean>()
@@ -160,7 +119,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         val paymentsButton = states.last().generalMenuItems.first { it.title == R.string.more_menu_button_payments }
         assertThat(paymentsButton.icon).isEqualTo(R.drawable.ic_more_menu_payments)
         assertThat(paymentsButton.badgeState?.textColor).isEqualTo(
-            R.color.color_on_surface_inverted
+            R.color.color_on_surface
         )
         assertThat(paymentsButton.badgeState?.badgeSize).isEqualTo(
             R.dimen.major_110
@@ -341,7 +300,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         prefsChanges.emit(false)
 
         // THEN
-        assertThat(states.last().moreMenuItems.first().badgeState).isNotNull
+        assertThat(states.last().generalMenuItems.first().badgeState).isNotNull
     }
 
     @Test
@@ -357,7 +316,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         prefsChanges.emit(true)
 
         // THEN
-        assertThat(states.last().moreMenuItems.first().badgeState).isNull()
+        assertThat(states.last().generalMenuItems.first().badgeState).isNull()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -32,7 +32,7 @@ import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodFr
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewModel
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewState.Loading
 import com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodViewState.Success
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -99,7 +99,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     private val wooStore: WooCommerceStore = mock {
         on { getStoreCountryCode(site) }.thenReturn(COUNTRY_CODE)
     }
-    private val isTapToPayAvailable: IsTapToPayAvailable = mock()
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
     private val appPrefs: AppPrefs = mock()
 
     @Test
@@ -170,7 +170,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(cardPaymentCollectibilityChecker.isCollectable(order)).thenReturn(true)
-            whenever(isTapToPayAvailable(COUNTRY_CODE)).thenReturn(IsTapToPayAvailable.Result.Available)
+            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(TapToPayAvailabilityStatus.Result.Available)
             val orderId = 1L
 
             // WHEN
@@ -185,7 +185,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(cardPaymentCollectibilityChecker.isCollectable(order)).thenReturn(false)
-            whenever(isTapToPayAvailable(COUNTRY_CODE)).thenReturn(IsTapToPayAvailable.Result.Available)
+            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(TapToPayAvailabilityStatus.Result.Available)
             val orderId = 1L
 
             // WHEN
@@ -200,8 +200,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(cardPaymentCollectibilityChecker.isCollectable(order)).thenReturn(true)
-            whenever(isTapToPayAvailable(COUNTRY_CODE)).thenReturn(
-                IsTapToPayAvailable.Result.NotAvailable.NfcNotAvailable
+            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(
+                TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable
             )
             val orderId = 1L
 
@@ -835,8 +835,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             // GIVEN
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
-            val tapToPayDisabled = IsTapToPayAvailable.Result.NotAvailable.TapToPayDisabled
-            whenever(isTapToPayAvailable(COUNTRY_CODE)).thenReturn(tapToPayDisabled)
+            val tapToPayDisabled = TapToPayAvailabilityStatus.Result.NotAvailable.TapToPayDisabled
+            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPayDisabled)
 
             // WHEN
             initViewModel(param)
@@ -851,8 +851,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             // GIVEN
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
-            val tapToPaySystemNotSupported = IsTapToPayAvailable.Result.NotAvailable.SystemVersionNotSupported
-            whenever(isTapToPayAvailable(COUNTRY_CODE)).thenReturn(tapToPaySystemNotSupported)
+            val tapToPaySystemNotSupported = TapToPayAvailabilityStatus.Result.NotAvailable.SystemVersionNotSupported
+            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPaySystemNotSupported)
 
             // WHEN
             initViewModel(param)
@@ -867,8 +867,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             // GIVEN
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
-            val tapToPayCountryNotSupported = IsTapToPayAvailable.Result.NotAvailable.CountryNotSupported
-            whenever(isTapToPayAvailable(COUNTRY_CODE)).thenReturn(tapToPayCountryNotSupported)
+            val tapToPayCountryNotSupported = TapToPayAvailabilityStatus.Result.NotAvailable.CountryNotSupported
+            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPayCountryNotSupported)
 
             // WHEN
             initViewModel(param)
@@ -881,8 +881,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     fun `given payment flow ttp gps not available, when vm init, then tracks ttp gps`() =
         testBlocking {
             // GIVEN
-            val tapToPayGpsNotAvailable = IsTapToPayAvailable.Result.NotAvailable.GooglePlayServicesNotAvailable
-            whenever(isTapToPayAvailable(COUNTRY_CODE)).thenReturn(tapToPayGpsNotAvailable)
+            val tapToPayGpsNotAvailable = TapToPayAvailabilityStatus.Result.NotAvailable.GooglePlayServicesNotAvailable
+            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPayGpsNotAvailable)
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
 
@@ -899,8 +899,8 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             // GIVEN
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
-            val tapToPayNfcNotAvailable = IsTapToPayAvailable.Result.NotAvailable.NfcNotAvailable
-            whenever(isTapToPayAvailable(COUNTRY_CODE)).thenReturn(tapToPayNfcNotAvailable)
+            val tapToPayNfcNotAvailable = TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable
+            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPayNfcNotAvailable)
 
             // WHEN
             initViewModel(param)
@@ -924,7 +924,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             learnMoreUrlProvider,
             cardReaderTracker,
             wooStore,
-            isTapToPayAvailable,
+            tapToPayAvailabilityStatus,
             appPrefs,
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -60,7 +60,6 @@ import java.math.BigDecimal
 
 private const val PAYMENT_URL = "paymentUrl"
 private const val ORDER_TOTAL = "100$"
-private const val COUNTRY_CODE = "US"
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SelectPaymentMethodViewModelTest : BaseUnitTest() {
@@ -96,9 +95,6 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val learnMoreUrlProvider: LearnMoreUrlProvider = mock()
     private val cardReaderTracker: CardReaderTracker = mock()
-    private val wooStore: WooCommerceStore = mock {
-        on { getStoreCountryCode(site) }.thenReturn(COUNTRY_CODE)
-    }
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
     private val appPrefs: AppPrefs = mock()
 
@@ -170,7 +166,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(cardPaymentCollectibilityChecker.isCollectable(order)).thenReturn(true)
-            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(TapToPayAvailabilityStatus.Result.Available)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(TapToPayAvailabilityStatus.Result.Available)
             val orderId = 1L
 
             // WHEN
@@ -185,7 +181,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(cardPaymentCollectibilityChecker.isCollectable(order)).thenReturn(false)
-            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(TapToPayAvailabilityStatus.Result.Available)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(TapToPayAvailabilityStatus.Result.Available)
             val orderId = 1L
 
             // WHEN
@@ -200,7 +196,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(cardPaymentCollectibilityChecker.isCollectable(order)).thenReturn(true)
-            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(
+            whenever(tapToPayAvailabilityStatus()).thenReturn(
                 TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable
             )
             val orderId = 1L
@@ -836,7 +832,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
             val tapToPayDisabled = TapToPayAvailabilityStatus.Result.NotAvailable.TapToPayDisabled
-            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPayDisabled)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(tapToPayDisabled)
 
             // WHEN
             initViewModel(param)
@@ -852,7 +848,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
             val tapToPaySystemNotSupported = TapToPayAvailabilityStatus.Result.NotAvailable.SystemVersionNotSupported
-            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPaySystemNotSupported)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(tapToPaySystemNotSupported)
 
             // WHEN
             initViewModel(param)
@@ -868,7 +864,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
             val tapToPayCountryNotSupported = TapToPayAvailabilityStatus.Result.NotAvailable.CountryNotSupported
-            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPayCountryNotSupported)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(tapToPayCountryNotSupported)
 
             // WHEN
             initViewModel(param)
@@ -882,7 +878,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             val tapToPayGpsNotAvailable = TapToPayAvailabilityStatus.Result.NotAvailable.GooglePlayServicesNotAvailable
-            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPayGpsNotAvailable)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(tapToPayGpsNotAvailable)
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
 
@@ -900,7 +896,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             val orderId = 1L
             val param = Payment(orderId = orderId, paymentType = ORDER)
             val tapToPayNfcNotAvailable = TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable
-            whenever(tapToPayAvailabilityStatus(COUNTRY_CODE)).thenReturn(tapToPayNfcNotAvailable)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(tapToPayNfcNotAvailable)
 
             // WHEN
             initViewModel(param)
@@ -923,7 +919,6 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             cardPaymentCollectibilityChecker,
             learnMoreUrlProvider,
             cardReaderTracker,
-            wooStore,
             tapToPayAvailabilityStatus,
             appPrefs,
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderTrackerTest.kt
@@ -40,7 +40,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentGatewayProvider
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.NotAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -171,7 +171,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         initViewModel()
 
         assertThat((viewModel.viewStateData.getOrAwaitValue()).rows)
-            .noneMatch() {
+            .noneMatch {
                 it.icon == R.drawable.ic_card_reader_manual &&
                     it.label == UiStringRes(R.string.settings_card_reader_manuals)
             }
@@ -1269,7 +1269,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1296,7 +1296,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1322,7 +1322,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1351,7 +1351,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1383,7 +1383,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
             whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(false)
 
             // WHEN
@@ -1444,7 +1444,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1472,7 +1472,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp is disabled, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(TapToPayDisabled)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(TapToPayDisabled)
 
         // WHEN
         initViewModel()
@@ -1487,7 +1487,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp system not supported, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(SystemVersionNotSupported)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(SystemVersionNotSupported)
 
         // WHEN
         initViewModel()
@@ -1502,7 +1502,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp gps not available, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(GooglePlayServicesNotAvailable)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(GooglePlayServicesNotAvailable)
 
         // WHEN
         initViewModel()
@@ -1517,7 +1517,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp nfc not available, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(NfcNotAvailable)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(NfcNotAvailable)
 
         // WHEN
         initViewModel()
@@ -1532,7 +1532,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp country not supported, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("CA")
-        whenever(tapToPayAvailabilityStatus("CA")).thenReturn(CountryNotSupported)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(CountryNotSupported)
 
         // WHEN
         initViewModel()
@@ -1548,7 +1548,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given tpp available, when tap to pay clicked, then navigate to tap to pay summary screen event emitted`() {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
 
         // WHEN
         initViewModel()
@@ -1564,7 +1564,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given tpp available, when tap to pay clicked, then tap is tracked`() {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
 
         // WHEN
         initViewModel()
@@ -1613,7 +1613,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given hub flow with ttp, when view model initiated, then navigate to ttp emitted`() {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
 
         // WHEN
         initViewModel(OpenInHub.TAP_TO_PAY_SUMMARY)
@@ -1626,7 +1626,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given hub flow with ttp when ttp is not available, when view model initiated, then show toast emitted`() {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(SystemVersionNotSupported)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(SystemVersionNotSupported)
 
         // WHEN
         initViewModel(OpenInHub.TAP_TO_PAY_SUMMARY)
@@ -1651,7 +1651,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(true)
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
         whenever(cardReaderCountryConfigProvider.provideCountryConfigFor("US"))
             .thenReturn(CardReaderConfigForUSA)
 
@@ -1672,7 +1672,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
             .thenReturn(FeatureFeedbackSettings(FeatureFeedbackSettings.Feature.TAP_TO_PAY))
         whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(true)
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
         whenever(cardReaderCountryConfigProvider.provideCountryConfigFor("US"))
             .thenReturn(CardReaderConfigForUSA)
 
@@ -1691,7 +1691,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(true)
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus()).thenReturn(Available)
         whenever(cardReaderCountryConfigProvider.provideCountryConfigFor("US"))
             .thenReturn(CardReaderConfigForUSA)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -34,13 +34,13 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowP
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.StripeAccountPendingRequirement
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.Available
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.NotAvailable.CountryNotSupported
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.NotAvailable.GooglePlayServicesNotAvailable
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.NotAvailable.NfcNotAvailable
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.NotAvailable.SystemVersionNotSupported
-import com.woocommerce.android.ui.payments.taptopay.IsTapToPayAvailable.Result.NotAvailable.TapToPayDisabled
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.Available
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable.CountryNotSupported
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable.GooglePlayServicesNotAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable.SystemVersionNotSupported
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable.TapToPayDisabled
 import com.woocommerce.android.util.UtmProvider
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -86,7 +86,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     private val learnMoreUrlProvider: LearnMoreUrlProvider = mock()
     private val cardReaderTracker: CardReaderTracker = mock()
     private val paymentMenuUtmProvider: UtmProvider = mock()
-    private val isTapToPayAvailable: IsTapToPayAvailable = mock()
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
     private val appPrefs: AppPrefs = mock()
     private val feedbackRepository: FeedbackRepository = mock {
         on { getFeatureFeedbackSetting(any()) }.thenReturn(
@@ -1269,7 +1269,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(isTapToPayAvailable("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1296,7 +1296,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(isTapToPayAvailable("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1322,7 +1322,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(isTapToPayAvailable("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1351,7 +1351,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(isTapToPayAvailable("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1383,7 +1383,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(isTapToPayAvailable("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
             whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(false)
 
             // WHEN
@@ -1444,7 +1444,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-            whenever(isTapToPayAvailable("US")).thenReturn(Available)
+            whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(
                 mock<CardReaderOnboardingState.OnboardingCompleted>()
             )
@@ -1472,7 +1472,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp is disabled, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(TapToPayDisabled)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(TapToPayDisabled)
 
         // WHEN
         initViewModel()
@@ -1487,7 +1487,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp system not supported, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(SystemVersionNotSupported)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(SystemVersionNotSupported)
 
         // WHEN
         initViewModel()
@@ -1502,7 +1502,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp gps not available, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(GooglePlayServicesNotAvailable)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(GooglePlayServicesNotAvailable)
 
         // WHEN
         initViewModel()
@@ -1517,7 +1517,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp nfc not available, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(NfcNotAvailable)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(NfcNotAvailable)
 
         // WHEN
         initViewModel()
@@ -1532,7 +1532,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given ttp country not supported, when view model started, then do not show ttp row`() = testBlocking {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("CA")
-        whenever(isTapToPayAvailable("CA")).thenReturn(CountryNotSupported)
+        whenever(tapToPayAvailabilityStatus("CA")).thenReturn(CountryNotSupported)
 
         // WHEN
         initViewModel()
@@ -1548,7 +1548,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given tpp available, when tap to pay clicked, then navigate to tap to pay summary screen event emitted`() {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
 
         // WHEN
         initViewModel()
@@ -1564,7 +1564,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given tpp available, when tap to pay clicked, then tap is tracked`() {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
 
         // WHEN
         initViewModel()
@@ -1613,7 +1613,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given hub flow with ttp, when view model initiated, then navigate to ttp emitted`() {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
 
         // WHEN
         initViewModel(OpenInHub.TAP_TO_PAY_SUMMARY)
@@ -1626,7 +1626,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     fun `given hub flow with ttp when ttp is not available, when view model initiated, then show toast emitted`() {
         // GIVEN
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(SystemVersionNotSupported)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(SystemVersionNotSupported)
 
         // WHEN
         initViewModel(OpenInHub.TAP_TO_PAY_SUMMARY)
@@ -1651,7 +1651,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(true)
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
         whenever(cardReaderCountryConfigProvider.provideCountryConfigFor("US"))
             .thenReturn(CardReaderConfigForUSA)
 
@@ -1672,7 +1672,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
             .thenReturn(FeatureFeedbackSettings(FeatureFeedbackSettings.Feature.TAP_TO_PAY))
         whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(true)
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
         whenever(cardReaderCountryConfigProvider.provideCountryConfigFor("US"))
             .thenReturn(CardReaderConfigForUSA)
 
@@ -1691,7 +1691,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(appPrefs.isTTPWasUsedAtLeastOnce()).thenReturn(true)
         whenever(wooStore.getStoreCountryCode(selectedSite.get())).thenReturn("US")
-        whenever(isTapToPayAvailable("US")).thenReturn(Available)
+        whenever(tapToPayAvailabilityStatus("US")).thenReturn(Available)
         whenever(cardReaderCountryConfigProvider.provideCountryConfigFor("US"))
             .thenReturn(CardReaderConfigForUSA)
 
@@ -1746,7 +1746,7 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
             cardReaderCountryConfigProvider,
             cardReaderTracker,
             paymentMenuUtmProvider,
-            isTapToPayAvailable,
+            tapToPayAvailabilityStatus,
             appPrefs,
             feedbackRepository,
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -86,7 +86,9 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     private val learnMoreUrlProvider: LearnMoreUrlProvider = mock()
     private val cardReaderTracker: CardReaderTracker = mock()
     private val paymentMenuUtmProvider: UtmProvider = mock()
-    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock {
+        on { invoke() }.thenReturn(Available)
+    }
     private val appPrefs: AppPrefs = mock()
     private val feedbackRepository: FeedbackRepository = mock {
         on { getFeatureFeedbackSetting(any()) }.thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-class IsTapToPayAvailableTest {
+class TapToPayAvailabilityStatusTest {
     private val systemVersionUtilsWrapper = mock<SystemVersionUtilsWrapper> {
         on { isAtLeastP() }.thenReturn(true)
     }
@@ -32,14 +32,14 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
-        val result = IsTapToPayAvailable(
+        val result = TapToPayAvailabilityStatus(
             appPrefs,
             deviceFeatures,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
         ).invoke("US")
 
-        assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.NfcNotAvailable)
+        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable)
     }
 
     @Test
@@ -51,14 +51,14 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
-        val result = IsTapToPayAvailable(
+        val result = TapToPayAvailabilityStatus(
             appPrefs,
             deviceFeatures,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
         ).invoke("US")
 
-        assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.GooglePlayServicesNotAvailable)
+        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.NotAvailable.GooglePlayServicesNotAvailable)
     }
 
     @Test
@@ -70,14 +70,14 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(false)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
-        val result = IsTapToPayAvailable(
+        val result = TapToPayAvailabilityStatus(
             appPrefs,
             context,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
         ).invoke("US")
 
-        assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.SystemVersionNotSupported)
+        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.NotAvailable.SystemVersionNotSupported)
     }
 
     @Test
@@ -89,14 +89,14 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
-        val result = IsTapToPayAvailable(
+        val result = TapToPayAvailabilityStatus(
             appPrefs,
             context,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
         ).invoke("CA")
 
-        assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.CountryNotSupported)
+        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.NotAvailable.CountryNotSupported)
     }
 
     @Test
@@ -108,14 +108,14 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(false)
 
-        val result = IsTapToPayAvailable(
+        val result = TapToPayAvailabilityStatus(
             appPrefs,
             context,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
         ).invoke("US")
 
-        assertThat(result).isEqualTo(IsTapToPayAvailable.Result.NotAvailable.TapToPayDisabled)
+        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.NotAvailable.TapToPayDisabled)
     }
 
     @Test
@@ -127,13 +127,13 @@ class IsTapToPayAvailableTest {
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
-        val result = IsTapToPayAvailable(
+        val result = TapToPayAvailabilityStatus(
             appPrefs,
             context,
             systemVersionUtilsWrapper,
             cardReaderCountryConfigProvider
         ).invoke("US")
 
-        assertThat(result).isEqualTo(IsTapToPayAvailable.Result.Available)
+        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.Available)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
@@ -104,6 +104,7 @@ class TapToPayAvailabilityStatusTest {
         }
         whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
+        whenever(wooStore.getStoreCountryCode(siteModel)).thenReturn("RU")
 
         val result = TapToPayAvailabilityStatus(
             appPrefs,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8922
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds badges to attract more attention to the newly added TTP feature to the "menu" button and payments button on the menu screen

I also renamed `IsTapToPayAvailability` -> `TapToPayAvailabilityStatus`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Use clean build
* Notice the red badge on the menu button
* Open the menu screen and notice the badge on the row of the payment

The red badge on the menu should be gone after you see the row of the payment once. The badge on the row of the payment should go after it's clicked once.

Badges should not be visible if TTP is not available, because the device is not supported, the country or feature is not enabled via beta flags menu

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/4923871/235657866-9887a27a-b81d-4def-a202-ab43daecab2e.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
