### PR TITLE
Update Jetpack banner copy to reflect push notifications status

### DIFF
--- a/WooCommerce/src/main/res/layout/view_jetpack_benefits_bottom_banner.xml
+++ b/WooCommerce/src/main/res/layout/view_jetpack_benefits_bottom_banner.xml
@@ -3,8 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@color/jetpack_black"
     android:minHeight="@dimen/major_350"
-    android:background="@color/jetpack_black">
+    android:paddingTop="@dimen/major_75"
+    android:paddingBottom="@dimen/major_75">
 
     <ImageView
         android:id="@+id/jetpack_logo"
@@ -40,6 +42,7 @@
         android:text="@string/jetpack_benefits_bottom_banner_subtitle"
         android:textAppearance="?attr/textAppearanceSubtitle2"
         android:textColor="@color/woo_white_alpha_060"
+        android:lineSpacingExtra="@dimen/minor_25"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/dismiss_button"
         app:layout_constraintStart_toEndOf="@id/jetpack_logo"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2265,8 +2265,8 @@
     <string name="notifications_permission_description">We need your permission to send you push notifications for new orders, reviews, etc. delivered to your device.</string>
 
     <!-- Jetpack Connection Package -->
-    <string name="jetpack_benefits_bottom_banner_title">Get the full experience with Jetpack</string>
-    <string name="jetpack_benefits_bottom_banner_subtitle">See the benefits</string>
+    <string name="jetpack_benefits_bottom_banner_title">Get order notifications and more</string>
+    <string name="jetpack_benefits_bottom_banner_subtitle">Stay updated and boost store security. Explore Jetpack now.</string>
     <string name="jetpack_benefits_modal_title">Get the most out of your store</string>
     <string name="jetpack_benefits_modal_subtitle">Install the free Jetpack plugin to experience the best mobile experience.</string>
     <string name="jetpack_benefits_modal_push_notifications_title">Push Notifications</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Copy update to explain that push notifications are only available if Jetpack is installed. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a store that doesn't have Jetpack installed
2. Check the Jetpack banner has the following text: 

<img width="300"  src="https://user-images.githubusercontent.com/2663464/236406160-29f5b9ac-5842-41ea-9695-189a78f8b804.png"> 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
