### PR TITLE
Support non-JP users on Privacy Screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -13,9 +13,11 @@ import javax.inject.Inject
 
 class AppPrefsWrapper @Inject constructor() {
 
-    fun sendUsageStats(enabled: Boolean) {
+    fun setSendUsageStats(enabled: Boolean) {
         AnalyticsTracker.sendUsageStats = enabled
     }
+
+    fun getSendUsageStats() = AnalyticsTracker.sendUsageStats
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
         AppPrefs.getReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
@@ -59,13 +59,11 @@ class PrivacySettingsViewModel @Inject constructor(
                     }
                 )
             }
-        } else {
-            _state.value =
-                _state.value?.copy(sendUsageStats = appPrefs.getSendUsageStats())
         }
     }
 
-    private fun getSendUsageStats() = !accountStore.account.tracksOptOut
+    private fun getSendUsageStats() =
+        if (isWpComUser()) !accountStore.account.tracksOptOut else appPrefs.getSendUsageStats()
 
     private fun getCrashReportingEnabled() = appPrefs.isCrashReportingEnabled()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
@@ -34,7 +34,7 @@ class PrivacySettingsViewModel @Inject constructor(
     }
 
     fun initialize() {
-        if (isWpComUser()) {
+        if (repository.isUserWPCOM()) {
             launch {
                 _state.value = _state.value?.copy(progressBarVisible = true)
                 val event = repository.fetchAccountSettings()
@@ -61,7 +61,7 @@ class PrivacySettingsViewModel @Inject constructor(
     }
 
     private fun getSendUsageStats() =
-        if (isWpComUser()) !repository.userOptOutFromTracks() else appPrefs.getSendUsageStats()
+        if (repository.isUserWPCOM()) !repository.userOptOutFromTracks() else appPrefs.getSendUsageStats()
 
     private fun getCrashReportingEnabled() = appPrefs.isCrashReportingEnabled()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
@@ -62,7 +62,7 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
 
             // then
             assertThat(sut.state.value?.sendUsageStats).isTrue
-            verify(appPrefs).sendUsageStats(true)
+            verify(appPrefs).setSendUsageStats(true)
         }
 
     @Test
@@ -105,7 +105,7 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
 
             // then
             assertThat(sut.state.value?.sendUsageStats).isFalse
-            verify(appPrefs).sendUsageStats(false)
+            verify(appPrefs).setSendUsageStats(false)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.model.AccountModel
@@ -128,5 +129,26 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             // then
             assertThat(sut.state.value?.sendUsageStats).isFalse
             assertThat(sut.event.value).isInstanceOf(MultiLiveEvent.Event.ShowActionSnackbar::class.java)
+        }
+
+    @Test
+    fun `given user is not WPCOM, when user opens the screen, load settings from local preferences`() =
+        testBlocking {
+            // given
+            accountStore.stub {
+                on { hasAccessToken() } doReturn false
+            }
+            appPrefs.stub {
+                on { getSendUsageStats() } doReturn false
+            }
+
+            // when
+            init()
+            runCurrent()
+
+            // then
+            verify(appPrefs).getSendUsageStats()
+            verify(repository, never()).fetchAccountSettings()
+            assertThat(sut.state.value?.sendUsageStats).isFalse()
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
@@ -118,8 +118,8 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     fun `given user is not WPCOM, when user opens the screen, load settings from local preferences`() =
         testBlocking {
             // given
-            accountStore.stub {
-                on { hasAccessToken() } doReturn false
+            repository.stub {
+                on { isUserWPCOM() } doReturn false
             }
             appPrefs.stub {
                 on { getSendUsageStats() } doReturn false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8969
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds behavior of ignoring WPCOM tracking settings if the user is not a WPCOM.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log in as non-WPCOM user
2. Enable Analytics in Settings Screen
3. **See that Tracks events are recorded in the app ("Tracked: " logs)**
4. Open the Settings Screen
5. **Assert that Analytics settings are enabled**
6. Disable Analytics
7. **See that Tracks events are not recorded in the app**
8. Open the Settings Screen
9. **Assert that Analytics settings are disabled**

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
