### PR TITLE
EU-Bound Shipping Notice:  Add customs description constraints

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
@@ -58,6 +58,10 @@ data class CustomsLine(
             originCountry = originCountry.code
         )
     }
+
+    companion object {
+        const val MINIMUM_EU_DESCRIPTION_LENGTH = 3
+    }
 }
 
 enum class ContentsType(@StringRes val title: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -210,7 +210,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
 
             with(binding.shippingNoticeBanner) {
                 isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
-                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
+                onLearnMoreClicked = viewModel::onShippingNoticeLearnMoreClicked
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -35,7 +35,8 @@ class ShippingCustomsAdapter(
     private val weightUnit: String,
     private val currencyUnit: String,
     private val countries: Array<Location>,
-    private val listener: ShippingCustomsFormListener
+    private val listener: ShippingCustomsFormListener,
+    private val isShippingNoticeActive: Boolean = false
 ) : RecyclerView.Adapter<PackageCustomsViewHolder>() {
     init {
         setHasStableIds(true)
@@ -58,7 +59,10 @@ class ShippingCustomsAdapter(
     }
 
     override fun onBindViewHolder(holder: PackageCustomsViewHolder, position: Int) {
-        holder.bind(customsPackages[position])
+        holder.bind(
+            uiState = customsPackages[position],
+            shouldDisplayShippingNotice = isShippingNoticeActive && position == 0
+        )
     }
 
     override fun getItemId(position: Int): Long {
@@ -140,7 +144,7 @@ class ShippingCustomsAdapter(
         }
 
         @SuppressLint("SetTextI18n")
-        fun bind(uiState: CustomsPackageUiState) {
+        fun bind(uiState: CustomsPackageUiState, shouldDisplayShippingNotice: Boolean) {
             val (customsPackage, validationState) = uiState
             binding.packageId.text = customsPackage.labelPackage.getTitle(context)
             binding.packageName.text = "- ${customsPackage.labelPackage.selectedPackage!!.title}"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -324,7 +324,7 @@ class ShippingCustomsLineAdapter(
 
             binding.errorView.isVisible = !validationState.isValid
 
-            binding.shippingNoticeIcon.isVisible = shouldDisplayShippingNotice
+            binding.shippingNoticeIcon.isVisible = shouldDisplayShippingNotice && validationState.isValid
             binding.shippingNoticeIcon.setOnClickListener { listener.onShippingNoticeClicked() }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -88,6 +88,7 @@ class ShippingCustomsFragment :
             with(binding.shippingNoticeBanner) {
                 isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
                 onLearnMoreClicked = viewModel::onShippingNoticeLearnMoreClicked
+                onDismissClicked = viewModel::onShippingNoticeDismissClicked
             }
         }
 
@@ -111,10 +112,7 @@ class ShippingCustomsFragment :
                 binding.packagesList.isVisible = !show
             }
             new.isShippingNoticeVisible.takeIfNotEqualTo(old?.isShippingNoticeVisible) { show ->
-                with(binding.shippingNoticeBanner) {
-                    isVisible = show
-                    onLearnMoreClicked = viewModel::onShippingNoticeLearnMoreClicked
-                }
+                binding.shippingNoticeBanner.isVisible = show
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -46,6 +46,7 @@ class ShippingCustomsFragment :
             weightUnit = viewModel.weightUnit,
             currencyUnit = viewModel.currencyUnit,
             countries = viewModel.countries.toTypedArray(),
+            isShippingNoticeActive = viewModel.isEUShippingScenario,
             listener = viewModel
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -87,7 +87,7 @@ class ShippingCustomsFragment :
         if (viewModel.isEUShippingScenario) {
             with(binding.shippingNoticeBanner) {
                 isVisible = AppPrefs.isEUShippingNoticeDismissed.not()
-                setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
+                onLearnMoreClicked = viewModel::onShippingNoticeLearnMoreClicked
             }
         }
 
@@ -113,7 +113,7 @@ class ShippingCustomsFragment :
             new.isShippingNoticeVisible.takeIfNotEqualTo(old?.isShippingNoticeVisible) { show ->
                 with(binding.shippingNoticeBanner) {
                     isVisible = show
-                    setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
+                    onLearnMoreClicked = viewModel::onShippingNoticeLearnMoreClicked
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -110,6 +110,12 @@ class ShippingCustomsFragment :
                 binding.progressView.isVisible = show
                 binding.packagesList.isVisible = !show
             }
+            new.isShippingNoticeVisible.takeIfNotEqualTo(old?.isShippingNoticeVisible) { show ->
+                with(binding.shippingNoticeBanner) {
+                    isVisible = show
+                    setLearnMoreClickListener(viewModel::onShippingNoticeLearnMoreClicked)
+                }
+            }
         }
 
         viewModel.event.observe(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -302,7 +302,11 @@ class ShippingCustomsViewModel @Inject constructor(
         fun CustomsLine.validateItemDescription(): String? {
             return if (itemDescription.isBlank()) {
                 resourceProvider.getString(R.string.shipping_label_customs_required_field)
-            } else null
+            } else if (isEUShippingScenario && itemDescription.length < 3) {
+                resourceProvider.getString(R.string.shipping_label_customs_item_description_too_short)
+            } else {
+                null
+            }
         }
 
         fun CustomsLine.validateWeight(): String? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -87,7 +87,7 @@ class ShippingCustomsViewModel @Inject constructor(
             }
             viewState = viewState.copy(
                 isProgressViewShown = false,
-                isShippingNoticeVisible = args.isEUShippingScenario,
+                isShippingNoticeVisible = isEUShippingScenario,
                 customsPackages = packagesUiStates
             )
         }
@@ -141,6 +141,10 @@ class ShippingCustomsViewModel @Inject constructor(
 
     fun onShippingNoticeLearnMoreClicked(learnMoreUrl: String) {
         triggerEvent(OpenShippingInstructions(learnMoreUrl))
+    }
+
+    fun onShippingNoticeDismissClicked() {
+        viewState = viewState.copy(isShippingNoticeVisible = false)
     }
 
     override fun onPackageExpandedChanged(position: Int, isExpanded: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.model.ContentsType
 import com.woocommerce.android.model.CustomsLine
+import com.woocommerce.android.model.CustomsLine.Companion.MINIMUM_EU_DESCRIPTION_LENGTH
 import com.woocommerce.android.model.CustomsPackage
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.RestrictionType
@@ -302,7 +303,7 @@ class ShippingCustomsViewModel @Inject constructor(
         fun CustomsLine.validateItemDescription(): String? {
             return if (itemDescription.isBlank()) {
                 resourceProvider.getString(R.string.shipping_label_customs_required_field)
-            } else if (isEUShippingScenario && itemDescription.length < 3) {
+            } else if (isEUShippingScenario && itemDescription.length < MINIMUM_EU_DESCRIPTION_LENGTH) {
                 resourceProvider.getString(R.string.shipping_label_customs_item_description_too_short)
             } else {
                 null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -87,6 +87,7 @@ class ShippingCustomsViewModel @Inject constructor(
             }
             viewState = viewState.copy(
                 isProgressViewShown = false,
+                isShippingNoticeVisible = args.isEUShippingScenario,
                 customsPackages = packagesUiStates
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -207,6 +207,10 @@ class ShippingCustomsViewModel @Inject constructor(
         updateLine(packagePosition, linePosition, newLine)
     }
 
+    override fun onShippingNoticeClicked() {
+        viewState = viewState.copy(isShippingNoticeVisible = true)
+    }
+
     private fun updateLine(packagePosition: Int, linePosition: Int, line: CustomsLine) {
         val customsPackage = viewState.customsPackages[packagePosition]
         val customsLines = customsPackage.data.lines.toMutableList()
@@ -328,7 +332,8 @@ class ShippingCustomsViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val customsPackages: List<CustomsPackageUiState> = emptyList(),
-        val isProgressViewShown: Boolean = false
+        val isProgressViewShown: Boolean = false,
+        val isShippingNoticeVisible: Boolean = false
     ) : Parcelable {
         @IgnoredOnParcel
         val canSubmitForm: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.databinding.ShippingNoticeBannerBinding
 import com.woocommerce.android.extensions.collapse
+import com.woocommerce.android.extensions.expand
 
 class ShippingNoticeCard @JvmOverloads constructor(
     context: Context,
@@ -20,6 +21,13 @@ class ShippingNoticeCard @JvmOverloads constructor(
 
     var onDismissClicked: () -> Unit = {}
     var onLearnMoreClicked: (url: String) -> Unit = {}
+    var isVisible: Boolean = visibility == VISIBLE
+        set(show) {
+            if (show != isVisible) {
+                field = show
+                if (show) expand() else collapse()
+            }
+        }
 
     init {
         binding.dismissButton.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/ShippingNoticeCard.kt
@@ -18,16 +18,18 @@ class ShippingNoticeCard @JvmOverloads constructor(
         LayoutInflater.from(context), this, true
     )
 
+    var onDismissClicked: () -> Unit = {}
+    var onLearnMoreClicked: (url: String) -> Unit = {}
+
     init {
         binding.dismissButton.setOnClickListener {
+            onDismissClicked()
             AppPrefs.isEUShippingNoticeDismissed = true
             collapse()
         }
-    }
 
-    fun setLearnMoreClickListener(action: (url: String) -> Unit) {
         binding.learnMoreButton.setOnClickListener {
-            action(AppUrls.EU_SHIPPING_CUSTOMS_REQUIREMENTS)
+            onLearnMoreClicked(AppUrls.EU_SHIPPING_CUSTOMS_REQUIREMENTS)
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
@@ -35,14 +35,18 @@
             android:id="@+id/shipping_notice_icon"
             android:layout_width="@dimen/image_minor_50"
             android:layout_height="@dimen/image_minor_50"
+            android:clickable="true"
+            android:focusable="true"
             android:visibility="gone"
             app:srcCompat="@drawable/ic_tintable_info_outline_24dp"
-            app:tint="@color/color_secondary" />
+            app:tint="@color/color_secondary"
+            tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/error_view"
             android:layout_width="@dimen/image_minor_50"
             android:layout_height="@dimen/image_minor_50"
+            android:layout_marginStart="@dimen/minor_100"
             app:srcCompat="@drawable/mtrl_ic_error"
             app:tint="@color/woo_red_50" />
 

--- a/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
@@ -32,6 +32,14 @@
             tools:text="Custom Line 1" />
 
         <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/shipping_notice_icon"
+            android:layout_width="@dimen/image_minor_50"
+            android:layout_height="@dimen/image_minor_50"
+            android:visibility="gone"
+            app:srcCompat="@drawable/ic_tintable_info_outline_24dp"
+            app:tint="@color/color_secondary" />
+
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/error_view"
             android:layout_width="@dimen/image_minor_50"
             android:layout_height="@dimen/image_minor_50"

--- a/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
@@ -33,20 +33,22 @@
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/shipping_notice_icon"
-            android:layout_width="@dimen/image_minor_50"
+            android:layout_width="wrap_content"
             android:layout_height="@dimen/image_minor_50"
             android:clickable="true"
             android:focusable="true"
             android:visibility="gone"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:paddingHorizontal="@dimen/minor_100"
             app:srcCompat="@drawable/ic_tintable_info_outline_24dp"
             app:tint="@color/color_secondary"
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/error_view"
-            android:layout_width="@dimen/image_minor_50"
+            android:layout_width="wrap_content"
             android:layout_height="@dimen/image_minor_50"
-            android:layout_marginStart="@dimen/minor_100"
+            android:paddingHorizontal="@dimen/minor_100"
             app:srcCompat="@drawable/mtrl_ic_error"
             app:tint="@color/woo_red_50" />
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1008,6 +1008,7 @@
     <string name="shipping_label_customs_contents_type_description_missing">Please describe what kind of goods this package contains.</string>
     <string name="shipping_label_customs_restriction_type_description_missing">Please describe what kind of restrictions this package must have.</string>
     <string name="shipping_label_customs_required_field">This field is required</string>
+    <string name="shipping_label_customs_item_description_too_short">Item weight must be larger</string>
     <string name="shipping_label_customs_weight_zero_error">Weight must be greater than zero</string>
     <string name="shipping_label_customs_value_zero_error">Declared value must be greater than zero</string>
     <string name="shipping_label_customs_form">Customs form</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1008,7 +1008,7 @@
     <string name="shipping_label_customs_contents_type_description_missing">Please describe what kind of goods this package contains.</string>
     <string name="shipping_label_customs_restriction_type_description_missing">Please describe what kind of restrictions this package must have.</string>
     <string name="shipping_label_customs_required_field">This field is required</string>
-    <string name="shipping_label_customs_item_description_too_short">Item weight must be larger</string>
+    <string name="shipping_label_customs_item_description_too_short">You must provide a clear, specific description for every item.</string>
     <string name="shipping_label_customs_weight_zero_error">Weight must be greater than zero</string>
     <string name="shipping_label_customs_value_zero_error">Declared value must be greater than zero</string>
     <string name="shipping_label_customs_form">Customs form</string>


### PR DESCRIPTION
Summary
==========
Fix issue #8891 by introducing guidance inside the Customs form when the Shipping Label creation meets the EU-bound scenario.

Screen Capture
==========
https://user-images.githubusercontent.com/5920403/235808505-1f2e5137-fbde-482d-ae5f-315e865f8a83.mp4

How to Test
==========
For better testing the scenarios introduced here, I recommend setting the `AppPrefs.isEUShippingNoticeDismissed` always to return `false`.

1. Open the app using a store with the `Shipping Labels` plugin activated
2. Open the Order Details of an order with the `Processing` status
3. Hit the `Create Shipping Label` button
4. Verify that the Banner only appears when the Origin country is `US` and the Destination country is one of the EU countries listed above.
5. Verify that the `Customs` view also follows the exact same visibility configuration from the `Create Shipping Label` view
6. Verify that the Custom Line 1 always show the `info` sign icon when there is no validation error inside of it
7. Verify that clicking the `info` icon opens the info banner at the top of the view
8. Verify that every item description requires at least a description with three characters

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.