### PR TITLE
Insufficient stock status support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
 import com.woocommerce.android.extensions.isEquivalentTo
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.isNotSet
 import com.woocommerce.android.extensions.parseFromIso8601DateFormat
 import com.woocommerce.android.ui.products.ProductBackorderStatus
@@ -81,7 +82,8 @@ data class Product(
     override val width: Float,
     override val height: Float,
     override val weight: Float,
-    val subscription: SubscriptionDetails?
+    val subscription: SubscriptionDetails?,
+    val specialStockStatus: ProductStockStatus? = null
 ) : Parcelable, IProduct {
     companion object {
         const val TAX_CLASS_DEFAULT = "standard"
@@ -141,7 +143,8 @@ data class Product(
             downloadExpiry == product.downloadExpiry &&
             isDownloadable == product.isDownloadable &&
             attributes == product.attributes &&
-            subscription == product.subscription
+            subscription == product.subscription &&
+            specialStockStatus == product.specialStockStatus
     }
 
     val hasCategories get() = categories.isNotEmpty()
@@ -327,7 +330,8 @@ data class Product(
                 downloads = updatedProduct.downloads,
                 downloadLimit = updatedProduct.downloadLimit,
                 downloadExpiry = updatedProduct.downloadExpiry,
-                subscription = updatedProduct.subscription
+                subscription = updatedProduct.subscription,
+                specialStockStatus = specialStockStatus
             )
         } ?: this.copy()
     }
