### PR TITLE
[STP] Tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -300,6 +300,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_CARD_READER_TYPE_BUILT_IN = "built_in"
 
         const val VALUE_ORDER_PAYMENTS_FLOW = "order_payment"
+        const val VALUE_SCAN_TO_PAY_PAYMENT_FLOW = "scan_to_pay"
         const val VALUE_TTP_TRY_PAYMENT_FLOW = "tap_to_pay_try_a_payment"
 
         const val KEY_JITM = "jitm"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -72,6 +72,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     private val order: Order = mock {
         on { paymentUrl }.thenReturn(PAYMENT_URL)
         on { total }.thenReturn(BigDecimal(1L))
+        on { id }.thenReturn(1L)
     }
     private val orderEntity: OrderEntity = mock()
 
@@ -302,6 +303,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_CASH,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_ORDER_PAYMENTS_FLOW,
                 )
             )
@@ -321,6 +323,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_CASH,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FLOW,
                 )
             )
@@ -340,6 +343,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_CARD,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_ORDER_PAYMENTS_FLOW,
                     "card_reader_type" to "external"
                 )
@@ -360,6 +364,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_CARD,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FLOW,
                     "card_reader_type" to "external"
                 )
@@ -418,6 +423,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     "payment_method" to "card",
+                    "order_id" to 1L,
                     "flow" to "simple_payment",
                     "card_reader_type" to "built_in",
                 )
@@ -438,6 +444,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     "payment_method" to "card",
+                    "order_id" to 1L,
                     "flow" to "order_payment",
                     "card_reader_type" to "built_in",
                 )
@@ -510,6 +517,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COMPLETED,
                 mapOf(
                     AnalyticsTracker.KEY_AMOUNT to "100$",
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_CARD,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_ORDER_PAYMENTS_FLOW,
                 )
@@ -531,6 +539,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COMPLETED,
                 mapOf(
                     AnalyticsTracker.KEY_AMOUNT to "100$",
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_CARD,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FLOW,
                 )
@@ -621,6 +630,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_ORDER_PAYMENTS_FLOW,
                 )
             )
@@ -640,6 +650,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FLOW,
                 )
             )
@@ -659,6 +670,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to "tap_to_pay_try_a_payment",
                 )
             )
@@ -678,6 +690,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COMPLETED,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FLOW,
                 )
             )
@@ -697,6 +710,7 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.PAYMENTS_FLOW_COMPLETED,
                 mapOf(
                     AnalyticsTracker.KEY_PAYMENT_METHOD to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK,
+                    "order_id" to 1L,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_ORDER_PAYMENTS_FLOW,
                 )
             )
@@ -1000,6 +1014,28 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when onScanToPayClicked, then collect tracked`() {
+        // GIVEN
+        val orderId = 1L
+        val param = Payment(orderId = orderId, paymentType = ORDER)
+        whenever(isScanToPayAvailable()).thenReturn(true)
+        val viewModel = initViewModel(param)
+
+        // WHEN
+        viewModel.onScanToPayClicked()
+
+        // THEN
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsEvent.PAYMENTS_FLOW_COLLECT,
+            mapOf(
+                "payment_method" to "scan_to_pay",
+                "order_id" to 1L,
+                "flow" to "order_payment",
+            )
+        )
+    }
+
+    @Test
     fun `given order payment type, when onScanToPayCompleted, then NavigateBackToOrderList`() =
         testBlocking {
             // GIVEN
@@ -1014,6 +1050,27 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
             // THEN
             assertThat(viewModel.event.value).isEqualTo(NavigateBackToOrderList)
         }
+
+    @Test
+    fun `when onScanToPayCompleted, then completed tracked`() {
+        // GIVEN
+        val orderId = 1L
+        val param = Payment(orderId = orderId, paymentType = ORDER)
+        val viewModel = initViewModel(param)
+
+        // WHEN
+        viewModel.onScanToPayCompleted()
+
+        // THEN
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsEvent.PAYMENTS_FLOW_COMPLETED,
+            mapOf(
+                "payment_method" to "scan_to_pay",
+                "order_id" to 1L,
+                "flow" to "order_payment",
+            )
+        )
+    }
 
     @Test
     fun `given simple payment type, when onScanToPayCompleted, then NavigateBackToHub`() =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8989
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a new payment method (`scan_to_pay`) to `payments_flow_collect` and `payments_flow_completed` events. Also adds order id to these events

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Run TTP, IPP, STP, Share Payment URL flows
* Look into logcat with filter `Tracked`
* Notice `payments_flow_collect` and `payments_flow_completed` events with `order_id` and `payment_method` including `scan_to_pay`

```
🔵 Tracked: payments_flow_collect, Properties: {"payment_method":"scan_to_pay","order_id":7216,"flow":"simple_payment","blog_id":192152755,"is_wpcom_store":true,"is_debug":true}
🔵 Tracked: payments_flow_completed, Properties: {"payment_method":"scan_to_pay","order_id":7216,"flow":"simple_payment","blog_id":192152755,"is_wpcom_store":true,"is_debug":true}
```

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
