### PR TITLE
Variations: Fix the rotation bug

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -81,7 +81,6 @@ class VariationListViewModel @Inject constructor(
 
     private val _variationList = MutableLiveData<List<ProductVariation>>()
     val variationList: LiveData<List<ProductVariation>> = Transformations.map(_variationList) { variations ->
-        val isEmpty = viewState.parentProduct?.variationEnabledAttributes?.isEmpty() == true
         variations.apply {
             viewState = viewState.copy(
                 isEmptyViewVisible = isEmpty,


### PR DESCRIPTION
Fixes #8194.

The PR fixes a bug when the empty view disappears on rotation.

[device-2023-05-08-151156.webm](https://user-images.githubusercontent.com/1522856/236833461-e9061fd8-569e-4c6d-9fc5-9d49033d9c2a.webm)

**To test:**
1. Go to Products
2. Select a variable product with no variations
3. Tap on Add variations
4. Notice the empty view with a button is shown
5. Rotate the screen
6. Notice the empty view is shown