### PR TITLE
Add More Privacy Options row

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/icons/OpenInNew.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/icons/OpenInNew.kt
@@ -1,0 +1,46 @@
+@file:Suppress("MagicNumber")
+package com.woocommerce.android.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val OpenInNew: ImageVector
+    get() {
+        if (_openInNew != null) {
+            return _openInNew!!
+        }
+        _openInNew = materialIcon(name = "Filled.OpenInNew") {
+            materialPath {
+                moveTo(19.0f, 19.0f)
+                horizontalLineTo(5.0f)
+                verticalLineTo(5.0f)
+                horizontalLineToRelative(7.0f)
+                verticalLineTo(3.0f)
+                horizontalLineTo(5.0f)
+                curveToRelative(-1.11f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
+                verticalLineToRelative(14.0f)
+                curveToRelative(0.0f, 1.1f, 0.89f, 2.0f, 2.0f, 2.0f)
+                horizontalLineToRelative(14.0f)
+                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                verticalLineToRelative(-7.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(7.0f)
+                close()
+                moveTo(14.0f, 3.0f)
+                verticalLineToRelative(2.0f)
+                horizontalLineToRelative(3.59f)
+                lineToRelative(-9.83f, 9.83f)
+                lineToRelative(1.41f, 1.41f)
+                lineTo(19.0f, 6.41f)
+                verticalLineTo(10.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineTo(3.0f)
+                horizontalLineToRelative(-7.0f)
+                close()
+            }
+        }
+        return _openInNew!!
+    }
+
+private var _openInNew: ImageVector? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
@@ -129,7 +129,7 @@ fun PrivacySettingsScreen(
 }
 
 @Composable
-private fun ExplanationText() {
+private fun ExplanationText(modifier: Modifier = Modifier) {
     val privacyPolicyPart =
         stringResource(R.string.settings_advertising_options_explanation_privacy_policy)
     val cookiePolicyPart =
@@ -174,7 +174,7 @@ private fun ExplanationText() {
         text = annotatedString,
         onClick = {
         },
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+        modifier = modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
         style = MaterialTheme.typography.caption,
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
@@ -94,7 +94,7 @@ fun PrivacySettingsScreen(
                     ) {
                         Icon(
                             imageVector = OpenInNew,
-                            contentDescription = stringResource(id = R.string.cancel)
+                            contentDescription = stringResource(id = R.string.settings_advertising_options)
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Switch
@@ -28,6 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.icons.OpenInNew
 
 @Composable
 fun PrivacySettingsScreen(
@@ -60,84 +63,112 @@ fun PrivacySettingsScreen(
                 text = stringResource(R.string.settings_privacy_statement),
                 modifier = Modifier.padding(16.dp)
             )
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp),
-                elevation = 8.dp,
-                content = {
-                    Column {
-                        OptionRow(
-                            switchChecked = state.sendUsageStats,
-                            onAnalyticsSettingChanged,
-                            sectionHeader = stringResource(R.string.settings_tracking_header),
-                            sectionTitle = stringResource(R.string.settings_tracking_analytics),
-                            sectionDescription = stringResource(R.string.settings_tracking_analytics_description),
-                        )
-                        OptionRow(
-                            switchChecked = state.crashReportingEnabled,
-                            onReportCrashesChanged,
-                            sectionHeader = stringResource(R.string.settings_reports_header),
-                            sectionTitle = stringResource(R.string.settings_reports_report_crashes),
-                            sectionDescription = stringResource(R.string.settings_reports_report_crashes_description),
+            OptionCard(
+                sectionHeader = stringResource(R.string.settings_tracking_header),
+                sectionTitle = stringResource(R.string.settings_tracking_analytics),
+                sectionDescription = stringResource(R.string.settings_tracking_analytics_description),
+                actionContent = {
+                    Switch(
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = MaterialTheme.colors.primary
+                        ),
+                        modifier = Modifier.padding(start = 8.dp),
+                        checked = state.sendUsageStats,
+                        onCheckedChange = onAnalyticsSettingChanged,
+                    )
+                }
+            )
+            OptionCard(
+                sectionHeader = stringResource(R.string.settings_more_privacy_options_header),
+                sectionTitle = stringResource(R.string.settings_advertising_options),
+                sectionDescription = stringResource(R.string.settings_advertising_options_description),
+                actionContent = {
+                    IconButton(
+                        modifier = Modifier.padding(start = 8.dp),
+                        onClick = { /*TODO*/
+                        }
+                    ) {
+                        Icon(
+                            imageVector = OpenInNew,
+                            contentDescription = stringResource(id = R.string.cancel)
                         )
                     }
-                },
+                }
+            )
+            Text(
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                style = MaterialTheme.typography.caption,
+                text = stringResource(R.string.settings_advertising_options_explanation)
+            )
+            OptionCard(
+                sectionHeader = stringResource(R.string.settings_reports_header),
+                sectionTitle = stringResource(R.string.settings_reports_report_crashes),
+                sectionDescription = stringResource(R.string.settings_reports_report_crashes_description),
+                actionContent = {
+                    Switch(
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = MaterialTheme.colors.primary
+                        ),
+                        modifier = Modifier.padding(start = 8.dp),
+                        checked = state.crashReportingEnabled,
+                        onCheckedChange = onReportCrashesChanged,
+                    )
+                }
             )
         }
     }
 }
 
 @Composable
-private fun OptionRow(
-    switchChecked: Boolean,
-    onSwitchChanged: (Boolean) -> Unit,
+private fun OptionCard(
     sectionHeader: String,
     sectionTitle: String,
     sectionDescription: String,
+    actionContent: @Composable () -> Unit,
 ) {
-    Column(modifier = Modifier.padding(16.dp)) {
-        Text(
-            text = sectionHeader,
-            style = MaterialTheme.typography.caption,
-            modifier = Modifier.padding(bottom = 16.dp),
-            color = MaterialTheme.colors.primary,
-        )
-        Row(
-            modifier = Modifier
-                .height(IntrinsicSize.Min)
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(end = 16.dp)
-            ) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp),
+        elevation = 4.dp,
+        content = {
+            Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = sectionTitle,
-                )
-                Text(
+                    text = sectionHeader,
                     style = MaterialTheme.typography.caption,
-                    text = sectionDescription,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                    color = MaterialTheme.colors.primary,
                 )
+                Row(
+                    modifier = Modifier
+                        .height(IntrinsicSize.Min)
+                        .fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 16.dp)
+                    ) {
+                        Text(
+                            text = sectionTitle,
+                        )
+                        Text(
+                            style = MaterialTheme.typography.caption,
+                            text = sectionDescription,
+                        )
+                    }
+                    Divider(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .padding(vertical = 8.dp)
+                            .width(1.dp)
+                    )
+                    actionContent()
+                }
             }
-            Divider(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .padding(vertical = 8.dp)
-                    .width(1.dp)
-            )
-            Switch(
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = MaterialTheme.colors.primary
-                ),
-                modifier = Modifier.padding(start = 8.dp),
-                checked = switchChecked,
-                onCheckedChange = onSwitchChanged,
-            )
         }
-    }
+    )
 }
 
 @Preview(name = "Light mode")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
