### PR TITLE
[TTP] Test TTP on a emulator

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
@@ -24,7 +24,8 @@ class TapToPayAvailabilityStatus @Inject constructor(
             !appPrefs.isTapToPayEnabled -> Result.NotAvailable.TapToPayDisabled
             !systemVersionUtilsWrapper.isAtLeastP() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
-            !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
+            !deviceFeatures.isNFCAvailable() && !appPrefs.isSimulatedReaderEnabled ->
+                Result.NotAvailable.NfcNotAvailable
             !isTppSupportedInCountry(wooStore.getStoreCountryCode(selectedSite.get())) ->
                 Result.NotAvailable.CountryNotSupported
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
@@ -55,6 +55,28 @@ class TapToPayAvailabilityStatusTest {
     }
 
     @Test
+    fun `given device has no NFC and ttp enabled and simulated reader enabled, when invoking, then nfc Available returned`() {
+        val deviceFeatures = mock<DeviceFeatures> {
+            whenever(it.isNFCAvailable()).thenReturn(false)
+            whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
+        }
+        whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
+        whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
+        whenever(appPrefs.isSimulatedReaderEnabled).thenReturn(true)
+
+        val result = TapToPayAvailabilityStatus(
+            appPrefs,
+            selectedSite,
+            deviceFeatures,
+            systemVersionUtilsWrapper,
+            cardReaderCountryConfigProvider,
+            wooStore
+        ).invoke()
+
+        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.Available)
+    }
+
+    @Test
     fun `given device has no Google Play Services and ttp enabled, when invoking, then GPS not available`() {
         val deviceFeatures = mock<DeviceFeatures> {
             whenever(it.isNFCAvailable()).thenReturn(true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8973 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds extra check that if NFC is not available but simulated card reader enabled then TTP is available

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Enabled simulated card reader via dev settings of the app
* Notice that you can do TTP payments on the emulator now
* Disable simulated card reader via dev settings of the app
* Notice that on the emulator TTP is unavailable 


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

https://user-images.githubusercontent.com/4923871/236753175-3e37936b-4f5b-4014-a911-891ea94c0dd6.mp4



<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
