### PR TITLE
[TTP] When tax is added then autorefund doesn't work because amount missmatches

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -207,6 +207,7 @@ data class Order(
         val name: String?,
         val total: BigDecimal,
         val totalTax: BigDecimal,
+        var taxStatus: FeeLineTaxStatus,
     ) : Parcelable {
         fun getTotalValue(): BigDecimal = total + totalTax
 
@@ -215,8 +216,13 @@ data class Order(
                 id = 0,
                 name = "",
                 total = BigDecimal.ZERO,
-                totalTax = BigDecimal.ZERO
+                totalTax = BigDecimal.ZERO,
+                taxStatus = FeeLineTaxStatus.UNKNOWN,
             )
+        }
+
+        enum class FeeLineTaxStatus {
+            TAXABLE, NONE, UNKNOWN,
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.Order.Item
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.WCMetaData
+import org.wordpress.android.fluxc.model.order.FeeLineTaxStatus
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.TaxLine
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
@@ -75,6 +76,11 @@ class OrderMapper @Inject constructor(private val getLocations: GetLocations) {
             name = it.name ?: StringUtils.EMPTY,
             totalTax = it.totalTax?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
             total = it.total?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+            taxStatus = when (it.taxStatus) {
+                FeeLineTaxStatus.Taxable -> Order.FeeLine.FeeLineTaxStatus.TAXABLE
+                FeeLineTaxStatus.None -> Order.FeeLine.FeeLineTaxStatus.NONE
+                else -> Order.FeeLine.FeeLineTaxStatus.UNKNOWN
+            }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -96,7 +96,7 @@ class TapToPaySummaryViewModel @Inject constructor(
         refundStore.createAmountRefund(
             selectedSite.get(),
             order.id,
-            order.total,
+            calculateRefundAmount(order),
             resourceProvider.getString(R.string.tap_to_pay_refund_reason),
             true,
         ).apply {
@@ -108,6 +108,13 @@ class TapToPaySummaryViewModel @Inject constructor(
             }
         }
     }
+
+    private fun calculateRefundAmount(order: Order) =
+        if (order.feesLines.first().taxStatus == Order.FeeLine.FeeLineTaxStatus.TAXABLE) {
+            order.total
+        } else {
+            order.total - order.totalTax
+        }
 
     private fun showSuccessfulRefundNotification(orderId: Long) {
         triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -110,7 +110,7 @@ class TapToPaySummaryViewModel @Inject constructor(
     }
 
     private fun calculateRefundAmount(order: Order) =
-        if (order.feesLines.first().taxStatus == Order.FeeLine.FeeLineTaxStatus.TAXABLE) {
+        if (order.feesLines.firstOrNull()?.taxStatus == Order.FeeLine.FeeLineTaxStatus.TAXABLE) {
             order.total
         } else {
             order.total - order.totalTax


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8966
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes a bug when an auto refund of the test TTP paid didn't work because the amount that was about to be refund was incorrect due to a tax

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Enable tax calculation on your website
* Try TTP test payment both with tax included and tax exploded in the payment
* Notice that both are refunded automatically and successfully

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/4923871/236779479-8822ab82-d9e2-4274-91c6-90eb725c04aa.mp4




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