@@ -26,6 +27,9 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -34,7 +38,7 @@ import com.woocommerce.android.ui.icons.OpenInNew
 
 @Composable
 fun PrivacySettingsScreen(
-    viewModel: PrivacySettingsViewModel
+    viewModel: PrivacySettingsViewModel,
 ) {
     val state: PrivacySettingsViewModel.State by viewModel.state.observeAsState(
         PrivacySettingsViewModel.State(sendUsageStats = false, crashReportingEnabled = false)
@@ -95,11 +99,7 @@ fun PrivacySettingsScreen(
                     }
                 }
             )
-            Text(
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
-                style = MaterialTheme.typography.caption,
-                text = stringResource(R.string.settings_advertising_options_explanation)
-            )
+            ExplanationText()
             OptionCard(
                 sectionHeader = stringResource(R.string.settings_reports_header),
                 sectionTitle = stringResource(R.string.settings_reports_report_crashes),
@@ -117,6 +117,51 @@ fun PrivacySettingsScreen(
             )
         }
     }
+}
+
+@Composable
+private fun ExplanationText() {
+    val privacyPolicyPart = stringResource(R.string.settings_advertising_options_explanation_privacy_policy)
+    val cookiePolicyPart = stringResource(R.string.settings_advertising_options_explanation_cookie_policy)
+    val formattedString =
+        stringResource(R.string.settings_advertising_options_explanation, privacyPolicyPart, cookiePolicyPart)
+    val annotatedString = AnnotatedString.Builder(formattedString).apply {
+        addStyle(
+            SpanStyle(color = MaterialTheme.colors.onBackground),
+            0,
+            formattedString.length
+        )
+        addStyle(
+            SpanStyle(
+                textDecoration = TextDecoration.Underline,
+                color = MaterialTheme.colors.primary,
+            ),
+            formattedString.indexOf(cookiePolicyPart),
+            formattedString.indexOf(cookiePolicyPart) + cookiePolicyPart.length
+        )
+        addStyle(
+            SpanStyle(
+                textDecoration = TextDecoration.Underline,
+                color = MaterialTheme.colors.primary,
+            ),
+            formattedString.indexOf(privacyPolicyPart),
+            formattedString.indexOf(privacyPolicyPart) + privacyPolicyPart.length
+        )
+        addStringAnnotation(
+            "",
+            formattedString,
+            formattedString.indexOf(cookiePolicyPart),
+            formattedString.indexOf(cookiePolicyPart) + cookiePolicyPart.length
+        )
+    }.toAnnotatedString()
+
+    ClickableText(
+        text = annotatedString,
+        onClick = {
+        },
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+        style = MaterialTheme.typography.caption,
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsScreen.kt
@@ -95,7 +95,7 @@ fun PrivacySettingsScreen(
                         onRowClicked = {}
                     ) {
                         IconButton(
-                            modifier = Modifier.padding(start = 8.dp),
+                            modifier = Modifier.padding(horizontal = 8.dp),
                             onClick = { /*TODO*/
                             }
                         ) {
@@ -105,6 +105,7 @@ fun PrivacySettingsScreen(
                             )
                         }
                     }
+                    Spacer(modifier = Modifier.height(16.dp))
                     ExplanationText()
                     Spacer(modifier = Modifier.height(16.dp))
                     OptionRow(
@@ -214,6 +215,7 @@ private fun OptionRow(
                     style = MaterialTheme.typography.subtitle1,
                 )
                 Text(
+                    modifier = Modifier.padding(top = 4.dp),
                     style = textAppearanceWooBody2(),
                     text = sectionDescription,
                 )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1914,6 +1914,12 @@
     <string name="settings_tracking_header">Tracking</string>
     <string name="settings_tracking_analytics">Analytics</string>
     <string name="settings_tracking_analytics_description">These cookies allow us to optimize performance by collecting information on how users interact with our mobile apps.</string>
+    <string name="settings_more_privacy_options_header">More privacy options</string>
+    <string name="settings_advertising_options">Advertising Options</string>
+    <string name="settings_advertising_options_description">More Privacy Options Available. Check here to learn more.</string>
+    <string name="settings_advertising_options_explanation">To learn more about how we use your data to optimize our mobile apps, enhance your experience, and deliver relevant marketing, learn more in our %1$s and %2$s.</string>
+    <string name="settings_advertising_options_explanation_privacy_policy">Privacy Policy</string>
+    <string name="settings_advertising_options_explanation_cookie_policy">Cookie Policy</string>
     <string name="settings_reports_header">Reports</string>
     <string name="settings_reports_report_crashes">Report Crashes</string>
     <string name="settings_reports_report_crashes_description">To help us improve the app’s performance and fix the occasional bug, enable automatic crash report.</string>
@@ -3265,8 +3271,4 @@
     <string name="shipping_notice_banner_content">When shipping to countries that follow European Union (EU) customs rules, you must provide a clear, specific description of every item. Otherwise, shipments may be delayed or interrupted at customs.</string>
     <string name="shipping_notice_learn_more">Learn More</string>
     <string name="shipping_notice_dismiss">Dismiss</string>
-    <string name="settings_more_privacy_options_header">More privacy options</string>
-    <string name="settings_advertising_options">Advertising Options</string>
-    <string name="settings_advertising_options_description">More Privacy Options Available. Check here to learn more.</string>
-    <string name="settings_advertising_options_explanation">To learn more about how we use your data to optimize our mobile apps, enhance your experience, and deliver relevant marketing, learn more in our Privacy Policy and Cookie Policy.</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3265,4 +3265,8 @@
     <string name="shipping_notice_banner_content">When shipping to countries that follow European Union (EU) customs rules, you must provide a clear, specific description of every item. Otherwise, shipments may be delayed or interrupted at customs.</string>
     <string name="shipping_notice_learn_more">Learn More</string>
     <string name="shipping_notice_dismiss">Dismiss</string>
+    <string name="settings_more_privacy_options_header">More privacy options</string>
+    <string name="settings_advertising_options">Advertising Options</string>
+    <string name="settings_advertising_options_description">More Privacy Options Available. Check here to learn more.</string>
+    <string name="settings_advertising_options_explanation">To learn more about how we use your data to optimize our mobile apps, enhance your experience, and deliver relevant marketing, learn more in our Privacy Policy and Cookie Policy.</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8938 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds UI for "More Privacy Options" screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This PR only adds UI - no tests needed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="300" alt="image" src="https://user-images.githubusercontent.com/5845095/236892593-e22f7dce-5e78-4efb-a4bd-be1dacbc2cc5.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
