### PR TITLE
Remove check for hasWooCommerce while installing site

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationConst.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationConst.kt
@@ -2,6 +2,6 @@ package com.woocommerce.android.ui.login.storecreation.installation
 
 object InstallationConst {
     const val STORE_LOAD_RETRIES_LIMIT = 10
-    const val INITIAL_STORE_CREATION_DELAY = 40000L
+    const val INITIAL_STORE_CREATION_DELAY = 30000L
     const val SITE_CHECK_DEBOUNCE = 5000L
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/ObserveSiteInstallation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/ObserveSiteInstallation.kt
@@ -66,7 +66,7 @@ class ObserveSiteInstallation @Inject constructor(
     }
 
     private val SiteModel?.isReadyToUse: Boolean
-        get() = this?.isJetpackInstalled == true && this.isJetpackConnected && this.hasWooCommerce
+        get() = this?.isJetpackInstalled == true && this.isJetpackConnected
 
     private fun SiteModel?.isDesynced(expectedName: String): Boolean =
         this?.isJetpackInstalled == true && this.isJetpackConnected &&

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/installation/ObserveSiteInstallationTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/installation/ObserveSiteInstallationTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ObserveSiteInstallationTest : BaseUnitTest(StandardTestDispatcher()) {
@@ -123,9 +124,7 @@ class ObserveSiteInstallationTest : BaseUnitTest(StandardTestDispatcher()) {
             runCurrent()
 
             // then
-            assertThat(installationStates.last()).isEqualTo(
-                OutOfSync
-            )
+            assertTrue(installationStates.contains(OutOfSync))
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

Remove the check for `hasWooCommerce` while installing the app.


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We noticed that when creating new free trial sites the app was always timing out during the "installation" phase. This resulted in users seeing an error screen after a very long loading experience. This is because we rely on checking the API returned value for `woocommerce_is_active` being `true`. The problem is: It takes close to 10 minutes or more for this value to be set to true from the backend. So, we can't rely on checking this. 

This fix is a workaround. We will work on applying the same logic the web is using for NUX to verify a store is ready to be used from the app. 

### Important note
If the backend takes close to 10 mins to set `"woocommerce_is_active": true`, how is it possible for the app site picker to display the newly created site as a WooCommerce site (meaning `hasWooCommerce` value is true in the app) ? 

The answer lies in [this piece of code](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7d44ea7eecabc32200d900b8065760964de04d10/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt#L103) from `WooCommerceStore`: 
```kotlin
        // Fetch WooCommerce availability for non-Jetpack sites
        siteStore.sites
            .filter { it.needsAdditionalCheckForWooInstallation }
            .forEach { site ->
                val isResultUpdated = fetchAndUpdateNonJetpackSite(site)
                if (isResultUpdated.model == true && !fetchResult.updatedSites.contains(site)) {
                    rowsAffected++
                }
            }
```
This code checks for each of the fetched sites from the API if [`needsAdditionalCheckForWooInstallation`.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7d44ea7eecabc32200d900b8065760964de04d10/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt#L73) Which turns out to be true for trial sites that have just been created because the following values from the API response are:

![Screenshot 2023-05-11 at 19 47 07](https://github.com/woocommerce/woocommerce-android/assets/2663464/4d83229c-f642-43f1-b22a-050f999a3507)

When `needsAdditionalCheckForWooInstallation` is true, it  triggers an [additional check `fetchAndUpdateWooCommerceAvailability`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7d44ea7eecabc32200d900b8065760964de04d10/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt#LL302C25-L302C62) that returns the CORRECT and UPDATED value about whether the WooCommerce plugin is installed and active. 

![Screenshot 2023-05-11 at 19 31 34](https://github.com/woocommerce/woocommerce-android/assets/2663464/6ce60180-a126-4af3-8322-10c0b7d2d6a1)

We might be able to reuse this in the installation process to verify the correct status of the plugin. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Trigger store creation
2. Check you land on My Store tab before the installation phase times out
3. Add a product
4. Go to site picker and check the site is displayed correctly as a WooCommerce site. 


https://github.com/woocommerce/woocommerce-android/assets/2663464/405949f6-be2a-463e-a158-7081403088b8


https://github.com/woocommerce/woocommerce-android/assets/2663464/759bfcb7-e9f0-4686-adb6-735ecd59ffae


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
