### PR TITLE
Activate: Remove pre-login notifications

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
@@ -17,7 +17,6 @@ import androidx.core.content.ContextCompat
 import com.bumptech.glide.Glide
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Notification
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.WooLog
@@ -64,48 +63,6 @@ class WooNotificationBuilder @Inject constructor(private val context: Context) {
         putExtra(MainActivity.FIELD_PUSH_ID, pushId)
         if (notification.remoteNoteId != 0L) {
             putExtra(MainActivity.FIELD_REMOTE_NOTIFICATION, notification)
-        }
-    }
-
-    fun buildAndDisplayZendeskNotification(
-        channelId: String,
-        notification: Notification
-    ) {
-        getNotificationBuilder(channelId, notification).apply {
-            showNotification(notification.noteId, notification = notification, builder = this)
-        }
-    }
-
-    fun buildAndDisplayLoginHelpNotification(
-        notificationLocalId: Int,
-        channelId: String,
-        notification: Notification,
-        notificationTappedIntent: Intent,
-        actions: List<Pair<String, Intent>> = emptyList()
-    ) {
-        val channelType = notification.channelType
-        getNotificationBuilder(channelId, notification).apply {
-            val notificationContentIntent =
-                buildPendingIntentForGivenIntent(notificationLocalId, notificationTappedIntent)
-            setContentIntent(notificationContentIntent)
-            actions.forEach { action ->
-                addAction(
-                    R.drawable.ic_woo_w_notification,
-                    action.first,
-                    buildPendingIntentForGivenIntent(notificationLocalId, action.second)
-                )
-            }
-            setLargeIcon(getLargeIconBitmap(context, notification.icon, channelType.shouldCircularizeNoteIcon()))
-            // Call processing service when notification is dismissed
-            val pendingDeleteIntent = NotificationsProcessingService.getPendingIntentForNotificationDismiss(
-                context, notificationLocalId
-            )
-            setDeleteIntent(pendingDeleteIntent)
-            NotificationManagerCompat.from(context).notify(
-                LoginNotificationScheduler.LOGIN_HELP_NOTIFICATION_TAG,
-                notificationLocalId,
-                build()
-            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/WooNotificationBuilder.kt
@@ -158,15 +158,6 @@ class WooNotificationBuilder @Inject constructor(private val context: Context) {
         }
     }
 
-    private fun buildPendingIntentForGivenIntent(notificationLocalId: Int, intent: Intent): PendingIntent {
-        val flags = if (SystemVersionUtils.isAtLeastS()) {
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        } else {
-            PendingIntent.FLAG_UPDATE_CURRENT
-        }
-        return PendingIntent.getActivity(context, notificationLocalId, intent, flags)
-    }
-
     fun createNotificationChannels() {
         for (noteType in NotificationChannelType.values()) {
             createNotificationChannel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.support.zendesk.TicketType
 import com.woocommerce.android.support.zendesk.ZendeskSettings
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
@@ -48,7 +47,6 @@ class HelpActivity : AppCompatActivity() {
     @Inject lateinit var supportHelper: SupportHelper
     @Inject lateinit var zendeskSettings: ZendeskSettings
     @Inject lateinit var selectedSite: SelectedSite
-    @Inject lateinit var loginNotificationScheduler: LoginNotificationScheduler
 
     private lateinit var binding: ActivityHelpBinding
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -90,10 +90,6 @@ class HelpActivity : AppCompatActivity() {
 
         binding.textVersion.text = getString(R.string.version_with_name_param, PackageUtils.getVersionName(this))
 
-        if (originFromExtras == HelpOrigin.LOGIN_HELP_NOTIFICATION) {
-            loginNotificationScheduler.onNotificationTapped(extraTagsFromExtras?.first())
-        }
-
         if (originFromExtras == HelpOrigin.SITE_PICKER_JETPACK_TIMEOUT) {
             viewModel.contactSupport(TicketType.MobileApp)
         }
@@ -240,7 +236,7 @@ class HelpActivity : AppCompatActivity() {
         ): Intent {
             val intent = Intent(context, HelpActivity::class.java)
             intent.putExtra(ORIGIN_KEY, origin)
-            if (extraSupportTags != null && extraSupportTags.isNotEmpty()) {
+            if (!extraSupportTags.isNullOrEmpty()) {
                 intent.putStringArrayListExtra(EXTRA_TAGS_KEY, extraSupportTags as ArrayList<String>?)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -46,7 +46,6 @@ import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorView
 import com.woocommerce.android.ui.login.error.LoginNoWPcomAccountFoundDialogFragment
 import com.woocommerce.android.ui.login.error.LoginNotWPDialogFragment
 import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailPasswordFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
@@ -144,7 +143,6 @@ class LoginActivity :
     @Inject internal lateinit var experimentTracker: ExperimentTracker
     @Inject internal lateinit var appPrefsWrapper: AppPrefsWrapper
     @Inject internal lateinit var dispatcher: Dispatcher
-    @Inject internal lateinit var loginNotificationScheduler: LoginNotificationScheduler
     @Inject internal lateinit var uiMessageResolver: UIMessageResolver
 
     private var loginMode: LoginMode? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -46,12 +46,6 @@ import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorView
 import com.woocommerce.android.ui.login.error.LoginNoWPcomAccountFoundDialogFragment
 import com.woocommerce.android.ui.login.error.LoginNotWPDialogFragment
 import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.DEFAULT_HELP
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_EMAIL_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_PASSWORD_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_WPCOM_EMAIL_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_WPCOM_PASSWORD_ERROR
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailPasswordFragment

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.login
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -45,7 +44,6 @@ import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorView
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchPrimaryButton
 import com.woocommerce.android.ui.login.error.LoginNoWPcomAccountFoundDialogFragment
 import com.woocommerce.android.ui.login.error.LoginNotWPDialogFragment
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailPasswordFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
@@ -115,25 +113,10 @@ class LoginActivity :
 
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
         private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
-        private const val KEY_LOGIN_HELP_NOTIFICATION = "KEY_LOGIN_HELP_NOTIFICATION"
         private const val KEY_CONNECT_SITE_INFO = "KEY_CONNECT_SITE_INFO"
 
         const val LOGIN_WITH_WPCOM_EMAIL_ACTION = "login_with_wpcom_email"
         const val EMAIL_PARAMETER = "email"
-
-        fun createIntent(
-            context: Context,
-            notificationType: LoginHelpNotificationType,
-        ): Intent {
-            val intent = Intent(context, LoginActivity::class.java)
-            intent.apply {
-                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or
-                    Intent.FLAG_ACTIVITY_CLEAR_TASK
-                putExtra(KEY_LOGIN_HELP_NOTIFICATION, notificationType.toString())
-                LoginMode.WOO_LOGIN_MODE.putInto(this)
-            }
-            return intent
-        }
     }
 
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/localnotifications/LoginHelpNotificationWorker.kt
@@ -2,34 +2,22 @@ package com.woocommerce.android.ui.login.localnotifications
 
 import android.content.Context
 import android.content.Intent
-import androidx.annotation.StringRes
 import androidx.hilt.work.HiltWorker
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.LOGIN_LOCAL_NOTIFICATION_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.model.Notification
-import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.push.WooNotificationBuilder
-import com.woocommerce.android.push.WooNotificationType
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
-import com.woocommerce.android.ui.login.LoginActivity
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.DEFAULT_HELP
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_EMAIL_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_SITE_ADDRESS_PASSWORD_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_WPCOM_EMAIL_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginHelpNotificationType.LOGIN_WPCOM_PASSWORD_ERROR
-import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_HELP_NOTIFICATION_ID
 import com.woocommerce.android.ui.login.localnotifications.LoginNotificationScheduler.Companion.LOGIN_NOTIFICATION_TYPE_KEY
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
 @HiltWorker
+@Suppress("UnusedPrivateMember")
 class LoginHelpNotificationWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParams: WorkerParameters,
@@ -41,14 +29,6 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         val notificationType = LoginHelpNotificationType.fromString(
             inputData.getString(LOGIN_NOTIFICATION_TYPE_KEY)
         )
-        when (notificationType) {
-            LOGIN_SITE_ADDRESS_ERROR -> siteAddressErrorNotification(notificationType)
-            LOGIN_SITE_ADDRESS_EMAIL_ERROR,
-            LOGIN_WPCOM_EMAIL_ERROR -> invalidEmailErrorNotification(notificationType)
-            LOGIN_SITE_ADDRESS_PASSWORD_ERROR,
-            LOGIN_WPCOM_PASSWORD_ERROR -> invalidPasswordErrorNotification(notificationType)
-            DEFAULT_HELP -> defaultLoginSupportNotification()
-        }
         AnalyticsTracker.track(
             LOGIN_LOCAL_NOTIFICATION_DISPLAYED,
             mapOf(AnalyticsTracker.KEY_TYPE to notificationType.toString())
@@ -58,68 +38,36 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
         return Result.success()
     }
 
-    private fun defaultLoginSupportNotification(
-        notificationType: LoginHelpNotificationType = DEFAULT_HELP,
-        actions: List<Pair<String, Intent>> = emptyList()
-    ) {
-        wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
-            notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
-            appContext.getString(R.string.notification_channel_pre_login_id),
-            notification = buildLoginNotification(
-                title = R.string.login_help_notification_default_title,
-                description = R.string.login_help_notification_no_interaction_default_description
-            ),
-            notificationTappedIntent = buildOpenSupportScreenIntent(notificationType),
-            actions = actions
-        )
-    }
-
-    private fun siteAddressErrorNotification(notificationType: LoginHelpNotificationType) {
-        wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
-            notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
-            appContext.getString(R.string.notification_channel_pre_login_id),
-            notification = buildLoginNotification(
-                title = R.string.login_help_notification_default_title,
-                description = R.string.login_help_notification_site_error_description
-            ),
-            notificationTappedIntent = buildOpenLoginFlowForNotificationType(notificationType),
-            actions = getActionsForSiteAddressErrorNotification(notificationType)
-        )
-    }
-
-    private fun invalidEmailErrorNotification(notificationType: LoginHelpNotificationType) {
-        defaultLoginSupportNotification(
-            notificationType, getActionsForInvalidEmailErrorNotification(notificationType)
-        )
-    }
-
-    private fun invalidPasswordErrorNotification(notificationType: LoginHelpNotificationType) {
-        wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
-            notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
-            appContext.getString(R.string.notification_channel_pre_login_id),
-            notification = buildLoginNotification(
-                title = R.string.login_help_notification_invalid_password_title,
-                description = R.string.login_help_notification_no_interaction_default_description
-            ),
-            notificationTappedIntent = buildOpenSupportScreenIntent(notificationType),
-            actions = getActionsForInvalidPasswordErrorNotification(notificationType)
-        )
-    }
-
-    private fun buildLoginNotification(
-        @StringRes title: Int,
-        @StringRes description: Int
-    ) = Notification(
-        noteId = LOGIN_HELP_NOTIFICATION_ID,
-        uniqueId = 0,
-        remoteNoteId = 0,
-        remoteSiteId = 0,
-        icon = null,
-        noteTitle = resourceProvider.getString(title),
-        noteMessage = resourceProvider.getString(description),
-        noteType = WooNotificationType.PRE_LOGIN,
-        channelType = NotificationChannelType.PRE_LOGIN
-    )
+//    private fun defaultLoginSupportNotification(
+//        notificationType: LoginHelpNotificationType = DEFAULT_HELP,
+//        actions: List<Pair<String, Intent>> = emptyList()
+//    ) {
+//        wooNotificationBuilder.buildAndDisplayLoginHelpNotification(
+//            notificationLocalId = LOGIN_HELP_NOTIFICATION_ID,
+//            appContext.getString(R.string.notification_channel_pre_login_id),
+//            notification = buildLoginNotification(
+//                title = R.string.login_help_notification_default_title,
+//                description = R.string.login_help_notification_no_interaction_default_description
+//            ),
+//            notificationTappedIntent = buildOpenSupportScreenIntent(notificationType),
+//            actions = actions
+//        )
+//    }
+//
+//    private fun buildLoginNotification(
+//        @StringRes title: Int,
+//        @StringRes description: Int
+//    ) = Notification(
+//        noteId = LOGIN_HELP_NOTIFICATION_ID,
+//        uniqueId = 0,
+//        remoteNoteId = 0,
+//        remoteSiteId = 0,
+//        icon = null,
+//        noteTitle = resourceProvider.getString(title),
+//        noteMessage = resourceProvider.getString(description),
+//        noteType = WooNotificationType.PRE_LOGIN,
+//        channelType = NotificationChannelType.PRE_LOGIN
+//    )
 
     private fun buildOpenSupportScreenIntent(notificationType: LoginHelpNotificationType): Intent =
         HelpActivity.createIntent(
@@ -127,42 +75,4 @@ class LoginHelpNotificationWorker @AssistedInject constructor(
             HelpOrigin.LOGIN_HELP_NOTIFICATION,
             arrayListOf(notificationType.toString())
         )
-
-    private fun buildOpenLoginFlowForNotificationType(notificationType: LoginHelpNotificationType): Intent =
-        LoginActivity.createIntent(appContext, notificationType)
-
-    private fun getActionsForSiteAddressErrorNotification(
-        notificationType: LoginHelpNotificationType
-    ): List<Pair<String, Intent>> =
-        listOf(
-            resourceProvider.getString(R.string.login_help_notification_wordpress_login_button)
-                to buildOpenLoginFlowForNotificationType(notificationType),
-            resourceProvider.getString(R.string.login_help_notification_contact_support_button)
-                to buildOpenSupportScreenIntent(notificationType),
-        )
-
-    private fun getActionsForInvalidEmailErrorNotification(
-        notificationType: LoginHelpNotificationType
-    ): List<Pair<String, Intent>> =
-        listOf(
-            resourceProvider.getString(R.string.login_help_notification_contact_support_button)
-                to buildOpenSupportScreenIntent(notificationType),
-        )
-
-    private fun getActionsForInvalidPasswordErrorNotification(
-        notificationType: LoginHelpNotificationType
-    ): List<Pair<String, Intent>> {
-        val actionsList = mutableListOf(
-            resourceProvider.getString(R.string.login_help_notification_contact_support_button)
-                to buildOpenSupportScreenIntent(notificationType)
-        )
-        if (prefsWrapper.getLoginEmail().isNotBlank()) {
-            actionsList.add(
-                index = 0,
-                element = resourceProvider.getString(R.string.login_help_notification_get_link_by_email_button)
-                    to buildOpenLoginFlowForNotificationType(notificationType),
-            )
-        }
-        return actionsList
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailPasswordFragment.kt
@@ -10,11 +10,8 @@ import com.bumptech.glide.Registry.MissingComponentException
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import dagger.android.support.AndroidSupportInjection
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.login.LoginEmailPasswordFragment
 import org.wordpress.android.login.LoginListener
-import org.wordpress.android.login.LoginWpcomService
 import org.wordpress.android.login.widgets.WPLoginInputRow
 
 class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
@@ -42,11 +39,6 @@ class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
         }
     }
 
-    interface Listener {
-        fun onPasswordError()
-    }
-
-    private lateinit var onPassWordErrorListener: Listener
     private var loginListener: LoginListener? = null
     private var email: String? = null
     private var isSocialLogin: Boolean = false
@@ -65,10 +57,6 @@ class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
             context
         } else {
             throw MissingComponentException("$context must implement LoginListener")
-        }
-
-        if (activity is Listener) {
-            onPassWordErrorListener = activity as Listener
         }
     }
 
@@ -93,14 +81,6 @@ class WooLoginEmailPasswordFragment : LoginEmailPasswordFragment() {
         val prefilledPassword = requireArguments().getString(ARG_PASSWORD)
         if (prefilledPassword.isNotNullOrEmpty()) {
             rootView.findViewById<WPLoginInputRow>(R.id.login_password_row)
-        }
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
-    override fun onLoginStateUpdated(loginState: LoginWpcomService.LoginState) {
-        super.onLoginStateUpdated(loginState)
-        if (loginState.step == LoginWpcomService.LoginStep.FAILURE_EMAIL_WRONG_PASSWORD) {
-            onPassWordErrorListener.onPasswordError()
         }
     }
 }


### PR DESCRIPTION
Fixes #9004, which is a subtask of #8999.

The PR removes the pre-login notifications because after updating the target SDK to 33, the new devices will get a notification permission request after they successfully log in.

**To test:**
Since the PR just removes the callbacks and worker scheduling calls, it should be enough to just run the app and make sure it doesn't crash.