### PR TITLE
Do not show draft products in popular and Last Sold sections

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -162,7 +162,12 @@ class ProductSelectorViewModel @Inject constructor(
         if (searchQuery.value.isNotNullOrEmpty() || filterState.value.filterOptions.isNotEmpty()) {
             return emptyList()
         }
-        return productsList.map { it.toUiModel(selectedIds) }
+        return productsList
+            .filter { product ->
+                productsRestrictions.map { restriction -> restriction(product) }
+                    .fold(true) { acc, result -> acc && result }
+            }
+            .map { it.toUiModel(selectedIds) }
     }
 
     private suspend fun loadRecentProducts() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -160,8 +160,7 @@ class ProductSelectorViewModel @Inject constructor(
         if (searchQuery.value.isNotNullOrEmpty() || filterState.value.filterOptions.isNotEmpty()) {
             return emptyList()
         }
-        return productsList.filter { product -> isProductRestricted(product = product) }
-            .map { it.toUiModel(selectedIds) }
+        return productsList.map { it.toUiModel(selectedIds) }
     }
 
     private fun isProductRestricted(product: Product): Boolean {
@@ -175,7 +174,9 @@ class ProductSelectorViewModel @Inject constructor(
             getProductIdsFromRecentlySoldOrders(
                 recentlySoldOrders
             ).distinctBy { it }
-        )
+        ).filter { product ->
+            isProductRestricted(product = product)
+        }
     }
 
     private suspend fun loadPopularProducts() {
@@ -188,7 +189,11 @@ class ProductSelectorViewModel @Inject constructor(
             .sortedByDescending { it.second }
             .take(NUMBER_OF_SUGGESTED_ITEMS)
             .toMap()
-        popularProducts.value = productsMapper.mapProductIdsToProduct(topPopularProductsSorted.keys.toList())
+        popularProducts.value = productsMapper.mapProductIdsToProduct(
+            topPopularProductsSorted.keys.toList()
+        ).filter { product ->
+            isProductRestricted(product = product)
+        }
     }
 
     private suspend fun getRecentlySoldOrders() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -405,6 +405,37 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     // region Sort by popularity and recently sold products
 
     @Test
+    fun `given published products restriction, when view model created, should not show draft products in the popular section`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            ).initSavedStateHandle()
+            val popularOrdersList = generatePopularOrders()
+            val ordersList = generateTestOrders()
+            val totalOrders = ordersList + popularOrdersList
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(
+                listOf(
+                    DRAFT_PRODUCT,
+                    DRAFT_PRODUCT,
+                    VALID_PRODUCT
+                )
+            )
+
+            val sut = createViewModel(navArgs)
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+            assertThat(viewState?.popularProducts).isNotEmpty
+            assertThat(viewState?.popularProducts?.filter { it.id == DRAFT_PRODUCT.remoteId }).isEmpty()
+        }
+    }
+
+    @Test
     fun `given popular products, when view model created, then verify popular products are sorted in descending order`() {
         testBlocking {
             val navArgs = ProductSelectorFragmentArgs(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -436,6 +436,35 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given published products restriction, when view model created, should not show draft products in the last sold section`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            ).initSavedStateHandle()
+            val ordersList = generateTestOrders()
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(ordersList)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(
+                listOf(
+                    DRAFT_PRODUCT,
+                    DRAFT_PRODUCT,
+                    VALID_PRODUCT
+                )
+            )
+
+            val sut = createViewModel(navArgs)
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+            assertThat(viewState?.recentProducts).isNotEmpty
+            assertThat(viewState?.recentProducts?.filter { it.id == DRAFT_PRODUCT.remoteId }).isEmpty()
+        }
+    }
+
+    @Test
     fun `given popular products, when view model created, then verify popular products are sorted in descending order`() {
         testBlocking {
             val navArgs = ProductSelectorFragmentArgs(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8927 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Draft products were displayed on the `Popular` and `Last Sold` sections in the product selector screen. This PR fixes this bug.

### Before this PR
Draft products are displayed on the `Popular` and `Last Sold` sections in the product selector screen.

### After this PR
Draft products are NOT displayed on the `Popular` and `Last Sold` sections in the product selector screen.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Make sure you log in to a store that has quite a few draft products (ideally, 1 page of draft products)
2. Opened the product selector screen (Orders -> "+" -> Add products)
3. Notice that it says there are no products to display
4. Updated one of the products to the published state
5. Come back to the product selector screen
6. Notice that you see the published products under the `Product` section. You won't find any `Popular` or `Last Sold` sections.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/1331230/235647059-f30aa3f4-afb3-45bb-87a4-76373c05a2a1.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
