### PR TITLE
[STP] Add scan to pay button to the payment method selection screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -117,8 +117,11 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
             }
         }
 
-        binding.tvScanToPay = state.isScanToPayAvailable
-        binding.dividerAfterScanToPay = state.isScanToPayAvailable
+        with (binding.tvScanToPay) {
+            isVisible = state.isScanToPayAvailable
+            setOnClickListener { viewModel.onScanToPayClicked() }
+        }
+        binding.dividerAfterScanToPay.isVisible = state.isScanToPayAvailable
 
         with(binding.learnMoreIppPaymentMethodsTv) {
             learnMore.setOnClickListener { state.learMoreIpp.onClick.invoke() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -117,7 +117,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
             }
         }
 
-        with (binding.tvScanToPay) {
+        with(binding.tvScanToPay) {
             isVisible = state.isScanToPayAvailable
             setOnClickListener { viewModel.onScanToPayClicked() }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -117,6 +117,9 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
             }
         }
 
+        binding.tvScanToPay = state.isScanToPayAvailable
+        binding.dividerAfterScanToPay = state.isScanToPayAvailable
+
         with(binding.learnMoreIppPaymentMethodsTv) {
             learnMore.setOnClickListener { state.learMoreIpp.onClick.invoke() }
             UiHelpers.setTextOrHide(binding.learnMoreIppPaymentMethodsTv.learnMore, state.learMoreIpp.label)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -69,6 +70,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private val cardReaderTracker: CardReaderTracker,
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val appPrefs: AppPrefs = AppPrefs,
+    private val isScanToPayAvailable: IsScanToPayAvailable,
 ) : ScopedViewModel(savedState) {
     private val navArgs: SelectPaymentMethodFragmentArgs by savedState.navArgs()
 
@@ -120,6 +122,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
         orderTotal = currencyFormatter.formatCurrency(order.total, currencyCode),
         isPaymentCollectableWithExternalCardReader = isPaymentCollectableWithCardReader,
         isPaymentCollectableWithTapToPay = isPaymentCollectableWithCardReader && isPaymentCollectableWithTapToPay,
+        isScanToPayAvailable = isScanToPayAvailable(),
         learMoreIpp = SelectPaymentMethodViewState.LearMoreIpp(
             label = UiStringRes(
                 R.string.card_reader_connect_learn_more,
@@ -342,4 +345,8 @@ class SelectPaymentMethodViewModel @Inject constructor(
         const val UTM_CONTENT = "upsell_card_readers"
         const val LEARN_MORE_SOURCE = "payment_methods"
     }
+}
+
+class IsScanToPayAvailable @Inject constructor() {
+    operator fun invoke() = FeatureFlag.IPP_SCAN_TO_PAY.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -253,6 +253,10 @@ class SelectPaymentMethodViewModel @Inject constructor(
         }
     }
 
+    fun onScanToPayClicked() {
+        TODO("Not yet implemented")
+    }
+
     fun onBackPressed() {
         // Simple payments flow is not canceled if we going back from this fragment
         if (cardReaderPaymentFlowParam.paymentType == ORDER) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewState.kt
@@ -9,6 +9,7 @@ sealed class SelectPaymentMethodViewState {
         val orderTotal: String,
         val isPaymentCollectableWithExternalCardReader: Boolean,
         val isPaymentCollectableWithTapToPay: Boolean,
+        val isScanToPayAvailable: Boolean,
         val learMoreIpp: LearMoreIpp,
     ) : SelectPaymentMethodViewState()
 

--- a/WooCommerce/src/main/res/drawable/ic_baseline_qr_code_scanner.xml
+++ b/WooCommerce/src/main/res/drawable/ic_baseline_qr_code_scanner.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9.5,6.5v3h-3v-3H9.5M11,5H5v6h6V5L11,5zM9.5,14.5v3h-3v-3H9.5M11,13H5v6h6V13L11,13zM17.5,6.5v3h-3v-3H17.5M19,5h-6v6h6V5L19,5zM13,13h1.5v1.5H13V13zM14.5,14.5H16V16h-1.5V14.5zM16,13h1.5v1.5H16V13zM13,16h1.5v1.5H13V16zM14.5,17.5H16V19h-1.5V17.5zM16,16h1.5v1.5H16V16zM17.5,14.5H19V16h-1.5V14.5zM17.5,17.5H19V19h-1.5V17.5zM22,7h-2V4h-3V2h5V7zM22,22v-5h-2v3h-3v2H22zM2,22h5v-2H4v-3H2V22zM2,2v5h2V4h3V2H2z"/>
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_baseline_qr_code_scanner.xml
+++ b/WooCommerce/src/main/res/drawable/ic_baseline_qr_code_scanner.xml
@@ -1,5 +1,9 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M9.5,6.5v3h-3v-3H9.5M11,5H5v6h6V5L11,5zM9.5,14.5v3h-3v-3H9.5M11,13H5v6h6V13L11,13zM17.5,6.5v3h-3v-3H17.5M19,5h-6v6h6V5L19,5zM13,13h1.5v1.5H13V13zM14.5,14.5H16V16h-1.5V14.5zM16,13h1.5v1.5H16V13zM13,16h1.5v1.5H13V16zM14.5,17.5H16V19h-1.5V17.5zM16,16h1.5v1.5H16V16zM17.5,14.5H19V16h-1.5V14.5zM17.5,17.5H19V19h-1.5V17.5zM22,7h-2V4h-3V2h5V7zM22,22v-5h-2v3h-3v2H22zM2,22h5v-2H4v-3H2V22zM2,2v5h2V4h3V2H2z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/color_on_surface"
+        android:pathData="M9.5,6.5v3h-3v-3H9.5M11,5H5v6h6V5L11,5zM9.5,14.5v3h-3v-3H9.5M11,13H5v6h6V13L11,13zM17.5,6.5v3h-3v-3H17.5M19,5h-6v6h6V5L19,5zM13,13h1.5v1.5H13V13zM14.5,14.5H16V16h-1.5V14.5zM16,13h1.5v1.5H16V13zM13,16h1.5v1.5H13V16zM14.5,17.5H16V19h-1.5V17.5zM16,16h1.5v1.5H16V16zM17.5,14.5H19V16h-1.5V14.5zM17.5,17.5H19V19h-1.5V17.5zM22,7h-2V4h-3V2h5V7zM22,22v-5h-2v3h-3v2H22zM2,22h5v-2H4v-3H2V22zM2,2v5h2V4h3V2H2z" />
 </vector>

--- a/WooCommerce/src/main/res/layout/fragment_select_payment_method.xml
+++ b/WooCommerce/src/main/res/layout/fragment_select_payment_method.xml
@@ -209,6 +209,26 @@
                 android:layout_height="1dp"
                 android:background="@color/divider_color" />
 
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/tvScanToPay"
+                style="@style/Woo.Card.Body.Bold"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="0dp"
+                android:background="?attr/selectableItemBackground"
+                android:drawableStart="@drawable/ic_baseline_qr_code_scanner"
+                android:drawableEnd="@drawable/ic_arrow_right"
+                android:drawablePadding="@dimen/major_100"
+                android:padding="@dimen/major_100"
+                android:text="@string/card_reader_type_selection_scan_to_pay" />
+
+            <com.google.android.material.divider.MaterialDivider
+                android:id="@+id/dividerAfterScanToPay"
+                android:layout_width="wrap_content"
+                android:layout_height="1dp"
+                android:background="@color/divider_color" />
+
         </LinearLayout>
 
         <!-- android:textColorHighlight="#00FFFFFF": Workaround for a bug https://stackoverflow.com/a/70394538/632516 -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1193,6 +1193,7 @@
     <string name="card_reader_type_selection_bluetooth_reader">Card Reader</string>
     <string name="card_reader_type_selection_bluetooth_reader_description">Card reader accepts tap, chip, and swipe payments with debit and credit cards.</string>
     <string name="tap_to_pay_refund_reason">Test Tap To Pay payment auto refund</string>
+    <string name="card_reader_type_selection_scan_to_pay">Scan To Pay</string>
 
     <!--
             Card Reader Interac refund

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowP
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Refund
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
+import com.woocommerce.android.ui.payments.methodselection.IsScanToPayAvailable
 import com.woocommerce.android.ui.payments.methodselection.NavigateBackToHub
 import com.woocommerce.android.ui.payments.methodselection.NavigateBackToOrderList
 import com.woocommerce.android.ui.payments.methodselection.NavigateToCardReaderHubFlow
@@ -97,6 +98,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     private val cardReaderTracker: CardReaderTracker = mock()
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
     private val appPrefs: AppPrefs = mock()
+    private val isScanToPayAvailable: IsScanToPayAvailable = mock()
 
     @Test
     fun `given hub flow, when view model init, then navigate to hub flow emitted`() = testBlocking {
@@ -905,6 +907,36 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             verify(cardReaderTracker).trackTapToPayNotAvailableReason(tapToPayNfcNotAvailable)
         }
 
+    @Test
+    fun `given scan to pay available, when vm init, then true returned`() =
+        testBlocking {
+            // GIVEN
+            val orderId = 1L
+            val param = Payment(orderId = orderId, paymentType = ORDER)
+            whenever(isScanToPayAvailable()).thenReturn(true)
+
+            // WHEN
+            val viewModel = initViewModel(param)
+
+            // THEN
+            assertThat((viewModel.viewStateData.value as Success).isScanToPayAvailable).isTrue()
+        }
+
+    @Test
+    fun `given scan to pay not available, when vm init, then false returned`() =
+        testBlocking {
+            // GIVEN
+            val orderId = 1L
+            val param = Payment(orderId = orderId, paymentType = ORDER)
+            whenever(isScanToPayAvailable()).thenReturn(false)
+
+            // WHEN
+            val viewModel = initViewModel(param)
+
+            // THEN
+            assertThat((viewModel.viewStateData.value as Success).isScanToPayAvailable).isFalse()
+        }
+
     private fun initViewModel(cardReaderFlowParam: CardReaderFlowParam): SelectPaymentMethodViewModel {
         return SelectPaymentMethodViewModel(
             SelectPaymentMethodFragmentArgs(cardReaderFlowParam = cardReaderFlowParam).initSavedStateHandle(),
@@ -921,6 +953,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             cardReaderTracker,
             tapToPayAvailabilityStatus,
             appPrefs,
+            isScanToPayAvailable,
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8986
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds scan to pay button to the payment method selection screen behind feature flag

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Try both debug and release builds
* Notice a new button on the payment method selection  Scan To Pay Button on debug
* Notice that  a new button on the payment method selection  Scan To Pay Button on release is missing

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="355" alt="Screenshot 2023-05-09 at 10 36 20" src="https://user-images.githubusercontent.com/4923871/237016362-6e36491e-ffac-422c-be5c-eb3b3bf2d1e6.png">
<img width="356" alt="Screenshot 2023-05-09 at 10 34 39" src="https://user-images.githubusercontent.com/4923871/237016370-b1ff7688-c25d-427a-bfe6-bef535df3052.png">
<img width="363" alt="Screenshot 2023-05-09 at 10 34 21" src="https://user-images.githubusercontent.com/4923871/237016373-8391f99f-da2e-40b4-8c60-eaa25560ab84.png">



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
