### PR TITLE
Subscription variation event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -523,6 +523,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
 
     // -- Product subscriptions
     PRODUCT_DETAILS_VIEW_SUBSCRIPTIONS_TAPPED,
+    PRODUCT_VARIATION_VIEW_SUBSCRIPTIONS_TAPPED,
 
     // -- Product attributes
     PRODUCT_ATTRIBUTE_EDIT_BUTTON_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -407,7 +407,7 @@ class VariationDetailCardBuilder(
                 onClick = {
                     viewModel.onEditVariationCardClicked(
                         ViewSubscription(subscription, salesDetails),
-                        AnalyticsEvent.PRODUCT_DETAILS_VIEW_SUBSCRIPTIONS_TAPPED
+                        AnalyticsEvent.PRODUCT_VARIATION_VIEW_SUBSCRIPTIONS_TAPPED
                     )
                 }
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8982

### Description
This PR adds the `product_variation_view_subscriptions_tapped` to follow the pattern of having 2 different event names when triggered from product details / variation details

Event [registration](https://github.com/Automattic/tracks-events-registration/pull/1586)

p1680601556325579/1680566861.229309-slack-C02KUCFCSFP

### Testing instructions
Install the WooCommerce Subscription extension and create 2 Subscriptions, 1 simple and one variable

TC1
1. Open the product list screen
2. Select a variable subscription product
3. Tap on Variations
4. Tap on one variation
5. Tap on the Subscription row
6. Check that the `product_variation_view_subscriptions_tapped` event is triggered

TC2
1. Open the product list screen
2. Select a simple subscription product
3. Tap on the Subscription row
4. Check that the app still triggers the `product_details_view_subscriptions_tapped` event


### Images/gif
```
🔵 Tracked: product_variation_view_subscriptions_tapped, Properties: {"blog_id":214253715,"is_wpcom_store":true,"is_debug":true}
```


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
