### PR TITLE
Feature/8955 close account UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
@@ -27,7 +27,8 @@ enum class HelpOrigin(private val stringValue: String) {
     LOGIN_WITH_QR_CODE("origin:qr-code-scanner"),
     STORE_CREATION("origin:store-creation"),
     DOMAIN_CHANGE("origin:domain-change"),
-    UPGRADES("origin:upgrades");
+    UPGRADES("origin:upgrades"),
+    ACCOUNT_DELETION("origin:account-deletion");
 
     override fun toString(): String {
         return stringValue

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.ui.prefs
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.Text
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.R.style
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class CloseAccountDialogFragment : DialogFragment() {
+
+    private val viewModel: CloseAccountViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        // Specify transition animations
+        dialog?.window?.attributes?.windowAnimations = style.Woo_Animations_Dialog
+
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    viewModel.viewState.observeAsState().value?.let { state ->
+                        Text(text = "Closing account for user ${state.userName}")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
@@ -4,14 +4,40 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
-import com.woocommerce.android.R.style
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.R.color
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.prefs.CloseAccountViewModel.CloseAccountState
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -21,7 +47,7 @@ class CloseAccountDialogFragment : DialogFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         // Specify transition animations
-        dialog?.window?.attributes?.windowAnimations = style.Woo_Animations_Dialog
+        dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
 
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -29,10 +55,91 @@ class CloseAccountDialogFragment : DialogFragment() {
             setContent {
                 WooThemeWithBackground {
                     viewModel.viewState.observeAsState().value?.let { state ->
-                        Text(text = "Closing account for user ${state.userName}")
+                        CloseAccountDialog(state)
                     }
                 }
             }
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is Event.Exit -> {
+                    findNavController().popBackStack()
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun CloseAccountDialog(state: CloseAccountState) {
+        val focusRequester = remember { FocusRequester() }
+        Column {
+            Column(
+                modifier = Modifier.padding(dimensionResource(id = dimen.major_100)),
+                verticalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.major_75)),
+
+                ) {
+                Text(
+                    text = stringResource(id = string.settings_close_account_dialog_title),
+                    style = MaterialTheme.typography.h6,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = stringResource(id = string.settings_close_account_dialog_description),
+                    style = MaterialTheme.typography.subtitle1,
+                )
+                Text(
+                    text = state.userName,
+                    style = MaterialTheme.typography.subtitle1,
+                )
+                WCOutlinedTextField(
+                    modifier = Modifier
+                        .focusRequester(focusRequester)
+                        .padding(top = dimensionResource(id = dimen.minor_100)),
+                    value = state.enteredUserName,
+                    onValueChange = { viewModel.onUserNameInputChanged(it) },
+                    label = stringResource(id = string.username),
+                    singleLine = true,
+                )
+            }
+            Divider(
+                color = colorResource(id = color.divider_color),
+                thickness = dimensionResource(id = dimen.minor_10)
+            )
+            Row(
+                modifier = Modifier.padding(
+                    start = dimensionResource(id = dimen.major_100),
+                    end = dimensionResource(id = dimen.major_100),
+                    bottom = dimensionResource(id = dimen.minor_100),
+                ),
+                verticalAlignment = Alignment.CenterVertically
+            )
+            {
+                WCTextButton(
+                    onClick = viewModel::onCloseAccountDismissed
+                ) {
+                    Text(
+                        text = stringResource(id = string.cancel),
+                        style = MaterialTheme.typography.subtitle1
+                    )
+                }
+                WCTextButton(
+                    onClick = viewModel::onConfirmCloseAccount,
+                    enabled = state.enteredUserName == state.userName
+                ) {
+                    Text(
+                        text = stringResource(id = string.settings_close_account_dialog_confirm_button),
+                        style = MaterialTheme.typography.subtitle1,
+                        textAlign = TextAlign.Center,
+                        color =
+                        if (state.enteredUserName == state.userName) colorResource(id = color.color_error)
+                        else colorResource(id = color.color_on_surface_disabled)
+                    )
+                }
+            }
+        }
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
@@ -5,9 +5,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -129,14 +133,24 @@ class CloseAccountDialogFragment : DialogFragment() {
                     onClick = viewModel::onConfirmCloseAccount,
                     enabled = state.enteredUserName == state.userName
                 ) {
-                    Text(
-                        text = stringResource(id = string.settings_close_account_dialog_confirm_button),
-                        style = MaterialTheme.typography.subtitle1,
-                        textAlign = TextAlign.Center,
-                        color =
-                        if (state.enteredUserName == state.userName) colorResource(id = color.color_error)
-                        else colorResource(id = color.color_on_surface_disabled)
-                    )
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (state.isLoading) {
+                            CircularProgressIndicator(modifier = Modifier.size(size = dimensionResource(id = dimen.major_150)))
+                        } else {
+                            Text(
+                                text = stringResource(id = string.settings_close_account_dialog_confirm_button),
+                                style = MaterialTheme.typography.subtitle1,
+                                textAlign = TextAlign.Center,
+                                color =
+                                if (state.enteredUserName == state.userName) colorResource(id = color.color_error)
+                                else colorResource(id = color.color_on_surface_disabled)
+                            )
+                        }
+                    }
+
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -86,6 +85,7 @@ class CloseAccountDialogFragment : DialogFragment() {
                         origin = event.origin,
                         extraTags = ArrayList()
                     ).let { activity?.startActivity(it) }
+                    findNavController().popBackStack()
                 }
             }
         }
@@ -95,7 +95,7 @@ class CloseAccountDialogFragment : DialogFragment() {
     private fun LoadingDialog() {
         Column(
             modifier = Modifier
-                .padding(dimensionResource(id = R.dimen.major_100))
+                .padding(dimensionResource(id = R.dimen.major_150))
                 .fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -114,7 +114,7 @@ class CloseAccountDialogFragment : DialogFragment() {
         focusRequester: FocusRequester
     ) {
         Column(
-            modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100)),
+            modifier = Modifier.padding(dimensionResource(id = R.dimen.major_125)),
             verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_75)),
         ) {
             Text(
@@ -126,30 +126,29 @@ class CloseAccountDialogFragment : DialogFragment() {
                 text = stringResource(id = state.description),
                 style = MaterialTheme.typography.subtitle1,
             )
-            Text(
-                text = state.currentUserName,
-                style = MaterialTheme.typography.subtitle1,
-            )
-            WCOutlinedTextField(
-                modifier = Modifier
-                    .focusRequester(focusRequester)
-                    .padding(top = dimensionResource(id = R.dimen.minor_100)),
-                value = state.enteredUserName,
-                onValueChange = { viewModel.onUserNameInputChanged(it) },
-                label = stringResource(id = R.string.username),
-                singleLine = true,
-            )
+            if (!state.isAccountDeletionError) {
+                Text(
+                    text = state.currentUserName,
+                    style = MaterialTheme.typography.subtitle1,
+                )
+                WCOutlinedTextField(
+                    modifier = Modifier
+                        .focusRequester(focusRequester)
+                        .padding(top = dimensionResource(id = R.dimen.minor_100)),
+                    value = state.enteredUserName,
+                    onValueChange = { viewModel.onUserNameInputChanged(it) },
+                    label = stringResource(id = R.string.username),
+                    singleLine = true,
+                )
+            }
         }
-        Divider(
-            color = colorResource(id = R.color.divider_color),
-            thickness = dimensionResource(id = R.dimen.minor_10)
-        )
         Row(
             modifier = Modifier.padding(
                 start = dimensionResource(id = R.dimen.major_100),
                 end = dimensionResource(id = R.dimen.major_100),
                 bottom = dimensionResource(id = R.dimen.minor_100),
             ),
+            horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         )
         {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
@@ -150,8 +150,7 @@ class CloseAccountDialogFragment : DialogFragment() {
             ),
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
-        )
-        {
+        ) {
             WCTextButton(
                 onClick = viewModel::onCloseAccountDismissed
             ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
@@ -6,6 +6,8 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,7 +26,10 @@ class CloseAccountViewModel @Inject constructor(
     val viewState = _viewState
 
     fun onConfirmCloseAccount() {
-
+        launch {
+            _viewState.value = _viewState.value?.copy(isLoading = true)
+            delay(3000)
+        }
     }
 
     fun onCloseAccountDismissed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
@@ -37,7 +37,7 @@ class CloseAccountViewModel @Inject constructor(
     fun onConfirmCloseAccount() {
         launch {
             _viewState.value = _viewState.value?.copy(isLoading = true)
-            delay(3000)
+            @Suppress("MagicNumber") delay(3000)
             _viewState.value = _viewState.value?.copy(
                 title = R.string.settings_close_account_error_dialog_title,
                 description = R.string.settings_close_account_error_dialog_description,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
@@ -2,9 +2,8 @@ package com.woocommerce.android.ui.prefs
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.login.AccountRepository
-import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -18,29 +17,28 @@ class CloseAccountViewModel @Inject constructor(
     private val _viewState = MutableLiveData(
         CloseAccountState(
             userName = accountRepository.getUserAccount()?.userName
-                ?: error("Account deletion setting requires user to log in with WP.com account")
+                ?: error("Account deletion setting requires user to log in with WP.com account"),
+            enteredUserNameError = null
         )
     )
     val viewState = _viewState
 
-    fun onCloseAccountClicked() {
-        triggerEvent(
-            MultiLiveEvent.Event.ShowDialog(
-                titleId = R.string.store_onboarding_dialog_title,
-                messageId = R.string.store_onboarding_dialog_description,
-                positiveButtonId = R.string.remove,
-                positiveBtnAction = { dialog, _ ->
+    fun onConfirmCloseAccount() {
 
-                    dialog.dismiss()
-                },
-                negativeBtnAction = { dialog, _ -> dialog.dismiss() },
-                negativeButtonId = R.string.cancel,
-            )
-        )
+    }
+
+    fun onCloseAccountDismissed() {
+        triggerEvent(Exit)
+    }
+
+    fun onUserNameInputChanged(input: String) {
+        _viewState.value = _viewState.value?.copy(enteredUserName = input)
     }
 
     data class CloseAccountState(
         val userName: String,
+        val enteredUserName: String = "",
+        val enteredUserNameError: String?,
         val isLoading: Boolean = false
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
@@ -1,8 +1,12 @@
 package com.woocommerce.android.ui.prefs
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,9 +22,14 @@ class CloseAccountViewModel @Inject constructor(
 
     private val _viewState = MutableLiveData(
         CloseAccountState(
-            userName = accountRepository.getUserAccount()?.userName
+            title = R.string.settings_close_account_dialog_title,
+            description = R.string.settings_close_account_dialog_description,
+            mainButtonText = R.string.settings_close_account_dialog_confirm_button,
+            currentUserName = accountRepository.getUserAccount()?.userName
                 ?: error("Account deletion setting requires user to log in with WP.com account"),
-            enteredUserNameError = null
+            enteredUserName = "",
+            isLoading = false,
+            isAccountDeletionError = false,
         )
     )
     val viewState = _viewState
@@ -29,7 +38,18 @@ class CloseAccountViewModel @Inject constructor(
         launch {
             _viewState.value = _viewState.value?.copy(isLoading = true)
             delay(3000)
+            _viewState.value = _viewState.value?.copy(
+                title = R.string.settings_close_account_error_dialog_title,
+                description = R.string.settings_close_account_error_dialog_description,
+                mainButtonText = R.string.settings_close_account_dialog_contact_support_button,
+                isLoading = false,
+                isAccountDeletionError = true
+            )
         }
+    }
+
+    fun onContactSupportClicked() {
+        triggerEvent(ContactSupport(HelpOrigin.ACCOUNT_DELETION))
     }
 
     fun onCloseAccountDismissed() {
@@ -41,9 +61,14 @@ class CloseAccountViewModel @Inject constructor(
     }
 
     data class CloseAccountState(
-        val userName: String,
-        val enteredUserName: String = "",
-        val enteredUserNameError: String?,
-        val isLoading: Boolean = false
+        @StringRes val title: Int,
+        @StringRes val description: Int,
+        @StringRes val mainButtonText: Int,
+        val currentUserName: String,
+        val enteredUserName: String,
+        val isAccountDeletionError: Boolean,
+        val isLoading: Boolean
     )
+
+    data class ContactSupport(val origin: HelpOrigin) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.prefs
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CloseAccountViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val accountRepository: AccountRepository,
+) : ScopedViewModel(savedStateHandle) {
+
+    private val _viewState = MutableLiveData(
+        CloseAccountState(
+            userName = accountRepository.getUserAccount()?.userName
+                ?: error("Account deletion setting requires user to log in with WP.com account")
+        )
+    )
+    val viewState = _viewState
+
+    fun onCloseAccountClicked() {
+        triggerEvent(
+            MultiLiveEvent.Event.ShowDialog(
+                titleId = R.string.store_onboarding_dialog_title,
+                messageId = R.string.store_onboarding_dialog_description,
+                positiveButtonId = R.string.remove,
+                positiveBtnAction = { dialog, _ ->
+
+                    dialog.dismiss()
+                },
+                negativeBtnAction = { dialog, _ -> dialog.dismiss() },
+                negativeButtonId = R.string.cancel,
+            )
+        )
+    }
+
+    data class CloseAccountState(
+        val userName: String,
+        val isLoading: Boolean = false
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -12,10 +12,10 @@ interface MainSettingsContract {
         fun setupAnnouncementOption()
         fun setupJetpackInstallOption()
         fun setupApplicationPasswordsSettings()
-
         fun setupOnboardingListVisibilitySetting()
 
         val isDomainOptionVisible: Boolean
+        val isCloseAccountOptionVisible: Boolean
     }
 
     interface View : BaseView<Presenter> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -207,9 +207,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         binding.optionTheme.setOnClickListener {
             showThemeChooser()
         }
-        binding.btnOptionCloseAccount.setOnClickListener {
-            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_closeAccountDialogFragment)
-        }
 
         lifecycleScope.launch {
             binding.optionDomain.isVisible = presenter.isDomainOptionVisible
@@ -217,6 +214,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                 AnalyticsTracker.track(SETTINGS_DOMAINS_TAPPED)
                 showDomainDashboard()
             }
+        }
+
+        binding.containerOptionCloseAccount.isVisible = presenter.isCloseAccountOptionVisible
+        binding.btnOptionCloseAccount.setOnClickListener {
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_closeAccountDialogFragment)
         }
 
         presenter.setupAnnouncementOption()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -205,8 +205,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
         binding.optionTheme.optionValue = getString(AppPrefs.getAppTheme().label)
         binding.optionTheme.setOnClickListener {
-            // FIXME AMANDA tracks event
             showThemeChooser()
+        }
+        binding.btnOptionCloseAccount.setOnClickListener {
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_closeAccountDialogFragment)
         }
 
         lifecycleScope.launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -97,4 +97,7 @@ class MainSettingsPresenter @Inject constructor(
 
     override val isDomainOptionVisible: Boolean
         get() = selectedSite.get().isWPComAtomic
+
+    override val isCloseAccountOptionVisible: Boolean
+        get() = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -233,6 +233,15 @@
 
         <View style="@style/Woo.Divider" />
 
+        <com.woocommerce.android.ui.prefs.WCSettingsButton
+            android:id="@+id/btn_option_close_account"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/color_error"
+            android:text="@string/settings_close_account" />
+
+        <View style="@style/Woo.Divider" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -73,9 +73,9 @@
                 android:id="@+id/option_store_onboarding_list_visibility"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 app:toggleOptionDesc="@string/store_onboarding_setting_description"
-                app:toggleOptionTitle="@string/store_onboarding_setting_title"
-                android:visibility="gone" />
+                app:toggleOptionTitle="@string/store_onboarding_setting_title" />
 
             <View style="@style/Woo.Divider" />
 
@@ -233,14 +233,22 @@
 
         <View style="@style/Woo.Divider" />
 
-        <com.woocommerce.android.ui.prefs.WCSettingsButton
-            android:id="@+id/btn_option_close_account"
-            android:layout_width="match_parent"
+        <LinearLayout
+            android:id="@+id/container_option_close_account"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/color_error"
-            android:text="@string/settings_close_account" />
+            android:orientation="vertical"
+            android:visibility="gone">
 
-        <View style="@style/Woo.Divider" />
+            <com.woocommerce.android.ui.prefs.WCSettingsButton
+                android:id="@+id/btn_option_close_account"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_close_account"
+                android:textColor="@color/color_error" />
+
+            <View style="@style/Woo.Divider" />
+        </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -41,6 +41,9 @@
                 android:defaultValue="SETTINGS"
                 app:argType="com.woocommerce.android.ui.prefs.domain.DomainFlowSource" />
         </action>
+        <action
+            android:id="@+id/action_mainSettingsFragment_to_closeAccountDialogFragment"
+            app:destination="@id/closeAccountDialogFragment" />
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"
@@ -141,4 +144,8 @@
         android:name="com.woocommerce.android.ui.prefs.DeveloperOptionsFragment"
         android:label="DeveloperOptionsFragment" />
     <include app:graph="@navigation/nav_graph_domain_change" />
+    <dialog
+        android:id="@+id/closeAccountDialogFragment"
+        android:name="com.woocommerce.android.ui.prefs.CloseAccountDialogFragment"
+        android:label="CloseAccountDialogFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1894,6 +1894,7 @@
     <string name="beta_features_coupons">Coupons Management</string>
     <string name="beta_features_simple_payments">Simple payments</string>
     <string name="settings_signout">Log out</string>
+    <string name="settings_close_account">Close Account</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_confirm_logout_site_credentials">Are you sure you want to log out of your account?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1895,6 +1895,9 @@
     <string name="beta_features_simple_payments">Simple payments</string>
     <string name="settings_signout">Log out</string>
     <string name="settings_close_account">Close Account</string>
+    <string name="settings_close_account_dialog_title">Confirm Close Account</string>
+    <string name="settings_close_account_dialog_description">To confirm, please re-enter your username before closing</string>
+    <string name="settings_close_account_dialog_confirm_button">Permanently Close Account</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_confirm_logout_site_credentials">Are you sure you want to log out of your account?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1898,6 +1898,7 @@
     <string name="settings_close_account_dialog_title">Confirm Close Account</string>
     <string name="settings_close_account_dialog_description">To confirm, please re-enter your username before closing</string>
     <string name="settings_close_account_dialog_confirm_button">Permanently Close Account</string>
+    <string name="settings_close_account_dialog_loading_title">Closing account…</string>
     <string name="settings_close_account_error_dialog_title">Couldn\'t close account</string>
     <string name="settings_close_account_error_dialog_description">An error occurred while attempting to close your account.</string>
     <string name="settings_close_account_dialog_contact_support_button">Contact Support</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1898,6 +1898,9 @@
     <string name="settings_close_account_dialog_title">Confirm Close Account</string>
     <string name="settings_close_account_dialog_description">To confirm, please re-enter your username before closing</string>
     <string name="settings_close_account_dialog_confirm_button">Permanently Close Account</string>
+    <string name="settings_close_account_error_dialog_title">Couldn\'t close account</string>
+    <string name="settings_close_account_error_dialog_description">An error occurred while attempting to close your account.</string>
+    <string name="settings_close_account_dialog_contact_support_button">Contact Support</string>
     <string name="settings_preferences">Preferences</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_confirm_logout_site_credentials">Are you sure you want to log out of your account?</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8955 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Upcoming policies from Google require us to provide a way to close accounts. More on that in the linked issues. This PR adds the UI needed to close an account from settings. 

No request is fired. The loading is simply a delay for testing purposes. 

The UI for this feature is replicating iOS behavior with some slight changes. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to settings 
- Click close account
- Verify the behavior is as shown in the screen recording

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/33f47eee-c179-4b8a-a909-5963e6ea4c4a


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
