### PR TITLE
Issue/8942 business logic google code scanner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CodeScannerModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CodeScannerModule.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.di
 
 import android.content.Context
+import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import com.woocommerce.android.ui.orders.creation.CodeScanner
 import com.woocommerce.android.ui.orders.creation.GoogleCodeScanner
@@ -16,8 +17,9 @@ class CodeScannerModule {
     @Provides
     @Reusable
     fun provideGoogleCodeScanner(context: Context): CodeScanner {
+        val options = GmsBarcodeScannerOptions.Builder().allowManualInput().build()
         return GoogleCodeScanner(
-            GmsBarcodeScanning.getClient(context)
+            GmsBarcodeScanning.getClient(context, options)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CodeScannerModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CodeScannerModule.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.di
+
+import android.content.Context
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
+import com.woocommerce.android.ui.orders.creation.CodeScanner
+import com.woocommerce.android.ui.orders.creation.GoogleCodeScanner
+import dagger.Module
+import dagger.Provides
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@InstallIn(SingletonComponent::class)
+@Module
+class CodeScannerModule {
+    @Provides
+    @Reusable
+    fun provideGoogleCodeScanner(context: Context): CodeScanner {
+        return GoogleCodeScanner(
+            GmsBarcodeScanning.getClient(context)
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InPersonPaymentsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InPersonPaymentsModule.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.di
 
 import android.app.Application
-import android.content.Context
-import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.CardReaderManagerFactory
 import com.woocommerce.android.cardreader.CardReaderStore
@@ -10,8 +8,6 @@ import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.creation.CodeScanner
-import com.woocommerce.android.ui.orders.creation.GoogleCodeScanner
 import com.woocommerce.android.ui.payments.cardreader.onboarding.toInPersonPaymentsPluginType
 import com.woocommerce.android.util.CapturePaymentResponseMapper
 import com.woocommerce.android.util.WooLog
@@ -80,14 +76,6 @@ class InPersonPaymentsModule {
     @Provides
     @Reusable
     fun provideCardReaderConfigFactory() = CardReaderConfigFactory()
-
-    @Provides
-    @Reusable
-    fun provideGoogleCodeScanner(context: Context): CodeScanner {
-        return GoogleCodeScanner(
-            GmsBarcodeScanning.getClient(context)
-        )
-    }
 }
 
 @InstallIn(SingletonComponent::class)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InPersonPaymentsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InPersonPaymentsModule.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.di
 
 import android.app.Application
+import android.content.Context
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.cardreader.CardReaderManagerFactory
 import com.woocommerce.android.cardreader.CardReaderStore
@@ -8,6 +10,8 @@ import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.creation.CodeScanner
+import com.woocommerce.android.ui.orders.creation.GoogleCodeScanner
 import com.woocommerce.android.ui.payments.cardreader.onboarding.toInPersonPaymentsPluginType
 import com.woocommerce.android.util.CapturePaymentResponseMapper
 import com.woocommerce.android.util.WooLog
@@ -76,6 +80,14 @@ class InPersonPaymentsModule {
     @Provides
     @Reusable
     fun provideCardReaderConfigFactory() = CardReaderConfigFactory()
+
+    @Provides
+    @Reusable
+    fun provideGoogleCodeScanner(context: Context): CodeScanner {
+        return GoogleCodeScanner(
+            GmsBarcodeScanning.getClient(context)
+        )
+    }
 }
 
 @InstallIn(SingletonComponent::class)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
@@ -15,7 +15,15 @@ class GoogleCodeScanner @Inject constructor(private val scanner: GmsBarcodeScann
         return callbackFlow {
             scanner.startScan()
                 .addOnSuccessListener { code ->
-                    this@callbackFlow.trySend(CodeScannerStatus.Success(code.rawValue))
+                    code.rawValue?.let {
+                        this@callbackFlow.trySend(CodeScannerStatus.Success(code.rawValue))
+                    } ?: run {
+                        this@callbackFlow.trySend(
+                            CodeScannerStatus.Failure(
+                                Throwable("Failed to find a valid raw value!")
+                            )
+                        )
+                    }
                     this@callbackFlow.close()
                 }
                 .addOnFailureListener { throwable ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
@@ -22,7 +22,7 @@ class GoogleCodeScanner @Inject constructor(private val scanner: GmsBarcodeScann
                     this@callbackFlow.trySend(CodeScannerStatus.Failure(throwable.cause))
                     this@callbackFlow.close()
                 }
-            awaitClose {  }
+            awaitClose()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 interface CodeScanner {
-    fun startScan() : Flow<CodeScannerStatus>
+    fun startScan(): Flow<CodeScannerStatus>
 }
 
 class GoogleCodeScanner @Inject constructor(private val scanner: GmsBarcodeScanner) : CodeScanner {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanner
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+
+interface CodeScanner {
+    fun startScan() : Flow<CodeScannerStatus>
+}
+
+class GoogleCodeScanner @Inject constructor(private val scanner: GmsBarcodeScanner) : CodeScanner {
+    override fun startScan(): Flow<CodeScannerStatus> {
+        return callbackFlow {
+            scanner.startScan()
+                .addOnSuccessListener { code ->
+                    this@callbackFlow.trySend(CodeScannerStatus.Success(code.rawValue))
+                    this@callbackFlow.close()
+                }
+                .addOnFailureListener { throwable ->
+                    this@callbackFlow.trySend(CodeScannerStatus.Failure(throwable.cause))
+                    this@callbackFlow.close()
+                }
+            awaitClose {  }
+        }
+    }
+}
+
+sealed class CodeScannerStatus {
+    data class Success(val code: String?) : CodeScannerStatus()
+    data class Failure(val error: Throwable?) : CodeScannerStatus()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -203,7 +203,7 @@ class OrderCreateEditFormFragment :
                     AddButton(
                         text = getString(R.string.order_creation_add_product_via_barcode_scanning),
                         onClickListener = {
-
+                            viewModel.startScan()
                         }
                     )
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -62,6 +62,7 @@ class OrderCreateEditFormFragment :
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var isAddProductViaBarcodeScanningEnabled: IsAddProductViaBarcodeScanningEnabled
 
     private var createOrderMenuItem: MenuItem? = null
     private var progressDialog: CustomProgressDialog? = null
@@ -191,14 +192,31 @@ class OrderCreateEditFormFragment :
 
     private fun FragmentOrderCreateEditFormBinding.initProductsSection() {
         productsSection.setAddButtons(
-            listOf(
-                AddButton(
-                    text = getString(R.string.order_creation_add_products),
-                    onClickListener = {
-                        viewModel.onAddProductClicked()
-                    }
+            if (isAddProductViaBarcodeScanningEnabled()) {
+                listOf(
+                    AddButton(
+                        text = getString(R.string.order_creation_add_products),
+                        onClickListener = {
+                            viewModel.onAddProductClicked()
+                        }
+                    ),
+                    AddButton(
+                        text = getString(R.string.order_creation_add_product_via_barcode_scanning),
+                        onClickListener = {
+
+                        }
+                    )
                 )
-            )
+            } else {
+                listOf(
+                    AddButton(
+                        text = getString(R.string.order_creation_add_products),
+                        onClickListener = {
+                            viewModel.onAddProductClicked()
+                        }
+                    )
+                )
+            }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -95,6 +95,7 @@ class OrderCreateEditViewModel @Inject constructor(
     private val createOrderItem: CreateOrderItem,
     private val determineMultipleLinesContext: DetermineMultipleLinesContext,
     private val tracker: AnalyticsTrackerWrapper,
+    private val codeScanner: CodeScanner,
     autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
     parameterRepository: ParameterRepository
@@ -283,6 +284,21 @@ class OrderCreateEditViewModel @Inject constructor(
                 }
 
                 _orderDraft.update { order -> order.updateItems(order.items + itemsToAdd) }
+            }
+        }
+    }
+
+    fun startScan() {
+        launch {
+            codeScanner.startScan().collect { status ->
+                when (status) {
+                    is CodeScannerStatus.Failure -> {
+                    // TODO handle failure case
+                    }
+                    is CodeScannerStatus.Success -> {
+                        // TODO handle success case
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -293,7 +293,7 @@ class OrderCreateEditViewModel @Inject constructor(
             codeScanner.startScan().collect { status ->
                 when (status) {
                     is CodeScannerStatus.Failure -> {
-                    // TODO handle failure case
+                        // TODO handle failure case
                     }
                     is CodeScannerStatus.Success -> {
                         // TODO handle success case

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -56,6 +56,7 @@
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/add_buttons_layout"
+        android:orientation="vertical"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -514,6 +514,7 @@
     <string name="order_creation_add_customer_note">Add note</string>
     <string name="order_creation_products">Products</string>
     <string name="order_creation_add_products">Add products</string>
+    <string name="order_creation_add_product_via_barcode_scanning">Add products via scanner</string>
     <string name="order_creation_add_fee">Add fee</string>
     <string name="order_creation_customer_details">Customer details</string>
     <string name="order_creation_product_stock_quantity">%s in stock</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
@@ -30,13 +30,20 @@ class CodeScannerTest : BaseUnitTest() {
     @Test
     fun `when scanning code succeeds, then success is emitted`() {
         testBlocking {
+            val barcodeRawValue = "12345"
             val mockBarcode = mock<Task<Barcode>>()
             whenever(scanner.startScan()).thenAnswer {
                 mockBarcode
             }
             whenever(mockBarcode.addOnSuccessListener(any())).thenAnswer {
                 @Suppress("UNCHECKED_CAST")
-                (it.arguments[0] as OnSuccessListener<Barcode>).onSuccess(mock())
+                (it.arguments[0] as OnSuccessListener<Barcode>).onSuccess(
+                    mock {
+                        on {
+                            rawValue
+                        }.thenReturn(barcodeRawValue)
+                    }
+                )
                 mock<Task<Barcode>>()
             }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
@@ -43,4 +43,30 @@ class CodeScannerTest : BaseUnitTest() {
             Assertions.assertThat(result).isExactlyInstanceOf(CodeScannerStatus.Success::class.java)
         }
     }
+
+    @Test
+    fun `when scanning code succeeds, then proper barcode value is emitted`() {
+        testBlocking {
+            val mockBarcode = mock<Task<Barcode>>()
+            whenever(scanner.startScan()).thenAnswer {
+                mockBarcode
+            }
+            val barcodeRawValue = "12345"
+            whenever(mockBarcode.addOnSuccessListener(any())).thenAnswer {
+                @Suppress("UNCHECKED_CAST")
+                (it.arguments[0] as OnSuccessListener<Barcode>).onSuccess(
+                    mock() {
+                        on {
+                            rawValue
+                        }.thenReturn(barcodeRawValue)
+                    }
+                )
+                mock<Task<Barcode>>()
+            }
+
+            val result = codeScanner.startScan().first()
+
+            Assertions.assertThat((result as CodeScannerStatus.Success).code).isEqualTo(barcodeRawValue)
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanner
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class CodeScannerTest : BaseUnitTest() {
+
+    private val scanner: GmsBarcodeScanner = mock()
+    private lateinit var codeScanner: CodeScanner
+
+    @Before
+    fun setup() {
+        codeScanner = GoogleCodeScanner(scanner)
+    }
+
+    @Test
+    fun `when scanning code succeeds, then success is emitted`() {
+        testBlocking {
+            val mockBarcode = mock<Task<Barcode>>()
+            whenever(scanner.startScan()).thenAnswer {
+                mockBarcode
+            }
+            whenever(mockBarcode.addOnSuccessListener(any())).thenAnswer {
+                @Suppress("UNCHECKED_CAST")
+                (it.arguments[0] as OnSuccessListener<Barcode>).onSuccess(mock())
+                mock<Task<Barcode>>()
+            }
+
+            val result = codeScanner.startScan().first()
+
+            Assertions.assertThat(result).isExactlyInstanceOf(CodeScannerStatus.Success::class.java)
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
@@ -139,6 +139,32 @@ class CodeScannerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when scanning code succeeds but does not contain raw value, then failure is emitted`() {
+        testBlocking {
+//            val errorMessage = "Invalid Barcode"
+            val mockBarcode = mock<Task<Barcode>>()
+            whenever(scanner.startScan()).thenAnswer {
+                mockBarcode
+            }
+            whenever(mockBarcode.addOnSuccessListener(any())).thenAnswer {
+                @Suppress("UNCHECKED_CAST")
+                (it.arguments[0] as OnSuccessListener<Barcode>).onSuccess(
+                    mock {
+                        on {
+                            rawValue
+                        }.thenReturn(null)
+                    }
+                )
+                mock<Task<Barcode>>()
+            }
+
+            val result = codeScanner.startScan().first()
+
+            assertThat(result).isExactlyInstanceOf(CodeScannerStatus.Failure::class.java)
+        }
+    }
+
+    @Test
     fun `when scanning code fails, then flow is terminated`() {
         testBlocking {
             val mockBarcode = mock<Task<Barcode>>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
@@ -137,4 +137,24 @@ class CodeScannerTest : BaseUnitTest() {
             assertThat((result as CodeScannerStatus.Failure).error?.message).isEqualTo(errorMessage)
         }
     }
+
+    @Test
+    fun `when scanning code fails, then flow is terminated`() {
+        testBlocking {
+            val mockBarcode = mock<Task<Barcode>>()
+            whenever(scanner.startScan()).thenAnswer {
+                mockBarcode
+            }
+            whenever(mockBarcode.addOnSuccessListener(any())).thenReturn(mockBarcode)
+            whenever(mockBarcode.addOnFailureListener(any())).thenAnswer {
+                @Suppress("UNCHECKED_CAST")
+                (it.arguments[0] as OnFailureListener).onFailure(mock())
+                mock<Task<Barcode>>()
+            }
+
+            val result = codeScanner.startScan().toList()
+
+            assertThat(result.size).isEqualTo(1)
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
@@ -165,6 +165,32 @@ class CodeScannerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when scanning code succeeds but does not contain raw value, then proper failure message is emitted`() {
+        testBlocking {
+            val errorMessage = "Failed to find a valid raw value!"
+            val mockBarcode = mock<Task<Barcode>>()
+            whenever(scanner.startScan()).thenAnswer {
+                mockBarcode
+            }
+            whenever(mockBarcode.addOnSuccessListener(any())).thenAnswer {
+                @Suppress("UNCHECKED_CAST")
+                (it.arguments[0] as OnSuccessListener<Barcode>).onSuccess(
+                    mock {
+                        on {
+                            rawValue
+                        }.thenReturn(null)
+                    }
+                )
+                mock<Task<Barcode>>()
+            }
+
+            val result = codeScanner.startScan().first()
+
+            assertThat((result as CodeScannerStatus.Failure).error?.message).isEqualTo(errorMessage)
+        }
+    }
+
+    @Test
     fun `when scanning code fails, then flow is terminated`() {
         testBlocking {
             val mockBarcode = mock<Task<Barcode>>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -340,7 +340,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             parameterRepository = parameterRepository,
             autoSyncOrder = autoSyncOrder,
             autoSyncPriceModifier = autoSyncPriceModifier,
-            tracker = tracker
+            tracker = tracker,
+            codeScanner = mock()
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8942 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR 
1. Adds a button "Add products via scanner" in the order creation screen (The actual design, the entry point, and the text on the button are temporary, Waiting for the design input)
2. Uses Google Code Scanner for scanning the barcode and returning the `rawValue`

Code scanner logic is extracted into a separate class so that it can be reused in some other screens as well. There's some demand for the code scanner in product creation. p1682698644899609-slack-C013AAPA4G0, p1683536861550519-slack-C025A8VV728

This PR does not handle the SKU search from the resulting `rawValue`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### "Add products via scanner" button is only visible in the debug build
1. Run the debug build of the app
2. Navigate to the order creation screen (orders -> tap on + button)
3. Make sure you see the "Add product via scanner" button in the products section

#### "Add products via scanner" button is NOT visible in the release build
1. Run the release build of the app
2. Navigate to the order creation screen (orders -> tap on + button)
3. Make sure you DO NOT see the "Add product via scanner" button in the products section.

#### Clicking on the button opens a scanner
1. Run the debug build of the app
2. Navigate to the order creation screen (orders -> tap on + button)
3. Make sure you see the "Add product via scanner" button in the products section
4. Click on the button
5. Ensure the scanner screen opens and you can see the camera

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/1331230/a0e0d8f4-1472-4107-979a-b139cf114d36



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->