@@ -558,7 +562,12 @@ fun WCProductModel.toAppModel(): Product {
         upsellProductIds = this.getUpsellProductIdList(),
         variationIds = this.getVariationIdList(),
         isPurchasable = this.purchasable,
-        subscription = subscription
+        subscription = subscription,
+        specialStockStatus = if (this.specialStockStatus.isNotNullOrEmpty()) {
+            ProductStockStatus.fromString(this.specialStockStatus)
+        } else {
+            null
+        }
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapItemToProductUiModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapItemToProductUiModel.kt
@@ -31,7 +31,7 @@ class MapItemToProductUiModel @Inject constructor(
                     imageUrl = product?.firstImageUrl.orEmpty(),
                     isStockManaged = product?.isStockManaged ?: false,
                     stockQuantity = product?.stockQuantity ?: 0.0,
-                    stockStatus = product?.stockStatus ?: ProductStockStatus.InStock
+                    stockStatus = product?.specialStockStatus ?: product?.stockStatus ?: ProductStockStatus.InStock
                 )
                 // TODO check if we need to disable the plus button depending on stock quantity
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
@@ -15,7 +15,7 @@ import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.orders.creation.ProductUIModel
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.ProductUtils
+import com.woocommerce.android.util.getStockText
 import org.wordpress.android.util.HtmlUtils
 import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
@@ -63,7 +63,7 @@ class ProductItemView @JvmOverloads constructor(
             if (productUIModel.item.isVariation && productUIModel.item.attributesDescription.isNotEmpty()) {
                 append(productUIModel.item.attributesDescription)
             } else {
-                append(ProductUtils.getStockText(productUIModel, context))
+                append(productUIModel.getStockText(context))
             }
             append(" $bullet ")
             append(decimalFormatter(productUIModel.item.total).replace(" ", "\u00A0"))
@@ -133,7 +133,7 @@ class ProductItemView @JvmOverloads constructor(
         val decimalFormatter = getDecimalFormatter(currencyFormatter, currencyCode)
 
         val statusHtml = getProductStatusHtml(product.status)
-        val stock = ProductUtils.getStockText(product, context)
+        val stock = product.getStockText(context)
         val stockAndStatus = if (statusHtml != null) "$statusHtml $bullet $stock" else stock
         val stockStatusPrice = if (product.price != null) {
             val fmtPrice = decimalFormatter(product.price)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStockStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStockStatus.kt
@@ -14,6 +14,7 @@ sealed class ProductStockStatus(@StringRes val stringResource: Int = 0, val valu
     @Parcelize object InStock : ProductStockStatus(R.string.product_stock_status_instock)
     @Parcelize object OutOfStock : ProductStockStatus(R.string.product_stock_status_out_of_stock)
     @Parcelize object OnBackorder : ProductStockStatus(R.string.product_stock_status_on_backorder)
+    @Parcelize object InsufficientStock : ProductStockStatus(R.string.product_stock_status_insufficient_stock)
     @Parcelize object NotAvailable : ProductStockStatus()
     class Custom(value: String) : ProductStockStatus(value = value)
 
@@ -31,6 +32,7 @@ sealed class ProductStockStatus(@StringRes val stringResource: Int = 0, val valu
                 "instock" -> InStock
                 "outofstock" -> OutOfStock
                 "onbackorder" -> OnBackorder
+                "insufficientstock" -> InsufficientStock
                 null, "" -> NotAvailable
                 else -> Custom(value)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -26,7 +26,7 @@ import com.woocommerce.android.ui.products.variations.selector.VariationSelector
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel.VariationSelectionResult
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
-import com.woocommerce.android.util.ProductUtils
+import com.woocommerce.android.util.getStockText
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -223,7 +223,7 @@ class ProductSelectorViewModel @Inject constructor(
             }
         }
 
-        val stockStatus = ProductUtils.getStockText(this, resourceProvider)
+        val stockStatus = getStockText(resourceProvider)
 
         val price = price?.let { PriceUtils.formatCurrency(price, currencyCode, currencyFormatter) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -7,16 +7,12 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R.string
 import com.woocommerce.android.extensions.combine
-import com.woocommerce.android.extensions.isInteger
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToProductFilter
 import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToVariationSelector
 import com.woocommerce.android.ui.products.ProductStatus
-import com.woocommerce.android.ui.products.ProductStockStatus.Custom
-import com.woocommerce.android.ui.products.ProductStockStatus.InStock
-import com.woocommerce.android.ui.products.ProductStockStatus.NotAvailable
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
@@ -30,6 +26,7 @@ import com.woocommerce.android.ui.products.variations.selector.VariationSelector
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel.VariationSelectionResult
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
+import com.woocommerce.android.util.ProductUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -226,20 +223,7 @@ class ProductSelectorViewModel @Inject constructor(
             }
         }
 
-        val stockStatus = when (stockStatus) {
-            InStock -> {
-                if (isVariable()) {
-                    resourceProvider.getString(
-                        string.product_stock_status_instock_with_variations,
-                        numVariations
-                    )
-                } else {
-                    getStockStatusLabel()
-                }
-            }
-            NotAvailable, is Custom -> null
-            else -> resourceProvider.getString(stockStatus.stringResource)
-        }
+        val stockStatus = ProductUtils.getStockText(this, resourceProvider)
 
         val price = price?.let { PriceUtils.formatCurrency(price, currencyCode, currencyFormatter) }
 
@@ -256,16 +240,6 @@ class ProductSelectorViewModel @Inject constructor(
             selectedVariationIds = variationIds.intersect(selectedItems.variationIds.toSet()),
             selectionState = getProductSelection()
         )
-    }
-
-    private fun Product.getStockStatusLabel() = if (isStockManaged) {
-        val quantity = if (stockQuantity.isInteger()) stockQuantity.toInt() else stockQuantity
-        resourceProvider.getString(
-            string.product_stock_status_instock_quantified,
-            quantity.toString()
-        )
-    } else {
-        resourceProvider.getString(string.product_stock_status_instock)
     }
 
     fun onClearButtonClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ProductUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ProductUtils.kt
@@ -1,0 +1,114 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.orders.creation.ProductUIModel
+import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.viewmodel.ResourceProvider
+
+object ProductUtils {
+    fun getStockText(product: Product, context: Context): String {
+        return when (product.specialStockStatus ?: product.stockStatus) {
+            ProductStockStatus.InStock -> {
+                if (product.productType == ProductType.VARIABLE) {
+                    if (product.numVariations > 0) {
+                        context.getString(
+                            R.string.product_stock_status_instock_with_variations,
+                            product.numVariations
+                        )
+                    } else {
+                        context.getString(R.string.product_stock_status_instock)
+                    }
+                } else {
+                    if (product.stockQuantity > 0) {
+                        context.getString(
+                            R.string.product_stock_count,
+                            StringUtils.formatCountDecimal(product.stockQuantity)
+                        )
+                    } else {
+                        context.getString(R.string.product_stock_status_instock)
+                    }
+                }
+            }
+            ProductStockStatus.OutOfStock -> {
+                context.getString(R.string.product_stock_status_out_of_stock)
+            }
+            ProductStockStatus.OnBackorder -> {
+                context.getString(R.string.product_stock_status_on_backorder)
+            }
+            ProductStockStatus.InsufficientStock -> {
+                context.getString(R.string.product_stock_status_insufficient_stock)
+            }
+            else -> {
+                product.stockStatus.value
+            }
+        }
+    }
+
+    fun getStockText(product: Product, resourceProvider: ResourceProvider): String {
+        return when (product.specialStockStatus ?: product.stockStatus) {
+            ProductStockStatus.InStock -> {
+                if (product.productType == ProductType.VARIABLE) {
+                    if (product.numVariations > 0) {
+                        resourceProvider.getString(
+                            R.string.product_stock_status_instock_with_variations,
+                            product.numVariations
+                        )
+                    } else {
+                        resourceProvider.getString(R.string.product_stock_status_instock)
+                    }
+                } else {
+                    if (product.stockQuantity > 0) {
+                        resourceProvider.getString(
+                            R.string.product_stock_count,
+                            StringUtils.formatCountDecimal(product.stockQuantity)
+                        )
+                    } else {
+                        resourceProvider.getString(R.string.product_stock_status_instock)
+                    }
+                }
+            }
+            ProductStockStatus.OutOfStock -> {
+                resourceProvider.getString(R.string.product_stock_status_out_of_stock)
+            }
+            ProductStockStatus.OnBackorder -> {
+                resourceProvider.getString(R.string.product_stock_status_on_backorder)
+            }
+            ProductStockStatus.InsufficientStock -> {
+                resourceProvider.getString(R.string.product_stock_status_insufficient_stock)
+            }
+            else -> {
+                product.stockStatus.value
+            }
+        }
+    }
+
+    fun getStockText(product: ProductUIModel, context: Context): String {
+        return when (product.stockStatus) {
+            ProductStockStatus.InStock -> {
+                if (product.stockQuantity > 0) {
+                    context.getString(
+                        R.string.product_stock_count,
+                        StringUtils.formatCountDecimal(product.stockQuantity)
+                    )
+                } else {
+                    context.getString(R.string.product_stock_status_instock)
+                }
+            }
+            ProductStockStatus.OutOfStock -> {
+                context.getString(R.string.product_stock_status_out_of_stock)
+            }
+            ProductStockStatus.OnBackorder -> {
+                context.getString(R.string.product_stock_status_on_backorder)
+            }
+            ProductStockStatus.InsufficientStock -> {
+                context.getString(R.string.product_stock_status_insufficient_stock)
+            }
+            else -> {
+                product.stockStatus.value
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ProductUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ProductUtils.kt
@@ -8,107 +8,81 @@ import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.viewmodel.ResourceProvider
 
-object ProductUtils {
-    fun getStockText(product: Product, context: Context): String {
-        return when (product.specialStockStatus ?: product.stockStatus) {
-            ProductStockStatus.InStock -> {
-                if (product.productType == ProductType.VARIABLE) {
-                    if (product.numVariations > 0) {
-                        context.getString(
-                            R.string.product_stock_status_instock_with_variations,
-                            product.numVariations
-                        )
-                    } else {
-                        context.getString(R.string.product_stock_status_instock)
-                    }
-                } else {
-                    if (product.stockQuantity > 0) {
-                        context.getString(
-                            R.string.product_stock_count,
-                            StringUtils.formatCountDecimal(product.stockQuantity)
-                        )
-                    } else {
-                        context.getString(R.string.product_stock_status_instock)
-                    }
-                }
-            }
-            ProductStockStatus.OutOfStock -> {
-                context.getString(R.string.product_stock_status_out_of_stock)
-            }
-            ProductStockStatus.OnBackorder -> {
-                context.getString(R.string.product_stock_status_on_backorder)
-            }
-            ProductStockStatus.InsufficientStock -> {
-                context.getString(R.string.product_stock_status_insufficient_stock)
-            }
-            else -> {
-                product.stockStatus.value
-            }
-        }
+fun Product.getStockText(context: Context): String {
+    return getStockText(
+        this.specialStockStatus ?: this.stockStatus,
+        this.productType,
+        this.stockQuantity,
+        this.numVariations,
+    ) { resId: Int, param: Any? ->
+        param?.let {
+            context.getString(resId, it)
+        } ?: context.getString(resId)
     }
+}
 
-    fun getStockText(product: Product, resourceProvider: ResourceProvider): String {
-        return when (product.specialStockStatus ?: product.stockStatus) {
-            ProductStockStatus.InStock -> {
-                if (product.productType == ProductType.VARIABLE) {
-                    if (product.numVariations > 0) {
-                        resourceProvider.getString(
-                            R.string.product_stock_status_instock_with_variations,
-                            product.numVariations
-                        )
-                    } else {
-                        resourceProvider.getString(R.string.product_stock_status_instock)
-                    }
-                } else {
-                    if (product.stockQuantity > 0) {
-                        resourceProvider.getString(
-                            R.string.product_stock_count,
-                            StringUtils.formatCountDecimal(product.stockQuantity)
-                        )
-                    } else {
-                        resourceProvider.getString(R.string.product_stock_status_instock)
-                    }
-                }
-            }
-            ProductStockStatus.OutOfStock -> {
-                resourceProvider.getString(R.string.product_stock_status_out_of_stock)
-            }
-            ProductStockStatus.OnBackorder -> {
-                resourceProvider.getString(R.string.product_stock_status_on_backorder)
-            }
-            ProductStockStatus.InsufficientStock -> {
-                resourceProvider.getString(R.string.product_stock_status_insufficient_stock)
-            }
-            else -> {
-                product.stockStatus.value
-            }
-        }
+fun Product.getStockText(resourceProvider: ResourceProvider): String {
+    return getStockText(
+        this.specialStockStatus ?: this.stockStatus,
+        this.productType,
+        this.stockQuantity,
+        this.numVariations,
+    ) { resId: Int, param: Any? ->
+        param?.let {
+            resourceProvider.getString(resId, it)
+        } ?: resourceProvider.getString(resId)
     }
+}
 
-    fun getStockText(product: ProductUIModel, context: Context): String {
-        return when (product.stockStatus) {
-            ProductStockStatus.InStock -> {
-                if (product.stockQuantity > 0) {
-                    context.getString(
-                        R.string.product_stock_count,
-                        StringUtils.formatCountDecimal(product.stockQuantity)
-                    )
-                } else {
-                    context.getString(R.string.product_stock_status_instock)
-                }
-            }
-            ProductStockStatus.OutOfStock -> {
-                context.getString(R.string.product_stock_status_out_of_stock)
-            }
-            ProductStockStatus.OnBackorder -> {
-                context.getString(R.string.product_stock_status_on_backorder)
-            }
-            ProductStockStatus.InsufficientStock -> {
-                context.getString(R.string.product_stock_status_insufficient_stock)
-            }
-            else -> {
-                product.stockStatus.value
-            }
+fun ProductUIModel.getStockText(context: Context): String {
+    return getStockText(
+        this.stockStatus,
+        null,
+        this.stockQuantity
+    ) { resId: Int, param: Any? ->
+        param?.let {
+            context.getString(resId, it)
+        } ?: context.getString(resId)
+    }
+}
+
+private fun getStockText(
+    stockStatus: ProductStockStatus,
+    productType: ProductType?,
+    stockQuantity: Double = 0.0,
+    numVariations: Int = 0,
+    getString: (resId: Int, param: Any?) -> String
+): String {
+    return when (stockStatus) {
+        ProductStockStatus.InStock -> getInStockText(productType, stockQuantity, numVariations, getString)
+        ProductStockStatus.OutOfStock -> getString(R.string.product_stock_status_out_of_stock, null)
+        ProductStockStatus.OnBackorder -> getString(R.string.product_stock_status_on_backorder, null)
+        ProductStockStatus.InsufficientStock -> getString(R.string.product_stock_status_insufficient_stock, null)
+        else -> stockStatus.value
+    }
+}
+
+private fun getInStockText(
+    productType: ProductType?,
+    stockQuantity: Double = 0.0,
+    numVariations: Int = 0,
+    getString: (resId: Int, param: Any?) -> String
+): String {
+    return when {
+        productType == ProductType.VARIABLE && numVariations > 0 -> {
+            getString(
+                R.string.product_stock_status_instock_with_variations,
+                numVariations
+            )
         }
+
+        stockQuantity > 0 -> {
+            getString(
+                R.string.product_stock_count,
+                StringUtils.formatCountDecimal(stockQuantity)
+            )
+        }
+
+        else -> getString(R.string.product_stock_status_instock, null)
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1593,6 +1593,7 @@
     <string name="product_stock_status_instock_with_variations">In stock \u2022 %d variations</string>
     <string name="product_stock_status_out_of_stock">Out of stock</string>
     <string name="product_stock_status_on_backorder">On backorder</string>
+    <string name="product_stock_status_insufficient_stock">Insufficient stock</string>
     <string name="product_stock_count">%s in stock</string>
     <string name="product_backorders_no">Do not allow</string>
     <string name="product_backorders_yes">Allow</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products.selector
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_CONFIRM_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_COUNT
@@ -87,7 +86,6 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        whenever(resourceProvider.getString(R.string.product_stock_status_instock)).thenReturn("In stock")
         val site: SiteModel = mock()
         whenever(selectedSite.get()).thenReturn(site)
         whenever(siteSettings.currencyCode).thenReturn("USD")

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.26.0'
+    fluxCVersion = 'trunk-81b570f69e66511f85ab74af46cbeefd1f15e540'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #8961

### Description
This PR brings support to the insufficient stock status added by Bundle Products when one of the products inside the bundle is `out-of-stock`. It does that by using the new special stock status field when present. 
This PR also moves the `getStockText` function to the new `ProductUtils` so we concentrate in one class the logic to display the stock text.

### Testing instructions
TC1
1. Install the Bundle Product extension in your store
2. Create a bundle product containing one product with the stock status out-of-stock
3. Open the app products tap and check that the bundle product status on the list is `Insufficient stock`
4. Tap on the bundle product and check that the inventory  card displays the product's stock status and NOT `Insufficient stock`

TC2
1. Open the app orders tap (+) to create a new order
2. Tap on Add products
3. Search for the bundle product containing the out-of-stock product
4. Check that the bundle product status on the selection list is `Insufficient stock`
5. Add the bundle product to the order
6. Check that the bundle product status on the products list of the new order is `Insufficient stock` 
7. Tap on the bundle product
8. Check that the bundle product status on the product screen  is `Insufficient stock`

TC3
1. Update the out-of-stock product inside the  bundle product  to in-stock
2. Open the app products tap, and check that the bundle product status on the list is `In stock`

TC4
Check that the other stock status keep working as expected

### Images/gif

https://user-images.githubusercontent.com/18119390/236373963-e1a21c73-8c8a-4559-9f4f-cbec9fa132be.mp4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
