### PR TITLE
fix: crash on trial period calculation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/domain/CalculatePlanRemainingPeriod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/domain/CalculatePlanRemainingPeriod.kt
@@ -1,17 +1,29 @@
 package com.woocommerce.android.ui.plans.domain
 
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.extensions.clock
 import com.woocommerce.android.tools.SelectedSite
+import java.time.Clock
 import java.time.Period
 import java.time.ZonedDateTime
 import javax.inject.Inject
 
 class CalculatePlanRemainingPeriod @Inject constructor(
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val crashLogging: CrashLogging,
 ) {
 
     operator fun invoke(expirationDate: ZonedDateTime): Period {
-        val currentDateInSiteTimezone = ZonedDateTime.now(selectedSite.get().clock).toLocalDate()
+        val siteClock = selectedSite.getIfExists()?.clock
+
+        val clock = if (siteClock == null) {
+            crashLogging.sendReport(message = "Site is null, which should not happen.")
+            Clock.systemDefaultZone()
+        } else {
+            siteClock
+        }
+
+        val currentDateInSiteTimezone = ZonedDateTime.now(clock).toLocalDate()
 
         return Period.between(
             currentDateInSiteTimezone,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/plans/domain/CalculatePlanRemainingPeriodTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/plans/domain/CalculatePlanRemainingPeriodTest.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.ui.plans.domain
+
+import com.automattic.android.tracks.crashlogging.CrashLogging
+import com.woocommerce.android.tools.SelectedSite
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class CalculatePlanRemainingPeriodTest {
+
+    private val selectedSite: SelectedSite = mock()
+    private val crashLogging: CrashLogging = mock()
+
+    private val sut = CalculatePlanRemainingPeriod(selectedSite, crashLogging)
+
+    @Test
+    fun `given the scenario where site does not exist, should not crash and report event`() {
+        // given
+        selectedSite.stub { on { getIfExists() }.thenReturn(null) }
+        val expirationDate =
+            ZonedDateTime.of(2023, 10, 10, 0, 0, 0, 0, ZoneId.of("UTC"))
+
+        // when
+        sut(expirationDate)
+
+        // then
+        verify(crashLogging).sendReport(message = "Site is null, which should not happen.")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9038
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I couldn't reproduce the original issue.

It shouldn't ever happen, as at this point a site should be selected. `calculatePlanRemainingPeriod` is invoked in `DetermineTrialStatusBarState` after checking if `selectedSite` is `freeTrial` - so we **had** to have site selected at this point 🤔 .

Added crash logging report to observe how often this scenario happens.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not needed

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
