### PR TITLE
[JITM] Add possibility to stub response with locally provided json for testing

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -409,6 +409,10 @@ android.buildTypes.all { buildType ->
             "IAP_TESTING_SANDBOX_URL",
             "\"${project.properties.getOrDefault('iap_testing_sandbox_url', '')}\""
 
+    buildConfigField "String",
+            "JITM_TESTING_JSON_FILE_NAME",
+            "\"${project.properties.getOrDefault('jitm_testing_json_file_name', '')}\""
+
     // If Google services file doesn't exist, copy example file.
     if (!file("google-services.json").exists()) {
         tasks.copyGoogleServicesExampleFile.copy()

--- a/WooCommerce/src/debug/assets/jitm_testing.json
+++ b/WooCommerce/src/debug/assets/jitm_testing.json
@@ -1,0 +1,33 @@
+[
+  {
+    "content": {
+      "message": "In-person card payments",
+      "icon": "",
+      "iconPath": null,
+      "list": [],
+      "description": "Sell anywhere and take card or digital wallet payments using a mobile card reader.",
+      "classes": "",
+      "title": "",
+      "disclaimer": []
+    },
+    "CTA": {
+      "message": "Buy a card reader",
+      "hook": "",
+      "newWindow": true,
+      "primary": true,
+      "link": "https:\/\/woocommerce.com\/products\/hardware\/US"
+    },
+    "template": "default",
+    "ttl": 300,
+    "id": "woomobile_ipp_barcode_users",
+    "feature_class": "woomobile_ipp",
+    "expires": 3628800,
+    "max_dismissal": 2,
+    "activate_module": null,
+    "is_dismissible": true,
+    "is_user_created_by_partner": null,
+    "message_expiration": null,
+    "url": "https:\/\/jetpack.com\/redirect\/?source=jitm-woomobile_ipp_barcode_users&#038;site=paymentstest.mystagingwebsite.com&#038;u=4",
+    "jitm_stats_url": "https:\/\/pixel.wp.com\/b.gif?v=wpcom2&rand=d6e30334b77899a164af60f96d759457&x_jetpack-jitm=woomobile_ipp_barcode_users"
+  }
+]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapper.kt
@@ -20,6 +20,7 @@ class JitmStoreWrapper @Inject constructor(
     private val jsonFileName = BuildConfig.JITM_TESTING_JSON_FILE_NAME
     private val isTestingModeEnabled = PackageUtils.isDebugBuild() && jsonFileName.isNotBlank()
 
+    @Suppress("TooGenericExceptionCaught")
     suspend fun fetchJitmMessage(
         site: SiteModel,
         messagePath: String,
@@ -31,6 +32,7 @@ class JitmStoreWrapper @Inject constructor(
                 WooLog.d(WooLog.T.JITM, "Using JITM JSON file: $jsonFileName")
                 WooResult(parseJsonFile(jsonFileName))
             } catch (e: Exception) {
+                WooLog.e(WooLog.T.JITM, e)
                 error("Failed to parse JITM JSON file: $jsonFileName")
             }
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapper.kt
@@ -13,10 +13,9 @@ import org.wordpress.android.fluxc.store.JitmStore
 import javax.inject.Inject
 
 class JitmStoreWrapper @Inject constructor(
-    private val context: Context,
-    private val gson: Gson,
     private val realStore: JitmStore,
-    private val wrapperData: JitmStoreWrapperData
+    private val wrapperData: JitmStoreWrapperData,
+    private val jsonReader: JitmStoreWrapperJsonReader,
 ) {
     @Suppress("TooGenericExceptionCaught")
     suspend fun fetchJitmMessage(
@@ -29,7 +28,7 @@ class JitmStoreWrapper @Inject constructor(
             delay(RESPONSE_DELAY)
             try {
                 WooLog.d(WooLog.T.JITM, "Using JITM JSON file: $jsonFileName")
-                WooResult(parseJsonFile(jsonFileName))
+                WooResult(jsonReader.parseJsonFile(jsonFileName))
             } catch (e: Exception) {
                 WooLog.e(WooLog.T.JITM, e)
                 error("Failed to parse JITM JSON file: $jsonFileName")
@@ -52,13 +51,18 @@ class JitmStoreWrapper @Inject constructor(
         }
     }
 
-    private fun parseJsonFile(fileName: String): Array<JITMApiResponse>? {
-        val json = context.assets.open(fileName).bufferedReader().use { it.readText() }
-        return gson.fromJson(json, Array<JITMApiResponse>::class.java)
-    }
-
     private companion object {
         private const val RESPONSE_DELAY = 1000L
+    }
+}
+
+class JitmStoreWrapperJsonReader @Inject constructor(
+    private val context: Context,
+    private val gson: Gson,
+) {
+    fun parseJsonFile(fileName: String): Array<JITMApiResponse>? {
+        val json = context.assets.open(fileName).bufferedReader().use { it.readText() }
+        return gson.fromJson(json, Array<JITMApiResponse>::class.java)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapper.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.jitm
+
+import android.content.Context
+import com.google.gson.Gson
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.util.PackageUtils
+import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.delay
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMApiResponse
+import org.wordpress.android.fluxc.store.JitmStore
+import javax.inject.Inject
+
+class JitmStoreWrapper @Inject constructor(
+    private val context: Context,
+    private val gson: Gson,
+    private val realStore: JitmStore,
+) {
+    private val jsonFileName = BuildConfig.JITM_TESTING_JSON_FILE_NAME
+    private val isTestingModeEnabled = PackageUtils.isDebugBuild() && jsonFileName.isNotBlank()
+
+    suspend fun fetchJitmMessage(
+        site: SiteModel,
+        messagePath: String,
+        query: String,
+    ): WooResult<Array<JITMApiResponse>> {
+        return if (isTestingModeEnabled) {
+            delay(RESPONSE_DELAY)
+            try {
+                WooLog.d(WooLog.T.JITM, "Using JITM JSON file: $jsonFileName")
+                WooResult(parseJsonFile(jsonFileName))
+            } catch (e: Exception) {
+                error("Failed to parse JITM JSON file: $jsonFileName")
+            }
+        } else {
+            realStore.fetchJitmMessage(site, messagePath, query)
+        }
+    }
+
+    suspend fun dismissJitmMessage(
+        site: SiteModel,
+        jitmId: String,
+        featureClass: String,
+    ): WooResult<Boolean> {
+        return if (isTestingModeEnabled) {
+            WooLog.d(WooLog.T.JITM, "Dissmissing JITM message in test mode")
+            WooResult(true)
+        } else {
+            realStore.dismissJitmMessage(site, jitmId, featureClass)
+        }
+    }
+
+    private fun parseJsonFile(fileName: String): Array<JITMApiResponse>? {
+        val json = context.assets.open(fileName).bufferedReader().use { it.readText() }
+        return gson.fromJson(json, Array<JITMApiResponse>::class.java)
+    }
+
+    private companion object {
+        private const val RESPONSE_DELAY = 1000L
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapper.kt
@@ -16,17 +16,16 @@ class JitmStoreWrapper @Inject constructor(
     private val context: Context,
     private val gson: Gson,
     private val realStore: JitmStore,
+    private val wrapperData: JitmStoreWrapperData
 ) {
-    private val jsonFileName = BuildConfig.JITM_TESTING_JSON_FILE_NAME
-    private val isTestingModeEnabled = PackageUtils.isDebugBuild() && jsonFileName.isNotBlank()
-
     @Suppress("TooGenericExceptionCaught")
     suspend fun fetchJitmMessage(
         site: SiteModel,
         messagePath: String,
         query: String,
     ): WooResult<Array<JITMApiResponse>> {
-        return if (isTestingModeEnabled) {
+        return if (wrapperData.isTestingModeEnabled) {
+            val jsonFileName = wrapperData.jsonFileName
             delay(RESPONSE_DELAY)
             try {
                 WooLog.d(WooLog.T.JITM, "Using JITM JSON file: $jsonFileName")
@@ -45,8 +44,8 @@ class JitmStoreWrapper @Inject constructor(
         jitmId: String,
         featureClass: String,
     ): WooResult<Boolean> {
-        return if (isTestingModeEnabled) {
-            WooLog.d(WooLog.T.JITM, "Dissmissing JITM message in test mode")
+        return if (wrapperData.isTestingModeEnabled) {
+            WooLog.d(WooLog.T.JITM, "Dismissing JITM message in test mode")
             WooResult(true)
         } else {
             realStore.dismissJitmMessage(site, jitmId, featureClass)
@@ -61,4 +60,9 @@ class JitmStoreWrapper @Inject constructor(
     private companion object {
         private const val RESPONSE_DELAY = 1000L
     }
+}
+
+class JitmStoreWrapperData @Inject constructor() {
+    val jsonFileName = BuildConfig.JITM_TESTING_JSON_FILE_NAME
+    val isTestingModeEnabled = PackageUtils.isDebugBuild() && jsonFileName.isNotBlank()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmViewModel.kt
@@ -15,7 +15,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMApiResponse
-import org.wordpress.android.fluxc.store.JitmStore
 import javax.inject.Inject
 
 private typealias Assets = Map<String, String>?
@@ -23,7 +22,7 @@ private typealias Assets = Map<String, String>?
 @HiltViewModel
 class JitmViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    private val jitmStore: JitmStore,
+    private val jitmStore: JitmStoreWrapper,
     private val jitmTracker: JitmTracker,
     private val myStoreUtmProvider: MyStoreUtmProvider,
     private val queryParamsEncoder: QueryParamsEncoder,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapperTest.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.jitm
 
-import android.content.Context
-import com.google.gson.Gson
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
@@ -13,8 +11,6 @@ import org.wordpress.android.fluxc.store.JitmStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class JitmStoreWrapperTest : BaseUnitTest() {
-    private val context = mock<Context>()
-    private val gson = mock<Gson>()
     private val realStore = mock<JitmStore>()
 
     @Test
@@ -24,15 +20,18 @@ class JitmStoreWrapperTest : BaseUnitTest() {
             val site = mock<SiteModel>()
             val messagePath = "messagePath"
             val query = "query"
+            val jsonFile = "jsonFileName"
             val wrapperData = mock<JitmStoreWrapperData> {
                 on { isTestingModeEnabled }.thenReturn(true)
-                on { jsonFileName }.thenReturn("jsonFileName")
+                on { jsonFileName }.thenReturn(jsonFile)
+            }
+            val jsonReader: JitmStoreWrapperJsonReader = mock {
+                on { parseJsonFile(jsonFile) }.thenReturn(emptyArray())
             }
             val wrapper = JitmStoreWrapper(
-                context = context,
-                gson = gson,
                 realStore = realStore,
                 wrapperData = wrapperData,
+                jsonReader = jsonReader,
             )
 
             // WHEN
@@ -53,10 +52,9 @@ class JitmStoreWrapperTest : BaseUnitTest() {
                 on { isTestingModeEnabled }.thenReturn(false)
             }
             val wrapper = JitmStoreWrapper(
-                context = context,
-                gson = gson,
                 realStore = realStore,
                 wrapperData = wrapperData,
+                jsonReader = mock(),
             )
 
             // WHEN
@@ -75,13 +73,11 @@ class JitmStoreWrapperTest : BaseUnitTest() {
             val featureClass = "featureClass"
             val wrapperData = mock<JitmStoreWrapperData> {
                 on { isTestingModeEnabled }.thenReturn(true)
-                on { jsonFileName }.thenReturn("jsonFileName")
             }
             val wrapper = JitmStoreWrapper(
-                context = context,
-                gson = gson,
                 realStore = realStore,
                 wrapperData = wrapperData,
+                jsonReader = mock(),
             )
 
             // WHEN
@@ -102,10 +98,9 @@ class JitmStoreWrapperTest : BaseUnitTest() {
                 on { isTestingModeEnabled }.thenReturn(false)
             }
             val wrapper = JitmStoreWrapper(
-                context = context,
-                gson = gson,
                 realStore = realStore,
                 wrapperData = wrapperData,
+                jsonReader = mock()
             )
 
             // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreWrapperTest.kt
@@ -1,0 +1,117 @@
+package com.woocommerce.android.ui.jitm
+
+import android.content.Context
+import com.google.gson.Gson
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.JitmStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class JitmStoreWrapperTest : BaseUnitTest() {
+    private val context = mock<Context>()
+    private val gson = mock<Gson>()
+    private val realStore = mock<JitmStore>()
+
+    @Test
+    fun `given testing mode is enabled, when fetchJitmMessage is called, real store is not called`() =
+        testBlocking {
+            // GIVEN
+            val site = mock<SiteModel>()
+            val messagePath = "messagePath"
+            val query = "query"
+            val wrapperData = mock<JitmStoreWrapperData> {
+                on { isTestingModeEnabled }.thenReturn(true)
+                on { jsonFileName }.thenReturn("jsonFileName")
+            }
+            val wrapper = JitmStoreWrapper(
+                context = context,
+                gson = gson,
+                realStore = realStore,
+                wrapperData = wrapperData,
+            )
+
+            // WHEN
+            wrapper.fetchJitmMessage(site, messagePath, query)
+
+            // THEN
+            verify(realStore, never()).fetchJitmMessage(site, messagePath, query)
+        }
+
+    @Test
+    fun `given testing mode is disabled, when fetchJitmMessage is called, real store is called`() =
+        testBlocking {
+            // GIVEN
+            val site = mock<SiteModel>()
+            val messagePath = "messagePath"
+            val query = "query"
+            val wrapperData = mock<JitmStoreWrapperData> {
+                on { isTestingModeEnabled }.thenReturn(false)
+            }
+            val wrapper = JitmStoreWrapper(
+                context = context,
+                gson = gson,
+                realStore = realStore,
+                wrapperData = wrapperData,
+            )
+
+            // WHEN
+            wrapper.fetchJitmMessage(site, messagePath, query)
+
+            // THEN
+            verify(realStore).fetchJitmMessage(site, messagePath, query)
+        }
+
+    @Test
+    fun `given testing mode is enabled, when dismissJitmMessage is called, real store is not called`() =
+        testBlocking {
+            // GIVEN
+            val site = mock<SiteModel>()
+            val jitmId = "jitmId"
+            val featureClass = "featureClass"
+            val wrapperData = mock<JitmStoreWrapperData> {
+                on { isTestingModeEnabled }.thenReturn(true)
+                on { jsonFileName }.thenReturn("jsonFileName")
+            }
+            val wrapper = JitmStoreWrapper(
+                context = context,
+                gson = gson,
+                realStore = realStore,
+                wrapperData = wrapperData,
+            )
+
+            // WHEN
+            wrapper.dismissJitmMessage(site, jitmId, featureClass)
+
+            // THEN
+            verify(realStore, never()).dismissJitmMessage(site, jitmId, featureClass)
+        }
+
+    @Test
+    fun `given testing mode is disabled, when dismissJitmMessage is called, real store is called`() =
+        testBlocking {
+            // GIVEN
+            val site = mock<SiteModel>()
+            val jitmId = "jitmId"
+            val featureClass = "featureClass"
+            val wrapperData = mock<JitmStoreWrapperData> {
+                on { isTestingModeEnabled }.thenReturn(false)
+            }
+            val wrapper = JitmStoreWrapper(
+                context = context,
+                gson = gson,
+                realStore = realStore,
+                wrapperData = wrapperData,
+            )
+
+            // WHEN
+            wrapper.dismissJitmMessage(site, jitmId, featureClass)
+
+            // THEN
+            verify(realStore).dismissJitmMessage(site, jitmId, featureClass)
+        }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmViewModelTest.kt
@@ -29,14 +29,13 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMContent
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMCta
-import org.wordpress.android.fluxc.store.JitmStore
 
 @ExperimentalCoroutinesApi
 class JitmViewModelTest : BaseUnitTest() {
     private val savedState: SavedStateHandle = mock {
         on { get<String>(JITM_MESSAGE_PATH_KEY) }.thenReturn("woomobile:my_store:admin_notices")
     }
-    private val jitmStore: JitmStore = mock()
+    private val jitmStore: JitmStoreWrapper = mock()
     private val jitmTracker: JitmTracker = mock()
     private val utmProvider: MyStoreUtmProvider = mock()
     private val queryParamsEncoder: QueryParamsEncoder = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -23,6 +23,7 @@ object WooLog {
         MEDIA,
         CARD_READER,
         COUPONS,
+        JITM,
         SITE_PICKER
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9021
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Having `jitm_testing_json_file_name` with a file name in `gradle.properties` that is supposed to be placed in the `assets` folder will use the content of the file as a response to JITM endpoint requests

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Put `jitm_testing_json_file_name = jitm_testing.json` in your local `gradle.properties`
* Notice that now JITM generated based on the content of this file
* Remove this line
* Notice that remote call is used


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
