### PR TITLE
Parent child products data

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -98,7 +98,8 @@ data class Order(
         val totalTax: BigDecimal,
         val total: BigDecimal,
         val variationId: Long,
-        val attributesList: List<Attribute>
+        val attributesList: List<Attribute>,
+        val parent: Long? = null
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -120,7 +120,8 @@ class OrderMapper @Inject constructor(private val getLocations: GetLocations) {
                     it.variationId ?: 0,
                     it.getAttributeList().map { attribute ->
                         Item.Attribute(attribute.key.orEmpty(), attribute.value.orEmpty())
-                    }
+                    },
+                    it.bundledBy?.toLongOrNull()
                 )
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -488,7 +488,7 @@ class OrderDetailFragment :
         }
     }
 
-    private fun showOrderProducts(products: List<OrderDetailViewModel.OrderProduct>, currency: String) {
+    private fun showOrderProducts(products: List<OrderProduct>, currency: String) {
         products.whenNotNullNorEmpty {
             with(binding.orderDetailProductList) {
                 updateProductItemsList(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -607,27 +607,9 @@ class OrderDetailViewModel @Inject constructor(
     ): ListInfo<OrderProduct> {
         val products = refunds.list.getNonRefundedProducts(order.items)
         checkAddonAvailability(products)
-        val orderProducts = toOrderProducts(products)
+        val orderProducts = products.toOrderProducts()
         return ListInfo(isVisible = orderProducts.isNotEmpty(), list = orderProducts)
     }
-    @Suppress("MagicNumber")
-    private fun toOrderProducts(products: List<Order.Item>): List<OrderProduct> {
-        if (products.isEmpty()) return emptyList()
-        val mockList = products.toMutableList()
-        while (mockList.size < 7) {
-            mockList.addAll(products)
-        }
-        return buildList {
-            add(
-                OrderProduct.GroupedProductItem(
-                    product = mockList.first(),
-                    children = mockList.slice(1 until mockList.lastIndex - 2).map { OrderProduct.ProductItem(it) }
-                )
-            )
-            addAll(mockList.slice(mockList.lastIndex - 2 until mockList.lastIndex).map { OrderProduct.ProductItem(it) })
-        }
-    }
-
     private fun checkAddonAvailability(products: List<Order.Item>) {
         launch(coroutineDispatchers.computation) {
             products.forEach { it.containsAddons = addonsRepository.containsAddonsFrom(it) }
@@ -837,13 +819,4 @@ class OrderDetailViewModel @Inject constructor(
     ) : Parcelable
 
     data class ListInfo<T>(val isVisible: Boolean = true, val list: List<T> = emptyList())
-
-    @Parcelize
-    sealed class OrderProduct : Parcelable {
-        @Parcelize
-        data class ProductItem(val product: Order.Item) : OrderProduct()
-
-        @Parcelize
-        data class GroupedProductItem(val product: Order.Item, val children: List<ProductItem>) : OrderProduct()
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderProduct.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.orders.details
+
+import android.os.Parcelable
+import com.woocommerce.android.model.Order
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+sealed class OrderProduct : Parcelable {
+    @Parcelize
+    data class ProductItem(val product: Order.Item) : OrderProduct()
+
+    @Parcelize
+    data class GroupedProductItem(val product: Order.Item, val children: List<ProductItem>) : OrderProduct()
+}
+
+fun List<Order.Item>.toOrderProducts(): List<OrderProduct> {
+    if (isEmpty()) return emptyList()
+
+    val itemsMap = associateBy { item -> item.itemId }
+    val childrenMap = mutableMapOf<Long, MutableList<OrderProduct.ProductItem>>()
+
+    val result = mapNotNull { item ->
+        if (item.parent == null) {
+            item
+        } else {
+            val children = childrenMap.getOrPut(
+                item.parent
+            ) { mutableListOf() }
+
+            children.add(OrderProduct.ProductItem(item))
+            null
+        }
+    }.filter { item ->
+        (item.itemId in childrenMap.keys).not()
+    }.map<Order.Item, OrderProduct> { OrderProduct.ProductItem(it) }
+        .toMutableList()
+
+    for (parentId in childrenMap.keys) {
+        val parent = itemsMap[parentId] ?: continue
+        val children = childrenMap[parentId] ?: emptyList()
+
+        val groupedProduct = OrderProduct.GroupedProductItem(parent, children)
+        result.add(groupedProduct)
+    }
+    return result
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductChildItemListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductChildItemListAdapter.kt
@@ -12,13 +12,13 @@ import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderProductActionListener
-import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
+import com.woocommerce.android.ui.orders.details.OrderProduct
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 
 class OrderDetailProductChildItemListAdapter(
-    private val productItems: List<OrderDetailViewModel.OrderProduct.ProductItem>,
+    private val productItems: List<OrderProduct.ProductItem>,
     private val productImageMap: ProductImageMap,
     private val formatCurrencyForDisplay: (BigDecimal) -> String,
     private val productItemListener: OrderProductActionListener
@@ -50,7 +50,7 @@ class OrderDetailProductChildItemListAdapter(
     ) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(
-            productItem: OrderDetailViewModel.OrderProduct.ProductItem,
+            productItem: OrderProduct.ProductItem,
             productImageMap: ProductImageMap,
             productItemListener: OrderProductActionListener,
             formatCurrencyForDisplay: (BigDecimal) -> String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductItemListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductItemListAdapter.kt
@@ -12,13 +12,13 @@ import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderDetailProductItemView
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.ViewAddonClickListener
-import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
+import com.woocommerce.android.ui.orders.details.OrderProduct
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 
 class OrderDetailProductItemListAdapter(
-    private val productItems: List<OrderDetailViewModel.OrderProduct>,
+    private val productItems: List<OrderProduct>,
     private val productImageMap: ProductImageMap,
     private val formatCurrencyForDisplay: (BigDecimal) -> String,
     private val productItemListener: OrderProductActionListener,
@@ -26,7 +26,7 @@ class OrderDetailProductItemListAdapter(
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private inner class ProductItemViewHolder(val view: OrderDetailProductItemView) : RecyclerView.ViewHolder(view) {
         fun onBind(
-            productItem: OrderDetailViewModel.OrderProduct.ProductItem,
+            productItem: OrderProduct.ProductItem,
             productImageMap: ProductImageMap,
             formatCurrencyForDisplay: (BigDecimal) -> String,
             productItemListener: OrderProductActionListener,
@@ -49,7 +49,7 @@ class OrderDetailProductItemListAdapter(
     private inner class GroupedItemViewHolder(val binding: OrderDetailProductGroupItemBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun onBind(
-            groupedItem: OrderDetailViewModel.OrderProduct.GroupedProductItem,
+            groupedItem: OrderProduct.GroupedProductItem,
             productImageMap: ProductImageMap,
             formatCurrencyForDisplay: (BigDecimal) -> String,
             productItemListener: OrderProductActionListener,
@@ -106,8 +106,8 @@ class OrderDetailProductItemListAdapter(
 
     override fun getItemViewType(position: Int): Int {
         return when (productItems[position]) {
-            is OrderDetailViewModel.OrderProduct.GroupedProductItem -> GROUPED_PRODUCT_ITEM_VIEW
-            is OrderDetailViewModel.OrderProduct.ProductItem -> PRODUCT_ITEM_VIEW
+            is OrderProduct.GroupedProductItem -> GROUPED_PRODUCT_ITEM_VIEW
+            is OrderProduct.ProductItem -> PRODUCT_ITEM_VIEW
         }
     }
 
@@ -137,7 +137,7 @@ class OrderDetailProductItemListAdapter(
         when (getItemViewType(position)) {
             GROUPED_PRODUCT_ITEM_VIEW -> {
                 (holder as GroupedItemViewHolder).onBind(
-                    productItems[position] as OrderDetailViewModel.OrderProduct.GroupedProductItem,
+                    productItems[position] as OrderProduct.GroupedProductItem,
                     productImageMap,
                     formatCurrencyForDisplay,
                     productItemListener,
@@ -146,7 +146,7 @@ class OrderDetailProductItemListAdapter(
             }
             PRODUCT_ITEM_VIEW -> {
                 (holder as ProductItemViewHolder).onBind(
-                    productItems[position] as OrderDetailViewModel.OrderProduct.ProductItem,
+                    productItems[position] as OrderProduct.ProductItem,
                     productImageMap,
                     formatCurrencyForDisplay,
                     productItemListener,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.ViewAddonClickListener
-import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
+import com.woocommerce.android.ui.orders.details.OrderProduct
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailProductItemListAdapter
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailProductListAdapter
 import com.woocommerce.android.util.StringUtils
@@ -31,7 +31,7 @@ class OrderDetailProductListView @JvmOverloads constructor(
     private val binding = OrderDetailProductListBinding.inflate(LayoutInflater.from(ctx), this)
 
     fun updateProductItemsList(
-        orderProductItems: List<OrderDetailViewModel.OrderProduct>,
+        orderProductItems: List<OrderProduct>,
         productImageMap: ProductImageMap,
         formatCurrencyForDisplay: (BigDecimal) -> String,
         productClickListener: OrderProductActionListener,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderInfo
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.ViewState
 import com.woocommerce.android.ui.orders.details.OrderDetailsTransactionLauncher
+import com.woocommerce.android.ui.orders.details.OrderProduct
 import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingRepository
 import com.woocommerce.android.ui.payments.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
@@ -255,7 +256,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
         // product list should not be empty when shipping labels are not available and products are not refunded
-        val products = ArrayList<OrderDetailViewModel.OrderProduct>()
+        val products = ArrayList<OrderProduct>()
         viewModel.productList.observeForever {
             it?.let { products.addAll(it) }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2729-31d7c720708f007f72df6b21609f128e6802d06c'
+    fluxCVersion = 'trunk-a2ee13cbabc1d9e4268d545d0e88bf01f87a247d'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-81b570f69e66511f85ab74af46cbeefd1f15e540'
+    fluxCVersion = '2729-31d7c720708f007f72df6b21609f128e6802d06c'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #8403

### Why
On the Eagle team, we are working on improving the experience for our users across our Canonical Extensions. One of these extensions is Bundled Products, and one of our tasks and ideas to improve the experience was to display the relationship between a bundle and its products.

### Description
This PR uses the new `parent` field on the Order class to group all inner products inside its bundled parent.

### Testing instructions
#### Prerequisites
1. Create a bundled product containing products on wp-admin
2. Place an order containing at least one bundled product

#### Test case
1. Open the Orders list
2. Open an order containing a bundled product
3. Check that children products appear with more margin than parent/simple products

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/a9ac8cf1-4d29-465d-a7dd-51de1ccef3bd

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

