### PR TITLE
Search persistence fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -229,10 +229,12 @@ class OrderListFragment :
      */
     private fun refreshOptionsMenu() {
         if (!isChildFragmentShowing() && isSearching) {
-            enableSearchListeners()
             val savedSearchQuery = searchQuery
             searchMenuItem?.expandActionView()
+            enableSearchListeners()
             searchQuery = savedSearchQuery
+            searchView?.setQuery(searchQuery, false)
+            if (searchQuery.isEmpty()) binding.orderListView.clearAdapterData()
         } else {
             val showSearch = shouldShowSearchMenuItem()
             searchMenuItem?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -490,6 +490,7 @@ class OrderListFragment :
             submitSearchDelayed(newText)
         } else {
             binding.orderListView.clearAdapterData()
+            hideEmptyView()
         }
         return true
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -261,14 +261,14 @@ class ProductListFragment :
 
             val isSearchActive = viewModel.viewStateLiveData.liveData.value?.isSearchActive == true
             if (menuItem.isActionViewExpanded != isSearchActive) {
-                disableSearchListeners()
                 if (isSearchActive) {
+                    disableSearchListeners()
                     menuItem.expandActionView()
-                    searchView?.setQuery(viewModel.viewStateLiveData.liveData.value?.query, false)
                     val queryHint = getSearchQueryHint()
                     searchView?.queryHint = queryHint
+                    searchView?.setQuery(viewModel.viewStateLiveData.liveData.value?.query, false)
+                    enableSearchListeners()
                 }
-                enableSearchListeners()
             }
         }
     }
@@ -645,6 +645,7 @@ class ProductListFragment :
 
     private fun onProductClick(remoteProductId: Long, sharedView: View?) {
         if (shouldPreventDetailNavigation(remoteProductId)) return
+        disableSearchListeners()
         (activity as? MainNavigationRouter)?.let { router ->
             if (sharedView == null) {
                 router.showProductDetail(remoteProductId, enableTrash = true)


### PR DESCRIPTION
Fixes #7577.

[search.webm](https://user-images.githubusercontent.com/1522856/236152835-513f5402-2381-4aea-b8d2-0dfe763022a2.webm)

**To test:**

Orders
1. Go to Orders
2. Tap on the search button
3. Enter a query that returns some orders
4. Tap on an order
5. Go back
6. Notice the previous search result is persisted

Products
1. Go to Products
2. Tap on the search button
3. Enter a query that returns some products
4. Tap on an product
5. Go back
6. Notice the previous search result is persisted