### PR TITLE
[FIX] FeedbackPrefs as injectable object

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android
 
-import android.annotation.SuppressLint
 import android.content.Context
 import androidx.preference.PreferenceManager
 import com.google.gson.Gson
@@ -13,16 +12,12 @@ import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.util.PreferenceUtils
 import java.util.Date
 
-// Guaranteed to hold a reference to the application context, which is safe
-@SuppressLint("StaticFieldLeak")
-object FeedbackPrefs {
-    private lateinit var context: Context
+class FeedbackPrefs(
+    private val context: Context
+) {
     private val gson by lazy { Gson() }
     private val featureMapTypeToken by lazy { object : TypeToken<Map<String, String>>() {}.type }
     private val sharedPreferences get() = PreferenceManager.getDefaultSharedPreferences(context)
-
-    private const val THREE_MONTHS_IN_DAYS = 90
-    private const val SIX_MONTHS_IN_DAYS = 180
 
     private val featureMap
         get() = getString(FEATURE_FEEDBACK_SETTINGS)
@@ -43,10 +38,6 @@ object FeedbackPrefs {
         set(value) = value
             ?.time.toString()
             .let { setString(LAST_FEEDBACK_DATE, it) }
-
-    fun init(context: Context) {
-        FeedbackPrefs.context = context.applicationContext
-    }
 
     fun getFeatureFeedbackSettings(feature: FeatureFeedbackSettings.Feature) =
         featureMap[feature.toString()]
@@ -77,5 +68,10 @@ object FeedbackPrefs {
 
         // A map of every feature feedback the user has given within the app
         FEATURE_FEEDBACK_SETTINGS
+    }
+
+    companion object {
+        private const val THREE_MONTHS_IN_DAYS = 90
+        private const val SIX_MONTHS_IN_DAYS = 180
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppConfigModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppConfigModule.kt
@@ -38,8 +38,5 @@ class AppConfigModule {
 
     @Provides
     @Singleton
-    fun provideFeedbackPrefs(appContext: Context): FeedbackPrefs {
-        FeedbackPrefs.init(appContext)
-        return FeedbackPrefs
-    }
+    fun provideFeedbackPrefs(appContext: Context) = FeedbackPrefs(appContext)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -15,7 +15,7 @@ data class FeatureFeedbackSettings(
     val key
         get() = feature.toString()
 
-    fun registerItself() = FeedbackPrefs.setFeatureFeedbackSettings(this)
+    fun registerItself(feedbackPrefs: FeedbackPrefs) = feedbackPrefs.setFeatureFeedbackSettings(this)
 
     enum class FeedbackState {
         GIVEN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListFragment.kt
@@ -40,16 +40,18 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
         const val TAG: String = "CouponListFragment"
     }
 
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var feedbackPrefs: FeedbackPrefs
+
     private lateinit var searchMenuItem: MenuItem
     private lateinit var searchView: SearchView
     private var _binding: FragmentCouponListBinding? = null
     private val binding get() = _binding!!
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(COUPONS)?.feedbackState
+        get() = feedbackPrefs.getFeatureFeedbackSettings(COUPONS)?.feedbackState
             ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
     private val viewModel: CouponListViewModel by viewModels()
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -219,7 +221,7 @@ class CouponListFragment : BaseFragment(R.layout.fragment_coupon_list) {
         FeatureFeedbackSettings(
             COUPONS,
             state
-        ).registerItself()
+        ).registerItself(feedbackPrefs)
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRepository.kt
@@ -6,16 +6,16 @@ import com.woocommerce.android.model.FeatureFeedbackSettings.Feature
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
 import javax.inject.Inject
 
-class FeedbackRepository @Inject constructor() {
+class FeedbackRepository @Inject constructor(private val feedbackPrefs: FeedbackPrefs) {
     fun getFeatureFeedbackState(feature: Feature): FeedbackState {
-        return FeedbackPrefs.getFeatureFeedbackSettings(feature)?.feedbackState ?: FeedbackState.UNANSWERED
+        return feedbackPrefs.getFeatureFeedbackSettings(feature)?.feedbackState ?: FeedbackState.UNANSWERED
     }
 
     fun saveFeatureFeedback(feature: Feature, feedbackState: FeedbackState) {
-        FeedbackPrefs.setFeatureFeedbackSettings(FeatureFeedbackSettings(feature, feedbackState))
+        feedbackPrefs.setFeatureFeedbackSettings(FeatureFeedbackSettings(feature, feedbackState))
     }
 
     fun getFeatureFeedbackSetting(feature: Feature): FeatureFeedbackSettings {
-        return FeedbackPrefs.getFeatureFeedbackSettings(feature) ?: FeatureFeedbackSettings(feature)
+        return feedbackPrefs.getFeatureFeedbackSettings(feature) ?: FeatureFeedbackSettings(feature)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -21,7 +21,6 @@ import com.google.android.play.core.review.ReviewManagerFactory
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.FeedbackPrefs
-import com.woocommerce.android.FeedbackPrefs.userFeedbackIsDue
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.R.attr
@@ -93,6 +92,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
     @Inject lateinit var dateUtils: DateUtils
     @Inject lateinit var usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter
     @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Inject lateinit var feedbackPrefs: FeedbackPrefs
 
     private var _binding: FragmentMyStoreBinding? = null
     private val binding get() = _binding!!
@@ -502,9 +502,9 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
      * If should be and it's already visible, nothing happens
      */
     private fun handleFeedbackRequestCardState() = with(binding.storeFeedbackRequestCard) {
-        if (userFeedbackIsDue && visibility == View.GONE) {
+        if (feedbackPrefs.userFeedbackIsDue && visibility == View.GONE) {
             setupFeedbackRequestCard()
-        } else if (userFeedbackIsDue.not() && visibility == View.VISIBLE) {
+        } else if (feedbackPrefs.userFeedbackIsDue.not() && visibility == View.VISIBLE) {
             visibility = View.GONE
         }
     }
@@ -514,14 +514,14 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store) {
         val negativeCallback = {
             mainNavigationRouter?.showFeedbackSurvey()
             binding.storeFeedbackRequestCard.visibility = View.GONE
-            FeedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
+            feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
         }
         binding.storeFeedbackRequestCard.initView(negativeCallback, ::handleFeedbackRequestPositiveClick)
     }
 
     private fun handleFeedbackRequestPositiveClick() {
         // set last feedback date to now and hide the card
-        FeedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
+        feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
         binding.storeFeedbackRequestCard.visibility = View.GONE
 
         // Request a ReviewInfo object from the Google Reviews API. If this fails

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -100,6 +100,8 @@ class OrderDetailFragment :
     lateinit var dateUtils: DateUtils
     @Inject
     lateinit var cardReaderManager: CardReaderManager
+    @Inject
+    lateinit var feedbackPrefs: FeedbackPrefs
 
     private var _binding: FragmentOrderDetailBinding? = null
     private val binding get() = _binding!!
@@ -114,7 +116,7 @@ class OrderDetailFragment :
         }
 
     private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(SHIPPING_LABEL_M4)?.feedbackState
+        get() = feedbackPrefs.getFeatureFeedbackSettings(SHIPPING_LABEL_M4)?.feedbackState
             ?: UNANSWERED
 
     override fun onResume() {
@@ -596,7 +598,7 @@ class OrderDetailFragment :
         FeatureFeedbackSettings(
             SHIPPING_LABEL_M4,
             state
-        ).registerItself()
+        ).registerItself(feedbackPrefs)
     }
 
     private fun displayUndoSnackbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -26,6 +26,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialFadeThrough
 import com.woocommerce.android.AppConstants
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -84,6 +85,8 @@ class OrderListFragment :
     internal lateinit var selectedSite: SelectedSite
     @Inject
     internal lateinit var currencyFormatter: CurrencyFormatter
+    @Inject
+    lateinit var feedbackPrefs: FeedbackPrefs
 
     private val viewModel: OrderListViewModel by viewModels()
     private var snackBar: Snackbar? = null
@@ -635,7 +638,7 @@ class OrderListFragment :
                 FeatureFeedbackSettings(
                     FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS_AND_ORDER_CREATION,
                     FeedbackState.DISMISSED
-                ).registerItself()
+                ).registerItself(feedbackPrefs)
                 viewModel.onDismissOrderCreationSimplePaymentsFeedback()
             },
             showFeedbackButton = true
@@ -653,7 +656,7 @@ class OrderListFragment :
         FeatureFeedbackSettings(
             SIMPLE_PAYMENTS_AND_ORDER_CREATION,
             FeedbackState.GIVEN
-        ).registerItself()
+        ).registerItself(feedbackPrefs)
         NavGraphMainDirections
             .actionGlobalFeedbackSurveyFragment(SurveyType.ORDER_CREATION)
             .apply { findNavController().navigateSafely(this) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -81,6 +81,9 @@ class ProductListFragment :
     @Inject
     lateinit var currencyFormatter: CurrencyFormatter
 
+    @Inject
+    lateinit var feedbackPrefs: FeedbackPrefs
+
     private var _productAdapter: ProductListAdapter? = null
     private val productAdapter: ProductListAdapter
         get() = _productAdapter!!
@@ -104,7 +107,7 @@ class ProductListFragment :
 
     private val feedbackState: FeatureFeedbackSettings.FeedbackState
         get() =
-            FeedbackPrefs.getFeatureFeedbackSettings(FeatureFeedbackSettings.Feature.PRODUCT_VARIATIONS)?.feedbackState
+            feedbackPrefs.getFeatureFeedbackSettings(FeatureFeedbackSettings.Feature.PRODUCT_VARIATIONS)?.feedbackState
                 ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -725,7 +728,7 @@ class ProductListFragment :
         FeatureFeedbackSettings(
             FeatureFeedbackSettings.Feature.PRODUCT_VARIATIONS,
             state
-        ).registerItself()
+        ).registerItself(feedbackPrefs)
     }
 
     override fun shouldExpandToolbar(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -33,7 +33,7 @@ class OrderedAddonViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val dispatchers: CoroutineDispatchers,
     private val addonsRepository: AddonRepository,
-    val feedbackPrefs: FeedbackPrefs,
+    private val feedbackPrefs: FeedbackPrefs,
     parameterRepository: ParameterRepository
 ) : ScopedViewModel(savedState) {
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -33,6 +33,7 @@ class OrderedAddonViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val dispatchers: CoroutineDispatchers,
     private val addonsRepository: AddonRepository,
+    val feedbackPrefs: FeedbackPrefs,
     parameterRepository: ParameterRepository
 ) : ScopedViewModel(savedState) {
     companion object {
@@ -46,9 +47,9 @@ class OrderedAddonViewModel @Inject constructor(
     val orderedAddonsData: LiveData<List<Addon>> = _orderedAddons
 
     private val currentFeedbackSettings
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(PRODUCT_ADDONS)
+        get() = feedbackPrefs.getFeatureFeedbackSettings(PRODUCT_ADDONS)
             ?: FeatureFeedbackSettings(PRODUCT_ADDONS)
-                .apply { registerItself() }
+                .apply { registerItself(feedbackPrefs) }
 
     /**
      * Provides the currencyCode for views who requires display prices
@@ -79,7 +80,7 @@ class OrderedAddonViewModel @Inject constructor(
         FeatureFeedbackSettings(
             PRODUCT_ADDONS,
             GIVEN
-        ).registerItself()
+        ).registerItself(feedbackPrefs)
 
         triggerEvent(ShowSurveyView)
     }
@@ -90,7 +91,7 @@ class OrderedAddonViewModel @Inject constructor(
         FeatureFeedbackSettings(
             PRODUCT_ADDONS,
             DISMISSED
-        ).registerItself()
+        ).registerItself(feedbackPrefs)
 
         viewState = viewState.copy(shouldDisplayFeedbackCard = false)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.products.addons.order
 
-import android.content.Context
-import android.content.SharedPreferences
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Order
@@ -20,7 +18,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -32,6 +29,7 @@ import kotlin.test.fail
 class OrderedAddonViewModelTest : BaseUnitTest() {
     private lateinit var viewModelUnderTest: OrderedAddonViewModel
     private var addonRepositoryMock: AddonRepository = mock()
+    private val feedbackPrefs: FeedbackPrefs = mock()
 
     @Before
     fun setUp() {
@@ -49,18 +47,11 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
                 .doReturn(storeParametersMock)
         }
 
-        val editor = mock<SharedPreferences.Editor>()
-        val preferences = mock<SharedPreferences> { whenever(it.edit()).thenReturn(editor) }
-        mock<Context> {
-            whenever(it.applicationContext).thenReturn(it)
-            whenever(it.getSharedPreferences(any(), any())).thenReturn(preferences)
-            FeedbackPrefs.init(it)
-        }
-
         viewModelUnderTest = OrderedAddonViewModel(
             savedState,
             coroutinesTestRule.testDispatchers,
             addonRepositoryMock,
+            feedbackPrefs,
             parameterRepositoryMock
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In [the commit](https://github.com/woocommerce/woocommerce-android/commit/8dcfb74db57f76b891aba76c93ded373901d248b) I missed the fact that `FeedbackPrefs` is used in some places as object and this may cause that `init` was not invoked. This causes a crash because context is not provided to the object. This PR makes FeedbackPrefs an injectable object so we are protected against this by the compiler. Also, this makes it easier to test

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Run login flow
* Open the app when it's logged in
* Run any flow that uses `FeedbackPrefs`

Notice that there is no regression

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
